### PR TITLE
fix: enforce CDT validation guardrails (#8)

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -5,7 +5,7 @@ early_access: false
 enable_free_tier: true
 reviews:
   profile: chill
-  request_changes_workflow: false
+  request_changes_workflow: true
   high_level_summary: false
   high_level_summary_placeholder: "@coderabbitai summary"
   high_level_summary_in_walkthrough: false
@@ -41,7 +41,7 @@ reviews:
     auto_incremental_review: true
     ignore_title_keywords: []
     labels: []
-    drafts: false
+    drafts: true
     base_branches: []
   finishing_touches:
     docstrings:
@@ -109,6 +109,7 @@ reviews:
     # Semantic code analysis
     semgrep:
       enabled: true
+      config_file: semgrep.yaml
 
     # Python linter (ruff provides comprehensive Python analysis)
     ruff:

--- a/README.md
+++ b/README.md
@@ -112,16 +112,22 @@ fn main() -> CdtResult<()> {
     // Create triangulation from random points
     let triangulation = CdtTriangulation::from_random_points(20, 1, 2)?;
 
-    // Configure Monte Carlo simulation
+    // Configure Monte Carlo simulation. Full Metropolis execution currently
+    // returns UnsupportedOperation until the real CDT move kernels land.
     let metropolis_config = MetropolisConfig::new(1.0, 1000, 100, 10);
     let action_config = ActionConfig::default();
     let algorithm = MetropolisAlgorithm::new(metropolis_config, action_config);
 
-    // Run simulation
-    let results = algorithm.run(triangulation)?;
-
-    println!("Acceptance rate: {:.3}", results.acceptance_rate());
-    println!("Average action: {:.3}", results.average_action());
+    match algorithm.run(triangulation) {
+        Ok(results) => {
+            println!("Acceptance rate: {:.3}", results.acceptance_rate());
+            println!("Average action: {:.3}", results.average_action());
+        }
+        Err(causal_triangulations::CdtError::UnsupportedOperation { reason, .. }) => {
+            println!("Simulation unavailable: {reason}");
+        }
+        Err(err) => return Err(err),
+    }
     Ok(())
 }
 ```
@@ -132,23 +138,23 @@ fn main() -> CdtResult<()> {
 # Build the binary
 cargo build --release
 
-# Run a basic simulation
-./target/release/cdt --vertices 20 --timeslices 10 --steps 2000 --simulate
+# Build a triangulation and record the initial measurement
+./target/release/cdt --vertices 20 --timeslices 10 --steps 2000
 
-# Parameter sweep for phase transition studies
+# Configure a parameter sweep. Add --simulate after #55/#56 provide real moves.
 ./target/release/cdt \
   --vertices 50 --timeslices 12 \
   --temperature 1.5 --coupling-0 0.8 \
-  --steps 5000 --simulate
+  --steps 5000
 ```
 
 ### Ready-to-Use Scripts
 
 The `examples/scripts/` directory contains research workflows:
 
-- **`basic_simulation.sh`** - Simple test run and validation
-- **`parameter_sweep.sh`** - Temperature sweep for phase transition analysis
-- **`performance_test.sh`** - Performance benchmarking across system sizes
+- **`basic_simulation.sh`** - Simple simulation command and current guardrail check
+- **`parameter_sweep.sh`** - Temperature sweep setup; full analysis waits on real moves
+- **`performance_test.sh`** - Construction/guardrail timing across system sizes
 
 For detailed documentation, sample output, and usage instructions for each script, see [examples/scripts/README.md](examples/scripts/README.md).
 
@@ -164,7 +170,7 @@ cargo bench
 
 # Specific benchmark categories
 cargo bench triangulation_creation
-cargo bench metropolis_simulation
+cargo bench metropolis_errors
 cargo bench action_calculations
 
 # Performance regression testing

--- a/benches/README.md
+++ b/benches/README.md
@@ -32,8 +32,8 @@ cargo bench action_calculations
 # Ergodic move operations
 cargo bench ergodic_moves
 
-# Metropolis-Hastings simulation steps
-cargo bench metropolis_simulation
+# Metropolis-Hastings unsupported-operation guardrail
+cargo bench metropolis_errors
 
 # Simulation analysis operations
 cargo bench simulation_analysis
@@ -106,12 +106,12 @@ cargo bench -- --save-baseline my_baseline
   - `random_move_attempt`: Complete random move attempt
 - **Use Case**: Optimizing Monte Carlo move proposal
 
-### 6. Metropolis Simulation (`metropolis_simulation`)
+### 6. Metropolis Guardrails (`metropolis_errors`)
 
-- **Purpose**: Measures complete simulation step performance
-- **Test Configurations**: 10, 50, 100 MC steps
-- **Includes**: Move proposals, action calculations, acceptance decisions
-- **Use Case**: End-to-end simulation performance profiling
+- **Purpose**: Measures the current unsupported-operation short-circuit while real CDT moves are pending
+- **Test Configurations**: 10, 50, 100 requested MC steps
+- **Includes**: Configuration validation and the `MetropolisAlgorithm::run()` guardrail
+- **Use Case**: Tracking guardrail overhead until #55/#56 replace it with real move execution
 
 ### 7. Simulation Analysis (`simulation_analysis`)
 

--- a/benches/cdt_benchmarks.rs
+++ b/benches/cdt_benchmarks.rs
@@ -5,13 +5,13 @@
 //! This benchmark suite measures the performance of key CDT operations including:
 //! - Triangulation creation and initialization
 //! - Geometry operations (edge counting, queries)
-//! - Metropolis-Hastings simulation steps
+//! - Metropolis-Hastings guardrail errors while real moves are pending
 //! - Action calculations
 //! - Ergodic move operations
 
 use causal_triangulations::prelude::simulation::{
-    ActionConfig, ErgodicsSystem, MetropolisAlgorithm, MetropolisConfig, MoveType,
-    SimulationResultsBackend,
+    ActionConfig, ErgodicsSystem, Measurement, MetropolisAlgorithm, MetropolisConfig,
+    MonteCarloStep, MoveType, SimulationResultsBackend,
 };
 use causal_triangulations::prelude::triangulation::{CdtTriangulation2D, TriangulationQuery};
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
@@ -245,15 +245,14 @@ fn bench_ergodic_moves(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmark Metropolis-Hastings simulation steps
+/// Benchmark Metropolis-Hastings guardrail errors while real moves are pending.
 fn bench_metropolis_simulation(c: &mut Criterion) {
-    let mut group = c.benchmark_group("metropolis_simulation");
+    let mut group = c.benchmark_group("metropolis_errors");
 
-    // Test different step counts
+    // Keep this path measured without presenting it as simulation throughput.
     for steps in [10, 50, 100] {
-        group.throughput(Throughput::Elements(u64::from(steps)));
         group.bench_with_input(
-            BenchmarkId::new("simulation_steps", steps),
+            BenchmarkId::new("metropolis_shortcircuit", steps),
             &steps,
             |b, &steps| {
                 b.iter(|| {
@@ -289,9 +288,56 @@ fn bench_simulation_analysis(c: &mut Criterion) {
     let results = SimulationResultsBackend {
         config,
         action_config,
-        steps: vec![],
-        measurements: vec![],
-        elapsed_time: Duration::from_millis(0),
+        steps: vec![
+            MonteCarloStep {
+                step: 1,
+                move_type: MoveType::Move22,
+                accepted: true,
+                action_before: 12.5,
+                action_after: Some(11.8),
+                delta_action: Some(-0.7),
+            },
+            MonteCarloStep {
+                step: 2,
+                move_type: MoveType::Move13Add,
+                accepted: false,
+                action_before: 11.8,
+                action_after: None,
+                delta_action: Some(1.4),
+            },
+            MonteCarloStep {
+                step: 3,
+                move_type: MoveType::Move31Remove,
+                accepted: true,
+                action_before: 11.8,
+                action_after: Some(12.1),
+                delta_action: Some(0.3),
+            },
+        ],
+        measurements: vec![
+            Measurement {
+                step: 0,
+                action: 12.5,
+                vertices: 15,
+                edges: 32,
+                triangles: 18,
+            },
+            Measurement {
+                step: 10,
+                action: 11.8,
+                vertices: 16,
+                edges: 34,
+                triangles: 19,
+            },
+            Measurement {
+                step: 20,
+                action: 12.1,
+                vertices: 15,
+                edges: 31,
+                triangles: 17,
+            },
+        ],
+        elapsed_time: Duration::from_millis(37),
         triangulation,
     };
 

--- a/benches/cdt_benchmarks.rs
+++ b/benches/cdt_benchmarks.rs
@@ -11,10 +11,12 @@
 
 use causal_triangulations::prelude::simulation::{
     ActionConfig, ErgodicsSystem, MetropolisAlgorithm, MetropolisConfig, MoveType,
+    SimulationResultsBackend,
 };
 use causal_triangulations::prelude::triangulation::{CdtTriangulation2D, TriangulationQuery};
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
+use std::time::Duration;
 
 /// Benchmark triangulation creation with different vertex counts
 fn bench_triangulation_creation(c: &mut Criterion) {
@@ -262,10 +264,10 @@ fn bench_metropolis_simulation(c: &mut Criterion) {
                     let action_config = ActionConfig::default();
                     let algorithm = MetropolisAlgorithm::new(config, action_config);
 
-                    let results = algorithm
+                    let error = algorithm
                         .run(black_box(triangulation))
-                        .expect("Simulation should succeed");
-                    black_box(results)
+                        .expect_err("zero-move simulation should be rejected");
+                    black_box(error)
                 });
             },
         );
@@ -284,11 +286,14 @@ fn bench_simulation_analysis(c: &mut Criterion) {
 
     let config = MetropolisConfig::new(1.0, 100, 10, 5);
     let action_config = ActionConfig::default();
-    let algorithm = MetropolisAlgorithm::new(config, action_config);
-
-    let results = algorithm
-        .run(triangulation)
-        .expect("Simulation should succeed");
+    let results = SimulationResultsBackend {
+        config,
+        action_config,
+        steps: vec![],
+        measurements: vec![],
+        elapsed_time: Duration::from_millis(0),
+        triangulation,
+    };
 
     group.bench_function("acceptance_rate", |b| {
         b.iter(|| {

--- a/docs/CLI_EXAMPLES.md
+++ b/docs/CLI_EXAMPLES.md
@@ -2,6 +2,8 @@
 
 This document provides examples for using the `cdt` binary, the command-line interface for Causal Dynamical Triangulations simulations.
 
+> **Current simulation status:** examples that pass `--simulate` are unsupported until the real CDT move kernels in PRs #55/#56 are merged. Today those commands validate configuration and initial triangulation construction, then fail with `UnsupportedOperation` from `MetropolisAlgorithm::run`. Run the examples without `--simulate` for triangulation generation and initial measurement output.
+
 ## Basic Usage
 
 The `cdt` binary accepts various command-line arguments to configure and run CDT simulations.
@@ -9,10 +11,10 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 ### Quick Start
 
 ```bash
-# Basic 2D CDT simulation with default parameters
+# Basic 2D CDT triangulation with default parameters
 ./target/release/cdt --vertices 10 --timeslices 5
 
-# Run with custom temperature and steps
+# Build with custom simulation settings; omit --simulate while moves are pending
 ./target/release/cdt --vertices 20 --timeslices 10 --temperature 1.5 --steps 2000
 ```
 
@@ -39,7 +41,7 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 ### Additional Options
 
-- `--simulate`: Request full Monte Carlo simulation (default: false). Until real CDT move kernels land in #55/#56, this exits with an explicit unsupported-operation error instead of returning a zero-move simulation.
+- `--simulate`: Request full Monte Carlo simulation (default: false). **Unsupported today:** until real CDT move kernels land in PRs #55/#56, this raises `UnsupportedOperation` from `MetropolisAlgorithm::run` instead of returning a zero-move simulation. Omit `--simulate` for triangulation generation and initial measurements.
 
 ## Example Usage Scenarios
 
@@ -53,13 +55,15 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 **Expected Output:**
 
 - Creates a 5-vertex, 2-timeslice triangulation
-- Runs default 1000 Monte Carlo steps
-- Reports simulation statistics
+- Does not run Monte Carlo steps unless `--simulate` is passed
+- Reports the initial triangulation measurement
 
 ### 2. Medium-Scale Physics Study
 
+> **Unsupported with `--simulate`:** the physics-study examples in this section currently raise `UnsupportedOperation` until the CDT move kernels in PRs #55/#56 are merged. Omit `--simulate` to generate the initial triangulation, or wait for those PRs before treating these as Monte Carlo studies.
+
 ```bash
-# Medium triangulation for physics exploration  
+# Currently unsupported as a simulation; remove --simulate to build only
 ./target/release/cdt \
   --vertices 50 \
   --timeslices 10 \
@@ -74,8 +78,10 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 ### 3. High-Temperature Simulation
 
+> **Unsupported with `--simulate`:** this currently reaches the `MetropolisAlgorithm::run` guardrail. Remove `--simulate` for triangulation generation until PRs #55/#56 land.
+
 ```bash
-# High temperature (classical limit)
+# High temperature configuration; --simulate is currently unsupported
 ./target/release/cdt \
   --vertices 30 \
   --timeslices 8 \
@@ -88,8 +94,10 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 ### 4. Low-Temperature Simulation
 
+> **Unsupported with `--simulate`:** this currently raises `UnsupportedOperation` instead of running a Monte Carlo chain. Remove `--simulate` or wait for PRs #55/#56.
+
 ```bash
-# Low temperature (quantum regime)
+# Low temperature configuration; --simulate is currently unsupported
 ./target/release/cdt \
   --vertices 25 \
   --timeslices 12 \
@@ -103,8 +111,10 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 ### 5. Custom Physics Parameters
 
+> **Unsupported with `--simulate`:** custom couplings are validated, but full simulation still stops at the unsupported-operation guardrail until PRs #55/#56 provide real moves.
+
 ```bash
-# Modified coupling constants
+# Modified coupling constants; --simulate is currently unsupported
 ./target/release/cdt \
   --vertices 40 \
   --timeslices 8 \
@@ -129,6 +139,8 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 ### Batch Processing with Shell Scripts
 
+> **Unsupported with `--simulate`:** batch sweeps that include `--simulate` currently collect the same `UnsupportedOperation` error for each run. Remove `--simulate` to batch-generate initial triangulations, or wait for PRs #55/#56 before using this for simulation sweeps.
+
 Create a script to run parameter sweeps:
 
 ```bash
@@ -136,35 +148,40 @@ Create a script to run parameter sweeps:
 # parameter_sweep.sh
 
 for temp in 0.5 1.0 1.5 2.0 2.5; do
-    echo "Running simulation at temperature $temp"
+    echo "Building triangulation at temperature $temp"
     ./target/release/cdt \
         --vertices 30 \
         --timeslices 10 \
         --temperature $temp \
         --steps 2000 \
-        --simulate \
         > "results_T${temp}.log" 2>&1
 done
 ```
 
 ### Performance Testing
 
+> **Unsupported with `--simulate`:** full simulation performance testing is blocked on PRs #55/#56. Run without `--simulate` for construction/validation timing, or use the benchmark suite's `metropolis_errors` group to measure the current guardrail.
+
 ```bash
-# Large simulation for performance testing
+# Large triangulation construction for performance testing
 ./target/release/cdt \
   --vertices 200 \
   --timeslices 25 \
   --steps 10000 \
-  --measurement-frequency 100 \
-  --simulate
+  --measurement-frequency 100
 ```
 
 ### Logging and Output
 
+> **Unsupported with `--simulate`:** logging examples that include `--simulate` currently log the `UnsupportedOperation` guardrail after configuration and triangulation setup. Remove `--simulate` for successful triangulation-only runs.
+
 Enable detailed logging:
 
 ```bash
-# Set log level for detailed output
+# Set log level for detailed triangulation output
+RUST_LOG=debug ./target/release/cdt --vertices 10 --timeslices 5
+
+# Show the current unsupported-operation guardrail explicitly
 RUST_LOG=debug ./target/release/cdt --vertices 10 --timeslices 5 --simulate
 
 # Log only errors and warnings
@@ -178,16 +195,22 @@ RUST_LOG=warn ./target/release/cdt --vertices 50 --timeslices 10 --simulate
 
 ### Successful Run
 
+> **Successful runs currently omit `--simulate`:** commands with `--simulate` raise `UnsupportedOperation` until PRs #55/#56 merge.
+
 ```text
 [INFO] Dimensionality: 2
 [INFO] Number of vertices: 10
-[INFO] Time slices: 5
-[INFO] Starting CDT simulation with backend...
-[INFO] Temperature: 1.0
-[INFO] Total steps: 1000
-[INFO] Thermalization steps: 100
-[INFO] Simulation completed in 45.23ms
+[INFO] Number of timeslices: 5
+[INFO] Topology: OpenBoundary
+[INFO] Using trait-based backend system
+[INFO] Triangulation created with 10 vertices, <edge-count> edges, <face-count> faces
 [INFO] CDT simulation completed successfully
+```
+
+### Unsupported `--simulate` Run
+
+```text
+[ERROR] CDT simulation failed: Unsupported operation [MetropolisAlgorithm::run]: real CDT ergodic moves are not implemented yet (#55); refusing to return a zero-move simulation result
 ```
 
 ### Error Cases
@@ -212,9 +235,9 @@ RUST_LOG=warn ./target/release/cdt --vertices 50 --timeslices 10 --simulate
 
 ### Runtime
 
-- Test simulations (1000 steps): seconds
-- Physics studies (10000+ steps): minutes
-- Large systems: hours
+- Triangulation construction and validation: seconds for small examples
+- Full simulation timing with `--simulate`: unsupported until PRs #55/#56 merge
+- Physics studies and large simulation runs: wait for the real CDT move kernels
 
 ### Optimization Tips
 
@@ -252,8 +275,8 @@ RUST_LOG=warn ./target/release/cdt --vertices 50 --timeslices 10 --simulate
 ### Data Analysis
 
 ```bash
-# Pipe output to analysis tools
-./target/release/cdt --vertices 50 --timeslices 10 --simulate | \
+# Pipe triangulation-only output to analysis tools
+./target/release/cdt --vertices 50 --timeslices 10 | \
   python analysis_script.py
 ```
 
@@ -262,7 +285,7 @@ RUST_LOG=warn ./target/release/cdt --vertices 50 --timeslices 10 --simulate
 ```bash
 # Use in makefiles or CI/CD
 make run-simulation: 
- ./target/release/cdt --vertices $(VERTICES) --timeslices $(SLICES) --simulate
+ ./target/release/cdt --vertices $(VERTICES) --timeslices $(SLICES)
 ```
 
 ## Help and Documentation
@@ -275,4 +298,4 @@ make run-simulation:
 ./target/release/cdt --version
 ```
 
-This CLI interface provides a powerful way to explore CDT physics and test different simulation parameters efficiently from the command line.
+This CLI interface provides a way to explore CDT triangulation construction and validate simulation parameters from the command line while full Monte Carlo simulation remains blocked on PRs #55/#56.

--- a/docs/CLI_EXAMPLES.md
+++ b/docs/CLI_EXAMPLES.md
@@ -39,15 +39,15 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 ### Additional Options
 
-- `--simulate`: Run full Monte Carlo simulation (default: true; pass `--simulate false` to only generate the triangulation without running Monte Carlo steps)
+- `--simulate`: Request full Monte Carlo simulation (default: false). Until real CDT move kernels land in #55/#56, this exits with an explicit unsupported-operation error instead of returning a zero-move simulation.
 
 ## Example Usage Scenarios
 
 ### 1. Small Test Simulation
 
 ```bash
-# Quick test with minimal parameters
-./target/release/cdt --vertices 5 --timeslices 2 --simulate
+# Quick triangulation-generation test with minimal parameters
+./target/release/cdt --vertices 5 --timeslices 2
 ```
 
 **Expected Output:**
@@ -120,7 +120,7 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 ```bash
 # Generate triangulation without running Monte Carlo simulation
-./target/release/cdt --vertices 100 --timeslices 20 --simulate false
+./target/release/cdt --vertices 100 --timeslices 20
 ```
 
 **Use Case:** Generate initial configurations for other analysis tools

--- a/docs/PERFORMANCE_TESTING.md
+++ b/docs/PERFORMANCE_TESTING.md
@@ -217,7 +217,7 @@ The CI will:
 
 ### Variable Benchmarks (Relaxed Thresholds)
 
-- **Metropolis Simulation**: End-to-end simulation (randomness affects timing)
+- **Metropolis Guardrails**: Current `MetropolisAlgorithm::run()` unsupported-operation path while real CDT move kernels are pending
 - **File I/O Operations**: System-dependent operations
 
 ## Performance Optimization Workflow

--- a/examples/basic_cdt.rs
+++ b/examples/basic_cdt.rs
@@ -9,7 +9,7 @@
 //! - Extract and display results
 
 use causal_triangulations::prelude::simulation::{
-    CdtConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm,
+    CdtConfig, CdtError, CdtResult, CdtTriangulation, MetropolisAlgorithm,
 };
 use log::{LevelFilter, info};
 
@@ -54,7 +54,15 @@ fn main() -> CdtResult<()> {
     // Run the simulation
     info!("Running CDT simulation...");
     let algorithm = MetropolisAlgorithm::new(metropolis_config, action_config);
-    let results = algorithm.run(triangulation)?;
+    let results = match algorithm.run(triangulation) {
+        Ok(results) => results,
+        Err(CdtError::UnsupportedOperation { reason, .. }) => {
+            info!("Simulation unavailable: {reason}");
+            info!("Example completed after triangulation construction.");
+            return Ok(());
+        }
+        Err(err) => return Err(err),
+    };
 
     // Display results
     info!("Simulation completed!");

--- a/examples/basic_cdt.rs
+++ b/examples/basic_cdt.rs
@@ -5,8 +5,8 @@
 //! This example shows how to:
 //! - Create a CDT triangulation programmatically
 //! - Configure simulation parameters
-//! - Run a basic CDT simulation
-//! - Extract and display results
+//! - Attempt a basic CDT simulation
+//! - Report the current unsupported-operation guardrail until real moves land
 
 use causal_triangulations::prelude::simulation::{
     CdtConfig, CdtError, CdtResult, CdtTriangulation, MetropolisAlgorithm,
@@ -51,8 +51,9 @@ fn main() -> CdtResult<()> {
     let metropolis_config = config.to_metropolis_config();
     let action_config = config.to_action_config();
 
-    // Run the simulation
-    info!("Running CDT simulation...");
+    // Attempt the simulation. This currently reports the explicit guardrail
+    // until the real CDT move kernels land.
+    info!("Attempting CDT simulation...");
     let algorithm = MetropolisAlgorithm::new(metropolis_config, action_config);
     let results = match algorithm.run(triangulation) {
         Ok(results) => results,

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -1,12 +1,14 @@
 # CDT-RS CLI Example Scripts
 
-This directory contains shell scripts that demonstrate how to use the `cdt` command-line binary for various simulation scenarios.
+This directory contains shell scripts that demonstrate how to use the `cdt` command-line binary for simulation-oriented scenarios.
+
+> **Current simulation status:** scripts that pass `--simulate` currently reach the `MetropolisAlgorithm::run()` `UnsupportedOperation` guardrail until the real CDT move kernels in #55/#56 land. Remove `--simulate` for successful triangulation-only runs, or keep it when you explicitly want to observe the guardrail behavior.
 
 ## Available Scripts
 
 ### 1. `basic_simulation.sh`
 
-**Purpose**: Demonstrates a simple CDT simulation run **Usage**:
+**Purpose**: Demonstrates a simple CDT simulation command and, while moves are pending, the current unsupported-operation guardrail. **Usage**:
 
 ```bash
 ./examples/scripts/basic_simulation.sh
@@ -15,14 +17,14 @@ This directory contains shell scripts that demonstrate how to use the `cdt` comm
 **What it does**:
 
 - Builds the cdt binary in release mode
-- Runs a basic simulation (10 vertices, 5 timeslices, 1000 MC steps)
-- Shows logging output and success confirmation
+- Builds a 10-vertex, 5-timeslice command with 1000 requested MC steps
+- Shows logging output until the current `--simulate` guardrail exits non-zero
 
 **Use this for**: First-time testing, verifying installation
 
 ### 2. `parameter_sweep.sh`
 
-**Purpose**: Runs systematic temperature sweep for phase transition studies **Usage**:
+**Purpose**: Runs a systematic temperature-sweep command set. Full phase-transition studies require real CDT moves from #55/#56. **Usage**:
 
 ```bash
 ./examples/scripts/parameter_sweep.sh
@@ -31,11 +33,11 @@ This directory contains shell scripts that demonstrate how to use the `cdt` comm
 **What it does**:
 
 - Tests temperatures from 0.5 to 3.0
-- Runs 2000 MC steps for each temperature
+- Requests 2000 MC steps for each temperature
 - Saves individual logs to `sweep_results/`
-- Provides summary of successful runs
+- Encounters the current `--simulate` guardrail until the move kernels land
 
-**Use this for**: Physics studies, phase transition analysis, parameter exploration
+**Use this for**: Parameter exploration setup now; physics studies and phase-transition analysis after real moves land
 
 ### 3. `performance_test.sh`
 
@@ -48,11 +50,11 @@ This directory contains shell scripts that demonstrate how to use the `cdt` comm
 **What it does**:
 
 - Tests small to extra-large system configurations
-- Measures runtime and calculates throughput
+- Measures current command runtime and setup overhead
 - Generates performance summary report
 - Saves results to `performance_results.txt`
 
-**Use this for**: Performance analysis, scaling studies, optimization validation
+**Use this for**: Construction/guardrail timing now; full simulation scaling studies after real moves land
 
 ## Prerequisites
 
@@ -60,7 +62,7 @@ This directory contains shell scripts that demonstrate how to use the `cdt` comm
 
 - Bash shell (zsh also works)
 - `bc` calculator (for performance script)
-- Sufficient memory for large simulations
+- Sufficient memory for large triangulation runs
 
 ### Build Requirements
 
@@ -139,7 +141,7 @@ echo "=== Custom CDT Script ==="
 # Build the binary
 cargo build --release
 
-# Run simulation with custom parameters
+# Run with custom parameters. Remove --simulate for a successful triangulation-only run.
 RUST_LOG=info ./target/release/cdt \
     --vertices 25 \
     --timeslices 10 \
@@ -147,20 +149,20 @@ RUST_LOG=info ./target/release/cdt \
     --steps 3000 \
     --simulate
 
-echo "Custom simulation completed!"
+echo "Custom command completed!"
 ```
 
 ## Expected Output
 
-### Successful Runs
+### Current `--simulate` Runs
 
-Scripts will show:
+Scripts that pass `--simulate` currently show:
 
 - Build confirmation
 - Progress messages
-- Simulation logs (with RUST_LOG=info)
-- Success confirmation
-- Results summary (for sweep/performance scripts)
+- Simulation logs (with `RUST_LOG=info`)
+- `UnsupportedOperation` from `MetropolisAlgorithm::run()`
+- A non-zero exit from the `cdt` command unless `--simulate` is removed
 
 ### Error Handling
 
@@ -215,17 +217,15 @@ run-performance:
 
 ### Log Format
 
-Simulation logs contain:
+Triangulation-only logs contain:
 
 ```text
 [INFO] Dimensionality: 2
 [INFO] Number of vertices: 20
-[INFO] Time slices: 8
-[INFO] Starting CDT simulation with backend...
-[INFO] Temperature: 1.0
-[INFO] Total steps: 2000
-[INFO] Thermalization steps: 200
-[INFO] Simulation completed in 45.23ms
+[INFO] Number of timeslices: 8
+[INFO] Topology: OpenBoundary
+[INFO] Using trait-based backend system
+[INFO] Triangulation created with 20 vertices, <edge-count> edges, <face-count> faces
 [INFO] CDT simulation completed successfully
 ```
 
@@ -266,4 +266,4 @@ Simulation logs contain:
 - [`examples/basic_cdt.rs`](../basic_cdt.rs): Library usage examples
 - [`benches/README.md`](../../benches/README.md): Benchmarking documentation
 
-These scripts provide a practical starting point for exploring CDT physics and conducting computational studies with the cdt binary.
+These scripts provide a practical starting point for configuring CDT runs with the `cdt` binary while full simulation remains blocked on #55/#56.

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -18,7 +18,6 @@ rules:
       include:
         - "/src/**/*.rs"
       exclude:
-        - "/tests/**"
         - "/examples/**"
         - "/benches/**"
     patterns:
@@ -158,7 +157,6 @@ rules:
       include:
         - "/src/**/*.rs"
       exclude:
-        - "/tests/**"
         - "/examples/**"
         - "/benches/**"
     patterns:
@@ -202,6 +200,24 @@ rules:
           impl $TYPE {
               ...
           }
+
+  - id: causal-triangulations.rust.no-stringly-domain-validation-errors
+    languages:
+      - rust
+    severity: WARNING
+    message: "Use the dedicated CdtError variant instead of stringly ValidationFailed for this domain."
+    metadata:
+      category: maintainability
+      rationale: >-
+        Topology, foliation, and unsupported construction failures have typed
+        variants; routing them through ValidationFailed loses programmatic
+        debuggability.
+    paths:
+      include:
+        - "/src/**/*.rs"
+    pattern-regex: >-
+      (?s)CdtError::ValidationFailed\s*\{[^}]*
+      check:\s*"(?:foliation|topology|cdt_construction)"\.to_string\(\)
 
   - id: causal-triangulations.python.no-raw-exception-in-tests
     languages:

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -216,8 +216,7 @@ rules:
       include:
         - "/src/**/*.rs"
     pattern-regex: >-
-      (?s)CdtError::ValidationFailed\s*\{[^}]*
-      check:\s*"(?:foliation|topology|cdt_construction)"\.to_string\(\)
+      (?s)CdtError::ValidationFailed\s*\{(?=[^}]*\bcheck\s*:\s*(?:"(?:foliation|topology|cdt_construction)"(?:\s*\.\s*(?:to_string|into)\s*\(\s*\))?|String\s*::\s*from\s*\(\s*"(?:foliation|topology|cdt_construction)"\s*\)))[^}]*\}
 
   - id: causal-triangulations.python.no-raw-exception-in-tests
     languages:

--- a/src/cdt/action.rs
+++ b/src/cdt/action.rs
@@ -3,6 +3,8 @@
 //! This module implements the discrete Einstein-Hilbert action used in CDT,
 //! which is based on the Regge calculus formulation of general relativity.
 
+use crate::errors::{CdtError, CdtResult};
+
 /// Calculates the 2D Regge Action for a given triangulation.
 ///
 /// The 2D Regge Action in CDT is given by:
@@ -93,6 +95,27 @@ impl ActionConfig {
         }
     }
 
+    /// Validates that action couplings are finite.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidConfiguration`] when any coupling is NaN or
+    /// infinite.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::ActionConfig;
+    ///
+    /// assert!(ActionConfig::default().validate().is_ok());
+    /// assert!(ActionConfig::new(f64::NAN, 1.0, 0.1).validate().is_err());
+    /// ```
+    pub fn validate(&self) -> CdtResult<()> {
+        validate_coupling("coupling_0", self.coupling_0)?;
+        validate_coupling("coupling_2", self.coupling_2)?;
+        validate_coupling("cosmological_constant", self.cosmological_constant)
+    }
+
     /// Calculates the action for given simplex counts.
     ///
     /// # Examples
@@ -114,6 +137,19 @@ impl ActionConfig {
             self.coupling_2,
             self.cosmological_constant,
         )
+    }
+}
+
+/// Rejects non-finite action couplings before they can poison action/log-probability math.
+fn validate_coupling(setting: &str, value: f64) -> CdtResult<()> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(CdtError::InvalidConfiguration {
+            setting: setting.to_string(),
+            provided_value: value.to_string(),
+            expected: "finite".to_string(),
+        })
     }
 }
 

--- a/src/cdt/metropolis.rs
+++ b/src/cdt/metropolis.rs
@@ -9,15 +9,14 @@
 
 use crate::cdt::action::ActionConfig;
 use crate::cdt::ergodic_moves::MoveType;
-use crate::config::validate_simulation_settings;
+use crate::config::validate_schedule;
 use crate::errors::{CdtError, CdtResult};
 use crate::geometry::CdtTriangulation2D;
 use crate::geometry::traits::TriangulationQuery;
-use markov_chain_monte_carlo::{Chain, ProposalMut, Target};
+use markov_chain_monte_carlo::{ProposalMut, Target};
 use num_traits::cast::NumCast;
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
-use std::time::{Duration, Instant};
+use rand::Rng;
+use std::time::Duration;
 
 // Test utilities are now handled through backend-agnostic CdtTriangulation::new
 
@@ -123,24 +122,20 @@ impl MetropolisConfig {
     /// assert!(config.validate().is_ok());
     /// ```
     pub fn validate(&self) -> CdtResult<()> {
-        validate_simulation_settings(
+        validate_schedule(
             self.temperature,
             self.steps,
             self.thermalization_steps,
             self.measurement_frequency,
             |setting, provided_value, expected| {
-                invalid_simulation_configuration_from_parts(setting, provided_value, expected)
+                invalid_sim_config(setting, provided_value, expected)
             },
         )
     }
 }
 
 /// Adapts shared schedule validation errors to the Metropolis-specific error variant.
-fn invalid_simulation_configuration_from_parts(
-    setting: &str,
-    provided_value: String,
-    expected: String,
-) -> CdtError {
+fn invalid_sim_config(setting: &str, provided_value: String, expected: String) -> CdtError {
     CdtError::InvalidSimulationConfiguration {
         setting: setting.to_string(),
         provided_value,
@@ -199,7 +194,7 @@ impl CdtTarget {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{ActionConfig, CdtTarget};
+    /// use causal_triangulations::prelude::simulation::{ActionConfig, CdtTarget};
     ///
     /// let _target = CdtTarget::new(ActionConfig::default(), 1.0);
     /// ```
@@ -262,6 +257,10 @@ pub struct MetropolisAlgorithm {
     /// Algorithm configuration
     config: MetropolisConfig,
     /// Action calculation configuration
+    #[expect(
+        dead_code,
+        reason = "stored for real Metropolis wiring once #55 provides reversible CDT moves"
+    )]
     action_config: ActionConfig,
 }
 
@@ -271,7 +270,9 @@ impl MetropolisAlgorithm {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{ActionConfig, MetropolisAlgorithm, MetropolisConfig};
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, MetropolisAlgorithm, MetropolisConfig,
+    /// };
     ///
     /// let config = MetropolisConfig::new(1.0, 10, 2, 1);
     /// let _algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
@@ -286,133 +287,39 @@ impl MetropolisAlgorithm {
 
     /// Run the Monte Carlo simulation.
     ///
-    /// This runs the Metropolis-Hastings algorithm on the given triangulation
-    /// using the `markov-chain-monte-carlo` crate for acceptance/rejection.
+    /// This currently returns [`CdtError::UnsupportedOperation`] after
+    /// validating the configuration. Real reversible CDT moves are tracked in
+    /// issue #55; until those land, this method refuses to return a zero-move
+    /// simulation result.
     ///
     /// # Errors
     ///
-    /// Returns [`CdtError::Mcmc`] if the MCMC framework encounters a NaN
-    /// log-probability or proposal ratio.
     /// Returns [`CdtError::InvalidSimulationConfiguration`] if the Metropolis
     /// configuration is invalid.
-    ///
-    /// Measurements include the initial state at step 0, then the state after
-    /// each completed-move count divisible by
-    /// [`MetropolisConfig::measurement_frequency`]. Downstream equilibrium
-    /// filtering treats measurements with `step >= thermalization_steps` as
-    /// post-thermalization.
+    /// Returns [`CdtError::UnsupportedOperation`] while real ergodic moves are
+    /// unavailable.
     ///
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{ActionConfig, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig};
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtError, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
+    /// };
     ///
     /// let tri = CdtTriangulation::from_seeded_points(5, 2, 2, 53).unwrap();
     /// let config = MetropolisConfig::new(1.0, 2, 1, 1).with_seed(7);
-    /// let results = MetropolisAlgorithm::new(config, ActionConfig::default())
+    /// let err = MetropolisAlgorithm::new(config, ActionConfig::default())
     ///     .run(tri)
-    ///     .unwrap();
-    ///
-    /// assert_eq!(results.steps.len(), 2);
+    ///     .expect_err("real CDT moves are not implemented yet");
+    /// assert!(matches!(err, CdtError::UnsupportedOperation { .. }));
     /// ```
-    pub fn run(&self, triangulation: CdtTriangulation2D) -> CdtResult<SimulationResultsBackend> {
+    pub fn run(&self, _triangulation: CdtTriangulation2D) -> CdtResult<SimulationResultsBackend> {
         // Validate configuration to fail fast before any work
         self.config.validate()?;
 
-        let start_time = Instant::now();
-        let mut mc_steps = Vec::new();
-        let mut measurements = Vec::new();
-
-        // Ensure we have a concrete seed for provenance (generate one if not provided)
-        let seed = self.config.seed.unwrap_or_else(rand::random::<u64>);
-
-        log::info!("Starting Metropolis-Hastings simulation...");
-        log::info!("Temperature: {}", self.config.temperature);
-        log::info!("Total steps: {}", self.config.steps);
-        log::info!("Thermalization steps: {}", self.config.thermalization_steps);
-        log::info!("RNG seed: {seed}");
-
-        // Set up MCMC chain
-        let target = CdtTarget::new(self.action_config.clone(), self.config.temperature);
-        let proposal = CdtProposal;
-        let mut chain = Chain::new(triangulation, &target)?;
-
-        {
-            let g = chain.state().geometry();
-            measurements.push(Measurement {
-                step: 0,
-                action: -chain.log_prob() * self.config.temperature,
-                vertices: u32::try_from(g.vertex_count()).unwrap_or_default(),
-                edges: u32::try_from(g.edge_count()).unwrap_or_default(),
-                triangles: u32::try_from(g.face_count()).unwrap_or_default(),
-            });
-        }
-
-        // Create seeded RNG (always deterministic from the resolved seed)
-        let mut rng = StdRng::seed_from_u64(seed);
-
-        for step_num in 0..self.config.steps {
-            let action_before = -chain.log_prob() * self.config.temperature;
-            let accepted = chain.step_mut(&target, &proposal, &mut rng)?;
-            let action_after = -chain.log_prob() * self.config.temperature;
-
-            // TODO: Record actual move type once #55 provides real moves
-            let mc_step = MonteCarloStep {
-                step: step_num,
-                move_type: MoveType::Move22, // placeholder
-                accepted,
-                action_before,
-                action_after: if accepted { Some(action_after) } else { None },
-                delta_action: if accepted {
-                    Some(action_after - action_before)
-                } else {
-                    None
-                },
-            };
-            mc_steps.push(mc_step);
-
-            let completed_steps = step_num + 1;
-
-            // Record the post-step state whenever the completed-move count lands
-            // on a measurement boundary. The initial state at step 0 was already
-            // captured before entering the loop.
-            if completed_steps % self.config.measurement_frequency == 0 {
-                let g = chain.state().geometry();
-                measurements.push(Measurement {
-                    step: completed_steps,
-                    action: action_after,
-                    vertices: u32::try_from(g.vertex_count()).unwrap_or_default(),
-                    edges: u32::try_from(g.edge_count()).unwrap_or_default(),
-                    triangles: u32::try_from(g.face_count()).unwrap_or_default(),
-                });
-            }
-
-            // Progress reporting
-            if step_num % 100 == 0 {
-                log::debug!(
-                    "Step {}/{}, Action: {:.3}",
-                    step_num,
-                    self.config.steps,
-                    action_after,
-                );
-            }
-        }
-
-        let elapsed_time = start_time.elapsed();
-        log::info!("Simulation completed in {elapsed_time:.2?}");
-        log::info!("Acceptance rate: {:.2}%", chain.acceptance_rate() * 100.0);
-
-        // Store the resolved seed in the results for provenance
-        let mut result_config = self.config.clone();
-        result_config.seed = Some(seed);
-
-        Ok(SimulationResultsBackend {
-            config: result_config,
-            action_config: self.action_config.clone(),
-            steps: mc_steps,
-            measurements,
-            elapsed_time,
-            triangulation: chain.into_state(),
+        Err(CdtError::UnsupportedOperation {
+            operation: "MetropolisAlgorithm::run".to_string(),
+            reason: "real CDT ergodic moves are not implemented yet (#55); refusing to return a zero-move simulation result".to_string(),
         })
     }
 }
@@ -440,15 +347,22 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{ActionConfig, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig};
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    /// };
+    /// use std::time::Duration;
     ///
     /// let tri = CdtTriangulation::from_seeded_points(5, 2, 2, 53).unwrap();
     /// let config = MetropolisConfig::new(1.0, 1, 0, 1).with_seed(7);
-    /// let results = MetropolisAlgorithm::new(config, ActionConfig::default())
-    ///     .run(tri)
-    ///     .unwrap();
-    ///
-    /// assert!((0.0..=1.0).contains(&results.acceptance_rate()));
+    /// let results = SimulationResultsBackend {
+    ///     config,
+    ///     action_config: ActionConfig::default(),
+    ///     steps: vec![],
+    ///     measurements: vec![],
+    ///     elapsed_time: Duration::from_millis(0),
+    ///     triangulation: tri,
+    /// };
+    /// assert_eq!(results.acceptance_rate(), 0.0);
     /// ```
     #[must_use]
     pub fn acceptance_rate(&self) -> f64 {
@@ -470,15 +384,22 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{ActionConfig, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig};
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    /// };
+    /// use std::time::Duration;
     ///
     /// let tri = CdtTriangulation::from_seeded_points(5, 2, 2, 53).unwrap();
     /// let config = MetropolisConfig::new(1.0, 1, 0, 1).with_seed(7);
-    /// let results = MetropolisAlgorithm::new(config, ActionConfig::default())
-    ///     .run(tri)
-    ///     .unwrap();
-    ///
-    /// assert!(results.average_action().is_finite());
+    /// let results = SimulationResultsBackend {
+    ///     config,
+    ///     action_config: ActionConfig::default(),
+    ///     steps: vec![],
+    ///     measurements: vec![],
+    ///     elapsed_time: Duration::from_millis(0),
+    ///     triangulation: tri,
+    /// };
+    /// assert_eq!(results.average_action(), 0.0);
     /// ```
     #[must_use]
     pub fn average_action(&self) -> f64 {
@@ -505,16 +426,22 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{ActionConfig, MetropolisAlgorithm, MetropolisConfig};
-    /// use causal_triangulations::CdtTriangulation;
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    /// };
+    /// use std::time::Duration;
     ///
     /// let tri = CdtTriangulation::from_seeded_points(5, 2, 2, 53).unwrap();
     /// let config = MetropolisConfig::new(1.0, 2, 1, 1).with_seed(7);
-    /// let results = MetropolisAlgorithm::new(config, ActionConfig::default())
-    ///     .run(tri)
-    ///     .unwrap();
-    ///
-    /// assert!(!results.equilibrium_measurements().is_empty());
+    /// let results = SimulationResultsBackend {
+    ///     config,
+    ///     action_config: ActionConfig::default(),
+    ///     steps: vec![],
+    ///     measurements: vec![],
+    ///     elapsed_time: Duration::from_millis(0),
+    ///     triangulation: tri,
+    /// };
+    /// assert!(results.equilibrium_measurements().is_empty());
     /// ```
     #[must_use]
     pub fn equilibrium_measurements(&self) -> Vec<&Measurement> {
@@ -531,6 +458,19 @@ mod tests {
     use crate::cdt::triangulation::CdtTriangulation;
     use crate::geometry::traits::TriangulationQuery;
     use approx::assert_relative_eq;
+
+    fn assert_unsupported_simulation(err: CdtError) {
+        match err {
+            CdtError::UnsupportedOperation { operation, reason } => {
+                assert_eq!(operation, "MetropolisAlgorithm::run");
+                assert!(
+                    reason.contains("real CDT ergodic moves are not implemented yet"),
+                    "Unexpected unsupported-operation reason: {reason}"
+                );
+            }
+            other => panic!("Expected UnsupportedOperation, got {other:?}"),
+        }
+    }
 
     #[test]
     fn test_metropolis_config() {
@@ -612,40 +552,35 @@ mod tests {
     }
 
     #[test]
-    fn test_simulation_runs_with_seed() {
+    fn test_simulation_guardrail_rejects_zero_move_run_with_seed() {
         let config = MetropolisConfig::new(1.0, 10, 2, 2).with_seed(42);
         let action_config = ActionConfig::default();
         let algorithm = MetropolisAlgorithm::new(config, action_config);
 
         let triangulation =
             CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed to create");
-        let results = algorithm
+        let err = algorithm
             .run(triangulation)
-            .expect("Simulation should succeed");
-
-        // With placeholder proposal, all moves are rejected
-        assert_relative_eq!(results.acceptance_rate(), 0.0);
-        assert!(!results.measurements.is_empty());
-        assert_eq!(results.measurements[0].step, 0);
+            .expect_err("zero-move simulation should be rejected");
+        assert_unsupported_simulation(err);
     }
 
     #[test]
-    fn test_seeded_simulation_determinism() {
-        let run = |seed: u64| {
+    fn test_seeded_simulation_guardrail_is_deterministic() {
+        let run_error = |seed: u64| {
             let config = MetropolisConfig::new(1.0, 20, 5, 5).with_seed(seed);
             let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
             let tri = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
-            algorithm.run(tri).expect("Failed")
+            algorithm
+                .run(tri)
+                .expect_err("zero-move simulation should be rejected")
         };
 
-        let r1 = run(123);
-        let r2 = run(123);
+        let e1 = run_error(123);
+        let e2 = run_error(123);
 
-        assert_eq!(r1.steps.len(), r2.steps.len());
-        assert_eq!(r1.measurements.len(), r2.measurements.len());
-        for (m1, m2) in r1.measurements.iter().zip(r2.measurements.iter()) {
-            assert_relative_eq!(m1.action, m2.action);
-        }
+        assert_eq!(e1, e2);
+        assert_unsupported_simulation(e1);
     }
 
     #[test]
@@ -746,41 +681,27 @@ mod tests {
     }
 
     #[test]
-    fn test_run_accepts_boundary_aligned_equilibrium_measurement_schedule() {
+    fn test_run_validates_boundary_aligned_schedule_before_guardrail() {
         let config = MetropolisConfig::new(1.0, 20, 15, 10).with_seed(42);
         let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
         let tri = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
 
-        let results = algorithm
+        let err = algorithm
             .run(tri)
-            .expect("Boundary-aligned measurement schedule should be valid");
-        let measurement_steps: Vec<_> = results
-            .measurements
-            .iter()
-            .map(|measurement| measurement.step)
-            .collect();
-        let equilibrium_steps: Vec<_> = results
-            .equilibrium_measurements()
-            .into_iter()
-            .map(|measurement| measurement.step)
-            .collect();
-
-        assert_eq!(measurement_steps, vec![0, 10, 20]);
-        assert_eq!(equilibrium_steps, vec![20]);
+            .expect_err("valid schedule should reach the zero-move simulation guardrail");
+        assert_unsupported_simulation(err);
     }
 
     #[test]
-    fn test_run_records_seed_for_provenance() {
-        // When no seed is provided, run() should generate and record one
+    fn test_run_without_seed_reaches_guardrail() {
         let config = MetropolisConfig::new(1.0, 5, 1, 1); // no seed
         let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
         let tri = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
 
-        let results = algorithm.run(tri).expect("Should succeed");
-        assert!(
-            results.config.seed.is_some(),
-            "Results should always contain a resolved seed"
-        );
+        let err = algorithm
+            .run(tri)
+            .expect_err("zero-move simulation should be rejected");
+        assert_unsupported_simulation(err);
     }
 
     #[test]

--- a/src/cdt/metropolis.rs
+++ b/src/cdt/metropolis.rs
@@ -257,10 +257,6 @@ pub struct MetropolisAlgorithm {
     /// Algorithm configuration
     config: MetropolisConfig,
     /// Action calculation configuration
-    #[expect(
-        dead_code,
-        reason = "stored for real Metropolis wiring once #55 provides reversible CDT moves"
-    )]
     action_config: ActionConfig,
 }
 
@@ -316,6 +312,7 @@ impl MetropolisAlgorithm {
     pub fn run(&self, _triangulation: CdtTriangulation2D) -> CdtResult<SimulationResultsBackend> {
         // Validate configuration to fail fast before any work
         self.config.validate()?;
+        self.action_config.validate()?;
 
         Err(CdtError::UnsupportedOperation {
             operation: "MetropolisAlgorithm::run".to_string(),
@@ -693,6 +690,30 @@ mod tests {
     }
 
     #[test]
+    fn test_run_validates_action_config_before_guardrail() {
+        let config = MetropolisConfig::new(1.0, 20, 15, 10).with_seed(42);
+        let action_config = ActionConfig::new(f64::INFINITY, 1.0, 0.1);
+        let algorithm = MetropolisAlgorithm::new(config, action_config);
+        let tri = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
+
+        let err = algorithm
+            .run(tri)
+            .expect_err("invalid action config should be reported before the guardrail");
+        match err {
+            CdtError::InvalidConfiguration {
+                setting,
+                provided_value,
+                expected,
+            } => {
+                assert_eq!(setting, "coupling_0");
+                assert_eq!(provided_value, "inf");
+                assert_eq!(expected, "finite");
+            }
+            other => panic!("Expected InvalidConfiguration, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_run_without_seed_reaches_guardrail() {
         let config = MetropolisConfig::new(1.0, 5, 1, 1); // no seed
         let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
@@ -706,7 +727,33 @@ mod tests {
 
     #[test]
     fn test_simulation_results() {
-        let config = MetropolisConfig::default();
+        let config = MetropolisConfig::new(1.0, 20, 10, 5);
+        let steps = vec![
+            MonteCarloStep {
+                step: 1,
+                move_type: MoveType::Move22,
+                accepted: true,
+                action_before: 3.0,
+                action_after: Some(2.5),
+                delta_action: Some(-0.5),
+            },
+            MonteCarloStep {
+                step: 2,
+                move_type: MoveType::Move13Add,
+                accepted: false,
+                action_before: 2.5,
+                action_after: None,
+                delta_action: Some(0.8),
+            },
+            MonteCarloStep {
+                step: 3,
+                move_type: MoveType::Move31Remove,
+                accepted: true,
+                action_before: 2.5,
+                action_after: Some(2.0),
+                delta_action: Some(-0.5),
+            },
+        ];
         let measurements = vec![
             Measurement {
                 step: 0,
@@ -722,6 +769,13 @@ mod tests {
                 edges: 5,
                 triangles: 2,
             },
+            Measurement {
+                step: 15,
+                action: 3.0,
+                vertices: 5,
+                edges: 7,
+                triangles: 3,
+            },
         ];
 
         let triangulation =
@@ -730,12 +784,30 @@ mod tests {
         let results = SimulationResultsBackend {
             config,
             action_config: ActionConfig::default(),
-            steps: vec![],
+            steps,
             measurements,
             elapsed_time: Duration::from_millis(100),
             triangulation,
         };
 
-        assert_relative_eq!(results.average_action(), 1.5);
+        assert_relative_eq!(results.acceptance_rate(), 2.0 / 3.0);
+        assert_relative_eq!(results.average_action(), 2.0);
+
+        let equilibrium = results.equilibrium_measurements();
+        assert_eq!(equilibrium.len(), 2);
+        assert_eq!(equilibrium[0].step, 10);
+        assert_eq!(equilibrium[1].step, 15);
+    }
+
+    #[test]
+    fn test_cdt_proposal_placeholder_returns_no_move() {
+        use rand::{SeedableRng, rngs::StdRng};
+
+        let proposal = CdtProposal;
+        let mut triangulation = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
+        let mut rng = StdRng::seed_from_u64(7);
+
+        assert!(proposal.propose_mut(&mut triangulation, &mut rng).is_none());
+        proposal.undo(&mut triangulation, ());
     }
 }

--- a/src/cdt/triangulation.rs
+++ b/src/cdt/triangulation.rs
@@ -16,6 +16,7 @@ use crate::geometry::generators::{
 use crate::geometry::traits::{TriangulationMut, TriangulationQuery};
 use crate::util::f64_band_to_u32;
 use std::collections::{HashMap, HashSet};
+use std::ops::{Deref, DerefMut};
 use std::time::Instant;
 
 /// CDT-specific triangulation wrapper - completely geometry-agnostic
@@ -145,6 +146,33 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
         Self::wrap_unchecked(geometry, time_slices, dimension, CdtTopology::OpenBoundary)
     }
 
+    /// Fallible constructor for a CDT triangulation with open boundary topology.
+    ///
+    /// Validates metadata before returning so callers cannot accidentally wrap a
+    /// backend with a mismatched dimension or zero time slices.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidTriangulationMetadata`] if the supplied
+    /// metadata is inconsistent with the backend or topology.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::CdtTriangulation;
+    ///
+    /// let backend = MockBackend::create_triangle();
+    /// let tri = CdtTriangulation::try_new(backend, 2, 2)
+    ///     .expect("metadata matches backend");
+    /// assert_eq!(tri.time_slices(), 2);
+    /// ```
+    pub fn try_new(geometry: B, time_slices: u32, dimension: u8) -> CdtResult<Self> {
+        let tri = Self::wrap_unchecked(geometry, time_slices, dimension, CdtTopology::OpenBoundary);
+        tri.validate_metadata()?;
+        Ok(tri)
+    }
+
     /// Create new CDT triangulation with explicit topology.
     ///
     /// Wraps an existing geometry backend and tags it with [`CdtTopology`].
@@ -217,6 +245,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ) -> CdtResult<Self> {
         let mut tri = Self::wrap_unchecked(geometry, time_slices, dimension, topology);
         tri.apply_time_slices(time_slices)?;
+        tri.validate_metadata()?;
         Ok(tri)
     }
 
@@ -247,12 +276,46 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
 
     /// Encodes topology-specific time-slice metadata invariants in one reusable check.
     fn check_time_slices(topology: CdtTopology, time_slices: u32) -> CdtResult<()> {
+        if time_slices == 0 {
+            return Err(CdtError::InvalidTriangulationMetadata {
+                field: "timeslices".to_string(),
+                topology: Self::topology_label(topology).to_string(),
+                provided_value: "0".to_string(),
+                expected: "≥ 1".to_string(),
+            });
+        }
+
         if matches!(topology, CdtTopology::Toroidal) && time_slices < 3 {
             return Err(CdtError::InvalidTriangulationMetadata {
                 field: "timeslices".to_string(),
-                topology: "toroidal".to_string(),
+                topology: Self::topology_label(topology).to_string(),
                 provided_value: time_slices.to_string(),
                 expected: "≥ 3".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Human-readable topology label for metadata diagnostics.
+    const fn topology_label(topology: CdtTopology) -> &'static str {
+        match topology {
+            CdtTopology::OpenBoundary => "open boundary",
+            CdtTopology::Toroidal => "toroidal",
+        }
+    }
+
+    /// Validates CDT metadata against backend and topology invariants.
+    fn validate_metadata(&self) -> CdtResult<()> {
+        Self::check_time_slices(self.metadata.topology, self.metadata.time_slices)?;
+
+        let backend_dimension = self.geometry.dimension();
+        if usize::from(self.metadata.dimension) != backend_dimension {
+            return Err(CdtError::InvalidTriangulationMetadata {
+                field: "dimension".to_string(),
+                topology: Self::topology_label(self.metadata.topology).to_string(),
+                provided_value: self.metadata.dimension.to_string(),
+                expected: format!("backend dimension ({backend_dimension})"),
             });
         }
 
@@ -433,6 +496,8 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// assert!(tri.validate_topology().is_ok());
     /// ```
     pub fn validate_topology(&self) -> CdtResult<()> {
+        self.validate_metadata()?;
+
         let euler_char = self.geometry.euler_characteristic();
 
         if self.dimension() == 2 {
@@ -444,19 +509,13 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
             };
 
             if !expected.contains(&euler_char) {
-                let topo_label = match self.metadata.topology {
-                    CdtTopology::OpenBoundary => "open boundary (expected χ=1 or 2)",
-                    CdtTopology::Toroidal => "toroidal (expected χ=0)",
-                };
-                return Err(CdtError::ValidationFailed {
-                    check: "topology".to_string(),
-                    detail: format!(
-                        "Euler characteristic χ={euler_char} unexpected for 2D {topo_label} \
-                         triangulation (V={}, E={}, F={})",
-                        self.geometry.vertex_count(),
-                        self.geometry.edge_count(),
-                        self.geometry.face_count(),
-                    ),
+                return Err(CdtError::TopologyMismatch {
+                    topology: Self::topology_label(self.metadata.topology).to_string(),
+                    euler_characteristic: euler_char,
+                    expected_euler_characteristics: expected.to_vec(),
+                    vertices: self.geometry.vertex_count(),
+                    edges: self.geometry.edge_count(),
+                    faces: self.geometry.face_count(),
                 });
             }
         }
@@ -927,14 +986,14 @@ impl<B> CdtGeometryMut<'_, B> {
     }
 }
 
-impl<B> std::ops::Deref for CdtGeometryMut<'_, B> {
+impl<B> Deref for CdtGeometryMut<'_, B> {
     type Target = B;
     fn deref(&self) -> &Self::Target {
         self.geometry
     }
 }
 
-impl<B> std::ops::DerefMut for CdtGeometryMut<'_, B> {
+impl<B> DerefMut for CdtGeometryMut<'_, B> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.mark_backend_mutation();
         self.geometry
@@ -1022,49 +1081,31 @@ impl CdtTriangulation<DelaunayBackend2D> {
         backend: &DelaunayBackend2D,
         num_slices: u32,
     ) -> CdtResult<Vec<usize>> {
-        const UNLABELED_VERTEX_EXAMPLE_LIMIT: usize = 4;
-
         if num_slices == 0 {
-            return Err(CdtError::ValidationFailed {
-                check: "foliation".to_string(),
-                detail: "cannot validate foliation with 0 time slices".to_string(),
-            });
+            return Err(FoliationError::SliceSizeMismatch {
+                slice_sizes_len: 0,
+                num_slices,
+            }
+            .into());
         }
 
         let mut slice_sizes = vec![0usize; num_slices as usize];
-        let mut unlabeled_vertex_count = 0usize;
-        let mut unlabeled_vertex_examples = Vec::with_capacity(UNLABELED_VERTEX_EXAMPLE_LIMIT);
 
-        for vh in backend.vertices() {
+        for (vertex, vh) in backend.vertices().enumerate() {
             if let Some(t) = backend.vertex_data_by_key(vh.vertex_key()) {
                 let idx = t as usize;
                 if idx >= slice_sizes.len() {
-                    return Err(CdtError::ValidationFailed {
-                        check: "foliation".to_string(),
-                        detail: format!(
-                            "vertex {:?} has out-of-range time label {t}; expected 0..{}",
-                            vh.vertex_key(),
-                            slice_sizes.len(),
-                        ),
-                    });
+                    return Err(FoliationError::OutOfRangeVertexLabel {
+                        vertex,
+                        label: t,
+                        expected_range_end: slice_sizes.len(),
+                    }
+                    .into());
                 }
                 slice_sizes[idx] += 1;
             } else {
-                unlabeled_vertex_count += 1;
-                if unlabeled_vertex_examples.len() < UNLABELED_VERTEX_EXAMPLE_LIMIT {
-                    unlabeled_vertex_examples.push(format!("{:?}", vh.vertex_key()));
-                }
+                return Err(FoliationError::MissingVertexLabel { vertex }.into());
             }
-        }
-
-        if unlabeled_vertex_count > 0 {
-            return Err(CdtError::ValidationFailed {
-                check: "foliation".to_string(),
-                detail: format!(
-                    "{unlabeled_vertex_count} vertices are missing time labels; example vertex keys (up to {UNLABELED_VERTEX_EXAMPLE_LIMIT}): [{}]",
-                    unlabeled_vertex_examples.join(", "),
-                ),
-            });
         }
 
         Ok(slice_sizes)
@@ -1103,7 +1144,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
         let dt = generate_delaunay2(vertices, (0.0, 10.0), None)?;
         let backend = DelaunayBackend2D::from_triangulation(dt);
 
-        Ok(Self::new(backend, time_slices, dimension))
+        Self::try_new(backend, time_slices, dimension)
     }
 
     /// Create a new CDT triangulation with Delaunay backend from random points using a fixed seed.
@@ -1144,7 +1185,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
         let dt = generate_delaunay2(vertices, (0.0, 10.0), Some(seed))?;
         let backend = DelaunayBackend2D::from_triangulation(dt);
 
-        Ok(Self::new(backend, time_slices, dimension))
+        Self::try_new(backend, time_slices, dimension)
     }
 
     /// Wrap a labeled 2D Delaunay backend and derive foliation from vertex data.
@@ -1185,6 +1226,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
             return Err(CdtError::UnsupportedDimension(dimension.into()));
         }
 
+        Self::check_time_slices(CdtTopology::OpenBoundary, time_slices)?;
         let slice_sizes = Self::live_slice_sizes_from_vertex_labels(&backend, time_slices)?;
         for (slice, &size) in slice_sizes.iter().enumerate() {
             if size == 0 {
@@ -1194,7 +1236,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
         let foliation =
             Foliation::from_slice_sizes(slice_sizes, time_slices).map_err(CdtError::from)?;
 
-        let mut tri = Self::new(backend, time_slices, dimension);
+        let mut tri = Self::try_new(backend, time_slices, dimension)?;
         tri.foliation = Some(foliation);
         tri.mark_foliation_synchronized();
         Ok(tri)
@@ -1362,7 +1404,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
 
         let foliation =
             Foliation::from_slice_sizes(slice_sizes, num_slices).map_err(CdtError::from)?;
-        let mut tri = Self::new(backend, num_slices, 2);
+        let mut tri = Self::try_new(backend, num_slices, 2)?;
         tri.foliation = Some(foliation);
         tri.mark_foliation_synchronized();
 
@@ -1400,7 +1442,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     ///
     /// Returns [`CdtError::InvalidGenerationParameters`] if `vertices_per_slice < 4` or
     /// `num_slices < 2`.
-    /// Returns [`CdtError::ValidationFailed`] because explicit CDT mesh construction is
+    /// Returns [`CdtError::UnsupportedOperation`] because explicit CDT mesh construction is
     /// not yet implemented.
     ///
     /// # Examples
@@ -1435,10 +1477,9 @@ impl CdtTriangulation<DelaunayBackend2D> {
         // 3. Splitting quads into valid CDT triangles
         // 4. Building backend without relying on Delaunay
 
-        Err(CdtError::ValidationFailed {
-            check: "cdt_construction".to_string(),
-            detail: "from_cdt_strip is not yet implemented: requires explicit mesh backend"
-                .to_string(),
+        Err(CdtError::UnsupportedOperation {
+            operation: "CdtTriangulation::from_cdt_strip".to_string(),
+            reason: "explicit CDT strip construction is not yet implemented; requires explicit mesh backend".to_string(),
         })
     }
 
@@ -1624,6 +1665,10 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// assert!(tri.has_foliation());
     /// assert_eq!(tri.slice_sizes().iter().sum::<usize>(), tri.vertex_count());
     /// ```
+    #[expect(
+        clippy::too_many_lines,
+        reason = "foliation assignment stages labels, writes backend payloads, and rolls back on failure to preserve atomic metadata/foliation invariants"
+    )]
     pub fn assign_foliation_by_y(&mut self, num_slices: u32) -> CdtResult<()> {
         if num_slices == 0 {
             return Err(CdtError::InvalidGenerationParameters {
@@ -1695,33 +1740,86 @@ impl CdtTriangulation<DelaunayBackend2D> {
         let foliation =
             Foliation::from_slice_sizes(slice_sizes, num_slices).map_err(CdtError::from)?;
 
-        self.apply_time_slices(num_slices)?;
+        Self::check_time_slices(self.metadata.topology, num_slices)?;
 
         // Clear stale cell classifications from any previous classify_all_cells() call,
         // since vertex time labels are about to change.
         let face_keys: Vec<_> = self.geometry.faces().map(|f| f.cell_key()).collect();
+        let previous_cell_data: Vec<_> = face_keys
+            .iter()
+            .map(|&key| (key, self.geometry.cell_data_by_key(key)))
+            .collect();
+        let previous_vertex_data: Vec<_> = assignments
+            .iter()
+            .map(|&(key, _)| (key, self.geometry.vertex_data_by_key(key)))
+            .collect();
+
+        let rollback_payloads = |geometry: &mut DelaunayBackend2D| -> Vec<String> {
+            let mut rollback_errors = Vec::new();
+
+            for &(key, data) in &previous_cell_data {
+                if let Err(err) = geometry.set_cell_data_by_key(key, data) {
+                    rollback_errors.push(format!("face {key:?}: {err}"));
+                }
+            }
+
+            for &(key, data) in &previous_vertex_data {
+                if let Err(err) = geometry.set_vertex_data_by_key(key, data) {
+                    rollback_errors.push(format!("vertex {key:?}: {err}"));
+                }
+            }
+
+            rollback_errors
+        };
 
         for &key in &face_keys {
             if let Err(err) = self.geometry.set_cell_data_by_key(key, None) {
-                return Err(CdtError::BackendMutationFailed {
-                    operation: "set_cell_data_by_key".to_string(),
-                    target: format!("face {key:?}"),
-                    detail: err.to_string(),
-                });
+                let operation = "set_cell_data_by_key".to_string();
+                let target = format!("face {key:?}");
+                let detail = err.to_string();
+                let rollback_errors = rollback_payloads(&mut self.geometry);
+                return if rollback_errors.is_empty() {
+                    Err(CdtError::BackendMutationFailed {
+                        operation,
+                        target,
+                        detail,
+                    })
+                } else {
+                    Err(CdtError::BackendRollbackFailed {
+                        operation,
+                        target,
+                        detail,
+                        rollback_errors: rollback_errors.join("; "),
+                    })
+                };
             }
         }
 
         // Write time labels directly to vertex data via set_vertex_data_by_key (O(1) per vertex).
         for (vertex_key, t) in assignments {
             if let Err(err) = self.geometry.set_vertex_data_by_key(vertex_key, Some(t)) {
-                return Err(CdtError::BackendMutationFailed {
-                    operation: "set_vertex_data_by_key".to_string(),
-                    target: format!("vertex {vertex_key:?}"),
-                    detail: format!("failed while assigning time label {t}: {err}"),
-                });
+                let operation = "set_vertex_data_by_key".to_string();
+                let target = format!("vertex {vertex_key:?}");
+                let detail = format!("failed while assigning time label {t}: {err}");
+                let rollback_errors = rollback_payloads(&mut self.geometry);
+                return if rollback_errors.is_empty() {
+                    Err(CdtError::BackendMutationFailed {
+                        operation,
+                        target,
+                        detail,
+                    })
+                } else {
+                    Err(CdtError::BackendRollbackFailed {
+                        operation,
+                        target,
+                        detail,
+                        rollback_errors: rollback_errors.join("; "),
+                    })
+                };
             }
         }
 
+        self.metadata.time_slices = num_slices;
         self.bump_modification_count();
         self.foliation = Some(foliation);
         self.mark_foliation_synchronized();
@@ -2557,6 +2655,78 @@ mod tests {
     }
 
     #[test]
+    fn test_try_new_rejects_zero_time_slices() {
+        let backend = labeled_triangle_backend([0, 0, 1]);
+        let result = CdtTriangulation::try_new(backend, 0, 2);
+
+        assert!(matches!(
+            result,
+            Err(CdtError::InvalidTriangulationMetadata {
+                ref field,
+                ref topology,
+                ref provided_value,
+                ref expected,
+            }) if field == "timeslices"
+                && topology == "open boundary"
+                && provided_value == "0"
+                && expected == "≥ 1"
+        ));
+    }
+
+    #[test]
+    fn test_try_new_rejects_dimension_mismatch() {
+        let backend = labeled_triangle_backend([0, 0, 1]);
+        let result = CdtTriangulation::try_new(backend, 2, 3);
+
+        assert!(matches!(
+            result,
+            Err(CdtError::InvalidTriangulationMetadata {
+                ref field,
+                ref topology,
+                ref provided_value,
+                ref expected,
+            }) if field == "dimension"
+                && topology == "open boundary"
+                && provided_value == "3"
+                && expected == "backend dimension (2)"
+        ));
+    }
+
+    #[test]
+    fn test_validate_topology_rejects_legacy_dimension_mismatch() {
+        let backend = labeled_triangle_backend([0, 0, 1]);
+        let tri = CdtTriangulation::new(backend, 2, 3);
+        let result = tri.validate_topology();
+
+        assert!(matches!(
+            result,
+            Err(CdtError::InvalidTriangulationMetadata {
+                ref field,
+                ref provided_value,
+                ref expected,
+                ..
+            }) if field == "dimension"
+                && provided_value == "3"
+                && expected == "backend dimension (2)"
+        ));
+    }
+
+    #[test]
+    fn test_from_seeded_points_rejects_zero_time_slices() {
+        let result = CdtTriangulation::from_seeded_points(5, 0, 2, 53);
+
+        assert!(matches!(
+            result,
+            Err(CdtError::InvalidTriangulationMetadata {
+                ref field,
+                ref provided_value,
+                ref expected,
+                ..
+            }) if field == "timeslices" && provided_value == "0" && expected == "≥ 1"
+        ));
+    }
+
+    #[test]
     fn test_invalid_vertex_count() {
         let invalid_counts = [0, 1, 2];
         for count in invalid_counts {
@@ -3003,13 +3173,17 @@ mod tests {
     }
 
     #[test]
-    fn test_zero_time_slices() {
+    fn test_zero_time_slices_rejected() {
         let result = CdtTriangulation::from_random_points(5, 0, 2);
-        // This should still work - time_slices is just metadata
-        assert!(result.is_ok(), "Should allow 0 time slices");
-
-        let triangulation = result.unwrap();
-        assert_eq!(triangulation.time_slices(), 0);
+        assert!(matches!(
+            result,
+            Err(CdtError::InvalidTriangulationMetadata {
+                ref field,
+                ref provided_value,
+                ref expected,
+                ..
+            }) if field == "timeslices" && provided_value == "0" && expected == "≥ 1"
+        ));
     }
 
     #[test]
@@ -3344,9 +3518,12 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(CdtError::ValidationFailed { ref check, ref detail })
-                if check == "foliation"
-                    && detail == "cannot validate foliation with 0 time slices"
+            Err(CdtError::InvalidTriangulationMetadata {
+                ref field,
+                ref provided_value,
+                ref expected,
+                ..
+            }) if field == "timeslices" && provided_value == "0" && expected == "≥ 1"
         ));
     }
 
@@ -3383,8 +3560,9 @@ mod tests {
         let result = tri.validate_foliation();
         assert!(matches!(
             result,
-            Err(CdtError::ValidationFailed { ref check, ref detail })
-                if check == "foliation" && detail.contains("missing a time label")
+            Err(CdtError::Foliation(FoliationError::MissingVertexLabel {
+                vertex: 0
+            }))
         ));
     }
 
@@ -3414,10 +3592,11 @@ mod tests {
         let result = tri.validate_foliation();
         assert!(matches!(
             result,
-            Err(CdtError::ValidationFailed { ref check, ref detail })
-                if check == "foliation"
-                    && detail.contains("out-of-range time label 7")
-                    && detail.contains("expected 0..2")
+            Err(CdtError::Foliation(FoliationError::OutOfRangeVertexLabel {
+                vertex: 0,
+                label: 7,
+                expected_range_end: 2,
+            }))
         ));
     }
 
@@ -3447,10 +3626,7 @@ mod tests {
         let result = tri.validate_foliation();
         assert!(matches!(
             result,
-            Err(CdtError::ValidationFailed { ref check, ref detail })
-                if check == "foliation"
-                    && detail.contains("stored count")
-                    && detail.contains("live labels report")
+            Err(CdtError::Foliation(FoliationError::LabelMismatch { .. }))
         ));
     }
 
@@ -3468,10 +3644,10 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(CdtError::ValidationFailed { ref check, ref detail })
-                if check == "foliation"
-                    && detail.contains("labeled vertex count (2)")
-                    && detail.contains("triangulation vertex count (3)")
+            Err(CdtError::Foliation(FoliationError::LabelCountMismatch {
+                labeled: 2,
+                expected: 3,
+            }))
         ));
     }
 
@@ -3484,8 +3660,11 @@ mod tests {
         let result = CdtTriangulation::from_labeled_delaunay(backend, 2, 2);
         assert!(matches!(
             result,
-            Err(CdtError::ValidationFailed { ref check, ref detail })
-                if check == "foliation" && detail.contains("out-of-range time label 5")
+            Err(CdtError::Foliation(FoliationError::OutOfRangeVertexLabel {
+                label: 5,
+                expected_range_end: 2,
+                ..
+            }))
         ));
     }
 
@@ -3498,8 +3677,7 @@ mod tests {
         let result = CdtTriangulation::from_labeled_delaunay(backend, 3, 2);
         assert!(matches!(
             result,
-            Err(CdtError::ValidationFailed { ref check, ref detail })
-                if check == "foliation" && detail.contains("time slice 1 is empty")
+            Err(CdtError::Foliation(FoliationError::EmptySlice { slice: 1 }))
         ));
     }
 
@@ -3601,9 +3779,9 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(CdtError::ValidationFailed { ref check, ref detail })
-                if check == "cdt_construction"
-                    && detail.contains("from_cdt_strip is not yet implemented")
+            Err(CdtError::UnsupportedOperation { ref operation, ref reason })
+                if operation == "CdtTriangulation::from_cdt_strip"
+                    && reason.contains("not yet implemented")
         ));
     }
 
@@ -3717,8 +3895,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(CdtError::ValidationFailed { ref check, ref detail })
-                if check == "foliation" && detail.contains("time slice") && detail.contains("empty")
+            Err(CdtError::Foliation(FoliationError::EmptySlice { .. }))
         ));
         assert_eq!(tri.time_slices(), initial_time_slices);
         assert_eq!(
@@ -4277,19 +4454,12 @@ mod tests {
 
     #[test]
     fn test_foliation_error_converts_to_cdt_error() {
-        // Verify From<FoliationError> for CdtError produces ValidationFailed
         let fol_err = FoliationError::EmptySlice { slice: 3 };
         let cdt_err: CdtError = fol_err.into();
 
         match cdt_err {
-            CdtError::ValidationFailed { check, detail } => {
-                assert_eq!(check, "foliation");
-                assert!(
-                    detail.contains('3') && detail.contains("empty"),
-                    "Detail should describe the empty slice: {detail}"
-                );
-            }
-            other => panic!("Expected ValidationFailed, got {other:?}"),
+            CdtError::Foliation(FoliationError::EmptySlice { slice }) => assert_eq!(slice, 3),
+            other => panic!("Expected Foliation error, got {other:?}"),
         }
     }
 
@@ -4303,16 +4473,16 @@ mod tests {
         let cdt_err: CdtError = fol_err.into();
 
         match cdt_err {
-            CdtError::ValidationFailed { check, detail } => {
-                assert_eq!(check, "foliation");
-                assert!(
-                    detail.contains("vertex index 2")
-                        && detail.contains("out-of-range time label 7")
-                        && detail.contains("expected 0..2"),
-                    "Detail should preserve out-of-range label context: {detail}"
-                );
+            CdtError::Foliation(FoliationError::OutOfRangeVertexLabel {
+                vertex,
+                label,
+                expected_range_end,
+            }) => {
+                assert_eq!(vertex, 2);
+                assert_eq!(label, 7);
+                assert_eq!(expected_range_end, 2);
             }
-            other => panic!("Expected ValidationFailed, got {other:?}"),
+            other => panic!("Expected Foliation error, got {other:?}"),
         }
     }
 
@@ -4482,9 +4652,12 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(CdtError::ValidationFailed { ref check, ref detail })
-                if check == "topology"
-                    && detail.contains("open boundary (expected χ=1 or 2)")
+            Err(CdtError::TopologyMismatch {
+                ref topology,
+                euler_characteristic: 0,
+                ref expected_euler_characteristics,
+                ..
+            }) if topology == "open boundary" && expected_euler_characteristics == &[1, 2]
         ));
     }
 
@@ -4501,8 +4674,12 @@ mod tests {
         let result = tri.validate_topology();
         assert!(matches!(
             result,
-            Err(CdtError::ValidationFailed { ref check, ref detail })
-                if check == "topology" && detail.contains("toroidal (expected χ=0)")
+            Err(CdtError::TopologyMismatch {
+                ref topology,
+                euler_characteristic: 1,
+                ref expected_euler_characteristics,
+                ..
+            }) if topology == "toroidal" && expected_euler_characteristics == &[0]
         ));
     }
 
@@ -4889,8 +5066,13 @@ mod prop_tests {
         ) {
             let result = CdtTriangulation::from_random_points(vertices, timeslices, 2);
 
-            if vertices >= 3 {
-                prop_assert!(result.is_ok(), "Should succeed with valid vertex count: {}", vertices);
+            if vertices >= 3 && timeslices >= 1 {
+                prop_assert!(
+                    result.is_ok(),
+                    "Should succeed with valid vertex/time-slice count: vertices={}, timeslices={}",
+                    vertices,
+                    timeslices
+                );
 
                 let triangulation = result.unwrap();
                 let vertex_count_u32 =
@@ -4899,7 +5081,12 @@ mod prop_tests {
                 prop_assert_eq!(triangulation.time_slices(), timeslices, "Time slices should match input");
                 prop_assert_eq!(triangulation.dimension(), 2, "Dimension should be 2");
             } else {
-                prop_assert!(result.is_err(), "Should fail with invalid vertex count: {}", vertices);
+                prop_assert!(
+                    result.is_err(),
+                    "Should fail with invalid parameters: vertices={}, timeslices={}",
+                    vertices,
+                    timeslices
+                );
             }
         }
 

--- a/src/cdt/triangulation.rs
+++ b/src/cdt/triangulation.rs
@@ -1737,10 +1737,10 @@ impl CdtTriangulation<DelaunayBackend2D> {
             slice_sizes[t as usize] += 1;
         }
 
+        Self::check_time_slices(self.metadata.topology, num_slices)?;
+
         let foliation =
             Foliation::from_slice_sizes(slice_sizes, num_slices).map_err(CdtError::from)?;
-
-        Self::check_time_slices(self.metadata.topology, num_slices)?;
 
         // Clear stale cell classifications from any previous classify_all_cells() call,
         // since vertex time labels are about to change.

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use crate::cdt::metropolis::MetropolisConfig;
 use crate::errors::{CdtError, CdtResult};
 use clap::{Parser, ValueEnum};
 use dirs::home_dir;
+use std::fmt::Display;
 use std::path::{Component, Path, PathBuf};
 
 /// Topology of the spatial slices in the CDT triangulation.
@@ -83,8 +84,8 @@ pub struct CdtConfig {
     #[arg(long, default_value = "0.1")]
     pub cosmological_constant: f64,
 
-    /// Run full CDT simulation (default: true; disable to only generate triangulation)
-    #[arg(long, default_value_t = true)]
+    /// Run full CDT simulation (currently requires real move kernels from #55)
+    #[arg(long, default_value_t = false)]
     pub simulate: bool,
 
     /// Optional RNG seed for reproducible simulations
@@ -286,10 +287,14 @@ fn normalize_components(path: &Path) -> PathBuf {
             Component::ParentDir => {
                 // Don't pop if the path is empty or we're at the root
                 let mut components = normalized.components();
-                let at_root = components.next().is_some_and(|first| {
-                    components.next().is_none()
-                        && matches!(first, Component::RootDir | Component::Prefix(_))
-                });
+                let at_root = match components.next() {
+                    Some(Component::RootDir) => components.next().is_none(),
+                    Some(Component::Prefix(_)) => {
+                        matches!(components.next(), Some(Component::RootDir))
+                            && components.next().is_none()
+                    }
+                    _ => false,
+                };
                 let ends_with_parent = normalized
                     .components()
                     .next_back()
@@ -322,20 +327,16 @@ fn normalize_components(path: &Path) -> PathBuf {
 }
 
 /// Builds a typed configuration error from displayable values without duplicating field names.
-fn invalid_configuration(
+fn invalid_config(
     setting: &str,
-    provided_value: &impl std::fmt::Display,
-    expected: &impl std::fmt::Display,
+    provided_value: &impl Display,
+    expected: &impl Display,
 ) -> CdtError {
-    invalid_configuration_from_parts(setting, provided_value.to_string(), expected.to_string())
+    invalid_config_parts(setting, provided_value.to_string(), expected.to_string())
 }
 
 /// Preserves already-formatted validation values when shared validators produce owned strings.
-fn invalid_configuration_from_parts(
-    setting: &str,
-    provided_value: String,
-    expected: String,
-) -> CdtError {
+fn invalid_config_parts(setting: &str, provided_value: String, expected: String) -> CdtError {
     CdtError::InvalidConfiguration {
         setting: setting.to_string(),
         provided_value,
@@ -343,8 +344,17 @@ fn invalid_configuration_from_parts(
     }
 }
 
-/// Shares simulation schedule validation between top-level config and Metropolis config.
-pub(crate) fn validate_simulation_settings(
+/// Rejects non-finite action couplings before they can poison action/log-probability math.
+fn validate_coupling(setting: &str, value: f64) -> CdtResult<()> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(invalid_config(setting, &value, &"finite"))
+    }
+}
+
+/// Shares schedule validation between top-level config and Metropolis config.
+pub(crate) fn validate_schedule(
     temperature: f64,
     steps: u32,
     thermalization_steps: u32,
@@ -410,6 +420,14 @@ pub(crate) fn validate_simulation_settings(
 
 impl CdtConfig {
     /// Builds a new instance of `CdtConfig` from command line arguments.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use causal_triangulations::CdtConfig;
+    ///
+    /// let _config = CdtConfig::from_args();
+    /// ```
     #[must_use]
     pub fn from_args() -> Self {
         Self::parse()
@@ -440,7 +458,7 @@ impl CdtConfig {
             coupling_0: 1.0,
             coupling_2: 1.0,
             cosmological_constant: 0.1,
-            simulate: true,
+            simulate: false,
             seed: None,
             topology: CdtTopology::OpenBoundary,
         }
@@ -530,22 +548,22 @@ impl CdtConfig {
     /// ```
     pub fn validate(&self) -> CdtResult<()> {
         if self.vertices < 3 {
-            return Err(invalid_configuration("vertices", &self.vertices, &"≥ 3"));
+            return Err(invalid_config("vertices", &self.vertices, &"≥ 3"));
         }
 
         if self.timeslices == 0 {
-            return Err(invalid_configuration(
-                "timeslices",
-                &self.timeslices,
-                &"≥ 1",
-            ));
+            return Err(invalid_config("timeslices", &self.timeslices, &"≥ 1"));
         }
 
         if let Some(dim) = self.dimension
             && !(2..=3).contains(&dim)
         {
-            return Err(invalid_configuration("dimension", &dim, &"2 or 3"));
+            return Err(invalid_config("dimension", &dim, &"2 or 3"));
         }
+
+        validate_coupling("coupling_0", self.coupling_0)?;
+        validate_coupling("coupling_2", self.coupling_2)?;
+        validate_coupling("cosmological_constant", self.cosmological_constant)?;
 
         if matches!(self.topology, CdtTopology::Toroidal) {
             // Toroidal topology requires T ≥ 3 (T = 2 makes adjacent slices
@@ -554,14 +572,14 @@ impl CdtConfig {
             // slices with at least 3 per slice (any fewer and the spatial
             // ring degenerates).
             if self.timeslices < 3 {
-                return Err(invalid_configuration(
+                return Err(invalid_config(
                     "timeslices",
                     &self.timeslices,
                     &"≥ 3 for toroidal topology",
                 ));
             }
             if !self.vertices.is_multiple_of(self.timeslices) {
-                return Err(invalid_configuration_from_parts(
+                return Err(invalid_config_parts(
                     "vertices",
                     self.vertices.to_string(),
                     format!(
@@ -571,14 +589,14 @@ impl CdtConfig {
                 ));
             }
             let min_total = self.timeslices.checked_mul(3).ok_or_else(|| {
-                invalid_configuration_from_parts(
+                invalid_config_parts(
                     "timeslices",
                     self.timeslices.to_string(),
                     "3 · timeslices must fit in u32 for toroidal topology".to_string(),
                 )
             })?;
             if self.vertices < min_total {
-                return Err(invalid_configuration_from_parts(
+                return Err(invalid_config_parts(
                     "vertices",
                     self.vertices.to_string(),
                     format!("≥ 3 · timeslices ({min_total}) for toroidal topology"),
@@ -586,13 +604,13 @@ impl CdtConfig {
             }
         }
 
-        validate_simulation_settings(
+        validate_schedule(
             self.temperature,
             self.steps,
             self.thermalization_steps,
             self.measurement_frequency,
             |setting, provided_value, expected| {
-                invalid_configuration_from_parts(setting, provided_value, expected)
+                invalid_config_parts(setting, provided_value, expected)
             },
         )
     }
@@ -626,7 +644,7 @@ impl TestConfig {
             coupling_0: 1.0,
             coupling_2: 1.0,
             cosmological_constant: 0.1,
-            simulate: true,
+            simulate: false,
             seed: None,
             topology: CdtTopology::OpenBoundary,
         }
@@ -655,7 +673,7 @@ impl TestConfig {
             coupling_0: 1.0,
             coupling_2: 1.0,
             cosmological_constant: 0.1,
-            simulate: true,
+            simulate: false,
             seed: None,
             topology: CdtTopology::OpenBoundary,
         }
@@ -684,7 +702,7 @@ impl TestConfig {
             coupling_0: 1.0,
             coupling_2: 1.0,
             cosmological_constant: 0.1,
-            simulate: true,
+            simulate: false,
             seed: None,
             topology: CdtTopology::OpenBoundary,
         }
@@ -704,7 +722,7 @@ mod tests {
         assert_eq!(config.vertices, 32);
         assert_eq!(config.timeslices, 3);
         assert_eq!(config.dimension(), 2);
-        assert!(config.simulate);
+        assert!(!config.simulate);
     }
 
     #[test]
@@ -811,6 +829,39 @@ mod tests {
                 expected,
             }) if setting == "dimension" && provided_value == "4" && expected == "2 or 3"
         ));
+
+        for (setting, value) in [
+            ("coupling_0", f64::NAN),
+            ("coupling_2", f64::INFINITY),
+            ("cosmological_constant", f64::NEG_INFINITY),
+        ] {
+            let mut invalid_action_coupling = CdtConfig::new(32, 3);
+            match setting {
+                "coupling_0" => invalid_action_coupling.coupling_0 = value,
+                "coupling_2" => invalid_action_coupling.coupling_2 = value,
+                "cosmological_constant" => invalid_action_coupling.cosmological_constant = value,
+                _ => unreachable!("test case should name a known action coupling"),
+            }
+            assert!(matches!(
+                invalid_action_coupling.validate(),
+                Err(CdtError::InvalidConfiguration {
+                    setting: invalid_setting,
+                    expected,
+                    ..
+                }) if invalid_setting == setting && expected == "finite"
+            ));
+        }
+
+        let finite_action_couplings = CdtConfig {
+            coupling_0: -1.5,
+            coupling_2: 0.0,
+            cosmological_constant: 2.25,
+            ..CdtConfig::new(32, 3)
+        };
+        assert!(
+            finite_action_couplings.validate().is_ok(),
+            "finite signed action couplings should be accepted"
+        );
 
         let measurement_frequency_exceeds_steps = CdtConfig {
             measurement_frequency: 2_000,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -82,6 +82,27 @@ pub enum CdtError {
         /// Human-readable description of the failure
         detail: String,
     },
+    /// Topology metadata does not match the backend Euler characteristic.
+    #[error(
+        "Topology mismatch for {topology}: Euler characteristic χ={euler_characteristic}, expected one of {expected_euler_characteristics:?} (V={vertices}, E={edges}, F={faces})"
+    )]
+    TopologyMismatch {
+        /// Topology requested by CDT metadata.
+        topology: String,
+        /// Observed Euler characteristic from the backend.
+        euler_characteristic: i32,
+        /// Accepted Euler characteristics for the requested topology.
+        expected_euler_characteristics: Vec<i32>,
+        /// Backend vertex count at validation time.
+        vertices: usize,
+        /// Backend edge count at validation time.
+        edges: usize,
+        /// Backend face count at validation time.
+        faces: usize,
+    },
+    /// Foliation construction or validation failed with a typed foliation error.
+    #[error("Foliation validation failed: {0}")]
+    Foliation(#[from] FoliationError),
     /// Vertex construction failed during triangulation generation
     #[error("Vertex construction failed [{context}]: {underlying_error}")]
     VertexBuildFailed {
@@ -99,6 +120,28 @@ pub enum CdtError {
         target: String,
         /// Additional failure detail.
         detail: String,
+    },
+    /// Backend mutation failed and restoring previously staged payloads also failed.
+    #[error(
+        "Backend mutation failed [{operation}] on {target}: {detail}; rollback failed: {rollback_errors}"
+    )]
+    BackendRollbackFailed {
+        /// Mutation operation being attempted when the first failure occurred.
+        operation: String,
+        /// Human-readable target handle for the first failure.
+        target: String,
+        /// Primary mutation failure detail.
+        detail: String,
+        /// Rollback failure details for one or more payloads.
+        rollback_errors: String,
+    },
+    /// Requested operation is part of the planned API surface but is not implemented yet.
+    #[error("Unsupported operation [{operation}]: {reason}")]
+    UnsupportedOperation {
+        /// Operation being requested.
+        operation: String,
+        /// Human-readable explanation and migration/status detail.
+        reason: String,
     },
     /// An edge violates the causal structure by spanning more than one time slice
     /// (or, on toroidal topology, more than one *circular* slice step).
@@ -147,21 +190,13 @@ impl From<markov_chain_monte_carlo::McmcError> for CdtError {
     }
 }
 
-impl From<FoliationError> for CdtError {
-    fn from(err: FoliationError) -> Self {
-        Self::ValidationFailed {
-            check: "foliation".to_string(),
-            detail: err.to_string(),
-        }
-    }
-}
-
 /// Result type for CDT operations.
 pub type CdtResult<T> = Result<T, CdtError>;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error;
 
     #[test]
     fn test_invalid_configuration_error() {
@@ -248,13 +283,40 @@ mod tests {
     #[test]
     fn test_validation_failed_error() {
         let error = CdtError::ValidationFailed {
-            check: "topology".to_string(),
-            detail: "Euler characteristic χ=3 unexpected (V=5, E=8, F=6)".to_string(),
+            check: "geometry".to_string(),
+            detail: "backend reported invalid triangulation structure".to_string(),
         };
         let display = format!("{error}");
         assert_eq!(
             display,
-            "Validation failed [topology]: Euler characteristic χ=3 unexpected (V=5, E=8, F=6)"
+            "Validation failed [geometry]: backend reported invalid triangulation structure"
+        );
+    }
+
+    #[test]
+    fn test_topology_mismatch_error() {
+        let error = CdtError::TopologyMismatch {
+            topology: "toroidal".to_string(),
+            euler_characteristic: 1,
+            expected_euler_characteristics: vec![0],
+            vertices: 3,
+            edges: 3,
+            faces: 1,
+        };
+        let display = format!("{error}");
+        assert_eq!(
+            display,
+            "Topology mismatch for toroidal: Euler characteristic χ=1, expected one of [0] (V=3, E=3, F=1)"
+        );
+    }
+
+    #[test]
+    fn test_foliation_error_variant() {
+        let error = CdtError::Foliation(FoliationError::EmptySlice { slice: 3 });
+        let display = format!("{error}");
+        assert_eq!(
+            display,
+            "Foliation validation failed: time slice 3 is empty"
         );
     }
 
@@ -272,6 +334,22 @@ mod tests {
     }
 
     #[test]
+    fn test_backend_rollback_failed_error() {
+        let error = CdtError::BackendRollbackFailed {
+            operation: "set_vertex_data_by_key".to_string(),
+            target: "vertex VertexKey(123v1)".to_string(),
+            detail: "backend reported invalid vertex key".to_string(),
+            rollback_errors: "vertex VertexKey(7v1): backend reported invalid vertex key"
+                .to_string(),
+        };
+        let display = format!("{error}");
+        assert_eq!(
+            display,
+            "Backend mutation failed [set_vertex_data_by_key] on vertex VertexKey(123v1): backend reported invalid vertex key; rollback failed: vertex VertexKey(7v1): backend reported invalid vertex key"
+        );
+    }
+
+    #[test]
     fn test_backend_mutation_failed_error() {
         let error = CdtError::BackendMutationFailed {
             operation: "set_vertex_data".to_string(),
@@ -282,6 +360,19 @@ mod tests {
         assert_eq!(
             display,
             "Backend mutation failed [set_vertex_data] on vertex VertexKey(123v1): backend reported invalid vertex key"
+        );
+    }
+
+    #[test]
+    fn test_unsupported_operation_error() {
+        let error = CdtError::UnsupportedOperation {
+            operation: "MetropolisAlgorithm::run".to_string(),
+            reason: "real CDT ergodic moves are not implemented yet".to_string(),
+        };
+        let display = format!("{error}");
+        assert_eq!(
+            display,
+            "Unsupported operation [MetropolisAlgorithm::run]: real CDT ergodic moves are not implemented yet"
         );
     }
 
@@ -401,8 +492,6 @@ mod tests {
 
     #[test]
     fn test_std_error_trait() {
-        use std::error::Error;
-
         let error = CdtError::InvalidConfiguration {
             setting: "temperature".to_string(),
             provided_value: "NaN".to_string(),

--- a/src/geometry/operations.rs
+++ b/src/geometry/operations.rs
@@ -65,14 +65,9 @@ impl<V: Eq + Hash> Eq for UnorderedSet<V> {}
 impl<V: Hash> Hash for UnorderedSet<V> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Order-independent, duplicate-robust hash by hashing each unique element and sorting.
-        let mut hashes: Vec<u64> = self
-            .0
-            .iter()
-            .map(stable_hash)
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect();
+        let mut hashes: Vec<u64> = self.0.iter().map(stable_hash).collect();
         hashes.sort_unstable();
+        hashes.dedup();
         for h in hashes {
             state.write_u64(h);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@
 //!
 //! - Integration with delaunay crate for proper Delaunay triangulations
 //! - 2D Regge Action calculation for CDT
-//! - Standard ergodic moves: (2,2), (1,3), and edge flips
-//! - Metropolis-Hastings algorithm with configurable temperature
-//! - Comprehensive statistics and measurement collection
+//! - Foliated 2D triangulation construction and validation
+//! - Planned ergodic moves and Metropolis-Hastings sampling once real CDT
+//!   move kernels are implemented
 //!
 //! # Example
 //!
@@ -91,12 +91,13 @@ pub mod cdt {
 pub use cdt::action::{ActionConfig, compute_regge_action};
 pub use cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveType};
 pub use cdt::foliation::{CellType, EdgeType, Foliation};
-pub use cdt::metropolis::{CdtProposal, CdtTarget};
-pub use cdt::metropolis::{MetropolisAlgorithm, MetropolisConfig, SimulationResultsBackend};
+pub use cdt::metropolis::{
+    CdtProposal, CdtTarget, Measurement, MetropolisAlgorithm, MetropolisConfig, MonteCarloStep,
+    SimulationResultsBackend,
+};
 pub use config::{CdtConfig, CdtTopology, TestConfig};
 pub use errors::{CdtError, CdtResult};
 
-use cdt::metropolis::Measurement;
 use std::time::Duration;
 
 // Trait-based triangulation (recommended)
@@ -133,7 +134,8 @@ pub mod prelude {
 
     // Metropolis simulation
     pub use crate::cdt::metropolis::{
-        CdtProposal, CdtTarget, MetropolisAlgorithm, MetropolisConfig,
+        CdtProposal, CdtTarget, Measurement, MetropolisAlgorithm, MetropolisConfig, MonteCarloStep,
+        SimulationResultsBackend,
     };
 
     // Configuration and errors
@@ -177,7 +179,8 @@ pub mod prelude {
         pub use crate::cdt::action::{ActionConfig, compute_regge_action};
         pub use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveType};
         pub use crate::cdt::metropolis::{
-            CdtProposal, CdtTarget, MetropolisAlgorithm, MetropolisConfig,
+            CdtProposal, CdtTarget, Measurement, MetropolisAlgorithm, MetropolisConfig,
+            MonteCarloStep, SimulationResultsBackend,
         };
         pub use crate::config::{CdtConfig, CdtTopology};
         pub use crate::errors::{CdtError, CdtResult};
@@ -255,12 +258,13 @@ pub mod prelude {
 ///     thermalization_steps: 0,
 ///     measurement_frequency: 1,
 ///     seed: Some(7),
+///     simulate: false,
 ///     ..CdtConfig::new(5, 2)
 /// };
 /// let results = run_simulation(&config).unwrap();
-/// assert_eq!(results.steps.len(), 1);
+/// assert_eq!(results.measurements.len(), 1);
 /// ```
-pub fn run_simulation(config: &CdtConfig) -> CdtResult<cdt::metropolis::SimulationResultsBackend> {
+pub fn run_simulation(config: &CdtConfig) -> CdtResult<SimulationResultsBackend> {
     // Validate configuration early to fail fast with clear error messages
     config.validate()?;
 
@@ -286,12 +290,12 @@ pub fn run_simulation(config: &CdtConfig) -> CdtResult<cdt::metropolis::Simulati
     // `vertices % timeslices == 0` and `vertices >= 3 * timeslices`, so we
     // can safely divide to recover N = vertices/T per slice.
     let triangulation = match config.topology {
-        config::CdtTopology::Toroidal => {
+        CdtTopology::Toroidal => {
             log::info!("Constructing toroidal CDT (S¹×S¹)");
             let vertices_per_slice = vertices / timeslices;
             CdtTriangulation::from_toroidal_cdt(vertices_per_slice, timeslices)?
         }
-        config::CdtTopology::OpenBoundary => {
+        CdtTopology::OpenBoundary => {
             if let Some(seed) = config.seed {
                 log::info!("RNG seed: {seed}");
                 CdtTriangulation::from_seeded_points(vertices, timeslices, 2, seed)?
@@ -332,7 +336,7 @@ pub fn run_simulation(config: &CdtConfig) -> CdtResult<cdt::metropolis::Simulati
             u32::try_from(triangulation.face_count()).unwrap_or_default(),
         );
 
-        Ok(cdt::metropolis::SimulationResultsBackend {
+        Ok(SimulationResultsBackend {
             config: config.to_metropolis_config(),
             action_config: config.to_action_config(),
             steps: vec![],
@@ -368,7 +372,7 @@ mod lib_tests {
             cosmological_constant: 0.1,
             simulate: false,
             seed: Some(42),
-            topology: config::CdtTopology::OpenBoundary,
+            topology: CdtTopology::OpenBoundary,
         }
     }
 
@@ -482,6 +486,22 @@ mod lib_tests {
     }
 
     #[test]
+    fn test_run_simulation_rejects_simulate_until_real_moves_land() {
+        let mut config = create_test_config();
+        config.simulate = true;
+
+        let result = run_simulation(&config);
+        assert!(matches!(
+            result,
+            Err(CdtError::UnsupportedOperation {
+                ref operation,
+                ref reason,
+            }) if operation == "MetropolisAlgorithm::run"
+                && reason.contains("real CDT ergodic moves are not implemented yet")
+        ));
+    }
+
+    #[test]
     fn test_config_conversions() {
         let config = create_test_config();
 
@@ -514,7 +534,7 @@ mod lib_tests {
             cosmological_constant: 0.1,
             simulate: false,
             seed: None,
-            topology: config::CdtTopology::Toroidal,
+            topology: CdtTopology::Toroidal,
         };
 
         let results = run_simulation(&config).expect("toroidal simulation should run");
@@ -530,7 +550,7 @@ mod lib_tests {
         );
         assert!(matches!(
             results.triangulation.metadata().topology,
-            config::CdtTopology::Toroidal
+            CdtTopology::Toroidal
         ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 //! and runs causal dynamical triangulations simulations.
 
 use causal_triangulations::{CdtConfig, run_simulation};
+use std::process::exit;
 
 fn main() {
     // Initialize logging
@@ -18,7 +19,7 @@ fn main() {
         }
         Err(e) => {
             log::error!("CDT simulation failed: {e}");
-            std::process::exit(1);
+            exit(1);
         }
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -106,7 +106,7 @@ fn cdt_cli_invalid_measurement_frequency_too_large() {
 }
 
 #[test]
-fn cdt_cli_accepts_boundary_aligned_measurement_schedule() {
+fn cdt_cli_rejects_simulate_until_real_moves_land() {
     let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
 
     cmd.arg("--vertices").arg("10");
@@ -118,7 +118,9 @@ fn cdt_cli_accepts_boundary_aligned_measurement_schedule() {
     cmd.arg("--simulate");
     cmd.env("RUST_LOG", "error");
 
-    cmd.assert().success();
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "Unsupported operation [MetropolisAlgorithm::run]",
+    ));
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6,7 +6,7 @@
 //! workflows, topology preservation, error handling, and consistency between components.
 
 use causal_triangulations::prelude::simulation::{
-    ActionConfig, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
+    ActionConfig, CdtError, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
 };
 use std::time::Instant;
 
@@ -14,8 +14,21 @@ use std::time::Instant;
 mod integration_tests {
     use super::*;
 
+    fn assert_unsupported_simulation(err: CdtError) {
+        match err {
+            CdtError::UnsupportedOperation { operation, reason } => {
+                assert_eq!(operation, "MetropolisAlgorithm::run");
+                assert!(
+                    reason.contains("real CDT ergodic moves are not implemented yet"),
+                    "Unexpected unsupported-operation reason: {reason}"
+                );
+            }
+            other => panic!("Expected UnsupportedOperation, got {other:?}"),
+        }
+    }
+
     #[test]
-    fn test_complete_cdt_simulation_workflow() {
+    fn test_complete_cdt_simulation_workflow_hits_guardrail() {
         // Test full CDT simulation pipeline
         let triangulation = CdtTriangulation::from_random_points(8, 2, 2)
             .expect("Failed to create initial triangulation");
@@ -24,29 +37,12 @@ mod integration_tests {
         let action_config = ActionConfig::default();
         let algorithm = MetropolisAlgorithm::new(config, action_config);
 
-        // Run simulation
-        let results = algorithm
+        // Real move kernels are not implemented yet, so simulation must fail
+        // explicitly instead of returning a misleading zero-move result.
+        let err = algorithm
             .run(triangulation)
-            .expect("Simulation should succeed");
-
-        // Verify results
-        assert!(!results.steps.is_empty(), "Simulation should produce steps");
-        assert!(
-            !results.measurements.is_empty(),
-            "Simulation should produce measurements"
-        );
-        assert!(
-            results.acceptance_rate() >= 0.0,
-            "Acceptance rate should be non-negative"
-        );
-        assert!(
-            results.acceptance_rate() <= 1.0,
-            "Acceptance rate should not exceed 1.0"
-        );
-        assert!(
-            results.average_action().is_finite(),
-            "Average action should be finite"
-        );
+            .expect_err("zero-move simulation should be rejected");
+        assert_unsupported_simulation(err);
     }
 
     #[test]
@@ -167,8 +163,8 @@ mod integration_tests {
     }
 
     #[test]
-    fn test_simulation_reproducibility() {
-        // Test that simulations with same parameters produce consistent results structure
+    fn test_simulation_guardrail_reproducibility() {
+        // Test that valid simulation inputs consistently reach the guardrail.
         let triangulation1 = CdtTriangulation::from_random_points(5, 1, 2)
             .expect("Failed to create first triangulation");
         let triangulation2 = CdtTriangulation::from_random_points(5, 1, 2)
@@ -180,28 +176,15 @@ mod integration_tests {
         let algorithm1 = MetropolisAlgorithm::new(config.clone(), action_config.clone());
         let algorithm2 = MetropolisAlgorithm::new(config, action_config);
 
-        let results1 = algorithm1
+        let err1 = algorithm1
             .run(triangulation1)
-            .expect("Run 1 should succeed");
-        let results2 = algorithm2
+            .expect_err("Run 1 should hit guardrail");
+        let err2 = algorithm2
             .run(triangulation2)
-            .expect("Run 2 should succeed");
+            .expect_err("Run 2 should hit guardrail");
 
-        // Results should have same structure (though values may differ due to randomness)
-        assert_eq!(
-            results1.steps.len(),
-            results2.steps.len(),
-            "Should have same number of steps"
-        );
-        assert_eq!(
-            results1.measurements.len(),
-            results2.measurements.len(),
-            "Should have same number of measurements"
-        );
-
-        // Both should produce valid results
-        assert!(results1.acceptance_rate().is_finite() && results1.acceptance_rate() >= 0.0);
-        assert!(results2.acceptance_rate().is_finite() && results2.acceptance_rate() >= 0.0);
+        assert_eq!(err1, err2);
+        assert_unsupported_simulation(err1);
     }
 
     #[test]

--- a/tests/proptest_foliation.rs
+++ b/tests/proptest_foliation.rs
@@ -3,19 +3,19 @@
 
 use causal_triangulations::prelude::geometry::DelaunayBackend2D;
 use causal_triangulations::prelude::triangulation::*;
-use causal_triangulations::{CdtError, CdtResult};
 use proptest::prelude::*;
 
 fn assert_cdt_strip_known_failure(result: CdtResult<CdtTriangulation<DelaunayBackend2D>>) {
     match result {
-        Err(CdtError::ValidationFailed { check, detail }) => {
+        Err(CdtError::UnsupportedOperation { operation, reason }) => {
             assert!(
-                check == "cdt_construction" && detail.contains("not yet implemented"),
-                "Expected explicit strip-construction placeholder failure, got check={check:?}, detail={detail}"
+                operation == "CdtTriangulation::from_cdt_strip"
+                    && reason.contains("not yet implemented"),
+                "Expected explicit strip-construction placeholder failure, got operation={operation:?}, reason={reason}"
             );
         }
         Ok(_) => panic!("Expected explicit strip-construction rejection"),
-        Err(other) => panic!("Expected ValidationFailed, got {other:?}"),
+        Err(other) => panic!("Expected UnsupportedOperation, got {other:?}"),
     }
 }
 
@@ -25,6 +25,69 @@ fn cdt_strip_known_limitation_regression_guard() {
 }
 
 proptest! {
+    /// Property: public point constructors reject zero time slices as invalid
+    /// CDT metadata instead of creating triangulations whose validators can
+    /// silently skip time-slice checks.
+    #[test]
+    fn seeded_point_constructor_rejects_zero_time_slices(
+        vertices in 3u32..20,
+        seed in 0u64..1000,
+    ) {
+        let result = CdtTriangulation::from_seeded_points(vertices, 0, 2, seed);
+        match result {
+            Err(CdtError::InvalidTriangulationMetadata {
+                field,
+                provided_value,
+                expected,
+                ..
+            }) => {
+                prop_assert_eq!(field, "timeslices");
+                prop_assert_eq!(provided_value, "0");
+                prop_assert_eq!(expected, "≥ 1");
+            }
+            other => prop_assert!(
+                false,
+                "expected invalid timeslices metadata error, got {other:?}"
+            ),
+        }
+    }
+
+    /// Property: valid metadata survives construction unchanged.
+    #[test]
+    fn seeded_point_constructor_preserves_valid_metadata(
+        vertices in 3u32..20,
+        time_slices in 1u32..8,
+        seed in 0u64..1000,
+    ) {
+        let tri = CdtTriangulation::from_seeded_points(vertices, time_slices, 2, seed)
+            .expect("valid seeded construction should preserve metadata");
+
+        prop_assert_eq!(tri.time_slices(), time_slices);
+        prop_assert_eq!(tri.dimension(), 2);
+    }
+
+    /// Property: explicit toroidal construction preserves core topological and
+    /// foliation invariants for small generated N×T meshes.
+    #[test]
+    fn toroidal_cdt_static_invariants(
+        vertices_per_slice in 3u32..8,
+        num_slices in 3u32..8,
+    ) {
+        let tri = CdtTriangulation::from_toroidal_cdt(vertices_per_slice, num_slices)
+            .expect("valid toroidal CDT should build");
+
+        let expected_vertices = vertices_per_slice as usize * num_slices as usize;
+        prop_assert_eq!(tri.vertex_count(), expected_vertices);
+        prop_assert_eq!(tri.face_count(), 2 * expected_vertices);
+        prop_assert_eq!(tri.edge_count(), 3 * expected_vertices);
+        prop_assert!(tri.has_foliation());
+        let expected_slice_sizes = vec![vertices_per_slice as usize; num_slices as usize];
+        prop_assert_eq!(tri.slice_sizes(), expected_slice_sizes.as_slice());
+        prop_assert!(tri.validate_topology().is_ok());
+        prop_assert!(tri.validate_foliation().is_ok());
+        prop_assert!(tri.validate_causality().is_ok());
+    }
+
     /// Property: Explicit CDT strip construction always produces valid foliation and causality.
     ///
     /// For any valid (vertices_per_slice, num_slices, seed):

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -82,14 +82,20 @@ fn stringly_domain_validation_errors() {
 
     // ruleid: causal-triangulations.rust.no-stringly-domain-validation-errors
     let _ = CdtError::ValidationFailed {
-        check: "topology".to_string(),
         detail: "bad Euler characteristic".to_string(),
+        check: String::from("topology"),
     };
 
     // ruleid: causal-triangulations.rust.no-stringly-domain-validation-errors
     let _ = CdtError::ValidationFailed {
-        check: "cdt_construction".to_string(),
+        check: "cdt_construction".into(),
         detail: "not implemented".to_string(),
+    };
+
+    // ruleid: causal-triangulations.rust.no-stringly-domain-validation-errors
+    let _ = CdtError::ValidationFailed {
+        detail: "slice count is invalid".to_string(),
+        check: "foliation",
     };
 
     // ok: causal-triangulations.rust.no-stringly-domain-validation-errors

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -65,3 +65,36 @@ trait ProductionDynamicErrors {
 
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 fn doctest_style_error_is_ignored() {}
+
+enum CdtError {
+    ValidationFailed { check: String, detail: String },
+    TopologyMismatch,
+    Foliation,
+    UnsupportedOperation,
+}
+
+fn stringly_domain_validation_errors() {
+    // ruleid: causal-triangulations.rust.no-stringly-domain-validation-errors
+    let _ = CdtError::ValidationFailed {
+        check: "foliation".to_string(),
+        detail: "missing label".to_string(),
+    };
+
+    // ruleid: causal-triangulations.rust.no-stringly-domain-validation-errors
+    let _ = CdtError::ValidationFailed {
+        check: "topology".to_string(),
+        detail: "bad Euler characteristic".to_string(),
+    };
+
+    // ruleid: causal-triangulations.rust.no-stringly-domain-validation-errors
+    let _ = CdtError::ValidationFailed {
+        check: "cdt_construction".to_string(),
+        detail: "not implemented".to_string(),
+    };
+
+    // ok: causal-triangulations.rust.no-stringly-domain-validation-errors
+    let _ = CdtError::ValidationFailed {
+        check: "geometry".to_string(),
+        detail: "backend rejected structure".to_string(),
+    };
+}


### PR DESCRIPTION
- Reject zero-move CDT simulations and placeholder ergodic moves with typed unsupported-operation errors.
- Validate CDT metadata, topology, action couplings, and foliation mutation paths before committing state changes.
- Add typed errors, property tests, doctests, and Semgrep coverage for validation and diagnostics.
- Update examples, benchmarks, CLI docs, and preludes for the guarded simulation behavior.