### PR TITLE
feat: add toroidal topology infrastructure (#61)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ Key principle:
 
 - **Language**: Rust
 - **Project**: {2,3,4}D Causal Dynamical Triangulations library
-- **MSRV**: 1.94.0
+- **MSRV**: 1.95.0
 - **Edition**: 2024
 - **Unsafe code**: forbidden (`#![forbid(unsafe_code)]`)
 - **Architecture**: CDT physics layered over a pluggable geometry backend (`delaunay` crate). Direct `use delaunay::` imports are restricted to `src/geometry/` (`backends/delaunay.rs` and `generators.rs`); all other modules use the trait-based abstractions and `DelaunayBackend2D` type alias (see `docs/dev/rust.md § Geometry Backend Isolation`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Our community is built on the principles of:
 
 Before you begin, ensure you have:
 
-1. **Rust 1.94.0** (pinned via `rust-toolchain.toml` - automatically handled by rustup)
+1. **Rust 1.95.0** (pinned via `rust-toolchain.toml` - automatically handled by rustup)
 2. **Git** for version control
 3. **Just** (command runner): `cargo install just`
 
@@ -122,7 +122,7 @@ Before you begin, ensure you have:
 
 When you enter the project directory, `rustup` will automatically:
 
-- **Install the correct Rust version** (1.94.0) if you don't have it
+- **Install the correct Rust version** (1.95.0) if you don't have it
 - **Switch to the pinned version** for this project
 - **Install required components** (clippy, rustfmt, rust-docs, rust-src, rust-analyzer)
 - **Add cross-compilation targets** for supported platforms
@@ -137,7 +137,7 @@ When you enter the project directory, `rustup` will automatically:
 **First time in the project?** You'll see:
 
 ```text
-info: syncing channel updates for '1.94.0-<your-platform>'
+info: syncing channel updates for '1.95.0-<your-platform>'
 info: downloading component 'cargo'
 info: downloading component 'clippy'
 ...
@@ -239,7 +239,7 @@ just help-workflows  # Detailed workflow guidance
 ### Rust Code Style
 
 - **Edition**: Rust 2024
-- **MSRV**: Rust 1.94.0 (pinned in `rust-toolchain.toml`)
+- **MSRV**: Rust 1.95.0 (pinned in `rust-toolchain.toml`)
 - **Formatting**: Use `rustfmt` (configured in `rustfmt.toml`)
 - **Linting**: Strict clippy with warnings as errors
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -365,9 +365,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "delaunay"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab921d4a55d6e4f5ed8961ef048c76ec1e7c41e34aef9909896e397ac38b2ee7"
+checksum = "a58590d6d7af7947ef0e6c996f9dbd4f6dbc32f395498866a94fd8f017204d23"
 dependencies = [
  "arc-swap",
  "la-stack",
@@ -682,9 +682,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "markov-chain-monte-carlo"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09926c3ffb698bdc331fe2d12b8fbc2ff1ddb3ef798ebc2213b84660728ed41"
+checksum = "8fe2cb27f6677a7b14f7ef0c1ea8fe41ad58c13879ba3d58dd86d220c09705ec"
 dependencies = [
  "rand 0.10.0",
 ]
@@ -766,9 +766,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0218004a4aae742209bee9c3cef05672f6b2708be36a50add8eb613b1f2a4008"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
@@ -1074,9 +1074,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1216,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1315,9 +1315,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
  "num-traits",
  "predicates",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "slotmap",
  "thiserror",
@@ -365,15 +365,15 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "delaunay"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58590d6d7af7947ef0e6c996f9dbd4f6dbc32f395498866a94fd8f017204d23"
+checksum = "83544bc4bf3c674cbe8e6e2d79b404e47287a199152017e4f200c13a42fb2fdf"
 dependencies = [
  "arc-swap",
  "la-stack",
  "num-traits",
  "ordered-float",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rustc-hash",
  "serde",
  "slotmap",
@@ -638,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "la-stack"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02154c3637bfc64d8aef80c1ff018cc38585c9f1568d0fd75bb2e4bc88cb5f3"
+checksum = "938f8e88a7405e62e3f32dbf8e5a438ddd25812c7e401123ae255b08598a6a3b"
 dependencies = [
  "num-bigint",
  "num-rational",
@@ -682,11 +682,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "markov-chain-monte-carlo"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe2cb27f6677a7b14f7ef0c1ea8fe41ad58c13879ba3d58dd86d220c09705ec"
+checksum = "1f82ee9ef87baf12919174ad11bf89ead3d57cfc34161278a8ba800eb9a978f2"
 dependencies = [
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -960,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -1315,13 +1315,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ harness = false
 
 [dependencies]
 clap = { version = "4.6.0", features = [ "derive" ] }
-delaunay = "0.7.4"
-markov-chain-monte-carlo = "0.1.0"
+delaunay = "0.7.5"
+markov-chain-monte-carlo = "0.2.0"
 dirs = "6.0.0"
 env_logger = "0.11.10"
 float-ord = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = [
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/acgetchell/causal-triangulations"
-rust-version = "1.94.0"
+rust-version = "1.95.0"
 description = "Causal Dynamical Triangulations in d-dimensions"
 
 # Features removed - backend system is now internal implementation detail
@@ -33,8 +33,8 @@ harness = false
 
 [dependencies]
 clap = { version = "4.6.0", features = [ "derive" ] }
-delaunay = "0.7.5"
-markov-chain-monte-carlo = "0.2.0"
+delaunay = "0.7.6"
+markov-chain-monte-carlo = "0.2.1"
 dirs = "6.0.0"
 env_logger = "0.11.10"
 float-ord = "0.3.2"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The library currently supports an initial 2D CDT implementation, with planned ex
 
 ## ⚙️ Requirements
 
-- Rust 1.94 or newer (required by dependencies such as `delaunay` and `la-stack`)
+- Rust 1.95 or newer (required by dependencies such as `delaunay` and `la-stack`)
 
 **Why Rust for CDT?**
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,7 +2,7 @@
 # This ensures consistent configuration across all developers and IDEs
 
 # Minimum Supported Rust Version
-msrv = "1.94.0"
+msrv = "1.95.0"
 
 # Allow multiple crate versions - this is common in Rust dependency trees
 # and not something we can easily control without major refactoring

--- a/docs/project.md
+++ b/docs/project.md
@@ -36,14 +36,24 @@ Assigns each vertex to a discrete time slice, enabling classification of edges a
 ### `cdt/triangulation.rs` — Foliation integration
 
 - `from_foliated_cylinder(vertices_per_slice, num_slices, seed)` _(crate-internal, provisional)_ — point-set strip constructor used for internal diagnostics while explicit strip construction lands
+- `from_toroidal_cdt(vertices_per_slice, num_slices)` — explicit S¹×S¹ toroidal CDT (χ = 0); requires `vertices_per_slice ≥ 3` and `num_slices ≥ 3`
 - `assign_foliation_by_y(num_slices)` — bin existing vertices into time slices
 - Query methods: `time_label`, `edge_type`, `vertices_at_time`, `slice_sizes`, `has_foliation`
-- Validation: `validate_foliation()` (structural), `validate_causality()` (no edge spans >1 slice)
+- Validation: `validate_topology()` (χ expectation depends on `CdtTopology`), `validate_foliation()` (structural; closed S¹ spacelike rings on toroidal), `validate_causality()` (no edge spans >1 slice)
+
+### `config.rs` — `CdtTopology` enum
+
+- `OpenBoundary` (default) — finite strip with boundary, χ ∈ {1, 2}
+- `Toroidal` — periodic in space and time, S¹×S¹, χ = 0
+- Wired through `CdtConfig.topology`, `CdtConfigOverrides.topology`, the CLI `--topology` flag, and `CdtMetadata.topology`
+- `run_simulation()` dispatches on topology: `Toroidal` → `from_toroidal_cdt`, `OpenBoundary` → `from_seeded_points` / `from_random_points`
 
 ### `geometry/generators.rs` — Delaunay triangulation generators
 
 - `delaunay2_with_context` — builds a 2D Delaunay triangulation with optional seed
 - `build_delaunay2_with_data` — builds from coordinate + vertex-data pairs
+- `build_explicit_delaunay2` / `build_explicit_delaunay2_with_topology` — builds from explicit cell connectivity (no Delaunay point insertion); the latter also accepts `TopologyGuarantee` and `GlobalTopology` metadata so non-sphere Euler characteristics validate correctly
+- `build_explicit_delaunay2_toroidal` — convenience wrapper for explicit toroidal meshes (χ = 0)
 - `random_delaunay2`, `seeded_delaunay2` — convenience wrappers
 - `DelaunayTriangulation2D` — type alias for the concrete 2D triangulation type
 
@@ -57,6 +67,6 @@ Together with `backends/delaunay.rs`, this module is the only place that directl
 
 ## Key Dependencies
 
-- `delaunay` (v0.7.4) — geometry backend (Delaunay triangulations, vertex data for time labels, `set_vertex_data_by_key` for O(1) label mutation)
+- `delaunay` (v0.7.6) — geometry backend (Delaunay triangulations, vertex data for time labels, `set_vertex_data_by_key` for O(1) label mutation)
 - `markov-chain-monte-carlo` — MCMC framework (`Chain::step_mut`, `ProposalMut`, `Target`)
 - `num-traits` — `ToPrimitive` for safe float→integer conversion

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Pin to MSRV as specified in Cargo.toml
-channel = "1.94.0"
+channel = "1.95.0"
 
 # Essential components for development
 components = [

--- a/src/cdt/foliation.rs
+++ b/src/cdt/foliation.rs
@@ -155,6 +155,44 @@ pub enum FoliationError {
         /// Total labeled vertex count.
         labeled: usize,
     },
+    /// The spacelike subgraph of a toroidal spatial slice does not contain
+    /// every labeled vertex of that slice.
+    ///
+    /// On a toroidal CDT every vertex of slice `t` must participate in at
+    /// least one spacelike edge so the spacelike subgraph forms a closed S¹.
+    /// This variant fires when the number of distinct vertices observed in
+    /// the spacelike edges of slice `t` differs from `slice_sizes[t]`.
+    SpacelikeSubgraphSizeMismatch {
+        /// Slice index whose spacelike subgraph has the wrong vertex count.
+        slice: usize,
+        /// Number of distinct vertices observed via spacelike edges.
+        observed: usize,
+        /// Expected vertex count from `slice_sizes[slice]`.
+        expected: usize,
+    },
+    /// A vertex on a toroidal spatial slice has the wrong number of
+    /// spacelike neighbours (it must have exactly 2 to form a closed S¹).
+    SpacelikeDegreeViolation {
+        /// Slice index where the violation was detected.
+        slice: usize,
+        /// Human-readable identifier for the offending vertex (e.g.
+        /// `"VertexKey(123v1)"`).  Pre-formatted so this enum stays
+        /// backend-agnostic.
+        vertex: String,
+        /// Observed number of spacelike neighbours (expected 2).
+        observed_degree: usize,
+    },
+    /// The spacelike subgraph of a toroidal spatial slice is not a single
+    /// closed S¹ cycle (e.g. multiple disjoint cycles, a non-simple cycle,
+    /// or a cycle whose length differs from `slice_sizes[t]`).
+    SpacelikeNonClosedRing {
+        /// Slice index where the violation was detected.
+        slice: usize,
+        /// Number of vertices reached when walking from an arbitrary start.
+        walked: usize,
+        /// Expected number of vertices in the closed ring.
+        expected: usize,
+    },
 }
 
 impl fmt::Display for FoliationError {
@@ -194,6 +232,33 @@ impl fmt::Display for FoliationError {
             Self::SliceSizeSumMismatch { sum, labeled } => write!(
                 f,
                 "slice_sizes sum ({sum}) does not match labeled vertex count ({labeled})"
+            ),
+            Self::SpacelikeSubgraphSizeMismatch {
+                slice,
+                observed,
+                expected,
+            } => write!(
+                f,
+                "toroidal spatial slice {slice} spacelike subgraph contains {observed} \
+                 vertices but slice_sizes reports {expected}"
+            ),
+            Self::SpacelikeDegreeViolation {
+                slice,
+                vertex,
+                observed_degree,
+            } => write!(
+                f,
+                "toroidal spatial slice {slice} vertex {vertex} has {observed_degree} \
+                 spacelike neighbours, expected exactly 2 for a closed S¹"
+            ),
+            Self::SpacelikeNonClosedRing {
+                slice,
+                walked,
+                expected,
+            } => write!(
+                f,
+                "toroidal spatial slice {slice} is not a single closed S¹: walked a \
+                 cycle of length {walked} but slice has {expected} vertices"
             ),
         }
     }
@@ -488,6 +553,77 @@ mod tests {
         assert_ne!(
             FoliationError::EmptySlice { slice: 0 },
             FoliationError::EmptySlice { slice: 1 },
+        );
+    }
+
+    #[test]
+    fn test_foliation_error_spacelike_subgraph_size_mismatch_display() {
+        let err = FoliationError::SpacelikeSubgraphSizeMismatch {
+            slice: 2,
+            observed: 4,
+            expected: 5,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("slice 2")
+                && msg.contains("contains 4")
+                && msg.contains("reports 5")
+                && msg.contains("toroidal"),
+            "Display should describe the toroidal slice and both vertex counts: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_foliation_error_spacelike_degree_violation_display() {
+        let err = FoliationError::SpacelikeDegreeViolation {
+            slice: 1,
+            vertex: "VertexKey(7v3)".to_string(),
+            observed_degree: 3,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("slice 1")
+                && msg.contains("VertexKey(7v3)")
+                && msg.contains("3 spacelike neighbours")
+                && msg.contains("closed S¹"),
+            "Display should identify the slice, vertex, observed degree, and S¹ expectation: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_foliation_error_spacelike_non_closed_ring_display() {
+        let err = FoliationError::SpacelikeNonClosedRing {
+            slice: 0,
+            walked: 3,
+            expected: 6,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("slice 0")
+                && msg.contains("length 3")
+                && msg.contains("6 vertices")
+                && msg.contains("closed S¹"),
+            "Display should describe slice index, walked length, expected ring length, and S¹ expectation: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_foliation_error_spacelike_variant_equality() {
+        let a = FoliationError::SpacelikeSubgraphSizeMismatch {
+            slice: 2,
+            observed: 4,
+            expected: 5,
+        };
+        let b = a.clone();
+        let c = FoliationError::SpacelikeSubgraphSizeMismatch {
+            slice: 2,
+            observed: 5,
+            expected: 5,
+        };
+        assert_eq!(a, b, "identical Spacelike* variants should compare equal");
+        assert_ne!(
+            a, c,
+            "Spacelike* variants differing in any field should compare unequal"
         );
     }
 }

--- a/src/cdt/foliation.rs
+++ b/src/cdt/foliation.rs
@@ -193,6 +193,21 @@ pub enum FoliationError {
         /// Expected number of vertices in the closed ring.
         expected: usize,
     },
+    /// A toroidal spatial slice is missing the timelike adjacency required
+    /// for temporal wrap-around — every slice must have at least one
+    /// timelike edge to both its `(t-1) mod T` and `(t+1) mod T` neighbours.
+    ///
+    /// This catches "toroidal-tagged but actually a cylinder" misuse where
+    /// the underlying mesh has open time boundaries.  χ = 0 alone does not
+    /// distinguish a torus from a cylinder, so we additionally verify the
+    /// temporal wrap.
+    MissingTemporalWrapAround {
+        /// Slice index that is missing a timelike neighbour.
+        slice: usize,
+        /// The expected neighbour slice (either `(slice-1) mod T` or
+        /// `(slice+1) mod T`) that has no incident timelike edge.
+        missing_neighbor: usize,
+    },
 }
 
 impl fmt::Display for FoliationError {
@@ -259,6 +274,14 @@ impl fmt::Display for FoliationError {
                 f,
                 "toroidal spatial slice {slice} is not a single closed S¹: walked a \
                  cycle of length {walked} but slice has {expected} vertices"
+            ),
+            Self::MissingTemporalWrapAround {
+                slice,
+                missing_neighbor,
+            } => write!(
+                f,
+                "toroidal foliation has no timelike edge from slice {slice} to slice \
+                 {missing_neighbor}; toroidal topology requires temporal wrap-around"
             ),
         }
     }
@@ -604,6 +627,21 @@ mod tests {
                 && msg.contains("6 vertices")
                 && msg.contains("closed S¹"),
             "Display should describe slice index, walked length, expected ring length, and S¹ expectation: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_foliation_error_missing_temporal_wraparound_display() {
+        let err = FoliationError::MissingTemporalWrapAround {
+            slice: 0,
+            missing_neighbor: 2,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("slice 0")
+                && msg.contains("slice 2")
+                && msg.contains("temporal wrap-around"),
+            "Display should describe missing wrap-around between specific slices: {msg}"
         );
     }
 

--- a/src/cdt/metropolis.rs
+++ b/src/cdt/metropolis.rs
@@ -269,10 +269,10 @@ impl MetropolisAlgorithm {
         let mut chain = Chain::new(triangulation, &target)?;
 
         {
-            let g = chain.state.geometry();
+            let g = chain.state().geometry();
             measurements.push(Measurement {
                 step: 0,
-                action: -chain.log_prob * self.config.temperature,
+                action: -chain.log_prob() * self.config.temperature,
                 vertices: u32::try_from(g.vertex_count()).unwrap_or_default(),
                 edges: u32::try_from(g.edge_count()).unwrap_or_default(),
                 triangles: u32::try_from(g.face_count()).unwrap_or_default(),
@@ -283,9 +283,9 @@ impl MetropolisAlgorithm {
         let mut rng = StdRng::seed_from_u64(seed);
 
         for step_num in 0..self.config.steps {
-            let action_before = -chain.log_prob * self.config.temperature;
+            let action_before = -chain.log_prob() * self.config.temperature;
             let accepted = chain.step_mut(&target, &proposal, &mut rng)?;
-            let action_after = -chain.log_prob * self.config.temperature;
+            let action_after = -chain.log_prob() * self.config.temperature;
 
             // TODO: Record actual move type once #55 provides real moves
             let mc_step = MonteCarloStep {
@@ -308,7 +308,7 @@ impl MetropolisAlgorithm {
             // on a measurement boundary. The initial state at step 0 was already
             // captured before entering the loop.
             if completed_steps % self.config.measurement_frequency == 0 {
-                let g = chain.state.geometry();
+                let g = chain.state().geometry();
                 measurements.push(Measurement {
                     step: completed_steps,
                     action: action_after,
@@ -343,7 +343,7 @@ impl MetropolisAlgorithm {
             steps: mc_steps,
             measurements,
             elapsed_time,
-            triangulation: chain.state,
+            triangulation: chain.into_state(),
         })
     }
 }

--- a/src/cdt/triangulation.rs
+++ b/src/cdt/triangulation.rs
@@ -6,6 +6,7 @@
 use crate::cdt::foliation::{
     CellType, EdgeType, Foliation, FoliationError, classify_cell, classify_edge,
 };
+use crate::config::CdtTopology;
 use crate::errors::{CdtError, CdtResult};
 use crate::geometry::DelaunayBackend2D;
 use crate::geometry::backends::delaunay::{
@@ -36,6 +37,8 @@ pub struct CdtMetadata {
     pub time_slices: u32,
     /// Dimensionality of the spacetime
     pub dimension: u8,
+    /// Topology of the spatial slices
+    pub topology: CdtTopology,
     /// Time when this triangulation was created
     pub creation_time: Instant,
     /// Time of last modification
@@ -99,8 +102,18 @@ pub enum SimulationEvent {
 }
 
 impl<B: TriangulationQuery> CdtTriangulation<B> {
-    /// Create new CDT triangulation
+    /// Create new CDT triangulation with open boundary topology.
     pub fn new(geometry: B, time_slices: u32, dimension: u8) -> Self {
+        Self::with_topology(geometry, time_slices, dimension, CdtTopology::OpenBoundary)
+    }
+
+    /// Create new CDT triangulation with explicit topology.
+    pub fn with_topology(
+        geometry: B,
+        time_slices: u32,
+        dimension: u8,
+        topology: CdtTopology,
+    ) -> Self {
         let vertex_count = geometry.vertex_count();
         let creation_event = SimulationEvent::Created {
             vertex_count,
@@ -112,6 +125,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
             metadata: CdtMetadata {
                 time_slices,
                 dimension,
+                topology,
                 creation_time: Instant::now(),
                 last_modified: Instant::now(),
                 modification_count: 0,
@@ -218,20 +232,24 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     pub fn validate_topology(&self) -> CdtResult<()> {
         let euler_char = self.geometry.euler_characteristic();
 
-        // For 2D planar triangulations with boundary (random points), expect χ = 1
-        // For closed 2D surfaces, expect χ = 2. Since we generate from random points,
-        // we typically get triangulations with convex hull boundary (χ = 1)
-
         if self.dimension() == 2 {
-            // Planar triangulation with boundary should have χ = 1
-            // Closed surfaces would have χ = 2
-            if euler_char != 1 && euler_char != 2 {
+            let expected = match self.metadata.topology {
+                // Open boundary: planar with boundary χ=1, closed surface χ=2
+                CdtTopology::OpenBoundary => [1, 2].as_slice(),
+                // Toroidal (S¹×S¹): Euler characteristic must be 0
+                CdtTopology::Toroidal => [0].as_slice(),
+            };
+
+            if !expected.contains(&euler_char) {
+                let topo_label = match self.metadata.topology {
+                    CdtTopology::OpenBoundary => "open boundary (expected χ=1 or 2)",
+                    CdtTopology::Toroidal => "toroidal (expected χ=0)",
+                };
                 return Err(CdtError::ValidationFailed {
                     check: "topology".to_string(),
                     detail: format!(
-                        "Euler characteristic χ={euler_char} unexpected for 2D triangulation \
-                         (expected 1 for boundary or 2 for closed surface; \
-                         V={}, E={}, F={})",
+                        "Euler characteristic χ={euler_char} unexpected for 2D {topo_label} \
+                         triangulation (V={}, E={}, F={})",
                         self.geometry.vertex_count(),
                         self.geometry.edge_count(),
                         self.geometry.face_count(),
@@ -927,6 +945,81 @@ impl CdtTriangulation<DelaunayBackend2D> {
         Err(CdtError::ValidationFailed {
             check: "cdt_construction".to_string(),
             detail: "from_cdt_strip is not yet implemented: requires explicit mesh backend"
+                .to_string(),
+        })
+    }
+
+    /// Construct a foliated 1+1 CDT on a torus (S¹×S¹).
+    ///
+    /// Places `vertices_per_slice` vertices per time slice, uniformly spaced
+    /// on S¹ (spatial coordinate periodic in `[0, 1)`).  Time slices wrap:
+    /// slice `num_slices - 1` connects back to slice `0`.  Each quad between
+    /// adjacent slices is split into one Up (2,1) and one Down (1,2) triangle.
+    ///
+    /// The triangulation is built by explicit combinatorial connectivity via
+    /// [`build_explicit_delaunay2_with_topology`](crate::geometry::generators::build_explicit_delaunay2_with_topology),
+    /// guaranteeing CDT-valid structure by construction.
+    ///
+    /// # Arguments
+    ///
+    /// * `vertices_per_slice` — Number of vertices in each spatial slice (≥ 3).
+    /// * `num_slices` — Number of time slices (≥ 2).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidGenerationParameters`] if `vertices_per_slice < 3`
+    /// or `num_slices < 2`.
+    /// Returns [`CdtError::ValidationFailed`] because the underlying `delaunay` crate
+    /// does not yet support non-sphere Euler characteristics for explicit cell
+    /// construction (see [delaunay#313]).
+    ///
+    /// [delaunay#313]: https://github.com/acgetchell/delaunay/issues/313
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::*;
+    ///
+    /// // Placeholder: currently returns an error pending delaunay#313.
+    /// let result = CdtTriangulation::from_toroidal_cdt(4, 3);
+    /// assert!(result.is_err());
+    /// ```
+    pub fn from_toroidal_cdt(vertices_per_slice: u32, num_slices: u32) -> CdtResult<Self> {
+        if vertices_per_slice < 3 {
+            return Err(CdtError::InvalidGenerationParameters {
+                issue: "Insufficient vertices per slice".to_string(),
+                provided_value: vertices_per_slice.to_string(),
+                expected_range: "≥ 3".to_string(),
+            });
+        }
+        if num_slices < 2 {
+            return Err(CdtError::InvalidGenerationParameters {
+                issue: "Insufficient number of time slices".to_string(),
+                provided_value: num_slices.to_string(),
+                expected_range: "≥ 2".to_string(),
+            });
+        }
+
+        // TODO(delaunay#313): Implement toroidal CDT construction once the
+        // delaunay crate's explicit cell builder supports non-sphere Euler
+        // characteristics.  All infrastructure is in place:
+        // - CdtTopology enum and config/CLI wiring
+        // - build_explicit_delaunay2_with_topology() generator
+        // - Topology-aware validate_topology() (χ=0 for toroidal)
+        // - run_simulation() dispatches on topology
+        //
+        // The constructor will:
+        // 1. Build vertex_specs with periodic spatial coordinates
+        // 2. Build explicit CDT cells (Up/Down per quad, wrapping in both dims)
+        // 3. Call build_explicit_delaunay2_with_topology with Pseudomanifold
+        // 4. Set GlobalTopology::Toroidal on the resulting DT
+        // 5. Derive foliation from vertex labels and validate
+
+        Err(CdtError::ValidationFailed {
+            check: "toroidal_construction".to_string(),
+            detail: "from_toroidal_cdt is not yet implemented: blocked on \
+                     delaunay#313 (explicit cell construction rejects non-sphere \
+                     Euler characteristic)"
                 .to_string(),
         })
     }
@@ -3186,6 +3279,46 @@ mod tests {
             }
             other => panic!("Expected ValidationFailed, got {other:?}"),
         }
+    }
+
+    // =========================================================================
+    // Toroidal CDT tests (placeholder — blocked on delaunay#313)
+    // =========================================================================
+
+    /// Helper: assert `from_toroidal_cdt` returns the expected placeholder error.
+    fn assert_toroidal_cdt_blocked(result: CdtResult<CdtTriangulation<DelaunayBackend2D>>) {
+        match result {
+            Err(CdtError::ValidationFailed { check, detail }) => {
+                assert_eq!(check, "toroidal_construction");
+                assert!(
+                    detail.contains("delaunay#313"),
+                    "Error should reference the blocking issue: {detail}"
+                );
+            }
+            Ok(_) => panic!("Expected toroidal construction to be blocked"),
+            Err(other) => panic!("Expected ValidationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_from_toroidal_cdt_blocked() {
+        assert_toroidal_cdt_blocked(CdtTriangulation::from_toroidal_cdt(4, 3));
+    }
+
+    #[test]
+    fn test_from_toroidal_cdt_invalid_params() {
+        // Too few vertices per slice
+        assert!(CdtTriangulation::from_toroidal_cdt(2, 3).is_err());
+        // Too few slices
+        assert!(CdtTriangulation::from_toroidal_cdt(4, 1).is_err());
+    }
+
+    #[test]
+    fn test_validate_topology_open_boundary() {
+        let tri = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("create triangulation");
+
+        // OpenBoundary topology should pass validation
+        assert!(tri.validate_topology().is_ok());
     }
 }
 

--- a/src/cdt/triangulation.rs
+++ b/src/cdt/triangulation.rs
@@ -429,12 +429,81 @@ impl CdtTriangulation<DelaunayBackend2D> {
             }
         }
 
-        // Toroidal topology adds a stronger structural invariant: every spatial
-        // slice forms a closed S¹ (each vertex has exactly two spacelike
-        // neighbours and the spacelike subgraph of each slice is a single
-        // cycle, not several disjoint cycles or open chains).
+        // Toroidal topology adds two stronger structural invariants:
+        //  - every spatial slice forms a closed S¹ (each vertex has exactly
+        //    two spacelike neighbours and the subgraph of each slice is a
+        //    single cycle); and
+        //  - the time direction wraps: every slice has timelike adjacency to
+        //    both `(t-1) mod T` and `(t+1) mod T`.  χ = 0 alone does not
+        //    distinguish a torus from a cylinder, so we check the wrap
+        //    explicitly.
         if matches!(self.metadata.topology, CdtTopology::Toroidal) {
             self.validate_toroidal_spatial_rings()?;
+            self.validate_toroidal_temporal_wraparound()?;
+        }
+
+        Ok(())
+    }
+
+    /// Validates that the time direction wraps for toroidal topology.
+    ///
+    /// For each slice `t` (with `T = time_slices`), checks that the foliation
+    /// has at least one timelike edge to slice `(t - 1) mod T` and at least
+    /// one to slice `(t + 1) mod T`.  Cylinders (open in time) have χ = 0
+    /// like the torus, so this check is what actually distinguishes them.
+    fn validate_toroidal_temporal_wraparound(&self) -> CdtResult<()> {
+        let total = self.metadata.time_slices;
+        if total < 2 {
+            return Ok(());
+        }
+        let num_slices = total as usize;
+
+        // Collect, per slice, the set of slices reached via timelike (step
+        // distance == 1) edges.
+        let mut neighbor_slices: Vec<HashSet<usize>> = vec![HashSet::new(); num_slices];
+        for edge in self.geometry.edges() {
+            let Some((v0, v1)) = self.geometry.edge_endpoints(&edge) else {
+                continue;
+            };
+            let Some(t0) = self.geometry.vertex_data_by_key(v0.vertex_key()) else {
+                continue;
+            };
+            let Some(t1) = self.geometry.vertex_data_by_key(v1.vertex_key()) else {
+                continue;
+            };
+            if t0 >= total || t1 >= total {
+                continue;
+            }
+            if self.time_step_distance(t0, t1) != 1 {
+                continue;
+            }
+            let s0 = t0 as usize;
+            let s1 = t1 as usize;
+            neighbor_slices[s0].insert(s1);
+            neighbor_slices[s1].insert(s0);
+        }
+
+        for (slice, neighbors) in neighbor_slices.iter().enumerate() {
+            let prev = if slice == 0 {
+                num_slices - 1
+            } else {
+                slice - 1
+            };
+            let next = (slice + 1) % num_slices;
+            if !neighbors.contains(&prev) {
+                return Err(FoliationError::MissingTemporalWrapAround {
+                    slice,
+                    missing_neighbor: prev,
+                }
+                .into());
+            }
+            if !neighbors.contains(&next) {
+                return Err(FoliationError::MissingTemporalWrapAround {
+                    slice,
+                    missing_neighbor: next,
+                }
+                .into());
+            }
         }
 
         Ok(())
@@ -1443,12 +1512,17 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// `Toroidal` topology it is the circular distance
     /// `min(d, T − d)` where `T = time_slices`, so the wrap-around edge
     /// between slice `T − 1` and slice `0` reads as distance `1`.
+    ///
+    /// Out-of-range labels (`t ≥ time_slices`) bypass the toroidal wrap and
+    /// fall through to the raw difference so callers (e.g. validators) can
+    /// still detect them as causality violations rather than silently folding
+    /// `t == time_slices` into distance 0 via `min(T, 0)`.
     #[must_use]
     fn time_step_distance(&self, t0: u32, t1: u32) -> u32 {
         let raw = t0.abs_diff(t1);
         if matches!(self.metadata.topology, CdtTopology::Toroidal) {
             let total = self.metadata.time_slices;
-            if total > 0 && raw <= total {
+            if total > 0 && t0 < total && t1 < total {
                 return raw.min(total - raw);
             }
         }

--- a/src/cdt/triangulation.rs
+++ b/src/cdt/triangulation.rs
@@ -3,18 +3,19 @@
 //! This module provides CDT-specific triangulation data structures that work
 //! with any geometry backend implementing the trait interfaces.
 
-use crate::cdt::foliation::{
-    CellType, EdgeType, Foliation, FoliationError, classify_cell, classify_edge,
-};
+use crate::cdt::foliation::{CellType, EdgeType, Foliation, FoliationError, classify_cell};
 use crate::config::CdtTopology;
 use crate::errors::{CdtError, CdtResult};
 use crate::geometry::DelaunayBackend2D;
 use crate::geometry::backends::delaunay::{
     DelaunayEdgeHandle, DelaunayFaceHandle, DelaunayVertexHandle,
 };
-use crate::geometry::generators::{build_delaunay2_with_data, delaunay2_with_context};
+use crate::geometry::generators::{
+    build_delaunay2_with_data, build_explicit_delaunay2_toroidal, delaunay2_with_context,
+};
 use crate::geometry::traits::{TriangulationMut, TriangulationQuery};
 use crate::util::f64_band_to_u32;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 /// CDT-specific triangulation wrapper - completely geometry-agnostic
@@ -108,6 +109,31 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     }
 
     /// Create new CDT triangulation with explicit topology.
+    ///
+    /// Wraps an existing geometry backend and tags it with [`CdtTopology`].
+    /// The backend itself is not modified — pass a backend whose Euler
+    /// characteristic matches the supplied topology, otherwise
+    /// [`Self::validate_topology`] will reject it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::prelude::triangulation::*;
+    ///
+    /// let dt = build_delaunay2_with_data(&[
+    ///     ([0.0, 0.0], 0),
+    ///     ([1.0, 0.0], 0),
+    ///     ([0.5, 1.0], 1),
+    /// ])
+    /// .expect("build labeled triangle");
+    /// let backend = DelaunayBackend2D::from_triangulation(dt);
+    ///
+    /// let tri = CdtTriangulation::with_topology(backend, 2, 2, CdtTopology::OpenBoundary);
+    /// assert!(matches!(tri.metadata().topology, CdtTopology::OpenBoundary));
+    /// assert_eq!(tri.time_slices(), 2);
+    /// assert_eq!(tri.dimension(), 2);
+    /// ```
     pub fn with_topology(
         geometry: B,
         time_slices: u32,
@@ -398,6 +424,118 @@ impl CdtTriangulation<DelaunayBackend2D> {
                     slice,
                     expected,
                     actual,
+                }
+                .into());
+            }
+        }
+
+        // Toroidal topology adds a stronger structural invariant: every spatial
+        // slice forms a closed S¹ (each vertex has exactly two spacelike
+        // neighbours and the spacelike subgraph of each slice is a single
+        // cycle, not several disjoint cycles or open chains).
+        if matches!(self.metadata.topology, CdtTopology::Toroidal) {
+            self.validate_toroidal_spatial_rings()?;
+        }
+
+        Ok(())
+    }
+
+    /// Validates that every spatial slice forms a closed S¹.
+    ///
+    /// For each time slice `t` we iterate over backend edges, count incident
+    /// spacelike edges (`|Δt| = 0`) per vertex, and walk the resulting
+    /// spacelike subgraph to verify it is a single cycle of length
+    /// `slice_sizes[t]`.
+    fn validate_toroidal_spatial_rings(&self) -> CdtResult<()> {
+        let Some(foliation) = &self.foliation else {
+            return Ok(());
+        };
+
+        let num_slices = foliation.slice_sizes().len();
+        let mut spacelike_neighbors: Vec<HashMap<DelaunayVertexHandle, Vec<DelaunayVertexHandle>>> =
+            vec![HashMap::new(); num_slices];
+
+        for edge in self.geometry.edges() {
+            let Some((v0, v1)) = self.geometry.edge_endpoints(&edge) else {
+                continue;
+            };
+            let Some(t0) = self.geometry.vertex_data_by_key(v0.vertex_key()) else {
+                continue;
+            };
+            let Some(t1) = self.geometry.vertex_data_by_key(v1.vertex_key()) else {
+                continue;
+            };
+            if t0 != t1 {
+                continue;
+            }
+            let slice = t0 as usize;
+            if slice >= num_slices {
+                continue;
+            }
+            spacelike_neighbors[slice]
+                .entry(v0.clone())
+                .or_default()
+                .push(v1.clone());
+            spacelike_neighbors[slice].entry(v1).or_default().push(v0);
+        }
+
+        for (slice, adjacency) in spacelike_neighbors.iter().enumerate() {
+            let expected_size = foliation.slice_sizes()[slice];
+            if adjacency.len() != expected_size {
+                return Err(FoliationError::SpacelikeSubgraphSizeMismatch {
+                    slice,
+                    observed: adjacency.len(),
+                    expected: expected_size,
+                }
+                .into());
+            }
+            for (vertex, neighbors) in adjacency {
+                if neighbors.len() != 2 {
+                    return Err(FoliationError::SpacelikeDegreeViolation {
+                        slice,
+                        vertex: format!("{:?}", vertex.vertex_key()),
+                        observed_degree: neighbors.len(),
+                    }
+                    .into());
+                }
+            }
+
+            // Walk the cycle starting from any vertex; verify it visits every
+            // vertex of the slice and closes back on itself.
+            let Some(start) = adjacency.keys().next() else {
+                continue;
+            };
+            let mut visited: HashSet<DelaunayVertexHandle> = HashSet::new();
+            visited.insert(start.clone());
+            let mut prev = start.clone();
+            let mut current = adjacency[start][0].clone();
+            while current != *start {
+                if !visited.insert(current.clone()) {
+                    // Non-simple cycle: a vertex was revisited before the walk
+                    // returned to `start`.  Surface this through the same
+                    // typed variant as a short cycle — both indicate the
+                    // spacelike subgraph isn't a single closed S¹.
+                    return Err(FoliationError::SpacelikeNonClosedRing {
+                        slice,
+                        walked: visited.len(),
+                        expected: expected_size,
+                    }
+                    .into());
+                }
+                let neighbors = &adjacency[&current];
+                let next = if neighbors[0] == prev {
+                    neighbors[1].clone()
+                } else {
+                    neighbors[0].clone()
+                };
+                prev = current;
+                current = next;
+            }
+            if visited.len() != expected_size {
+                return Err(FoliationError::SpacelikeNonClosedRing {
+                    slice,
+                    walked: visited.len(),
+                    expected: expected_size,
                 }
                 .into());
             }
@@ -957,32 +1095,44 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// adjacent slices is split into one Up (2,1) and one Down (1,2) triangle.
     ///
     /// The triangulation is built by explicit combinatorial connectivity via
-    /// [`build_explicit_delaunay2_with_topology`](crate::geometry::generators::build_explicit_delaunay2_with_topology),
-    /// guaranteeing CDT-valid structure by construction.
+    /// [`crate::geometry::generators::build_explicit_delaunay2_toroidal`],
+    /// which sets `TopologyGuarantee::Pseudomanifold` and
+    /// `GlobalTopology::Toroidal` so the underlying validator expects χ = 0.
+    ///
+    /// # Mesh structure
+    ///
+    /// With `N = vertices_per_slice` and `T = num_slices` the resulting mesh
+    /// has `N · T` vertices, `3 · N · T` edges, and `2 · N · T` triangles
+    /// (`V − E + F = 0`, the Euler characteristic of the torus).  Each pair of
+    /// adjacent slices `(t, t+1) mod T` and each spatial pair `(i, i+1) mod N`
+    /// contribute exactly one Up `(i, t), (i+1, t), (i, t+1)` and one Down
+    /// `(i+1, t), (i+1, t+1), (i, t+1)` triangle, so every triangle has
+    /// exactly one spacelike edge and two timelike edges by construction.
     ///
     /// # Arguments
     ///
     /// * `vertices_per_slice` — Number of vertices in each spatial slice (≥ 3).
-    /// * `num_slices` — Number of time slices (≥ 2).
+    /// * `num_slices` — Number of time slices (≥ 3 to keep `t-1` and `t+1`
+    ///   distinct after wrap-around).
     ///
     /// # Errors
     ///
     /// Returns [`CdtError::InvalidGenerationParameters`] if `vertices_per_slice < 3`
-    /// or `num_slices < 2`.
-    /// Returns [`CdtError::ValidationFailed`] because the underlying `delaunay` crate
-    /// does not yet support non-sphere Euler characteristics for explicit cell
-    /// construction (see [delaunay#313]).
-    ///
-    /// [delaunay#313]: https://github.com/acgetchell/delaunay/issues/313
+    /// or `num_slices < 3`.
+    /// Returns [`CdtError::DelaunayGenerationFailed`] if the underlying explicit
+    /// builder rejects the mesh, and [`CdtError::ValidationFailed`] if the
+    /// constructed triangulation fails CDT validation.
     ///
     /// # Examples
     ///
     /// ```
     /// use causal_triangulations::prelude::triangulation::*;
     ///
-    /// // Placeholder: currently returns an error pending delaunay#313.
-    /// let result = CdtTriangulation::from_toroidal_cdt(4, 3);
-    /// assert!(result.is_err());
+    /// let tri = CdtTriangulation::from_toroidal_cdt(4, 3)
+    ///     .expect("build toroidal CDT");
+    /// assert_eq!(tri.vertex_count(), 12);
+    /// assert_eq!(tri.face_count(), 24);
+    /// assert!(tri.has_foliation());
     /// ```
     pub fn from_toroidal_cdt(vertices_per_slice: u32, num_slices: u32) -> CdtResult<Self> {
         if vertices_per_slice < 3 {
@@ -992,36 +1142,111 @@ impl CdtTriangulation<DelaunayBackend2D> {
                 expected_range: "≥ 3".to_string(),
             });
         }
-        if num_slices < 2 {
+        if num_slices < 3 {
+            // With T=2 the wrap-around makes every pair of adjacent slices
+            // identify (t-1, t) with (t, t+1), so each spatial edge would be
+            // shared by 4 triangles instead of 2 — a non-manifold mesh.
             return Err(CdtError::InvalidGenerationParameters {
                 issue: "Insufficient number of time slices".to_string(),
                 provided_value: num_slices.to_string(),
-                expected_range: "≥ 2".to_string(),
+                expected_range: "≥ 3".to_string(),
             });
         }
 
-        // TODO(delaunay#313): Implement toroidal CDT construction once the
-        // delaunay crate's explicit cell builder supports non-sphere Euler
-        // characteristics.  All infrastructure is in place:
-        // - CdtTopology enum and config/CLI wiring
-        // - build_explicit_delaunay2_with_topology() generator
-        // - Topology-aware validate_topology() (χ=0 for toroidal)
-        // - run_simulation() dispatches on topology
-        //
-        // The constructor will:
-        // 1. Build vertex_specs with periodic spatial coordinates
-        // 2. Build explicit CDT cells (Up/Down per quad, wrapping in both dims)
-        // 3. Call build_explicit_delaunay2_with_topology with Pseudomanifold
-        // 4. Set GlobalTopology::Toroidal on the resulting DT
-        // 5. Derive foliation from vertex labels and validate
+        let total_vertices = vertices_per_slice.checked_mul(num_slices).ok_or_else(|| {
+            CdtError::InvalidGenerationParameters {
+                issue: "Vertex count overflow".to_string(),
+                provided_value: format!("{vertices_per_slice} × {num_slices}"),
+                expected_range: "product ≤ u32::MAX".to_string(),
+            }
+        })?;
 
-        Err(CdtError::ValidationFailed {
-            check: "toroidal_construction".to_string(),
-            detail: "from_toroidal_cdt is not yet implemented: blocked on \
-                     delaunay#313 (explicit cell construction rejects non-sphere \
-                     Euler characteristic)"
-                .to_string(),
-        })
+        let n = vertices_per_slice as usize;
+        let t_count = num_slices as usize;
+
+        // Index helper: vertex (i, t) → i + t * N. Both axes are periodic.
+        let index = |i: usize, t: usize| -> usize { (t % t_count) * n + (i % n) };
+
+        // --- Vertex coordinates (S¹ × S¹) ---
+        //
+        // Spatial coordinate: x_i = i / N is periodic in [0, 1).
+        // Time coordinate: t_t = t / T is periodic in [0, 1) so the metadata
+        // domain matches what we pass to GlobalTopology::Toroidal.
+        let n_f = f64::from(vertices_per_slice);
+        let t_f = f64::from(num_slices);
+        let mut vertex_specs: Vec<([f64; 2], u32)> = Vec::with_capacity(total_vertices as usize);
+        for t in 0..num_slices {
+            for i in 0..vertices_per_slice {
+                let x = f64::from(i) / n_f;
+                let y = f64::from(t) / t_f;
+                vertex_specs.push(([x, y], t));
+            }
+        }
+
+        // --- Explicit cells (Up + Down per (i, t) quad) ---
+        let mut cells: Vec<Vec<usize>> = Vec::with_capacity(2 * total_vertices as usize);
+        for t in 0..t_count {
+            let t_next = (t + 1) % t_count;
+            for i in 0..n {
+                let i_next = (i + 1) % n;
+                // Up (2,1): two vertices on slice t, one on slice t+1.
+                cells.push(vec![index(i, t), index(i_next, t), index(i, t_next)]);
+                // Down (1,2): one vertex on slice t, two on slice t+1.
+                cells.push(vec![
+                    index(i_next, t),
+                    index(i_next, t_next),
+                    index(i, t_next),
+                ]);
+            }
+        }
+
+        let domain = [1.0_f64, 1.0_f64];
+        let dt =
+            build_explicit_delaunay2_toroidal(&vertex_specs, &cells, domain).map_err(
+                |e| match e {
+                    CdtError::DelaunayGenerationFailed {
+                        underlying_error, ..
+                    } => CdtError::DelaunayGenerationFailed {
+                        vertex_count: total_vertices,
+                        coordinate_range: (0.0, 1.0),
+                        attempt: 1,
+                        underlying_error,
+                    },
+                    other => other,
+                },
+            )?;
+
+        let backend = DelaunayBackend2D::from_triangulation(dt);
+        if backend.vertex_count() != total_vertices as usize {
+            return Err(CdtError::DelaunayGenerationFailed {
+                vertex_count: total_vertices,
+                coordinate_range: (0.0, 1.0),
+                attempt: 1,
+                underlying_error: format!(
+                    "explicit toroidal builder produced {} vertices, expected {}",
+                    backend.vertex_count(),
+                    total_vertices,
+                ),
+            });
+        }
+
+        let slice_sizes = vec![n; t_count];
+        let foliation =
+            Foliation::from_slice_sizes(slice_sizes, num_slices).map_err(CdtError::from)?;
+
+        let mut tri = Self::with_topology(backend, num_slices, 2, CdtTopology::Toroidal);
+        tri.foliation = Some(foliation);
+        tri.mark_foliation_synchronized();
+
+        // Propagate inner errors as-is so callers can pattern-match on the
+        // typed variant (e.g. `FoliationError::SpacelikeNonClosedRing` or
+        // `CausalityViolation`) instead of parsing a wrapped string.  Each
+        // inner validator already produces a precise, structured error.
+        tri.validate_foliation()?;
+        tri.validate_causality_delaunay()?;
+        tri.validate_topology()?;
+
+        Ok(tri)
     }
 
     // -------------------------------------------------------------------------
@@ -1212,10 +1437,80 @@ impl CdtTriangulation<DelaunayBackend2D> {
     // Cell (triangle) classification
     // -------------------------------------------------------------------------
 
+    /// Computes the temporal step distance between two time labels.
+    ///
+    /// For `OpenBoundary` topology this is just `t0.abs_diff(t1)`; for
+    /// `Toroidal` topology it is the circular distance
+    /// `min(d, T − d)` where `T = time_slices`, so the wrap-around edge
+    /// between slice `T − 1` and slice `0` reads as distance `1`.
+    #[must_use]
+    fn time_step_distance(&self, t0: u32, t1: u32) -> u32 {
+        let raw = t0.abs_diff(t1);
+        if matches!(self.metadata.topology, CdtTopology::Toroidal) {
+            let total = self.metadata.time_slices;
+            if total > 0 && raw <= total {
+                return raw.min(total - raw);
+            }
+        }
+        raw
+    }
+
+    /// Topology-aware variant of [`crate::cdt::foliation::classify_cell`].
+    ///
+    /// Uses [`Self::time_step_distance`] so the spacelike/timelike split
+    /// honours toroidal wrap.  Distinguishes Up vs Down by checking whether
+    /// the apex sits at `base + 1` or `base - 1` modulo `time_slices`.
+    fn classify_cell_with_topology(&self, t0: u32, t1: u32, t2: u32) -> Option<CellType> {
+        let mut dists = [
+            self.time_step_distance(t0, t1),
+            self.time_step_distance(t1, t2),
+            self.time_step_distance(t0, t2),
+        ];
+        dists.sort_unstable();
+        if dists != [0, 1, 1] {
+            return None;
+        }
+
+        let (base_slice, apex_slice) = if t0 == t1 {
+            (t0, t2)
+        } else if t1 == t2 {
+            (t1, t0)
+        } else if t0 == t2 {
+            (t0, t1)
+        } else {
+            return None;
+        };
+
+        let total = self.metadata.time_slices;
+        let toroidal = matches!(self.metadata.topology, CdtTopology::Toroidal) && total > 0;
+        let up_apex = if toroidal {
+            (base_slice + 1) % total
+        } else {
+            base_slice.checked_add(1)?
+        };
+        let down_apex = if toroidal {
+            if base_slice == 0 {
+                total - 1
+            } else {
+                base_slice - 1
+            }
+        } else {
+            base_slice.checked_sub(1)?
+        };
+        if apex_slice == up_apex {
+            Some(CellType::Up)
+        } else if apex_slice == down_apex {
+            Some(CellType::Down)
+        } else {
+            None
+        }
+    }
+
     /// Returns the causal classification of an edge from endpoint time labels.
     ///
     /// Returns `None` if no foliation is present, the edge endpoints cannot be
-    /// resolved, or either endpoint is missing a time label.
+    /// resolved, or either endpoint is missing a time label.  Distance is
+    /// circular when the topology is `Toroidal`.
     ///
     /// # Examples
     ///
@@ -1245,7 +1540,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
         let t0 = self.geometry.vertex_data_by_key(v0.vertex_key())?;
         let t1 = self.geometry.vertex_data_by_key(v1.vertex_key())?;
 
-        Some(match t0.abs_diff(t1) {
+        Some(match self.time_step_distance(t0, t1) {
             0 => EdgeType::Spacelike,
             1 => EdgeType::Timelike,
             _ => EdgeType::Acausal,
@@ -1280,10 +1575,13 @@ impl CdtTriangulation<DelaunayBackend2D> {
         if verts.len() != 3 {
             return None;
         }
-        let t0 = self.geometry.vertex_data_by_key(verts[0].vertex_key());
-        let t1 = self.geometry.vertex_data_by_key(verts[1].vertex_key());
-        let t2 = self.geometry.vertex_data_by_key(verts[2].vertex_key());
-        classify_cell(t0, t1, t2)
+        let t0 = self.geometry.vertex_data_by_key(verts[0].vertex_key())?;
+        let t1 = self.geometry.vertex_data_by_key(verts[1].vertex_key())?;
+        let t2 = self.geometry.vertex_data_by_key(verts[2].vertex_key())?;
+        match self.metadata.topology {
+            CdtTopology::Toroidal => self.classify_cell_with_topology(t0, t1, t2),
+            CdtTopology::OpenBoundary => classify_cell(Some(t0), Some(t1), Some(t2)),
+        }
     }
 
     /// Reads the stored cell type from cell data, if previously classified.
@@ -1350,10 +1648,18 @@ impl CdtTriangulation<DelaunayBackend2D> {
             self.geometry.vertex_data_by_key(verts[2].vertex_key())?,
         ];
 
+        let edge_classify = |a: u32, b: u32| -> Option<EdgeType> {
+            Some(match self.time_step_distance(a, b) {
+                0 => EdgeType::Spacelike,
+                1 => EdgeType::Timelike,
+                _ => EdgeType::Acausal,
+            })
+        };
+
         Some([
-            classify_edge(Some(t[0]), Some(t[1]))?,
-            classify_edge(Some(t[1]), Some(t[2]))?,
-            classify_edge(Some(t[2]), Some(t[0]))?,
+            edge_classify(t[0], t[1])?,
+            edge_classify(t[1], t[2])?,
+            edge_classify(t[2], t[0])?,
         ])
     }
 
@@ -1617,17 +1923,21 @@ impl CdtTriangulation<DelaunayBackend2D> {
                 })?;
 
             // CDT triangle invariant: exactly 1 spacelike edge, 2 timelike edges.
+            // On Toroidal topology the wrap-around edge between slice T−1 and 0
+            // is timelike, so we use the topology-aware step distance.
             let mut spacelike = 0;
             let mut timelike = 0;
 
             for (a, b) in [(t0, t1), (t1, t2), (t2, t0)] {
-                match a.abs_diff(b) {
+                let step_distance = self.time_step_distance(a, b);
+                match step_distance {
                     0 => spacelike += 1,
                     1 => timelike += 1,
                     _ => {
                         return Err(CdtError::CausalityViolation {
                             time_0: a.min(b),
                             time_1: a.max(b),
+                            step_distance,
                         });
                     }
                 }
@@ -3226,17 +3536,81 @@ mod tests {
             "Explicitly acausal edge should fail causality validation"
         );
 
-        // Verify the error is a CausalityViolation with |Δt| > 1
-        if let Err(CdtError::CausalityViolation { time_0, time_1 }) = result {
+        // Verify the error is a CausalityViolation reporting step_distance > 1.
+        // OpenBoundary topology means step_distance == |Δt|.
+        if let Err(CdtError::CausalityViolation {
+            time_0,
+            time_1,
+            step_distance,
+        }) = result
+        {
             assert!(
-                time_0.abs_diff(time_1) > 1,
-                "CausalityViolation should report |Δt| > 1, got t0={time_0}, t1={time_1}"
+                step_distance > 1,
+                "CausalityViolation should report step_distance > 1, got step_distance={step_distance} (t0={time_0}, t1={time_1})"
+            );
+            assert_eq!(
+                step_distance,
+                time_0.abs_diff(time_1),
+                "OpenBoundary step_distance must equal |Δt|; got step_distance={step_distance}, |Δt|={}",
+                time_0.abs_diff(time_1)
             );
         } else {
             panic!(
                 "Expected CausalityViolation error, got {result:?}; {}",
                 deterministic_triangle_debug_summary(tri.geometry())
             );
+        }
+    }
+
+    #[test]
+    fn test_toroidal_causality_violation_reports_circular_step_distance() {
+        // Build a real toroidal CDT with T=10 so wrap-around is non-trivial:
+        // mutating a slice-0 vertex to slice 8 makes its same-slice spacelike
+        // edges read as (raw |Δt|=8, circular distance 2), which exceeds the
+        // adjacency threshold of 1.  The reported step_distance must be the
+        // circular distance, not the raw difference.
+        let mut tri =
+            CdtTriangulation::from_toroidal_cdt(3, 10).expect("build toroidal CDT (3, 10)");
+
+        let slice0_vertex = tri
+            .geometry()
+            .vertices()
+            .find(|vh| tri.geometry().vertex_data_by_key(vh.vertex_key()) == Some(0))
+            .expect("Toroidal CDT should contain slice-0 vertices")
+            .vertex_key();
+
+        {
+            let mut geometry_mut = tri.geometry_mut();
+            let _previous_label = geometry_mut
+                .set_vertex_data_by_key(slice0_vertex, Some(8))
+                .expect("Expected valid vertex key while mutating label");
+        }
+
+        let result = tri.validate_causality_delaunay();
+        match result {
+            Err(CdtError::CausalityViolation {
+                time_0,
+                time_1,
+                step_distance,
+            }) => {
+                let raw = time_0.abs_diff(time_1);
+                let circular = raw.min(10 - raw);
+                assert_eq!(
+                    step_distance, circular,
+                    "Toroidal step_distance must equal circular distance min(|Δt|, T−|Δt|); \
+                     got step_distance={step_distance}, raw |Δt|={raw}, T=10"
+                );
+                assert!(
+                    step_distance > 1,
+                    "Violation must exceed adjacency threshold; got step_distance={step_distance}"
+                );
+                assert!(
+                    step_distance < raw,
+                    "With T=10 and labels {{0,1,8}}, every violation crosses the wrap; \
+                     step_distance={step_distance} should be < raw |Δt|={raw}"
+                );
+            }
+            other => panic!("Expected CausalityViolation on toroidal triangle, got {other:?}"),
         }
     }
 
@@ -3282,35 +3656,76 @@ mod tests {
     }
 
     // =========================================================================
-    // Toroidal CDT tests (placeholder — blocked on delaunay#313)
+    // Toroidal CDT tests
     // =========================================================================
 
-    /// Helper: assert `from_toroidal_cdt` returns the expected placeholder error.
-    fn assert_toroidal_cdt_blocked(result: CdtResult<CdtTriangulation<DelaunayBackend2D>>) {
-        match result {
-            Err(CdtError::ValidationFailed { check, detail }) => {
-                assert_eq!(check, "toroidal_construction");
-                assert!(
-                    detail.contains("delaunay#313"),
-                    "Error should reference the blocking issue: {detail}"
-                );
-            }
-            Ok(_) => panic!("Expected toroidal construction to be blocked"),
-            Err(other) => panic!("Expected ValidationFailed, got {other:?}"),
+    #[test]
+    fn test_from_toroidal_cdt_basic() {
+        let tri = CdtTriangulation::from_toroidal_cdt(4, 3)
+            .expect("toroidal CDT should build with delaunay v0.7.6");
+
+        // V = N*T = 12, F = 2*N*T = 24, E = 3*N*T = 36, χ = 0.
+        assert_eq!(tri.vertex_count(), 12);
+        assert_eq!(tri.face_count(), 24);
+        assert_eq!(tri.edge_count(), 36);
+        assert_eq!(tri.geometry().euler_characteristic(), 0);
+        assert_eq!(tri.dimension(), 2);
+        assert_eq!(tri.time_slices(), 3);
+        assert!(matches!(tri.metadata().topology, CdtTopology::Toroidal));
+    }
+
+    #[test]
+    fn test_from_toroidal_cdt_various_sizes() {
+        for (n, t) in [(3_u32, 3_u32), (4, 3), (5, 4), (6, 5), (8, 4)] {
+            let tri = CdtTriangulation::from_toroidal_cdt(n, t)
+                .unwrap_or_else(|err| panic!("toroidal CDT N={n} T={t} should build: {err}"));
+            let nt = (n as usize) * (t as usize);
+            assert_eq!(tri.vertex_count(), nt);
+            assert_eq!(tri.face_count(), 2 * nt);
+            assert_eq!(tri.edge_count(), 3 * nt);
+            assert_eq!(tri.geometry().euler_characteristic(), 0);
         }
     }
 
     #[test]
-    fn test_from_toroidal_cdt_blocked() {
-        assert_toroidal_cdt_blocked(CdtTriangulation::from_toroidal_cdt(4, 3));
+    fn test_from_toroidal_cdt_foliation_per_slice() {
+        let tri = CdtTriangulation::from_toroidal_cdt(5, 4).expect("build toroidal CDT");
+        assert!(tri.has_foliation());
+        assert_eq!(tri.slice_sizes(), &[5, 5, 5, 5]);
+        for t in 0..4 {
+            assert_eq!(
+                tri.vertices_at_time(t).len(),
+                5,
+                "slice {t} should contain N=5 vertices"
+            );
+        }
+    }
+
+    #[test]
+    fn test_from_toroidal_cdt_validate_passes() {
+        let tri = CdtTriangulation::from_toroidal_cdt(4, 3).expect("build toroidal CDT");
+        assert!(tri.validate_topology().is_ok());
+        assert!(tri.validate_foliation().is_ok());
+        assert!(tri.validate_causality().is_ok());
+    }
+
+    #[test]
+    fn test_from_toroidal_cdt_each_slice_is_closed_s1() {
+        // The toroidal validate_foliation extension already enforces that
+        // each slice is a closed S¹; building a torus and validating again
+        // exercises that path explicitly.
+        let tri = CdtTriangulation::from_toroidal_cdt(6, 4).expect("build toroidal CDT");
+        tri.validate_foliation()
+            .expect("explicit toroidal CDT must satisfy closed-S¹ per-slice invariant");
     }
 
     #[test]
     fn test_from_toroidal_cdt_invalid_params() {
-        // Too few vertices per slice
+        // Too few vertices per slice (N < 3 — no proper cycle).
         assert!(CdtTriangulation::from_toroidal_cdt(2, 3).is_err());
-        // Too few slices
+        // Too few slices (T < 3 — wrap-around makes the mesh non-manifold).
         assert!(CdtTriangulation::from_toroidal_cdt(4, 1).is_err());
+        assert!(CdtTriangulation::from_toroidal_cdt(4, 2).is_err());
     }
 
     #[test]
@@ -3319,6 +3734,23 @@ mod tests {
 
         // OpenBoundary topology should pass validation
         assert!(tri.validate_topology().is_ok());
+    }
+
+    #[test]
+    fn test_validate_topology_toroidal_rejects_chi_nonzero() {
+        // Build a non-toroidal triangulation, then label its metadata as
+        // Toroidal so validate_topology() expects χ=0 but gets χ1.
+        let dt = build_delaunay2_with_data(&[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.5, 1.0], 1)])
+            .expect("Should build labeled triangle");
+        let backend = DelaunayBackend2D::from_triangulation(dt);
+        let tri = CdtTriangulation::with_topology(backend, 2, 2, CdtTopology::Toroidal);
+
+        let result = tri.validate_topology();
+        assert!(matches!(
+            result,
+            Err(CdtError::ValidationFailed { ref check, ref detail })
+                if check == "topology" && detail.contains("toroidal (expected χ=0)")
+        ));
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,9 +10,29 @@
 use crate::cdt::action::ActionConfig;
 use crate::cdt::metropolis::MetropolisConfig;
 use crate::errors::{CdtError, CdtResult};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use dirs::home_dir;
 use std::path::{Component, Path, PathBuf};
+
+/// Topology of the spatial slices in the CDT triangulation.
+///
+/// Determines the boundary conditions for the simulation:
+/// - [`OpenBoundary`](Self::OpenBoundary) — finite strip with boundary (χ = 1)
+/// - [`Toroidal`](Self::Toroidal) — periodic in both space and time (S¹×S¹, χ = 0)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+pub enum CdtTopology {
+    /// Finite strip with open boundaries (Euler characteristic χ = 1).
+    ///
+    /// This is the current default while toroidal construction is blocked
+    /// on [delaunay#313](https://github.com/acgetchell/delaunay/issues/313).
+    #[default]
+    OpenBoundary,
+    /// Periodic in both space and time, forming a torus S¹×S¹ (χ = 0).
+    ///
+    /// Blocked on [delaunay#313](https://github.com/acgetchell/delaunay/issues/313);
+    /// will become the default once implemented.
+    Toroidal,
+}
 
 /// Main configuration structure for CDT simulations.
 ///
@@ -69,6 +89,10 @@ pub struct CdtConfig {
     /// Optional RNG seed for reproducible simulations
     #[arg(long)]
     pub seed: Option<u64>,
+
+    /// Topology of spatial slices
+    #[arg(long, value_enum, default_value_t = CdtTopology::default())]
+    pub topology: CdtTopology,
 }
 
 /// Controls how dimension overrides are applied when merging configuration.
@@ -114,6 +138,8 @@ pub struct CdtConfigOverrides {
         reason = "None=no override, Some(None)=clear seed, Some(Some(v))=set seed"
     )]
     pub seed: Option<Option<u64>>,
+    /// Optional override for the topology.
+    pub topology: Option<CdtTopology>,
 }
 
 impl CdtConfig {
@@ -179,6 +205,10 @@ impl CdtConfig {
 
         if let Some(seed) = overrides.seed {
             merged.seed = seed;
+        }
+
+        if let Some(topology) = overrides.topology {
+            merged.topology = topology;
         }
 
         merged
@@ -360,6 +390,7 @@ impl CdtConfig {
             cosmological_constant: 0.1,
             simulate: true,
             seed: None,
+            topology: CdtTopology::OpenBoundary,
         }
     }
 
@@ -451,6 +482,7 @@ impl TestConfig {
             cosmological_constant: 0.1,
             simulate: true,
             seed: None,
+            topology: CdtTopology::OpenBoundary,
         }
     }
 
@@ -470,6 +502,7 @@ impl TestConfig {
             cosmological_constant: 0.1,
             simulate: true,
             seed: None,
+            topology: CdtTopology::OpenBoundary,
         }
     }
 
@@ -489,6 +522,7 @@ impl TestConfig {
             cosmological_constant: 0.1,
             simulate: true,
             seed: None,
+            topology: CdtTopology::OpenBoundary,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,16 +21,16 @@ use std::path::{Component, Path, PathBuf};
 /// - [`Toroidal`](Self::Toroidal) — periodic in both space and time (S¹×S¹, χ = 0)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
 pub enum CdtTopology {
-    /// Finite strip with open boundaries (Euler characteristic χ = 1).
-    ///
-    /// This is the current default while toroidal construction is blocked
-    /// on [delaunay#313](https://github.com/acgetchell/delaunay/issues/313).
+    /// Finite strip with open boundaries (Euler characteristic χ = 1 for
+    /// disk-like or χ = 2 for sphere-like configurations).
     #[default]
     OpenBoundary,
     /// Periodic in both space and time, forming a torus S¹×S¹ (χ = 0).
     ///
-    /// Blocked on [delaunay#313](https://github.com/acgetchell/delaunay/issues/313);
-    /// will become the default once implemented.
+    /// Built via
+    /// [`CdtTriangulation::from_toroidal_cdt`](crate::cdt::triangulation::CdtTriangulation::from_toroidal_cdt),
+    /// which constructs an explicit `(N · T)`-vertex mesh with both spatial
+    /// and temporal wrap-around.
     Toroidal,
 }
 
@@ -430,6 +430,9 @@ impl CdtConfig {
     /// # Errors
     ///
     /// Returns a structured error describing the invalid configuration entry.
+    /// Toroidal topology additionally requires `timeslices ≥ 3`,
+    /// `vertices ≥ 3 · timeslices`, and `vertices` evenly divisible by
+    /// `timeslices` so each spatial slice carries the same `N ≥ 3` vertices.
     pub fn validate(&self) -> CdtResult<()> {
         if self.vertices < 3 {
             return Err(invalid_configuration("vertices", &self.vertices, &"≥ 3"));
@@ -447,6 +450,45 @@ impl CdtConfig {
             && !(2..=3).contains(&dim)
         {
             return Err(invalid_configuration("dimension", &dim, &"2 or 3"));
+        }
+
+        if matches!(self.topology, CdtTopology::Toroidal) {
+            // Toroidal topology requires T ≥ 3 (T = 2 makes adjacent slices
+            // share two timelike sides per spatial edge, producing a
+            // non-manifold mesh) and vertices distributed evenly among
+            // slices with at least 3 per slice (any fewer and the spatial
+            // ring degenerates).
+            if self.timeslices < 3 {
+                return Err(invalid_configuration(
+                    "timeslices",
+                    &self.timeslices,
+                    &"≥ 3 for toroidal topology",
+                ));
+            }
+            if !self.vertices.is_multiple_of(self.timeslices) {
+                return Err(invalid_configuration_from_parts(
+                    "vertices",
+                    self.vertices.to_string(),
+                    format!(
+                        "divisible by timeslices ({}) for toroidal topology",
+                        self.timeslices
+                    ),
+                ));
+            }
+            let min_total = self.timeslices.checked_mul(3).ok_or_else(|| {
+                invalid_configuration_from_parts(
+                    "timeslices",
+                    self.timeslices.to_string(),
+                    "3 · timeslices must fit in u32 for toroidal topology".to_string(),
+                )
+            })?;
+            if self.vertices < min_total {
+                return Err(invalid_configuration_from_parts(
+                    "vertices",
+                    self.vertices.to_string(),
+                    format!("≥ 3 · timeslices ({min_total}) for toroidal topology"),
+                ));
+            }
         }
 
         validate_simulation_settings(
@@ -743,6 +785,87 @@ mod tests {
             }
             other => panic!("Unexpected validation result: {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_config_validation_toroidal_topology() {
+        // Valid toroidal config: T=3, N=4 vertices/slice, total=12
+        let valid_toroidal = CdtConfig {
+            topology: CdtTopology::Toroidal,
+            vertices: 12,
+            timeslices: 3,
+            ..CdtConfig::new(12, 3)
+        };
+        assert!(
+            valid_toroidal.validate().is_ok(),
+            "Valid toroidal config (T=3, V=12) should validate"
+        );
+
+        // T < 3 must be rejected for toroidal topology.
+        let toroidal_t_too_small = CdtConfig {
+            topology: CdtTopology::Toroidal,
+            vertices: 6,
+            timeslices: 2,
+            ..CdtConfig::new(6, 2)
+        };
+        assert!(matches!(
+            toroidal_t_too_small.validate(),
+            Err(CdtError::InvalidConfiguration {
+                setting,
+                provided_value,
+                expected,
+            }) if setting == "timeslices"
+                && provided_value == "2"
+                && expected == "≥ 3 for toroidal topology"
+        ));
+
+        // Vertices not divisible by timeslices must be rejected.
+        let toroidal_indivisible = CdtConfig {
+            topology: CdtTopology::Toroidal,
+            vertices: 11,
+            timeslices: 3,
+            ..CdtConfig::new(11, 3)
+        };
+        assert!(matches!(
+            toroidal_indivisible.validate(),
+            Err(CdtError::InvalidConfiguration {
+                setting,
+                provided_value,
+                expected,
+            }) if setting == "vertices"
+                && provided_value == "11"
+                && expected == "divisible by timeslices (3) for toroidal topology"
+        ));
+
+        // Fewer than 3 vertices per slice must be rejected (e.g. T=3, N=2).
+        let toroidal_too_few_per_slice = CdtConfig {
+            topology: CdtTopology::Toroidal,
+            vertices: 6,
+            timeslices: 3,
+            ..CdtConfig::new(6, 3)
+        };
+        assert!(matches!(
+            toroidal_too_few_per_slice.validate(),
+            Err(CdtError::InvalidConfiguration {
+                setting,
+                provided_value,
+                expected,
+            }) if setting == "vertices"
+                && provided_value == "6"
+                && expected == "≥ 3 · timeslices (9) for toroidal topology"
+        ));
+
+        // OpenBoundary must NOT enforce divisibility/T≥3 rules.
+        let open_boundary_indivisible = CdtConfig {
+            topology: CdtTopology::OpenBoundary,
+            vertices: 11,
+            timeslices: 3,
+            ..CdtConfig::new(11, 3)
+        };
+        assert!(
+            open_boundary_indivisible.validate().is_ok(),
+            "OpenBoundary should not require vertex/timeslice divisibility"
+        );
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -70,11 +70,20 @@ pub enum CdtError {
         detail: String,
     },
     /// An edge violates the causal structure by spanning more than one time slice
+    /// (or, on toroidal topology, more than one *circular* slice step).
     CausalityViolation {
-        /// Time label of the first endpoint
+        /// Time label of the first endpoint.
         time_0: u32,
-        /// Time label of the second endpoint
+        /// Time label of the second endpoint.
         time_1: u32,
+        /// Topology-aware temporal step distance between the two labels.
+        ///
+        /// On `OpenBoundary` topology this equals `time_0.abs_diff(time_1)`.
+        /// On `Toroidal` topology it is the circular distance
+        /// `min(d, T − d)`, so the wrap-around edge between slice `T − 1`
+        /// and slice `0` reads as `1` rather than `T − 1`.  This is the
+        /// quantity that triggers the violation (`step_distance > 1`).
+        step_distance: u32,
     },
     /// MCMC framework error (e.g. NaN in log-probability)
     Mcmc(String),
@@ -139,12 +148,28 @@ impl fmt::Display for CdtError {
                 f,
                 "Backend mutation failed [{operation}] on {target}: {detail}"
             ),
-            Self::CausalityViolation { time_0, time_1 } => {
-                let dt = time_0.abs_diff(*time_1);
-                write!(
-                    f,
-                    "Causality violation: edge spans {dt} time slices (t={time_0} to t={time_1}), maximum allowed is 1"
-                )
+            Self::CausalityViolation {
+                time_0,
+                time_1,
+                step_distance,
+            } => {
+                let raw = time_0.abs_diff(*time_1);
+                if raw == *step_distance {
+                    write!(
+                        f,
+                        "Causality violation: edge spans {step_distance} time-slice steps \
+                         (t={time_0} to t={time_1}), maximum allowed is 1"
+                    )
+                } else {
+                    // Toroidal: the displayed step distance is the circular
+                    // distance, smaller than the raw label difference.
+                    write!(
+                        f,
+                        "Causality violation: edge spans {step_distance} time-slice steps \
+                         (t={time_0} to t={time_1}, |Δt|={raw} on the time circle), \
+                         maximum allowed is 1"
+                    )
+                }
             }
             Self::Mcmc(msg) => write!(f, "MCMC error: {msg}"),
         }
@@ -283,15 +308,33 @@ mod tests {
     }
 
     #[test]
-    fn test_causality_violation_error() {
+    fn test_causality_violation_open_boundary_error() {
+        // OpenBoundary topology: step_distance == |Δt|.
         let error = CdtError::CausalityViolation {
             time_0: 0,
             time_1: 3,
+            step_distance: 3,
         };
         let display = format!("{error}");
         assert_eq!(
             display,
-            "Causality violation: edge spans 3 time slices (t=0 to t=3), maximum allowed is 1"
+            "Causality violation: edge spans 3 time-slice steps (t=0 to t=3), maximum allowed is 1"
+        );
+    }
+
+    #[test]
+    fn test_causality_violation_toroidal_error_reports_circular_distance() {
+        // Toroidal T=10, t0=0, t1=8: raw |Δt|=8 but circular step distance is 2.
+        let error = CdtError::CausalityViolation {
+            time_0: 0,
+            time_1: 8,
+            step_distance: 2,
+        };
+        let display = format!("{error}");
+        assert_eq!(
+            display,
+            "Causality violation: edge spans 2 time-slice steps \
+             (t=0 to t=8, |Δt|=8 on the time circle), maximum allowed is 1"
         );
     }
 

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -11,10 +11,10 @@ use crate::geometry::traits::{
     FlipResult, GeometryBackend, SubdivisionResult, TriangulationMut, TriangulationQuery,
 };
 use delaunay::core::DataType;
-use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
 use delaunay::core::edge::EdgeKey;
-use delaunay::core::triangulation_data_structure::{CellKey, VertexKey};
+use delaunay::core::tds::{CellKey, VertexKey};
 use delaunay::geometry::kernel::AdaptiveKernel;
+use delaunay::triangulation::DelaunayTriangulation;
 
 /// Delaunay backend wrapping the delaunay crate's triangulation (f64 coordinates).
 ///
@@ -137,7 +137,7 @@ impl<VertexData: DataType, CellData: DataType, const D: usize>
     /// underlying triangulation.
     ///
     /// This exposes the [`GlobalTopology`](delaunay::topology::traits::GlobalTopology)
-    /// metadata attached by [`DelaunayTriangulationBuilder`](delaunay::core::builder::DelaunayTriangulationBuilder) at construction time.
+    /// metadata attached by [`DelaunayTriangulationBuilder`](delaunay::triangulation::builder::DelaunayTriangulationBuilder) at construction time.
     #[must_use]
     pub const fn topology_kind(&self) -> delaunay::topology::traits::TopologyKind {
         self.dt.topology_kind()

--- a/src/geometry/generators.rs
+++ b/src/geometry/generators.rs
@@ -7,6 +7,7 @@
 
 use crate::errors::{CdtError, CdtResult};
 use delaunay::core::builder::DelaunayTriangulationBuilder;
+use delaunay::core::triangulation::TopologyGuarantee;
 use delaunay::geometry::kernel::AdaptiveKernel;
 use delaunay::geometry::point::Point;
 use delaunay::geometry::traits::coordinate::Coordinate;
@@ -124,6 +125,79 @@ pub fn build_delaunay2_with_data(
             (lo.min(v), hi.max(v))
         });
     DelaunayTriangulationBuilder::from_vertices(&vertices)
+        .build::<i32>()
+        .map_err(|e| CdtError::DelaunayGenerationFailed {
+            vertex_count,
+            coordinate_range,
+            attempt: 1,
+            underlying_error: e.to_string(),
+        })
+}
+
+/// Builds a 2D triangulation from explicit vertex coordinates, data, and cell connectivity.
+///
+/// Each vertex is specified as `([x, y], data)`.  Each cell is a `Vec<usize>` of
+/// vertex indices (must contain exactly 3 indices for 2D).  The triangulation is
+/// assembled combinatorially — **no Delaunay point-insertion** is performed.
+///
+/// The `topology_guarantee` parameter controls which topological invariants the
+/// builder validates.  Use [`TopologyGuarantee::Pseudomanifold`] for non-spherical
+/// topologies (e.g., torus with χ = 0).
+///
+/// This is the only call site for
+/// [`DelaunayTriangulationBuilder::from_vertices_and_cells`], maintaining
+/// geometry backend isolation.
+///
+/// # Errors
+///
+/// Returns error if vertex construction fails or the explicit cell builder
+/// rejects the input (e.g., invalid cell arity, out-of-bounds indices, or
+/// topological validation failure).
+pub fn build_explicit_delaunay2(
+    coords_with_data: &[([f64; 2], u32)],
+    cells: &[Vec<usize>],
+) -> CdtResult<DelaunayTriangulation2D> {
+    build_explicit_delaunay2_with_topology(coords_with_data, cells, TopologyGuarantee::DEFAULT)
+}
+
+/// Like [`build_explicit_delaunay2`] but with an explicit [`TopologyGuarantee`].
+///
+/// Use [`TopologyGuarantee::Pseudomanifold`] for meshes whose Euler characteristic
+/// differs from the default closed-sphere expectation (e.g., toroidal meshes with χ = 0).
+///
+/// # Errors
+///
+/// Same as [`build_explicit_delaunay2`].
+pub fn build_explicit_delaunay2_with_topology(
+    coords_with_data: &[([f64; 2], u32)],
+    cells: &[Vec<usize>],
+    topology_guarantee: TopologyGuarantee,
+) -> CdtResult<DelaunayTriangulation2D> {
+    let vertices: Vec<_> = coords_with_data
+        .iter()
+        .enumerate()
+        .map(|(i, (coord, data))| {
+            let point = Point::<f64, 2>::new(*coord);
+            VertexBuilder::<f64, u32, 2>::default()
+                .point(point)
+                .data(*data)
+                .build()
+                .map_err(|e| CdtError::VertexBuildFailed {
+                    context: format!("vertex {i}"),
+                    underlying_error: e.to_string(),
+                })
+        })
+        .collect::<CdtResult<Vec<_>>>()?;
+
+    let vertex_count = u32::try_from(vertices.len()).unwrap_or(u32::MAX);
+    let coordinate_range = coords_with_data
+        .iter()
+        .flat_map(|(c, _)| c.iter().copied())
+        .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), v| {
+            (lo.min(v), hi.max(v))
+        });
+    DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, cells)
+        .topology_guarantee(topology_guarantee)
         .build::<i32>()
         .map_err(|e| CdtError::DelaunayGenerationFailed {
             vertex_count,

--- a/src/geometry/generators.rs
+++ b/src/geometry/generators.rs
@@ -6,20 +6,20 @@
 //! `docs/dev/rust.md § Geometry Backend Isolation`).
 
 use crate::errors::{CdtError, CdtResult};
-use delaunay::core::builder::DelaunayTriangulationBuilder;
 use delaunay::core::triangulation::TopologyGuarantee;
 use delaunay::geometry::kernel::AdaptiveKernel;
 use delaunay::geometry::point::Point;
 use delaunay::geometry::traits::coordinate::Coordinate;
 use delaunay::geometry::util::{generate_random_points, generate_random_points_seeded};
 use delaunay::prelude::VertexBuilder;
+use delaunay::topology::traits::topological_space::{GlobalTopology, ToroidalConstructionMode};
+use delaunay::triangulation::{DelaunayTriangulation, DelaunayTriangulationBuilder};
 
 /// Type alias for the 2D Delaunay triangulation returned by this crate's generators.
 ///
 /// Uses [`AdaptiveKernel`] (the default for [`DelaunayTriangulationBuilder::build`]) and
 /// `u32` vertex data storing the per-vertex time-slice label (foliation).
-pub type DelaunayTriangulation2D =
-    delaunay::core::delaunay_triangulation::DelaunayTriangulation<AdaptiveKernel<f64>, u32, i32, 2>;
+pub type DelaunayTriangulation2D = DelaunayTriangulation<AdaptiveKernel<f64>, u32, i32, 2>;
 
 /// Generates a Delaunay triangulation with optional seed for deterministic testing.
 ///
@@ -140,11 +140,12 @@ pub fn build_delaunay2_with_data(
 /// vertex indices (must contain exactly 3 indices for 2D).  The triangulation is
 /// assembled combinatorially — **no Delaunay point-insertion** is performed.
 ///
-/// The `topology_guarantee` parameter controls which topological invariants the
-/// builder validates.  Use [`TopologyGuarantee::Pseudomanifold`] for non-spherical
-/// topologies (e.g., torus with χ = 0).
+/// Topology defaults to [`TopologyGuarantee::DEFAULT`] (PL-manifold) and
+/// [`GlobalTopology::Euclidean`].  For non-spherical meshes (e.g. torus with
+/// χ = 0), use [`build_explicit_delaunay2_with_topology`] or the convenience
+/// wrapper [`build_explicit_delaunay2_toroidal`] instead.
 ///
-/// This is the only call site for
+/// This is one of the only call sites for
 /// [`DelaunayTriangulationBuilder::from_vertices_and_cells`], maintaining
 /// geometry backend isolation.
 ///
@@ -153,25 +154,75 @@ pub fn build_delaunay2_with_data(
 /// Returns error if vertex construction fails or the explicit cell builder
 /// rejects the input (e.g., invalid cell arity, out-of-bounds indices, or
 /// topological validation failure).
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::geometry::*;
+///
+/// // Single labeled triangle (PL-manifold-with-boundary, Euclidean):
+/// let vertices = [([0.0, 0.0], 0u32), ([1.0, 0.0], 0), ([0.5, 1.0], 1)];
+/// let cells = vec![vec![0, 1, 2]];
+///
+/// let dt = build_explicit_delaunay2(&vertices, &cells)
+///     .expect("explicit single-triangle mesh");
+/// assert_eq!(dt.number_of_vertices(), 3);
+/// assert_eq!(dt.number_of_cells(), 1);
+/// ```
 pub fn build_explicit_delaunay2(
     coords_with_data: &[([f64; 2], u32)],
     cells: &[Vec<usize>],
 ) -> CdtResult<DelaunayTriangulation2D> {
-    build_explicit_delaunay2_with_topology(coords_with_data, cells, TopologyGuarantee::DEFAULT)
+    build_explicit_delaunay2_with_topology(
+        coords_with_data,
+        cells,
+        TopologyGuarantee::DEFAULT,
+        GlobalTopology::Euclidean,
+    )
 }
 
-/// Like [`build_explicit_delaunay2`] but with an explicit [`TopologyGuarantee`].
+/// Like [`build_explicit_delaunay2`] but with explicit [`TopologyGuarantee`] and
+/// [`GlobalTopology`] metadata.
 ///
 /// Use [`TopologyGuarantee::Pseudomanifold`] for meshes whose Euler characteristic
-/// differs from the default closed-sphere expectation (e.g., toroidal meshes with χ = 0).
+/// differs from the default closed-sphere expectation, and pair it with the
+/// matching [`GlobalTopology`] (e.g., [`GlobalTopology::Toroidal`] with
+/// [`ToroidalConstructionMode::Explicit`]) so the builder validates against the
+/// correct expected χ.
 ///
 /// # Errors
 ///
 /// Same as [`build_explicit_delaunay2`].
+///
+/// # Examples
+///
+/// The `TopologyGuarantee` and `GlobalTopology` types come from the underlying
+/// `delaunay` crate — import them directly when calling this lower-level builder:
+///
+/// ```
+/// use causal_triangulations::prelude::geometry::*;
+/// use delaunay::core::triangulation::TopologyGuarantee;
+/// use delaunay::topology::traits::topological_space::GlobalTopology;
+///
+/// // Single labeled triangle, default PL-manifold guarantee, Euclidean global topology.
+/// let vertices = [([0.0, 0.0], 0u32), ([1.0, 0.0], 0), ([0.5, 1.0], 1)];
+/// let cells = vec![vec![0, 1, 2]];
+///
+/// let dt = build_explicit_delaunay2_with_topology(
+///     &vertices,
+///     &cells,
+///     TopologyGuarantee::DEFAULT,
+///     GlobalTopology::Euclidean,
+/// )
+/// .expect("explicit single-triangle mesh");
+/// assert_eq!(dt.number_of_vertices(), 3);
+/// assert_eq!(dt.number_of_cells(), 1);
+/// ```
 pub fn build_explicit_delaunay2_with_topology(
     coords_with_data: &[([f64; 2], u32)],
     cells: &[Vec<usize>],
     topology_guarantee: TopologyGuarantee,
+    global_topology: GlobalTopology<2>,
 ) -> CdtResult<DelaunayTriangulation2D> {
     let vertices: Vec<_> = coords_with_data
         .iter()
@@ -198,6 +249,7 @@ pub fn build_explicit_delaunay2_with_topology(
         });
     DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, cells)
         .topology_guarantee(topology_guarantee)
+        .global_topology(global_topology)
         .build::<i32>()
         .map_err(|e| CdtError::DelaunayGenerationFailed {
             vertex_count,
@@ -205,6 +257,75 @@ pub fn build_explicit_delaunay2_with_topology(
             attempt: 1,
             underlying_error: e.to_string(),
         })
+}
+
+/// Convenience wrapper for building a 2D toroidal explicit triangulation.
+///
+/// Sets [`TopologyGuarantee::Pseudomanifold`] and
+/// [`GlobalTopology::Toroidal`] with [`ToroidalConstructionMode::Explicit`]
+/// so the builder validates the mesh against χ = 0 instead of the default
+/// closed-sphere expectation.
+///
+/// In practice, most callers use the higher-level
+/// [`CdtTriangulation::from_toroidal_cdt`](crate::CdtTriangulation::from_toroidal_cdt)
+/// constructor, which assembles the vertex/cell layout for an `N × T` torus and
+/// then delegates here.
+///
+/// # Errors
+///
+/// Same as [`build_explicit_delaunay2_with_topology`].
+///
+/// # Examples
+///
+/// Build a 3 × 3 toroidal mesh by hand (V = 9, E = 27, F = 18, χ = 0):
+///
+/// ```
+/// use causal_triangulations::prelude::geometry::*;
+///
+/// const N: usize = 3;
+/// const T: usize = 3;
+///
+/// // Vertex (i, t) lives at index i + t*N, with x = i/N, y = t/T, label = t.
+/// let mut vertices: Vec<([f64; 2], u32)> = Vec::with_capacity(N * T);
+/// for t in 0..T {
+///     for i in 0..N {
+///         #[allow(clippy::cast_precision_loss)]
+///         let coord = [i as f64 / N as f64, t as f64 / T as f64];
+///         let label = u32::try_from(t).expect("slice index fits in u32");
+///         vertices.push((coord, label));
+///     }
+/// }
+///
+/// // Each (i, t) quad contributes one Up and one Down triangle.
+/// let mut cells: Vec<Vec<usize>> = Vec::with_capacity(2 * N * T);
+/// for t in 0..T {
+///     let t_next = (t + 1) % T;
+///     for i in 0..N {
+///         let i_next = (i + 1) % N;
+///         cells.push(vec![i + t * N, i_next + t * N, i + t_next * N]);
+///         cells.push(vec![i_next + t * N, i_next + t_next * N, i + t_next * N]);
+///     }
+/// }
+///
+/// let dt = build_explicit_delaunay2_toroidal(&vertices, &cells, [1.0, 1.0])
+///     .expect("explicit 3×3 toroidal mesh");
+/// assert_eq!(dt.number_of_vertices(), N * T);
+/// assert_eq!(dt.number_of_cells(), 2 * N * T);
+/// ```
+pub fn build_explicit_delaunay2_toroidal(
+    coords_with_data: &[([f64; 2], u32)],
+    cells: &[Vec<usize>],
+    domain: [f64; 2],
+) -> CdtResult<DelaunayTriangulation2D> {
+    build_explicit_delaunay2_with_topology(
+        coords_with_data,
+        cells,
+        TopologyGuarantee::Pseudomanifold,
+        GlobalTopology::Toroidal {
+            domain,
+            mode: ToroidalConstructionMode::Explicit,
+        },
+    )
 }
 
 // =========================================================================
@@ -246,6 +367,79 @@ pub(crate) fn seeded_delaunay2(
 mod tests {
     use super::*;
     use crate::errors::CdtError;
+
+    #[test]
+    fn test_build_explicit_delaunay2_single_triangle() {
+        // Default topology (PL-manifold + Euclidean) should accept a single
+        // triangle with the standard 0-1 strip labeling.
+        let vertices = [([0.0, 0.0], 0u32), ([1.0, 0.0], 0), ([0.5, 1.0], 1)];
+        let cells = vec![vec![0, 1, 2]];
+
+        let dt = build_explicit_delaunay2(&vertices, &cells)
+            .expect("single-triangle explicit mesh should build with defaults");
+        assert_eq!(dt.number_of_vertices(), 3);
+        assert_eq!(dt.number_of_cells(), 1);
+    }
+
+    #[test]
+    fn test_build_explicit_delaunay2_rejects_out_of_bounds_index() {
+        // Cell references vertex 3 which doesn't exist (only indices 0..3 are valid).
+        let vertices = [([0.0, 0.0], 0u32), ([1.0, 0.0], 0), ([0.5, 1.0], 1)];
+        let cells = vec![vec![0, 1, 3]];
+
+        let result = build_explicit_delaunay2(&vertices, &cells);
+        assert!(
+            matches!(result, Err(CdtError::DelaunayGenerationFailed { .. })),
+            "explicit builder must reject out-of-bounds vertex indices, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_build_explicit_delaunay2_with_topology_explicit_euclidean() {
+        // Same single-triangle mesh, but with explicit topology metadata.
+        let vertices = [([0.0, 0.0], 0u32), ([1.0, 0.0], 0), ([0.5, 1.0], 1)];
+        let cells = vec![vec![0, 1, 2]];
+
+        let dt = build_explicit_delaunay2_with_topology(
+            &vertices,
+            &cells,
+            TopologyGuarantee::DEFAULT,
+            GlobalTopology::Euclidean,
+        )
+        .expect("single-triangle explicit mesh with explicit topology should build");
+        assert_eq!(dt.number_of_vertices(), 3);
+        assert_eq!(dt.number_of_cells(), 1);
+    }
+
+    #[test]
+    fn test_build_explicit_delaunay2_toroidal_3x3_chi_zero() {
+        // A real 3×3 toroidal mesh: V=9, F=18, E=27, χ=0.
+        const N: usize = 3;
+        const T: usize = 3;
+        let mut vertices: Vec<([f64; 2], u32)> = Vec::with_capacity(N * T);
+        for t in 0..T {
+            for i in 0..N {
+                #[allow(clippy::cast_precision_loss)]
+                let coord = [i as f64 / N as f64, t as f64 / T as f64];
+                let label = u32::try_from(t).expect("slice index fits in u32");
+                vertices.push((coord, label));
+            }
+        }
+        let mut cells: Vec<Vec<usize>> = Vec::with_capacity(2 * N * T);
+        for t in 0..T {
+            let t_next = (t + 1) % T;
+            for i in 0..N {
+                let i_next = (i + 1) % N;
+                cells.push(vec![i + t * N, i_next + t * N, i + t_next * N]);
+                cells.push(vec![i_next + t * N, i_next + t_next * N, i + t_next * N]);
+            }
+        }
+
+        let dt = build_explicit_delaunay2_toroidal(&vertices, &cells, [1.0, 1.0])
+            .expect("3×3 toroidal mesh should build");
+        assert_eq!(dt.number_of_vertices(), N * T);
+        assert_eq!(dt.number_of_cells(), 2 * N * T);
+    }
 
     #[test]
     fn test_delaunay2_with_context_valid_parameters() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub use cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveType};
 pub use cdt::foliation::{CellType, EdgeType, Foliation};
 pub use cdt::metropolis::{CdtProposal, CdtTarget};
 pub use cdt::metropolis::{MetropolisAlgorithm, MetropolisConfig, SimulationResultsBackend};
-pub use config::{CdtConfig, TestConfig};
+pub use config::{CdtConfig, CdtTopology, TestConfig};
 pub use errors::{CdtError, CdtResult};
 
 use cdt::metropolis::Measurement;
@@ -132,7 +132,7 @@ pub mod prelude {
     };
 
     // Configuration and errors
-    pub use crate::config::CdtConfig;
+    pub use crate::config::{CdtConfig, CdtTopology};
     pub use crate::errors::{CdtError, CdtResult};
 
     /// Focused exports for CDT triangulation construction and queries.
@@ -233,14 +233,23 @@ pub fn run_simulation(config: &CdtConfig) -> CdtResult<cdt::metropolis::Simulati
     log::info!("Dimensionality: {}", config.dimension.unwrap_or(2));
     log::info!("Number of vertices: {vertices}");
     log::info!("Number of timeslices: {timeslices}");
+    log::info!("Topology: {:?}", config.topology);
     log::info!("Using trait-based backend system");
 
-    // Create initial triangulation (seeded if seed is provided for full reproducibility)
-    let triangulation = if let Some(seed) = config.seed {
-        log::info!("RNG seed: {seed}");
-        CdtTriangulation::from_seeded_points(vertices, timeslices, 2, seed)?
-    } else {
-        CdtTriangulation::from_random_points(vertices, timeslices, 2)?
+    // Create initial triangulation based on topology
+    let triangulation = match config.topology {
+        config::CdtTopology::Toroidal => {
+            log::info!("Constructing toroidal CDT (S¹×S¹)");
+            CdtTriangulation::from_toroidal_cdt(vertices, timeslices)?
+        }
+        config::CdtTopology::OpenBoundary => {
+            if let Some(seed) = config.seed {
+                log::info!("RNG seed: {seed}");
+                CdtTriangulation::from_seeded_points(vertices, timeslices, 2, seed)?
+            } else {
+                CdtTriangulation::from_random_points(vertices, timeslices, 2)?
+            }
+        }
     };
 
     log::info!(
@@ -310,6 +319,7 @@ mod lib_tests {
             cosmological_constant: 0.1,
             simulate: false,
             seed: Some(42),
+            topology: config::CdtTopology::OpenBoundary,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,11 +240,17 @@ pub fn run_simulation(config: &CdtConfig) -> CdtResult<cdt::metropolis::Simulati
     log::info!("Topology: {:?}", config.topology);
     log::info!("Using trait-based backend system");
 
-    // Create initial triangulation based on topology
+    // Create initial triangulation based on topology.
+    //
+    // `config.vertices` is always the *total* vertex count.  For
+    // [`CdtTopology::Toroidal`], `validate()` has already checked that
+    // `vertices % timeslices == 0` and `vertices >= 3 * timeslices`, so we
+    // can safely divide to recover N = vertices/T per slice.
     let triangulation = match config.topology {
         config::CdtTopology::Toroidal => {
             log::info!("Constructing toroidal CDT (S¹×S¹)");
-            CdtTriangulation::from_toroidal_cdt(vertices, timeslices)?
+            let vertices_per_slice = vertices / timeslices;
+            CdtTriangulation::from_toroidal_cdt(vertices_per_slice, timeslices)?
         }
         config::CdtTopology::OpenBoundary => {
             if let Some(seed) = config.seed {
@@ -448,5 +454,44 @@ mod lib_tests {
         assert_relative_eq!(action_config.coupling_0, 1.0);
         assert_relative_eq!(action_config.coupling_2, 1.0);
         assert_relative_eq!(action_config.cosmological_constant, 0.1);
+    }
+
+    #[test]
+    fn test_run_simulation_toroidal_uses_total_vertex_count() {
+        // For toroidal topology `config.vertices` is the *total* vertex
+        // count.  With vertices=12, timeslices=3 we expect a triangulation
+        // with exactly 12 vertices (4 per slice on a 3-slice torus), not
+        // 36 (which would result from treating the field as per-slice).
+        let config = CdtConfig {
+            dimension: Some(2),
+            vertices: 12,
+            timeslices: 3,
+            temperature: 1.0,
+            steps: 10,
+            thermalization_steps: 5,
+            measurement_frequency: 2,
+            coupling_0: 1.0,
+            coupling_2: 1.0,
+            cosmological_constant: 0.1,
+            simulate: false,
+            seed: None,
+            topology: config::CdtTopology::Toroidal,
+        };
+
+        let results = run_simulation(&config).expect("toroidal simulation should run");
+        assert_eq!(
+            results.triangulation.vertex_count(),
+            12,
+            "Toroidal run_simulation must treat config.vertices as the TOTAL vertex count"
+        );
+        assert_eq!(
+            results.triangulation.time_slices(),
+            3,
+            "Toroidal run_simulation must preserve the configured timeslice count"
+        );
+        assert!(matches!(
+            results.triangulation.metadata().topology,
+            config::CdtTopology::Toroidal
+        ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub mod prelude {
     pub use crate::geometry::traits::TriangulationQuery;
 
     // Foliation / classification
-    pub use crate::cdt::foliation::{CellType, EdgeType, Foliation};
+    pub use crate::cdt::foliation::{CellType, EdgeType, Foliation, FoliationError};
 
     // Action
     pub use crate::cdt::action::{ActionConfig, compute_regge_action};
@@ -149,7 +149,8 @@ pub mod prelude {
     /// ```
     pub mod triangulation {
         pub use crate::CdtTriangulation;
-        pub use crate::cdt::foliation::{CellType, EdgeType, Foliation};
+        pub use crate::cdt::foliation::{CellType, EdgeType, Foliation, FoliationError};
+        pub use crate::config::CdtTopology;
         pub use crate::errors::{CdtError, CdtResult};
         pub use crate::geometry::traits::TriangulationQuery;
     }
@@ -162,7 +163,7 @@ pub mod prelude {
         pub use crate::cdt::metropolis::{
             CdtProposal, CdtTarget, MetropolisAlgorithm, MetropolisConfig,
         };
-        pub use crate::config::CdtConfig;
+        pub use crate::config::{CdtConfig, CdtTopology};
         pub use crate::errors::{CdtError, CdtResult};
     }
 
@@ -191,7 +192,10 @@ pub mod prelude {
             DelaunayBackend, DelaunayEdgeHandle, DelaunayFaceHandle, DelaunayVertexHandle,
         };
         pub use crate::geometry::backends::mock::MockBackend;
-        pub use crate::geometry::generators::{build_delaunay2_with_data, delaunay2_with_context};
+        pub use crate::geometry::generators::{
+            build_delaunay2_with_data, build_explicit_delaunay2, build_explicit_delaunay2_toroidal,
+            build_explicit_delaunay2_with_topology, delaunay2_with_context,
+        };
         pub use crate::geometry::operations::TriangulationOps;
         pub use crate::geometry::traits::{TriangulationMut, TriangulationQuery};
     }


### PR DESCRIPTION
- Add CdtTopology enum (OpenBoundary, Toroidal) with CLI --topology arg, CdtConfigOverrides support, and CdtMetadata.topology field
- Add topology-aware validate_topology(): χ=1/2 for open boundary, χ=0 for toroidal
- Add CdtTriangulation::with_topology() constructor
- Add build_explicit_delaunay2_with_topology() generator wrapping DelaunayTriangulationBuilder::from_vertices_and_cells()
- Wire topology through run_simulation() to dispatch on CdtTopology
- Add from_toroidal_cdt() placeholder pending delaunay#313
- Update delaunay to 0.7.5, markov-chain-monte-carlo to 0.2.0
- Migrate Chain field access to accessor methods (state(), log_prob(), into_state())

Blocked: toroidal construction requires delaunay#313 (explicit cell builder rejects non-sphere Euler characteristic χ=0).