### PR TITLE
feat!: implement 2D CDT ergodic moves (#55)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ log = "0.4.29"
 num-traits = "0.2.19"
 rand = "0.10.1"
 serde = { version = "1.0.228", features = [ "derive" ] }
-thiserror = "2.0.17"
+thiserror = "2.0.18"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/benches/cdt_benchmarks.rs
+++ b/benches/cdt_benchmarks.rs
@@ -195,13 +195,14 @@ fn bench_ergodic_moves(c: &mut Criterion) {
                 ([1.0, 0.0], 0),
                 ([0.0, 1.0], 1),
                 ([1.0, 1.0], 1),
+                ([1.0 / 3.0, 1.0 / 3.0], 1),
             ],
-            &[vec![0, 1, 2], vec![1, 3, 2]],
+            &[vec![4, 0, 1], vec![4, 1, 2], vec![4, 2, 0], vec![1, 3, 2]],
         )
-        .expect("build square CDT benchmark fixture");
+        .expect("build subdivided square CDT benchmark fixture");
         let backend = DelaunayBackend2D::from_triangulation(dt);
         CdtTriangulation2D::from_labeled_delaunay(backend, 2, 2)
-            .expect("wrap square CDT benchmark fixture")
+            .expect("wrap subdivided square CDT benchmark fixture")
     };
 
     // Benchmark different move types

--- a/benches/cdt_benchmarks.rs
+++ b/benches/cdt_benchmarks.rs
@@ -9,9 +9,11 @@
 //! - Action calculations
 //! - Ergodic move operations
 
+use causal_triangulations::prelude::geometry::{DelaunayBackend2D, build_delaunay2_from_cells};
+use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveType};
 use causal_triangulations::prelude::simulation::{
-    ActionConfig, ErgodicsSystem, Measurement, MetropolisAlgorithm, MetropolisConfig,
-    MonteCarloStep, MoveType, SimulationResultsBackend,
+    ActionConfig, Measurement, MetropolisAlgorithm, MetropolisConfig, MonteCarloStep,
+    SimulationResultsBackend,
 };
 use causal_triangulations::prelude::triangulation::{CdtTriangulation2D, TriangulationQuery};
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
@@ -186,7 +188,21 @@ fn bench_action_calculations(c: &mut Criterion) {
 fn bench_ergodic_moves(c: &mut Criterion) {
     let mut group = c.benchmark_group("ergodic_moves");
 
-    let seed_triangulation = vec![vec![0, 1, 2], vec![1, 2, 3]]; // Simple test data
+    let seed_triangulation = || {
+        let dt = build_delaunay2_from_cells(
+            &[
+                ([0.0, 0.0], 0),
+                ([1.0, 0.0], 0),
+                ([0.0, 1.0], 1),
+                ([1.0, 1.0], 1),
+            ],
+            &[vec![0, 1, 2], vec![1, 3, 2]],
+        )
+        .expect("build square CDT benchmark fixture");
+        let backend = DelaunayBackend2D::from_triangulation(dt);
+        CdtTriangulation2D::from_labeled_delaunay(backend, 2, 2)
+            .expect("wrap square CDT benchmark fixture")
+    };
 
     // Benchmark different move types
     let move_types = [
@@ -202,7 +218,7 @@ fn bench_ergodic_moves(c: &mut Criterion) {
             &move_type,
             |b, &move_type| {
                 b.iter_batched(
-                    || (ErgodicsSystem::new(), seed_triangulation.clone()),
+                    || (ErgodicsSystem::new(), seed_triangulation()),
                     |(mut ergodics, mut triangulation)| {
                         let result = match move_type {
                             MoveType::Move22 => ergodics.attempt_22_move(&mut triangulation),
@@ -233,7 +249,7 @@ fn bench_ergodic_moves(c: &mut Criterion) {
     // Benchmark random move attempt (needs fresh triangulation each time)
     group.bench_function("random_move_attempt", |b| {
         b.iter_batched(
-            || (ErgodicsSystem::new(), seed_triangulation.clone()),
+            || (ErgodicsSystem::new(), seed_triangulation()),
             |(mut ergodics, mut triangulation)| {
                 let result = ergodics.attempt_random_move(&mut triangulation);
                 black_box(result)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,27 +4,15 @@ This document tracks all the pending improvements, features, and technical debt 
 
 ## High Priority - Core Functionality
 
-### Ergodic Moves Implementation
+### Ergodic Moves Follow-up
 
-- [ ] **Complete (2,2) move implementation** (`src/cdt/ergodic_moves.rs:160`)
-  - Implement actual edge flip logic with Delaunay integration
-  - Replace placeholder random acceptance with proper geometric validation
-  - Add causality constraint checking
+- [ ] **Weight move selection by available sites** (`src/cdt/ergodic_moves.rs`)
+  - Avoid uniform move-type sampling bias when different moves have different numbers of valid application sites
+  - Track rejected site searches separately from geometric flip failures
 
-- [ ] **Complete (1,3) move implementation** (`src/cdt/ergodic_moves.rs:177`)
-  - Implement vertex addition by triangle subdivision
-  - Integrate with Delaunay triangulation maintenance
-  - Validate geometric and causal constraints
-
-- [ ] **Complete (3,1) move implementation** (`src/cdt/ergodic_moves.rs:193`)
-  - Implement vertex removal by triangle merging
-  - Ensure proper Delaunay property maintenance
-  - Add causality checks for vertex removal
-
-- [ ] **Complete edge flip implementation** (`src/cdt/ergodic_moves.rs:209`)
-  - Implement standard Delaunay edge flip operations
-  - Maintain causal structure during flips
-  - Add geometric validity checks
+- [ ] **Broaden toroidal move tests** (`src/cdt/ergodic_moves.rs`)
+  - Exercise periodic boundary cells where Euclidean centroids are not enough
+  - Add regression fixtures for wrap-around k=2 candidates
 
 ### Metropolis Algorithm Improvements
 
@@ -34,7 +22,7 @@ This document tracks all the pending improvements, features, and technical debt 
   - Consider implementing moves that only apply after acceptance
 
 - [ ] **Integrate Tds-based ergodic moves** (`src/cdt/metropolis.rs:264`)
-  - Adapt ergodic move system to work directly with Tds structures
+  - Use the implemented `ErgodicsSystem` move kernels from the proposal path
   - Remove placeholder "not yet implemented" rejections
   - Ensure proper triangulation state management
 

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -128,13 +128,27 @@ Errors should be defined **within the module where they are used**.
 
 Avoid large centralized error enums.
 
+Error variants must be narrow, orthogonal, and purpose-specific. Do not collapse distinct failure modes into one catch-all variant when callers, tests, or debugging would need to distinguish them. Prefer a new variant over stringly typed detail when the distinction is part of the recovery or diagnostic path.
+
+Each variant should carry the structured context needed to debug the failure without parsing the `Display` string:
+
+- the operation being attempted, when the same error can occur from multiple operations
+- the relevant handle, key, index, coordinate, or configuration field
+- the expected invariant and the actual value when reporting validation failures
+- the source error as a typed source when possible, or as a string only at crate/backend boundaries where the upstream type is not part of this crate's public contract
+
+Keep error layers orthogonal. Invalid input or handles, unsupported operations, topology/causality violations, backend mutation failures, and internal postcondition failures should use different variants. Wrapping is appropriate only when crossing abstraction layers, and wrappers must preserve the lower-level detail.
+
+Public error enums must be `#[non_exhaustive]` so new variants remain additive.
+
 Example:
 
 ```rust
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum InsertError {
-    #[error("duplicate vertex")]
-    DuplicateVertex,
+    #[error("duplicate vertex at index {index}")]
+    DuplicateVertex { index: usize },
 }
 ```
 
@@ -179,6 +193,13 @@ just doc-check
 Types that are part of the crate's **stable public API** (documented, intended for external consumption) should be re-exported from the crate root (`src/lib.rs`). Internal-use public types (e.g., backend-specific handles) should not be re-exported to avoid API bloat.
 
 When adding a new public API type, add a corresponding `pub use` line in the re-export block at the top of `lib.rs`.
+
+Focused preludes under `prelude::` must remain small, orthogonal, and purpose-specific. Use them in doctests, integration tests, examples, and benchmarks instead of deep module paths when demonstrating public workflows:
+
+- `prelude::geometry` for backend construction, geometry generators, and geometry traits
+- `prelude::triangulation` for CDT wrappers, foliation classification, topology metadata, and triangulation queries
+- `prelude::moves` for local ergodic move kernels, move results, move types, and move statistics
+- `prelude::simulation` for Metropolis/action simulation workflows and simulation result types
 
 ---
 

--- a/docs/moves.md
+++ b/docs/moves.md
@@ -23,6 +23,7 @@ Returned by each `attempt_*` method:
 - `CausalityViolation` — rejected because the move would break causal layering
 - `GeometricViolation` — rejected because no geometrically valid candidate move exists
 - `Rejected(CdtError)` — rejected for another reason, with details; backend mutation failures are reported as `CdtError::BackendMutationFailed` rather than collapsed into `GeometricViolation`
+- `HardFailure(CdtError)` — the move already mutated geometry but then failed a required post-mutation synchronization step; this is distinct from `Rejected(CdtError)`, which reports reversible rejection reasons before an accepted mutation is finalized. See the `MoveResult` enum and `HardFailure(CdtError)` variant in `src/cdt/ergodic_moves.rs`.
 
 ### `MoveStatistics`
 

--- a/docs/moves.md
+++ b/docs/moves.md
@@ -2,6 +2,8 @@
 
 Ergodic moves are the local Monte Carlo updates that allow the triangulation to explore the space of geometries. This module implements the standard ergodic moves for 2D Causal Dynamical Triangulations (see `src/cdt/ergodic_moves.rs`).
 
+For public examples, doctests, benchmarks, and integration tests, import the focused move API with `use causal_triangulations::prelude::moves::*;`. Combine it with `prelude::triangulation::*` for CDT wrappers and `prelude::geometry::*` when constructing explicit Delaunay fixtures.
+
 ## Types
 
 ### `MoveType`
@@ -9,9 +11,9 @@ Ergodic moves are the local Monte Carlo updates that allow the triangulation to 
 Enumerates the available move types:
 
 - `Move22` — (2,2) move: flip the shared edge between two triangles, preserving vertex count; causality-aware — the CDT layer validates and rejects moves that break causal layering
-- `Move13Add` — (1,3) move: insert a new vertex by subdividing one triangle into three
-- `Move31Remove` — (3,1) move: remove a vertex by merging three triangles into one
-- `EdgeFlip` — raw Delaunay edge flip maintaining the Delaunay property; no causal-layer enforcement (operates at the geometry level)
+- `Move13Add` — (1,3) move: insert a new vertex by subdividing one triangle into three; when the triangulation is foliated, the inserted vertex receives the time label that keeps all replacement triangles causal
+- `Move31Remove` — (3,1) move: remove a degree-3 vertex by merging three triangles into one when the replacement triangle is causal and the removal does not empty a time slice
+- `EdgeFlip` — API-compatible alias for the 2D k=2 edge flip used by `Move22`; it records separate statistics but uses the same causal prechecks
 
 ### `MoveResult`
 
@@ -19,8 +21,8 @@ Returned by each `attempt_*` method:
 
 - `Success` — move was applied
 - `CausalityViolation` — rejected because the move would break causal layering
-- `GeometricViolation` — rejected because the resulting triangulation would be geometrically invalid
-- `Rejected(CdtError)` — rejected for another reason, with details
+- `GeometricViolation` — rejected because no geometrically valid candidate move exists
+- `Rejected(CdtError)` — rejected for another reason, with details; backend mutation failures are reported as `CdtError::BackendMutationFailed` rather than collapsed into `GeometricViolation`
 
 ### `MoveStatistics`
 
@@ -39,27 +41,26 @@ Owns a `MoveStatistics` instance and a thread-local RNG. Public API:
 
 - `new()` / `Default::default()` — construct
 - `select_random_move() -> MoveType` — samples uniformly from all four move types
-- `attempt_22_move(triangulation) -> MoveResult`
-- `attempt_13_move(triangulation) -> MoveResult`
-- `attempt_31_move(triangulation) -> MoveResult`
-- `attempt_edge_flip(triangulation) -> MoveResult`
-- `attempt_random_move(triangulation) -> MoveResult` — delegates to one of the above
+- `attempt_22_move(&mut CdtTriangulation2D) -> MoveResult`
+- `attempt_13_move(&mut CdtTriangulation2D) -> MoveResult`
+- `attempt_31_move(&mut CdtTriangulation2D) -> MoveResult`
+- `attempt_edge_flip(&mut CdtTriangulation2D) -> MoveResult`
+- `attempt_random_move(&mut CdtTriangulation2D) -> MoveResult` — delegates to one of the above
 
-> **Note**: All `attempt_*` methods are currently placeholder implementations that simulate realistic acceptance rates. Full integration with the `delaunay` crate's `Tds` type is planned for a future release.
+Accepted moves mutate the triangulation through the geometry backend, then rebuild CDT foliation bookkeeping from live vertex labels and refresh cell classifications.
 
 ## Architecture
 
 Move validation follows a two-layer design:
 
-- **`delaunay` crate** — pure geometric operations (bistellar flips, edge flips) with no physics constraints
-- **CDT crate** — wraps geometric operations with causality and time-slice validation
+- **`delaunay` crate** — pure geometric operations (`flip_k2`, `flip_k1_insert`, `flip_k1_remove`) with no physics constraints
+- **Geometry backend** — exposes the edit operations through `TriangulationMut` while preserving the CDT ↔ geometry boundary
+- **CDT crate** — chooses candidate sites, checks causality and time-slice integrity, and resynchronizes foliation metadata after accepted moves
 
-When the `delaunay` crate exposes `try_edge_flip` / `try_bistellar_flip`, the placeholder bodies will be replaced with calls to those methods guarded by CDT-specific pre-checks.
+The Metropolis proposal path still needs a rollback token before these mutating moves can be used for rejected Monte Carlo proposals.
 
 ## Planned Work
 
-- [ ] Implement `try_edge_flip()` in `delaunay` for (2,2) moves (used by `Move22` / `attempt_22_move()` and by `EdgeFlip` / `attempt_edge_flip()`)
-- [ ] Implement `try_bistellar_flip()` in `delaunay` for (1,3)/(3,1) moves (used by `attempt_13_move()` / `attempt_31_move()`)
-- [ ] Replace placeholder bodies with real geometric operations
-- [ ] Add causality and time-slice constraint validation
 - [ ] Weight `select_random_move()` by available application sites per move type to remove uniform-sampling chain bias
+- [ ] Add reversible move tokens so `CdtProposal` can undo rejected Metropolis-Hastings proposals
+- [ ] Broaden toroidal move-site tests around periodic boundary cells

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -201,6 +201,42 @@ rules:
               ...
           }
 
+  - id: causal-triangulations.rust.public-error-enums-non-exhaustive
+    languages:
+      - rust
+    severity: WARNING
+    message: "Public error enums must be #[non_exhaustive] so adding variants remains API-safe."
+    metadata:
+      category: maintainability
+      rationale: >-
+        Error enums grow as diagnostics become more precise; non-exhaustive
+        public enums keep that growth additive for downstream callers.
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/src/**/*.rs"
+    pattern-regex: '(?m)(?<!#\[non_exhaustive\]\n)^pub\s+enum\s+[A-Za-z_][A-Za-z0-9_]*Error\b'
+
+  - id: causal-triangulations.rust.prefer-focused-prelude-imports-in-public-usage
+    languages:
+      - rust
+    severity: WARNING
+    message: >-
+      Use causal_triangulations::prelude focused imports in examples,
+      benchmarks, and integration tests instead of deep crate module paths.
+    metadata:
+      category: maintainability
+      rationale: >-
+        Public-facing usage should model the small, orthogonal prelude import
+        surfaces users can copy into their own code.
+    paths:
+      include:
+        - "/examples/**/*.rs"
+        - "/benches/**/*.rs"
+        - "/tests/**/*.rs"
+    pattern-regex: >-
+      ^\s*use\s+causal_triangulations::(?:cdt|geometry)::
+
   - id: causal-triangulations.rust.no-stringly-domain-validation-errors
     languages:
       - rust

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -24,7 +24,7 @@ rules:
       - pattern-either:
           - pattern: println!(...)
           - pattern: eprintln!(...)
-      - pattern-not-inside: |
+      - pattern-not: |
           mod tests {
               ...
           }
@@ -215,7 +215,19 @@ rules:
       include:
         - "/src/**/*.rs"
         - "/tests/semgrep/src/**/*.rs"
-    pattern-regex: '(?m)(?<!#\[non_exhaustive\]\n)^pub\s+enum\s+[A-Za-z_][A-Za-z0-9_]*Error\b'
+    patterns:
+      - pattern: |
+          pub enum $X {
+              $Y
+          }
+      - metavariable-regex:
+          metavariable: $X
+          regex: ".*Error$"
+      - pattern-not: |
+          #[non_exhaustive]
+          pub enum $X {
+              $Y
+          }
 
   - id: causal-triangulations.rust.prefer-focused-prelude-imports-in-public-usage
     languages:

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -11,10 +11,8 @@
 use crate::config::CdtTopology;
 use crate::errors::CdtError;
 use crate::geometry::CdtTriangulation2D;
-use crate::geometry::backends::delaunay::{
-    DelaunayEdgeHandle, DelaunayFaceHandle, DelaunayVertexHandle,
-};
-use crate::geometry::traits::{TriangulationMut, TriangulationQuery};
+use crate::geometry::backends::delaunay::{DelaunayFaceHandle, DelaunayVertexHandle};
+use crate::geometry::traits::{EdgeAdjacentFaces, TriangulationMut, TriangulationQuery};
 use num_traits::cast::NumCast;
 use rand::RngExt;
 use rand::rngs::ThreadRng;
@@ -43,6 +41,8 @@ pub enum MoveResult {
     GeometricViolation,
     /// Move was rejected for other reasons
     Rejected(CdtError),
+    /// Move mutated geometry but failed a required post-mutation invariant refresh
+    HardFailure(CdtError),
 }
 
 /// Statistics tracking for ergodic moves.
@@ -366,13 +366,7 @@ impl ErgodicsSystem {
             }
         }
 
-        match triangulation.synchronize_foliation_from_live_labels() {
-            Ok(()) => {
-                self.stats.record_success(MoveType::Move13Add);
-                MoveResult::Success
-            }
-            Err(err) => MoveResult::Rejected(err),
-        }
+        self.finish_mutated_move(triangulation, MoveType::Move13Add)
     }
 
     /// Attempts a (3,1) move on the triangulation.
@@ -439,13 +433,7 @@ impl ErgodicsSystem {
         };
 
         match removal {
-            Ok(_) => match triangulation.synchronize_foliation_from_live_labels() {
-                Ok(()) => {
-                    self.stats.record_success(MoveType::Move31Remove);
-                    MoveResult::Success
-                }
-                Err(err) => MoveResult::Rejected(err),
-            },
+            Ok(_) => self.finish_mutated_move(triangulation, MoveType::Move31Remove),
             Err(err) => reject_backend("remove_vertex", removal_target, &err),
         }
     }
@@ -526,28 +514,31 @@ impl ErgodicsSystem {
     ) -> MoveResult {
         self.stats.record_attempt(move_type);
 
-        let flippable_edges: Vec<_> = triangulation
-            .geometry()
-            .edges()
-            .filter(|edge| triangulation.geometry().can_flip_edge(edge))
-            .collect();
-        if flippable_edges.is_empty() {
-            return MoveResult::GeometricViolation;
+        let mut geometric_candidate_seen = false;
+        let mut causal_candidate_count = 0;
+        let mut selected_edge = None;
+
+        let geometry = triangulation.geometry();
+        for edge in geometry.edges() {
+            let Ok(Some(adjacent)) = geometry.edge_adjacent_faces(&edge) else {
+                continue;
+            };
+            geometric_candidate_seen = true;
+            if !flip_is_causal(triangulation, &adjacent) {
+                continue;
+            }
+
+            causal_candidate_count += 1;
+            if self.rng.random_range(0..causal_candidate_count) == 0 {
+                selected_edge = Some(edge);
+            }
         }
 
-        let candidates: Vec<_> = flippable_edges
-            .into_iter()
-            .filter(|edge| flip_is_causal(triangulation, edge))
-            .collect();
-
-        let Some(edge) =
-            pick(&mut self.rng, candidates.len()).map(|index| candidates[index].clone())
-        else {
-            return if triangulation.has_foliation() {
-                MoveResult::CausalityViolation
-            } else {
-                MoveResult::GeometricViolation
-            };
+        let Some(edge) = selected_edge else {
+            if geometric_candidate_seen && triangulation.has_foliation() {
+                return MoveResult::CausalityViolation;
+            }
+            return MoveResult::GeometricViolation;
         };
 
         let flip_target = format!("{edge:?}");
@@ -557,14 +548,23 @@ impl ErgodicsSystem {
         };
 
         match flip_result {
-            Ok(_) => match triangulation.synchronize_foliation_from_live_labels() {
-                Ok(()) => {
-                    self.stats.record_success(move_type);
-                    MoveResult::Success
-                }
-                Err(err) => MoveResult::Rejected(err),
-            },
+            Ok(_) => self.finish_mutated_move(triangulation, move_type),
             Err(err) => reject_backend("flip_edge", flip_target, &err),
+        }
+    }
+
+    /// Completes a move after the backend mutation has already succeeded.
+    fn finish_mutated_move(
+        &mut self,
+        triangulation: &mut CdtTriangulation2D,
+        move_type: MoveType,
+    ) -> MoveResult {
+        match triangulation.synchronize_foliation_from_live_labels() {
+            Ok(()) => {
+                self.stats.record_success(move_type);
+                MoveResult::Success
+            }
+            Err(err) => MoveResult::HardFailure(err),
         }
     }
 }
@@ -678,59 +678,39 @@ fn cdt_vertices(triangulation: &CdtTriangulation2D, vertices: &[DelaunayVertexHa
     cdt_labels(triangulation, [*t0, *t1, *t2])
 }
 
-/// Predicts the two old edge endpoints and two opposite vertices for a k=2 flip.
-///
-/// The CDT layer needs this before mutating so it can validate the two
-/// replacement triangles that the backend will create.
-fn flip_vertices(
+/// Checks the CDT triangle rule for three live backend vertices without allocation.
+fn cdt_vertex_triple(
     triangulation: &CdtTriangulation2D,
-    edge: &DelaunayEdgeHandle,
-) -> Option<(
-    DelaunayVertexHandle,
-    DelaunayVertexHandle,
-    DelaunayVertexHandle,
-    DelaunayVertexHandle,
-)> {
-    let (endpoint_0, endpoint_1) = triangulation.geometry().edge_endpoints(edge)?;
-    let mut opposite = Vec::with_capacity(2);
-
-    for face in triangulation.geometry().faces() {
-        let vertices = triangulation.geometry().face_vertices(&face).ok()?;
-        let has_endpoint_0 = vertices.iter().any(|vertex| vertex == &endpoint_0);
-        let has_endpoint_1 = vertices.iter().any(|vertex| vertex == &endpoint_1);
-        if has_endpoint_0 && has_endpoint_1 {
-            let third = vertices
-                .into_iter()
-                .find(|vertex| vertex != &endpoint_0 && vertex != &endpoint_1)?;
-            opposite.push(third);
-        }
+    vertices: [&DelaunayVertexHandle; 3],
+) -> bool {
+    if !triangulation.has_foliation() {
+        return true;
     }
 
-    let [opposite_0, opposite_1] = opposite.as_slice() else {
-        return None;
+    let labels = vertices.map(|vertex| {
+        triangulation
+            .geometry()
+            .vertex_data_by_key(vertex.vertex_key())
+    });
+    let [Some(t0), Some(t1), Some(t2)] = labels else {
+        return false;
     };
-    Some((
-        endpoint_0,
-        endpoint_1,
-        opposite_0.clone(),
-        opposite_1.clone(),
-    ))
+    cdt_labels(triangulation, [t0, t1, t2])
 }
 
 /// Checks whether flipping an edge would preserve CDT triangle causality.
 ///
 /// This is a pre-mutation guard for `(2,2)` and `EdgeFlip`, both of which share
 /// the same underlying Delaunay k=2 flip.
-fn flip_is_causal(triangulation: &CdtTriangulation2D, edge: &DelaunayEdgeHandle) -> bool {
-    let Some((endpoint_0, endpoint_1, opposite_0, opposite_1)) = flip_vertices(triangulation, edge)
-    else {
-        return false;
-    };
+fn flip_is_causal(
+    triangulation: &CdtTriangulation2D,
+    adjacent: &EdgeAdjacentFaces<DelaunayVertexHandle, DelaunayFaceHandle>,
+) -> bool {
+    let (endpoint_0, endpoint_1) = &adjacent.endpoints;
+    let (opposite_0, opposite_1) = &adjacent.opposite_vertices;
 
-    cdt_vertices(
-        triangulation,
-        &[endpoint_0, opposite_0.clone(), opposite_1.clone()],
-    ) && cdt_vertices(triangulation, &[endpoint_1, opposite_0, opposite_1])
+    cdt_vertex_triple(triangulation, [endpoint_0, opposite_0, opposite_1])
+        && cdt_vertex_triple(triangulation, [endpoint_1, opposite_0, opposite_1])
 }
 
 /// Finds the inserted vertex label that makes a `(1,3)` subdivision causal.
@@ -932,18 +912,17 @@ mod tests {
         let result = system.attempt_22_move(&mut triangulation);
 
         assert_eq!(system.stats.moves_22_attempted, 1);
-        if matches!(result, MoveResult::Success) {
-            assert_eq!(system.stats.moves_22_accepted, 1);
-            assert!(
-                triangulation
-                    .geometry()
-                    .triangulation()
-                    .tds()
-                    .is_valid()
-                    .is_ok()
-            );
-            assert!(triangulation.validate_causality().is_ok());
-        }
+        assert_eq!(result, MoveResult::Success);
+        assert_eq!(system.stats.moves_22_accepted, 1);
+        assert!(
+            triangulation
+                .geometry()
+                .triangulation()
+                .tds()
+                .is_valid()
+                .is_ok()
+        );
+        assert!(triangulation.validate_causality().is_ok());
     }
 
     #[test]
@@ -980,19 +959,18 @@ mod tests {
         let result = system.attempt_13_move(&mut triangulation);
 
         assert_eq!(system.stats.moves_13_attempted, 1);
-        if matches!(result, MoveResult::Success) {
-            assert_eq!(triangulation.vertex_count(), before_vertices + 1);
-            assert!(
-                triangulation
-                    .geometry()
-                    .triangulation()
-                    .tds()
-                    .is_valid()
-                    .is_ok()
-            );
-            assert!(triangulation.validate_causality().is_ok());
-            assert!(triangulation.has_foliation());
-        }
+        assert_eq!(result, MoveResult::Success);
+        assert_eq!(triangulation.vertex_count(), before_vertices + 1);
+        assert!(
+            triangulation
+                .geometry()
+                .triangulation()
+                .tds()
+                .is_valid()
+                .is_ok()
+        );
+        assert!(triangulation.validate_causality().is_ok());
+        assert!(triangulation.has_foliation());
     }
 
     #[test]
@@ -1006,18 +984,17 @@ mod tests {
         let result = system.attempt_31_move(&mut triangulation);
 
         assert_eq!(system.stats.moves_31_attempted, 1);
-        if matches!(result, MoveResult::Success) {
-            assert_eq!(triangulation.vertex_count(), before_vertices - 1);
-            assert!(
-                triangulation
-                    .geometry()
-                    .triangulation()
-                    .tds()
-                    .is_valid()
-                    .is_ok()
-            );
-            assert!(triangulation.validate_causality().is_ok());
-        }
+        assert_eq!(result, MoveResult::Success);
+        assert_eq!(triangulation.vertex_count(), before_vertices - 1);
+        assert!(
+            triangulation
+                .geometry()
+                .triangulation()
+                .tds()
+                .is_valid()
+                .is_ok()
+        );
+        assert!(triangulation.validate_causality().is_ok());
     }
 
     #[test]
@@ -1054,10 +1031,9 @@ mod tests {
 
         assert_eq!(system.stats.edge_flips_attempted, 1);
         assert_eq!(system.stats.moves_22_attempted, 0);
-        if matches!(result, MoveResult::Success) {
-            assert_eq!(system.stats.edge_flips_accepted, 1);
-            assert!(triangulation.validate_causality().is_ok());
-        }
+        assert_eq!(result, MoveResult::Success);
+        assert_eq!(system.stats.edge_flips_accepted, 1);
+        assert!(triangulation.validate_causality().is_ok());
     }
 
     #[test]

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -358,7 +358,7 @@ impl ErgodicsSystem {
                 geometry.set_vertex_data_by_key(subdivision.new_vertex.vertex_key(), Some(label))
             };
             if let Err(err) = set_label {
-                return MoveResult::Rejected(CdtError::BackendMutationFailed {
+                return MoveResult::HardFailure(CdtError::BackendMutationFailed {
                     operation: "set_vertex_data_by_key".to_string(),
                     target: format!("vertex {:?}", subdivision.new_vertex.vertex_key()),
                     detail: err.to_string(),
@@ -752,17 +752,60 @@ fn centroid(triangulation: &CdtTriangulation2D, face: &DelaunayFaceHandle) -> Op
         return None;
     }
 
-    let mut centroid = [0.0, 0.0];
+    let mut coords = Vec::with_capacity(3);
     for vertex in vertices {
-        let coords = triangulation.geometry().vertex_coordinates(&vertex).ok()?;
-        let [x, y] = coords.as_slice() else {
+        let vertex_coords = triangulation.geometry().vertex_coordinates(&vertex).ok()?;
+        let [x, y] = vertex_coords.as_slice() else {
             return None;
         };
-        centroid[0] += *x;
-        centroid[1] += *y;
+        coords.push([*x, *y]);
+    }
+
+    if matches!(triangulation.metadata().topology, CdtTopology::Toroidal) {
+        return toroidal_centroid(&coords, triangulation.geometry().periodic_domain()?);
+    }
+
+    let mut centroid = [0.0, 0.0];
+    for [x, y] in coords {
+        centroid[0] += x;
+        centroid[1] += y;
     }
     centroid[0] /= 3.0;
     centroid[1] /= 3.0;
+    Some(centroid)
+}
+
+/// Computes a centroid in one periodic image, then wraps it back into the domain.
+fn toroidal_centroid(coords: &[[f64; 2]], domain: [f64; 2]) -> Option<[f64; 2]> {
+    let [reference, rest @ ..] = coords else {
+        return None;
+    };
+    if rest.len() != 2
+        || domain
+            .iter()
+            .any(|period| !period.is_finite() || *period <= 0.0)
+    {
+        return None;
+    }
+
+    let mut centroid = *reference;
+    for coord in rest {
+        for axis in 0..2 {
+            let period = domain[axis];
+            let mut unwrapped = coord[axis];
+            let delta = unwrapped - reference[axis];
+            if delta > period / 2.0 {
+                unwrapped -= period;
+            } else if delta < -period / 2.0 {
+                unwrapped += period;
+            }
+            centroid[axis] += unwrapped;
+        }
+    }
+
+    for axis in 0..2 {
+        centroid[axis] = (centroid[axis] / 3.0).rem_euclid(domain[axis]);
+    }
     Some(centroid)
 }
 
@@ -971,6 +1014,50 @@ mod tests {
         );
         assert!(triangulation.validate_causality().is_ok());
         assert!(triangulation.has_foliation());
+    }
+
+    #[test]
+    fn test_centroid_unwraps_toroidal_face_across_periodic_boundary() {
+        let triangulation =
+            CdtTriangulation2D::from_toroidal_cdt(4, 3).expect("build toroidal CDT");
+        let face = triangulation
+            .geometry()
+            .faces()
+            .find(|face| {
+                let vertices = triangulation
+                    .geometry()
+                    .face_vertices(face)
+                    .expect("face vertices");
+                let mut zero_x = 0;
+                let mut boundary_x = 0;
+                let mut zero_y = 0;
+                let mut next_y = 0;
+                for vertex in vertices {
+                    let coords = triangulation
+                        .geometry()
+                        .vertex_coordinates(&vertex)
+                        .expect("vertex coordinates");
+                    if (coords[0] - 0.0).abs() < 1e-12 {
+                        zero_x += 1;
+                    }
+                    if (coords[0] - 0.75).abs() < 1e-12 {
+                        boundary_x += 1;
+                    }
+                    if (coords[1] - 0.0).abs() < 1e-12 {
+                        zero_y += 1;
+                    }
+                    if (coords[1] - (1.0 / 3.0)).abs() < 1e-12 {
+                        next_y += 1;
+                    }
+                }
+                zero_x == 1 && boundary_x == 2 && zero_y == 2 && next_y == 1
+            })
+            .expect("wrap-around face");
+
+        let point = centroid(&triangulation, &face).expect("toroidal centroid");
+
+        assert_relative_eq!(point[0], 5.0 / 6.0, epsilon = 1e-12);
+        assert_relative_eq!(point[1], 1.0 / 9.0, epsilon = 1e-12);
     }
 
     #[test]

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -2,15 +2,22 @@
 
 //! Ergodic moves for 2D Causal Dynamical Triangulations.
 //!
-//! This module implements the standard ergodic moves used in CDT:
-//! - (2,2) moves: Flip edge between two triangles
-//! - (1,3) moves: Add/remove vertex with triangle subdivision
-//! - Edge flips: Standard Delaunay edge flips maintaining causality
+//! This module implements the standard local moves used in 2D CDT:
+//! - (2,2) moves: flip the shared edge between two triangles
+//! - (1,3) moves: split a triangle by inserting a vertex
+//! - (3,1) moves: collapse a degree-3 vertex back to one triangle
+//! - edge flips: retained as an API-compatible alias for the 2D (2,2) move
 
+use crate::config::CdtTopology;
 use crate::errors::CdtError;
-use crate::util::generate_random_float;
+use crate::geometry::CdtTriangulation2D;
+use crate::geometry::backends::delaunay::{
+    DelaunayEdgeHandle, DelaunayFaceHandle, DelaunayVertexHandle,
+};
+use crate::geometry::traits::{TriangulationMut, TriangulationQuery};
 use num_traits::cast::NumCast;
 use rand::RngExt;
+use rand::rngs::ThreadRng;
 
 /// Types of ergodic moves available in 2D CDT.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -21,7 +28,7 @@ pub enum MoveType {
     Move13Add,
     /// (3,1) move: Remove vertex by merging triangles
     Move31Remove,
-    /// Edge flip: Standard Delaunay edge flip
+    /// Edge flip: API-compatible alias for the 2D (2,2) move
     EdgeFlip,
 }
 
@@ -65,7 +72,7 @@ impl MoveStatistics {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::cdt::ergodic_moves::MoveStatistics;
+    /// use causal_triangulations::prelude::moves::MoveStatistics;
     ///
     /// let stats = MoveStatistics::new();
     /// assert_eq!(stats.moves_22_attempted, 0);
@@ -80,7 +87,7 @@ impl MoveStatistics {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::cdt::ergodic_moves::{MoveStatistics, MoveType};
+    /// use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
     ///
     /// let mut stats = MoveStatistics::new();
     /// stats.record_attempt(MoveType::Move22);
@@ -100,7 +107,7 @@ impl MoveStatistics {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::cdt::ergodic_moves::{MoveStatistics, MoveType};
+    /// use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
     ///
     /// let mut stats = MoveStatistics::new();
     /// stats.record_success(MoveType::EdgeFlip);
@@ -120,7 +127,7 @@ impl MoveStatistics {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::cdt::ergodic_moves::{MoveStatistics, MoveType};
+    /// use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
     ///
     /// let mut stats = MoveStatistics::new();
     /// stats.record_attempt(MoveType::Move22);
@@ -150,7 +157,7 @@ impl MoveStatistics {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::cdt::ergodic_moves::{MoveStatistics, MoveType};
+    /// use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
     ///
     /// let mut stats = MoveStatistics::new();
     /// stats.record_attempt(MoveType::Move22);
@@ -183,7 +190,13 @@ pub struct ErgodicsSystem {
     /// Move statistics
     pub stats: MoveStatistics,
     /// Random number generator
-    rng: rand::rngs::ThreadRng,
+    rng: ThreadRng,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InsertionLabel {
+    Unfoliated,
+    Label(u32),
 }
 
 impl ErgodicsSystem {
@@ -192,7 +205,7 @@ impl ErgodicsSystem {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::ErgodicsSystem;
+    /// use causal_triangulations::prelude::moves::ErgodicsSystem;
     ///
     /// let system = ErgodicsSystem::new();
     /// assert_eq!(system.stats.moves_22_attempted, 0);
@@ -210,7 +223,7 @@ impl ErgodicsSystem {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{ErgodicsSystem, MoveType};
+    /// use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveType};
     ///
     /// let mut system = ErgodicsSystem::new();
     /// let move_type = system.select_random_move();
@@ -231,19 +244,26 @@ impl ErgodicsSystem {
 
     /// Attempts a (2,2) move on the triangulation.
     ///
-    /// A (2,2) move flips an edge between two triangles, changing the
-    /// local triangulation while preserving the number of vertices.
-    ///
-    /// **Note**: This is currently a placeholder implementation for testing.
-    /// Full integration with delaunay crate Tds is planned for future versions.
+    /// A (2,2) move flips an interior edge shared by two triangles. In a
+    /// foliated triangulation the replacement triangles must still each have
+    /// exactly one spacelike edge and two timelike edges.
     ///
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{ErgodicsSystem, MoveResult};
+    /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::prelude::moves::*;
+    /// use causal_triangulations::prelude::triangulation::*;
     ///
+    /// let dt = build_delaunay2_from_cells(
+    ///     &[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.0, 1.0], 1), ([1.0, 1.0], 1)],
+    ///     &[vec![0, 1, 2], vec![1, 3, 2]],
+    /// )
+    /// .expect("build square CDT");
+    /// let backend = DelaunayBackend2D::from_triangulation(dt);
+    /// let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)
+    ///     .expect("wrap labeled square");
     /// let mut system = ErgodicsSystem::new();
-    /// let mut triangulation = vec![vec![0, 1, 2], vec![2, 1, 3]];
     /// let result = system.attempt_22_move(&mut triangulation);
     /// assert!(matches!(
     ///     result,
@@ -251,72 +271,134 @@ impl ErgodicsSystem {
     /// ));
     /// assert_eq!(system.stats.moves_22_attempted, 1);
     /// ```
-    pub fn attempt_22_move(&mut self, _triangulation: &mut Vec<Vec<usize>>) -> MoveResult {
-        self.stats.record_attempt(MoveType::Move22);
-
-        // Placeholder implementation: simulate move with realistic acceptance rate
-        // Real implementation would check geometric constraints and causality
-        let acceptance_probability = 0.6; // Typical acceptance rate for (2,2) moves
-        if generate_random_float() < acceptance_probability {
-            self.stats.record_success(MoveType::Move22);
-            MoveResult::Success
-        } else {
-            // Randomly choose rejection reason based on typical CDT constraints
-            if generate_random_float() < 0.3 {
-                MoveResult::GeometricViolation
-            } else {
-                MoveResult::CausalityViolation
-            }
-        }
+    pub fn attempt_22_move(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
+        self.attempt_causal_edge_flip(triangulation, MoveType::Move22)
     }
 
     /// Attempts a (1,3) move on the triangulation.
     ///
-    /// A (1,3) move adds a vertex by subdividing an existing triangle
-    /// into three smaller triangles.
-    ///
-    /// **Note**: This is currently a placeholder implementation for testing.
-    /// Full integration with delaunay crate Tds is planned for future versions.
+    /// A (1,3) move inserts a vertex at the selected triangle centroid. For a
+    /// foliated triangle, the inserted vertex receives the unique time label
+    /// that keeps all three replacement triangles causal.
     ///
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{ErgodicsSystem, MoveResult};
+    /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::prelude::moves::*;
+    /// use causal_triangulations::prelude::triangulation::*;
     ///
+    /// let dt = build_delaunay2_with_data(&[
+    ///     ([0.0, 0.0], 0),
+    ///     ([1.0, 0.0], 0),
+    ///     ([0.5, 1.0], 1),
+    /// ])
+    /// .expect("build labeled triangle");
+    /// let backend = DelaunayBackend2D::from_triangulation(dt);
+    /// let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)
+    ///     .expect("wrap labeled triangle");
     /// let mut system = ErgodicsSystem::new();
-    /// let mut triangulation = vec![vec![0, 1, 2]];
     /// let result = system.attempt_13_move(&mut triangulation);
     /// assert!(matches!(result, MoveResult::Success | MoveResult::GeometricViolation));
     /// assert_eq!(system.stats.moves_13_attempted, 1);
     /// ```
-    pub fn attempt_13_move(&mut self, _triangulation: &mut Vec<Vec<usize>>) -> MoveResult {
+    pub fn attempt_13_move(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
         self.stats.record_attempt(MoveType::Move13Add);
 
-        // Placeholder implementation: (1,3) moves typically have high acceptance
-        let acceptance_probability = 0.8;
-        if generate_random_float() < acceptance_probability {
-            self.stats.record_success(MoveType::Move13Add);
-            MoveResult::Success
-        } else {
-            MoveResult::GeometricViolation
+        let geometric_candidates: Vec<_> = triangulation
+            .geometry()
+            .faces()
+            .filter(|face| centroid(triangulation, face).is_some())
+            .collect();
+        if geometric_candidates.is_empty() {
+            return MoveResult::GeometricViolation;
+        }
+
+        let candidates: Vec<_> = geometric_candidates
+            .into_iter()
+            .filter(|face| insertion_label(triangulation, face).is_some())
+            .collect();
+        let Some(face) =
+            pick(&mut self.rng, candidates.len()).map(|index| candidates[index].clone())
+        else {
+            return if triangulation.has_foliation() {
+                MoveResult::CausalityViolation
+            } else {
+                MoveResult::GeometricViolation
+            };
+        };
+
+        let Some(point) = centroid(triangulation, &face) else {
+            return MoveResult::Rejected(CdtError::ValidationFailed {
+                check: "ergodic Move13Add candidate geometry".to_string(),
+                detail: format!(
+                    "face {:?} could not be converted to a 2D centroid",
+                    face.cell_key()
+                ),
+            });
+        };
+        let label = insertion_label(triangulation, &face);
+
+        let subdivision_target = format!("face {:?}", face.cell_key());
+        let subdivision = {
+            let mut geometry = triangulation.geometry_mut();
+            geometry.subdivide_face(face, &point)
+        };
+
+        let subdivision = match subdivision {
+            Ok(subdivision) => subdivision,
+            Err(err) => {
+                return reject_backend("subdivide_face", subdivision_target, &err);
+            }
+        };
+
+        if let Some(InsertionLabel::Label(label)) = label {
+            let set_label = {
+                let mut geometry = triangulation.geometry_mut();
+                geometry.set_vertex_data_by_key(subdivision.new_vertex.vertex_key(), Some(label))
+            };
+            if let Err(err) = set_label {
+                return MoveResult::Rejected(CdtError::BackendMutationFailed {
+                    operation: "set_vertex_data_by_key".to_string(),
+                    target: format!("vertex {:?}", subdivision.new_vertex.vertex_key()),
+                    detail: err.to_string(),
+                });
+            }
+        }
+
+        match triangulation.synchronize_foliation_from_live_labels() {
+            Ok(()) => {
+                self.stats.record_success(MoveType::Move13Add);
+                MoveResult::Success
+            }
+            Err(err) => MoveResult::Rejected(err),
         }
     }
 
     /// Attempts a (3,1) move on the triangulation.
     ///
-    /// A (3,1) move removes a vertex by merging its surrounding triangles
-    /// into a single triangle.
-    ///
-    /// **Note**: This is currently a placeholder implementation for testing.
-    /// Full integration with delaunay crate Tds is planned for future versions.
+    /// A (3,1) move removes a degree-3 vertex if its neighbouring vertices can
+    /// form one causal replacement triangle and the removal does not empty a
+    /// time slice.
     ///
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{ErgodicsSystem, MoveResult};
+    /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::prelude::moves::*;
+    /// use causal_triangulations::prelude::triangulation::*;
     ///
+    /// let dt = build_delaunay2_with_data(&[
+    ///     ([0.0, 0.0], 0),
+    ///     ([1.0, 0.0], 0),
+    ///     ([0.5, 1.0], 1),
+    /// ])
+    /// .expect("build labeled triangle");
+    /// let backend = DelaunayBackend2D::from_triangulation(dt);
+    /// let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)
+    ///     .expect("wrap labeled triangle");
     /// let mut system = ErgodicsSystem::new();
-    /// let mut triangulation = vec![vec![0, 1, 2], vec![0, 2, 3], vec![0, 3, 1]];
+    /// let _ = system.attempt_13_move(&mut triangulation);
     /// let result = system.attempt_31_move(&mut triangulation);
     /// assert!(matches!(
     ///     result,
@@ -324,54 +406,81 @@ impl ErgodicsSystem {
     /// ));
     /// assert_eq!(system.stats.moves_31_attempted, 1);
     /// ```
-    pub fn attempt_31_move(&mut self, _triangulation: &mut Vec<Vec<usize>>) -> MoveResult {
+    pub fn attempt_31_move(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
         self.stats.record_attempt(MoveType::Move31Remove);
 
-        // Placeholder implementation: (3,1) moves are more restrictive
-        let acceptance_probability = 0.4;
-        if generate_random_float() < acceptance_probability {
-            self.stats.record_success(MoveType::Move31Remove);
-            MoveResult::Success
-        } else {
-            // (3,1) moves often rejected due to causality constraints
-            if generate_random_float() < 0.7 {
+        let geometric_candidates: Vec<_> = triangulation
+            .geometry()
+            .vertices()
+            .filter(|vertex| neighbors3(triangulation, vertex).is_some())
+            .collect();
+        if geometric_candidates.is_empty() {
+            return MoveResult::GeometricViolation;
+        }
+
+        let candidates: Vec<_> = geometric_candidates
+            .into_iter()
+            .filter(|vertex| removal_is_causal(triangulation, vertex))
+            .collect();
+        let Some(vertex) =
+            pick(&mut self.rng, candidates.len()).map(|index| candidates[index].clone())
+        else {
+            return if triangulation.has_foliation() {
                 MoveResult::CausalityViolation
             } else {
                 MoveResult::GeometricViolation
-            }
+            };
+        };
+
+        let removal_target = format!("vertex {:?}", vertex.vertex_key());
+        let removal = {
+            let mut geometry = triangulation.geometry_mut();
+            geometry.remove_vertex(vertex)
+        };
+
+        match removal {
+            Ok(_) => match triangulation.synchronize_foliation_from_live_labels() {
+                Ok(()) => {
+                    self.stats.record_success(MoveType::Move31Remove);
+                    MoveResult::Success
+                }
+                Err(err) => MoveResult::Rejected(err),
+            },
+            Err(err) => reject_backend("remove_vertex", removal_target, &err),
         }
     }
 
     /// Attempts an edge flip move on the triangulation.
     ///
-    /// An edge flip maintains the Delaunay property while potentially
-    /// changing the causal structure.
-    ///
-    /// **Note**: This is currently a placeholder implementation for testing.
-    /// Full integration with delaunay crate Tds is planned for future versions.
+    /// In 2D this is the same bistellar k=2 operation as [`Self::attempt_22_move`].
+    /// The separate method is retained for API compatibility and records
+    /// `EdgeFlip` statistics.
     ///
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{ErgodicsSystem, MoveResult};
+    /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::prelude::moves::*;
+    /// use causal_triangulations::prelude::triangulation::*;
     ///
+    /// let dt = build_delaunay2_from_cells(
+    ///     &[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.0, 1.0], 1), ([1.0, 1.0], 1)],
+    ///     &[vec![0, 1, 2], vec![1, 3, 2]],
+    /// )
+    /// .expect("build square CDT");
+    /// let backend = DelaunayBackend2D::from_triangulation(dt);
+    /// let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)
+    ///     .expect("wrap labeled square");
     /// let mut system = ErgodicsSystem::new();
-    /// let mut triangulation = vec![vec![0, 1, 2], vec![2, 1, 3]];
     /// let result = system.attempt_edge_flip(&mut triangulation);
-    /// assert!(matches!(result, MoveResult::Success | MoveResult::CausalityViolation));
+    /// assert!(matches!(
+    ///     result,
+    ///     MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
+    /// ));
     /// assert_eq!(system.stats.edge_flips_attempted, 1);
     /// ```
-    pub fn attempt_edge_flip(&mut self, _triangulation: &mut Vec<Vec<usize>>) -> MoveResult {
-        self.stats.record_attempt(MoveType::EdgeFlip);
-
-        // Placeholder implementation: Edge flips generally have good acceptance
-        let acceptance_probability = 0.7;
-        if generate_random_float() < acceptance_probability {
-            self.stats.record_success(MoveType::EdgeFlip);
-            MoveResult::Success
-        } else {
-            MoveResult::CausalityViolation
-        }
+    pub fn attempt_edge_flip(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
+        self.attempt_causal_edge_flip(triangulation, MoveType::EdgeFlip)
     }
 
     /// Attempts a random ergodic move on the triangulation.
@@ -379,23 +488,83 @@ impl ErgodicsSystem {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{ErgodicsSystem, MoveResult};
+    /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::prelude::moves::*;
+    /// use causal_triangulations::prelude::triangulation::*;
     ///
+    /// let dt = build_delaunay2_with_data(&[
+    ///     ([0.0, 0.0], 0),
+    ///     ([1.0, 0.0], 0),
+    ///     ([0.5, 1.0], 1),
+    /// ])
+    /// .expect("build labeled triangle");
+    /// let backend = DelaunayBackend2D::from_triangulation(dt);
+    /// let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)
+    ///     .expect("wrap labeled triangle");
     /// let mut system = ErgodicsSystem::new();
-    /// let mut triangulation = vec![vec![0, 1, 2]];
     /// let result = system.attempt_random_move(&mut triangulation);
     /// assert!(matches!(
     ///     result,
     ///     MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
     /// ));
     /// ```
-    pub fn attempt_random_move(&mut self, triangulation: &mut Vec<Vec<usize>>) -> MoveResult {
+    pub fn attempt_random_move(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
         let move_type = self.select_random_move();
         match move_type {
             MoveType::Move22 => self.attempt_22_move(triangulation),
             MoveType::Move13Add => self.attempt_13_move(triangulation),
             MoveType::Move31Remove => self.attempt_31_move(triangulation),
             MoveType::EdgeFlip => self.attempt_edge_flip(triangulation),
+        }
+    }
+
+    /// Applies the shared 2D k=2 edge-flip implementation for `Move22` and `EdgeFlip`.
+    fn attempt_causal_edge_flip(
+        &mut self,
+        triangulation: &mut CdtTriangulation2D,
+        move_type: MoveType,
+    ) -> MoveResult {
+        self.stats.record_attempt(move_type);
+
+        let flippable_edges: Vec<_> = triangulation
+            .geometry()
+            .edges()
+            .filter(|edge| triangulation.geometry().can_flip_edge(edge))
+            .collect();
+        if flippable_edges.is_empty() {
+            return MoveResult::GeometricViolation;
+        }
+
+        let candidates: Vec<_> = flippable_edges
+            .into_iter()
+            .filter(|edge| flip_is_causal(triangulation, edge))
+            .collect();
+
+        let Some(edge) =
+            pick(&mut self.rng, candidates.len()).map(|index| candidates[index].clone())
+        else {
+            return if triangulation.has_foliation() {
+                MoveResult::CausalityViolation
+            } else {
+                MoveResult::GeometricViolation
+            };
+        };
+
+        let flip_target = format!("{edge:?}");
+        let flip_result = {
+            let mut geometry = triangulation.geometry_mut();
+            geometry.flip_edge(edge)
+        };
+
+        match flip_result {
+            Ok(_) => match triangulation.synchronize_foliation_from_live_labels() {
+                Ok(()) => {
+                    self.stats.record_success(move_type);
+                    MoveResult::Success
+                }
+                Err(err) => MoveResult::Rejected(err),
+            },
+            Err(err) => reject_backend("flip_edge", flip_target, &err),
         }
     }
 }
@@ -406,17 +575,319 @@ impl Default for ErgodicsSystem {
     }
 }
 
+/// Selects a random candidate index without borrowing the candidate list.
+fn pick(rng: &mut ThreadRng, len: usize) -> Option<usize> {
+    if len == 0 {
+        return None;
+    }
+    Some(rng.random_range(0..len))
+}
+
+/// Converts an unexpected backend edit error into the move-level rejection shape.
+///
+/// Candidate selection should screen out ordinary geometric and causal
+/// rejections before mutation. Reaching this helper means the backend refused
+/// a selected site or returned an operation-specific error that should remain
+/// visible to callers.
+fn reject_backend(
+    operation: impl Into<String>,
+    target: impl Into<String>,
+    err: &impl ToString,
+) -> MoveResult {
+    MoveResult::Rejected(CdtError::BackendMutationFailed {
+        operation: operation.into(),
+        target: target.into(),
+        detail: err.to_string(),
+    })
+}
+
+/// Computes topology-aware time distance between two slice labels.
+///
+/// Toroidal triangulations wrap around the time circle, so labels `0` and
+/// `T-1` are one step apart; open-boundary triangulations use raw absolute
+/// difference.
+fn time_dist(triangulation: &CdtTriangulation2D, t0: u32, t1: u32) -> u32 {
+    let raw = t0.abs_diff(t1);
+    if matches!(triangulation.metadata().topology, CdtTopology::Toroidal) {
+        let total = triangulation.time_slices();
+        if total > 0 && t0 < total && t1 < total {
+            return raw.min(total - raw);
+        }
+    }
+    raw
+}
+
+/// Reads time labels for a vertex tuple when the triangulation is foliated.
+///
+/// Missing labels make a move site invalid because subsequent foliation
+/// resynchronization would fail after mutation.
+fn labels(
+    triangulation: &CdtTriangulation2D,
+    vertices: &[DelaunayVertexHandle],
+) -> Option<Vec<u32>> {
+    if !triangulation.has_foliation() {
+        return None;
+    }
+    vertices
+        .iter()
+        .map(|vertex| {
+            triangulation
+                .geometry()
+                .vertex_data_by_key(vertex.vertex_key())
+        })
+        .collect()
+}
+
+/// Checks whether three time labels form one valid 2D CDT triangle.
+///
+/// A valid foliated CDT triangle has exactly one spacelike edge and two
+/// timelike edges, using toroidal time distance where appropriate.
+fn cdt_labels(triangulation: &CdtTriangulation2D, labels: [u32; 3]) -> bool {
+    let mut spacelike = 0;
+    let mut timelike = 0;
+
+    for (a, b) in [
+        (labels[0], labels[1]),
+        (labels[1], labels[2]),
+        (labels[2], labels[0]),
+    ] {
+        match time_dist(triangulation, a, b) {
+            0 => spacelike += 1,
+            1 => timelike += 1,
+            _ => return false,
+        }
+    }
+
+    spacelike == 1 && timelike == 2
+}
+
+/// Checks the CDT triangle rule for live backend vertices.
+///
+/// Unfoliated triangulations bypass the CDT time-label constraint because
+/// there is no causal labeling to preserve.
+fn cdt_vertices(triangulation: &CdtTriangulation2D, vertices: &[DelaunayVertexHandle]) -> bool {
+    if !triangulation.has_foliation() {
+        return true;
+    }
+    let Some(labels) = labels(triangulation, vertices) else {
+        return false;
+    };
+    let [t0, t1, t2] = labels.as_slice() else {
+        return false;
+    };
+    cdt_labels(triangulation, [*t0, *t1, *t2])
+}
+
+/// Predicts the two old edge endpoints and two opposite vertices for a k=2 flip.
+///
+/// The CDT layer needs this before mutating so it can validate the two
+/// replacement triangles that the backend will create.
+fn flip_vertices(
+    triangulation: &CdtTriangulation2D,
+    edge: &DelaunayEdgeHandle,
+) -> Option<(
+    DelaunayVertexHandle,
+    DelaunayVertexHandle,
+    DelaunayVertexHandle,
+    DelaunayVertexHandle,
+)> {
+    let (endpoint_0, endpoint_1) = triangulation.geometry().edge_endpoints(edge)?;
+    let mut opposite = Vec::with_capacity(2);
+
+    for face in triangulation.geometry().faces() {
+        let vertices = triangulation.geometry().face_vertices(&face).ok()?;
+        let has_endpoint_0 = vertices.iter().any(|vertex| vertex == &endpoint_0);
+        let has_endpoint_1 = vertices.iter().any(|vertex| vertex == &endpoint_1);
+        if has_endpoint_0 && has_endpoint_1 {
+            let third = vertices
+                .into_iter()
+                .find(|vertex| vertex != &endpoint_0 && vertex != &endpoint_1)?;
+            opposite.push(third);
+        }
+    }
+
+    let [opposite_0, opposite_1] = opposite.as_slice() else {
+        return None;
+    };
+    Some((
+        endpoint_0,
+        endpoint_1,
+        opposite_0.clone(),
+        opposite_1.clone(),
+    ))
+}
+
+/// Checks whether flipping an edge would preserve CDT triangle causality.
+///
+/// This is a pre-mutation guard for `(2,2)` and `EdgeFlip`, both of which share
+/// the same underlying Delaunay k=2 flip.
+fn flip_is_causal(triangulation: &CdtTriangulation2D, edge: &DelaunayEdgeHandle) -> bool {
+    let Some((endpoint_0, endpoint_1, opposite_0, opposite_1)) = flip_vertices(triangulation, edge)
+    else {
+        return false;
+    };
+
+    cdt_vertices(
+        triangulation,
+        &[endpoint_0, opposite_0.clone(), opposite_1.clone()],
+    ) && cdt_vertices(triangulation, &[endpoint_1, opposite_0, opposite_1])
+}
+
+/// Finds the inserted vertex label that makes a `(1,3)` subdivision causal.
+///
+/// The candidate label must keep all three replacement triangles valid CDT
+/// triangles; unfoliated triangulations return a marker that skips labeling.
+fn insertion_label(
+    triangulation: &CdtTriangulation2D,
+    face: &DelaunayFaceHandle,
+) -> Option<InsertionLabel> {
+    if !triangulation.has_foliation() {
+        return Some(InsertionLabel::Unfoliated);
+    }
+
+    let vertices = triangulation.geometry().face_vertices(face).ok()?;
+    let labels = labels(triangulation, &vertices)?;
+    let [t0, t1, t2] = labels.as_slice() else {
+        return None;
+    };
+    let mut candidates = vec![*t0, *t1, *t2];
+    candidates.sort_unstable();
+    candidates.dedup();
+
+    candidates.into_iter().find_map(|candidate| {
+        let valid = cdt_labels(triangulation, [candidate, *t0, *t1])
+            && cdt_labels(triangulation, [candidate, *t1, *t2])
+            && cdt_labels(triangulation, [candidate, *t2, *t0]);
+        valid.then_some(InsertionLabel::Label(candidate))
+    })
+}
+
+/// Computes a 2D face centroid for the `(1,3)` insertion point.
+///
+/// Returning `None` keeps malformed or non-triangular faces out of the mutation
+/// path instead of relying on the backend to reject them later.
+fn centroid(triangulation: &CdtTriangulation2D, face: &DelaunayFaceHandle) -> Option<[f64; 2]> {
+    let vertices = triangulation.geometry().face_vertices(face).ok()?;
+    if vertices.len() != 3 {
+        return None;
+    }
+
+    let mut centroid = [0.0, 0.0];
+    for vertex in vertices {
+        let coords = triangulation.geometry().vertex_coordinates(&vertex).ok()?;
+        let [x, y] = coords.as_slice() else {
+            return None;
+        };
+        centroid[0] += *x;
+        centroid[1] += *y;
+    }
+    centroid[0] /= 3.0;
+    centroid[1] /= 3.0;
+    Some(centroid)
+}
+
+/// Counts live vertices carrying a given time label.
+///
+/// `(3,1)` removal uses this to avoid emptying a time slice after deleting a
+/// labeled vertex.
+fn label_count(triangulation: &CdtTriangulation2D, label: u32) -> usize {
+    triangulation
+        .geometry()
+        .vertices()
+        .filter(|vertex| {
+            triangulation
+                .geometry()
+                .vertex_data_by_key(vertex.vertex_key())
+                == Some(label)
+        })
+        .count()
+}
+
+/// Collects the three distinct neighboring vertices around a removable vertex.
+///
+/// A `(3,1)` move is geometrically available only at a degree-3 vertex whose
+/// adjacent faces collapse back to one replacement triangle.
+fn neighbors3(
+    triangulation: &CdtTriangulation2D,
+    vertex: &DelaunayVertexHandle,
+) -> Option<Vec<DelaunayVertexHandle>> {
+    let adjacent_faces = triangulation.geometry().adjacent_faces(vertex).ok()?;
+    if adjacent_faces.len() != 3 {
+        return None;
+    }
+
+    let mut neighbors = Vec::with_capacity(3);
+    for face in adjacent_faces {
+        for candidate in triangulation.geometry().face_vertices(&face).ok()? {
+            if &candidate != vertex && !neighbors.iter().any(|seen| seen == &candidate) {
+                neighbors.push(candidate);
+            }
+        }
+    }
+
+    (neighbors.len() == 3).then_some(neighbors)
+}
+
+/// Checks CDT-specific preconditions for a `(3,1)` removal.
+///
+/// The replacement triangle must be causal, and in foliated triangulations the
+/// removed vertex must not be the last live vertex in its time slice.
+fn removal_is_causal(triangulation: &CdtTriangulation2D, vertex: &DelaunayVertexHandle) -> bool {
+    let Some(neighbors) = neighbors3(triangulation, vertex) else {
+        return false;
+    };
+    if !cdt_vertices(triangulation, &neighbors) {
+        return false;
+    }
+    if !triangulation.has_foliation() {
+        return true;
+    }
+
+    let Some(label) = triangulation
+        .geometry()
+        .vertex_data_by_key(vertex.vertex_key())
+    else {
+        return false;
+    };
+    label_count(triangulation, label) > 1
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::geometry::DelaunayBackend2D;
+    use crate::geometry::generators::{build_delaunay2_from_cells, build_delaunay2_with_data};
     use approx::assert_relative_eq;
     use std::collections::HashSet;
+
+    /// Builds the minimal foliated triangle fixture used by `(1,3)` tests.
+    fn single_triangle() -> CdtTriangulation2D {
+        let dt = build_delaunay2_with_data(&[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.5, 1.0], 1)])
+            .expect("build labeled triangle");
+        let backend = DelaunayBackend2D::from_triangulation(dt);
+        CdtTriangulation2D::from_labeled_delaunay(backend, 2, 2).expect("wrap labeled triangle")
+    }
+
+    /// Builds two foliated triangles sharing one interior edge for k=2 flips.
+    fn square_two_triangles() -> CdtTriangulation2D {
+        let dt = build_delaunay2_from_cells(
+            &[
+                ([0.0, 0.0], 0),
+                ([1.0, 0.0], 0),
+                ([0.0, 1.0], 1),
+                ([1.0, 1.0], 1),
+            ],
+            &[vec![0, 1, 2], vec![1, 3, 2]],
+        )
+        .expect("build square CDT");
+        let backend = DelaunayBackend2D::from_triangulation(dt);
+        CdtTriangulation2D::from_labeled_delaunay(backend, 2, 2).expect("wrap square CDT")
+    }
 
     #[test]
     fn test_move_statistics() {
         let mut stats = MoveStatistics::new();
 
-        // Test recording attempts and successes
         stats.record_attempt(MoveType::Move22);
         stats.record_attempt(MoveType::Move22);
         stats.record_success(MoveType::Move22);
@@ -454,71 +925,150 @@ mod tests {
     }
 
     #[test]
-    fn test_ergodics_system() {
+    fn test_22_move_uses_real_triangulation() {
         let mut system = ErgodicsSystem::new();
-        let mut triangulation = vec![vec![0, 1, 2]];
+        let mut triangulation = square_two_triangles();
 
-        // Test that moves can be attempted
         let result = system.attempt_22_move(&mut triangulation);
-        assert!(matches!(
-            result,
-            MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
-        ));
 
-        // Check that statistics are updated
         assert_eq!(system.stats.moves_22_attempted, 1);
+        if matches!(result, MoveResult::Success) {
+            assert_eq!(system.stats.moves_22_accepted, 1);
+            assert!(
+                triangulation
+                    .geometry()
+                    .triangulation()
+                    .tds()
+                    .is_valid()
+                    .is_ok()
+            );
+            assert!(triangulation.validate_causality().is_ok());
+        }
     }
 
     #[test]
-    fn test_placeholder_move_attempts_update_per_move_statistics() {
+    fn test_22_move_without_interior_edge_reports_geometric_violation() {
         let mut system = ErgodicsSystem::new();
-        let mut triangulation = vec![vec![0, 1, 2]];
+        let mut triangulation = single_triangle();
+        let counts_before = (
+            triangulation.vertex_count(),
+            triangulation.edge_count(),
+            triangulation.face_count(),
+        );
 
-        let move_13 = system.attempt_13_move(&mut triangulation);
-        assert!(matches!(
-            move_13,
-            MoveResult::Success | MoveResult::GeometricViolation
-        ));
+        let result = system.attempt_22_move(&mut triangulation);
+
+        assert_eq!(result, MoveResult::GeometricViolation);
+        assert_eq!(system.stats.moves_22_attempted, 1);
+        assert_eq!(system.stats.moves_22_accepted, 0);
+        assert_eq!(
+            (
+                triangulation.vertex_count(),
+                triangulation.edge_count(),
+                triangulation.face_count(),
+            ),
+            counts_before
+        );
+    }
+
+    #[test]
+    fn test_13_move_inserts_labeled_vertex_when_accepted() {
+        let mut system = ErgodicsSystem::new();
+        let mut triangulation = single_triangle();
+        let before_vertices = triangulation.vertex_count();
+
+        let result = system.attempt_13_move(&mut triangulation);
+
         assert_eq!(system.stats.moves_13_attempted, 1);
-        assert_eq!(
-            system.stats.moves_13_accepted,
-            <u64 as From<bool>>::from(matches!(move_13, MoveResult::Success))
-        );
+        if matches!(result, MoveResult::Success) {
+            assert_eq!(triangulation.vertex_count(), before_vertices + 1);
+            assert!(
+                triangulation
+                    .geometry()
+                    .triangulation()
+                    .tds()
+                    .is_valid()
+                    .is_ok()
+            );
+            assert!(triangulation.validate_causality().is_ok());
+            assert!(triangulation.has_foliation());
+        }
+    }
 
-        let move_31 = system.attempt_31_move(&mut triangulation);
-        assert!(matches!(
-            move_31,
-            MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
-        ));
+    #[test]
+    fn test_31_move_removes_degree_three_vertex_after_13_move() {
+        let mut system = ErgodicsSystem::new();
+        let mut triangulation = single_triangle();
+        let result = system.attempt_13_move(&mut triangulation);
+        assert!(matches!(result, MoveResult::Success));
+        let before_vertices = triangulation.vertex_count();
+
+        let result = system.attempt_31_move(&mut triangulation);
+
         assert_eq!(system.stats.moves_31_attempted, 1);
-        assert_eq!(
-            system.stats.moves_31_accepted,
-            <u64 as From<bool>>::from(matches!(move_31, MoveResult::Success))
+        if matches!(result, MoveResult::Success) {
+            assert_eq!(triangulation.vertex_count(), before_vertices - 1);
+            assert!(
+                triangulation
+                    .geometry()
+                    .triangulation()
+                    .tds()
+                    .is_valid()
+                    .is_ok()
+            );
+            assert!(triangulation.validate_causality().is_ok());
+        }
+    }
+
+    #[test]
+    fn test_31_move_without_degree_three_vertex_reports_geometric_violation() {
+        let mut system = ErgodicsSystem::new();
+        let mut triangulation = single_triangle();
+        let counts_before = (
+            triangulation.vertex_count(),
+            triangulation.edge_count(),
+            triangulation.face_count(),
         );
 
-        let edge_flip = system.attempt_edge_flip(&mut triangulation);
-        assert!(matches!(
-            edge_flip,
-            MoveResult::Success | MoveResult::CausalityViolation
-        ));
-        assert_eq!(system.stats.edge_flips_attempted, 1);
+        let result = system.attempt_31_move(&mut triangulation);
+
+        assert_eq!(result, MoveResult::GeometricViolation);
+        assert_eq!(system.stats.moves_31_attempted, 1);
+        assert_eq!(system.stats.moves_31_accepted, 0);
         assert_eq!(
-            system.stats.edge_flips_accepted,
-            <u64 as From<bool>>::from(matches!(edge_flip, MoveResult::Success))
+            (
+                triangulation.vertex_count(),
+                triangulation.edge_count(),
+                triangulation.face_count(),
+            ),
+            counts_before
         );
+    }
+
+    #[test]
+    fn test_edge_flip_is_k2_alias_with_separate_statistics() {
+        let mut system = ErgodicsSystem::new();
+        let mut triangulation = square_two_triangles();
+
+        let result = system.attempt_edge_flip(&mut triangulation);
+
+        assert_eq!(system.stats.edge_flips_attempted, 1);
+        assert_eq!(system.stats.moves_22_attempted, 0);
+        if matches!(result, MoveResult::Success) {
+            assert_eq!(system.stats.edge_flips_accepted, 1);
+            assert!(triangulation.validate_causality().is_ok());
+        }
     }
 
     #[test]
     fn test_random_move_selection() {
         let mut system = ErgodicsSystem::new();
 
-        // Test that we get different move types
         let mut move_types = HashSet::new();
         for _ in 0..100 {
             move_types.insert(system.select_random_move());
         }
 
-        // Should get multiple different move types
         assert!(move_types.len() > 1);
     }
 
@@ -526,7 +1076,6 @@ mod tests {
     fn test_total_acceptance_rate() {
         let mut stats = MoveStatistics::new();
 
-        // Add some test data
         stats.record_attempt(MoveType::Move22);
         stats.record_success(MoveType::Move22);
         stats.record_attempt(MoveType::Move13Add);

--- a/src/cdt/foliation.rs
+++ b/src/cdt/foliation.rs
@@ -145,6 +145,7 @@ pub fn classify_cell(t0: Option<u32>, t1: Option<u32>, t2: Option<u32>) -> Optio
 
 /// Error type for foliation construction and validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FoliationError {
     /// `slice_sizes` length does not match `num_slices`.
     SliceSizeMismatch {

--- a/src/cdt/triangulation.rs
+++ b/src/cdt/triangulation.rs
@@ -2250,6 +2250,28 @@ impl CdtTriangulation<DelaunayBackend2D> {
         Ok(Some(count))
     }
 
+    /// Rebuilds foliation bookkeeping from live backend vertex labels after a topology edit.
+    ///
+    /// Ergodic moves preserve labels on existing vertices and assign labels to
+    /// inserted vertices before calling this helper. The backend topology has
+    /// already been mutated, so this method only refreshes CDT-side aggregate
+    /// bookkeeping and cell payload classifications.
+    pub(crate) fn synchronize_foliation_from_live_labels(&mut self) -> CdtResult<()> {
+        if self.foliation.is_none() {
+            return Ok(());
+        }
+
+        let slice_sizes =
+            Self::live_slice_sizes_from_vertex_labels(&self.geometry, self.metadata.time_slices)?;
+        let foliation = Foliation::from_slice_sizes(slice_sizes, self.metadata.time_slices)
+            .map_err(CdtError::from)?;
+
+        self.foliation = Some(foliation);
+        self.mark_foliation_synchronized();
+        self.classify_all_cells()?;
+        Ok(())
+    }
+
     /// Validate CDT properties (geometry, Delaunay, topology, causality, foliation).
     ///
     /// # Errors

--- a/src/cdt/triangulation.rs
+++ b/src/cdt/triangulation.rs
@@ -2267,9 +2267,17 @@ impl CdtTriangulation<DelaunayBackend2D> {
             .map_err(CdtError::from)?;
 
         self.foliation = Some(foliation);
-        self.mark_foliation_synchronized();
-        self.classify_all_cells()?;
-        Ok(())
+        match self.classify_all_cells() {
+            Ok(_) => {
+                self.mark_foliation_synchronized();
+                Ok(())
+            }
+            Err(err) => {
+                self.foliation = None;
+                self.foliation_synced_at_modification = None;
+                Err(err)
+            }
+        }
     }
 
     /// Validate CDT properties (geometry, Delaunay, topology, causality, foliation).

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,7 @@ use crate::cdt::foliation::FoliationError;
 
 /// Main error type for CDT operations.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[non_exhaustive]
 pub enum CdtError {
     /// Invalid dimension specified
     #[error("Unsupported dimension: {0}. Only 2D is currently supported")]

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -10,7 +10,8 @@
 // cspell:ignore vkey
 
 use crate::geometry::traits::{
-    FlipResult, GeometryBackend, SubdivisionResult, TriangulationMut, TriangulationQuery,
+    EdgeAdjacentFaces, EdgeAdjacentFacesResult, FlipResult, GeometryBackend, SubdivisionResult,
+    TriangulationMut, TriangulationQuery,
 };
 use delaunay::core::DataType;
 use delaunay::core::edge::EdgeKey;
@@ -226,14 +227,17 @@ impl<VertexData: DataType, CellData: DataType, const D: usize>
                     continue;
                 }
 
-                let facet_vertices: Vec<_> = vertices
+                let mut facet_vertices = vertices
                     .iter()
                     .enumerate()
-                    .filter_map(|(idx, &key)| (idx != facet_index).then_some(key))
-                    .collect();
-                if facet_vertices.len() == 2
-                    && EdgeKey::new(facet_vertices[0], facet_vertices[1]) == edge
-                {
+                    .filter_map(|(idx, &key)| (idx != facet_index).then_some(key));
+                let Some(v0) = facet_vertices.next() else {
+                    continue;
+                };
+                let Some(v1) = facet_vertices.next() else {
+                    continue;
+                };
+                if facet_vertices.next().is_none() && EdgeKey::new(v0, v1) == edge {
                     let facet_index = u8::try_from(facet_index).ok()?;
                     return Some(FacetHandle::new(cell_key, facet_index));
                 }
@@ -587,6 +591,82 @@ impl<VertexData: DataType, CellData: DataType, const D: usize> TriangulationQuer
         );
 
         None
+    }
+
+    fn edge_adjacent_faces(
+        &self,
+        edge: &Self::EdgeHandle,
+    ) -> EdgeAdjacentFacesResult<Self::VertexHandle, Self::FaceHandle, Self::Error> {
+        if !self.edge_exists(edge.key) {
+            return Err(DelaunayError::InvalidEdge {
+                v0: edge.key.v0(),
+                v1: edge.key.v1(),
+            });
+        }
+
+        let Some(facet) = self.interior_facet_for_edge(edge.key) else {
+            return Ok(None);
+        };
+        let face_0 = facet.cell_key();
+        let facet_index = <usize as From<_>>::from(facet.facet_index());
+        let Some(cell_0) = self.dt.tds().get_cell(face_0) else {
+            return Err(DelaunayError::InvalidFace { key: face_0 });
+        };
+        let vertices_0 = cell_0.vertices();
+        if vertices_0.len() != 3 || facet_index >= vertices_0.len() {
+            return Ok(None);
+        }
+        let Some(face_1) = cell_0
+            .neighbors()
+            .and_then(|neighbors| neighbors.get(facet_index).copied().flatten())
+        else {
+            return Ok(None);
+        };
+
+        let mut endpoints = vertices_0
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, &key)| (idx != facet_index).then_some(key));
+        let Some(endpoint_0) = endpoints.next() else {
+            return Ok(None);
+        };
+        let Some(endpoint_1) = endpoints.next() else {
+            return Ok(None);
+        };
+        if endpoints.next().is_some() {
+            return Ok(None);
+        }
+
+        let Some(vertices_1) = self.dt.cell_vertices(face_1) else {
+            return Err(DelaunayError::InvalidFace { key: face_1 });
+        };
+        if vertices_1.len() != 3 {
+            return Ok(None);
+        }
+        let Some(opposite_1) = vertices_1
+            .iter()
+            .copied()
+            .find(|&key| key != endpoint_0 && key != endpoint_1)
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(EdgeAdjacentFaces::new(
+            (
+                DelaunayVertexHandle { key: endpoint_0 },
+                DelaunayVertexHandle { key: endpoint_1 },
+            ),
+            (
+                DelaunayFaceHandle { key: face_0 },
+                DelaunayFaceHandle { key: face_1 },
+            ),
+            (
+                DelaunayVertexHandle {
+                    key: vertices_0[facet_index],
+                },
+                DelaunayVertexHandle { key: opposite_1 },
+            ),
+        )))
     }
 
     fn adjacent_faces(

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -23,8 +23,9 @@ use delaunay::geometry::point::Point;
 use delaunay::geometry::traits::coordinate::Coordinate;
 use delaunay::prelude::VertexBuilder;
 use delaunay::prelude::triangulation::flips::BistellarFlips;
-use delaunay::topology::traits::TopologyKind;
+use delaunay::topology::traits::{GlobalTopology, TopologyKind};
 use delaunay::triangulation::DelaunayTriangulation;
+use std::collections::HashMap;
 
 /// Delaunay backend wrapping the delaunay crate's triangulation (f64 coordinates).
 ///
@@ -38,6 +39,8 @@ use delaunay::triangulation::DelaunayTriangulation;
 pub struct DelaunayBackend<VertexData: DataType, CellData: DataType, const D: usize> {
     /// The underlying Delaunay triangulation from the delaunay crate
     dt: DelaunayTriangulation<AdaptiveKernel<f64>, VertexData, CellData, D>,
+    /// Interior 2D edge to one incident facet suitable for k=2 local queries.
+    interior_facets_by_edge: HashMap<EdgeKey, FacetHandle>,
 }
 
 /// Opaque handle for vertices in Delaunay backend
@@ -212,11 +215,18 @@ impl<VertexData: DataType, CellData: DataType, const D: usize>
 
     /// Finds the 2D facet handle corresponding to a live interior edge.
     fn interior_facet_for_edge(&self, edge: EdgeKey) -> Option<FacetHandle> {
-        if D != 2 {
-            return None;
-        }
+        self.interior_facets_by_edge.get(&edge).copied()
+    }
 
-        for (cell_key, cell) in self.dt.cells() {
+    /// Builds the 2D interior edge-facet lookup from current cell adjacency.
+    fn build_interior_facets_by_edge(
+        dt: &DelaunayTriangulation<AdaptiveKernel<f64>, VertexData, CellData, D>,
+    ) -> HashMap<EdgeKey, FacetHandle> {
+        let mut facets_by_edge = HashMap::new();
+        if D != 2 {
+            return facets_by_edge;
+        }
+        for (cell_key, cell) in dt.cells() {
             let vertices = cell.vertices();
             let Some(neighbors) = cell.neighbors() else {
                 continue;
@@ -237,14 +247,23 @@ impl<VertexData: DataType, CellData: DataType, const D: usize>
                 let Some(v1) = facet_vertices.next() else {
                     continue;
                 };
-                if facet_vertices.next().is_none() && EdgeKey::new(v0, v1) == edge {
-                    let facet_index = u8::try_from(facet_index).ok()?;
-                    return Some(FacetHandle::new(cell_key, facet_index));
+                if facet_vertices.next().is_none() {
+                    let Ok(facet_index) = u8::try_from(facet_index) else {
+                        continue;
+                    };
+                    facets_by_edge
+                        .entry(EdgeKey::new(v0, v1))
+                        .or_insert_with(|| FacetHandle::new(cell_key, facet_index));
                 }
             }
         }
 
-        None
+        facets_by_edge
+    }
+
+    /// Refreshes cached edge adjacency after a topology mutation succeeds.
+    fn rebuild_interior_facet_index(&mut self) {
+        self.interior_facets_by_edge = Self::build_interior_facets_by_edge(&self.dt);
     }
 
     /// Returns whether the keyed edge is present in the triangulation.
@@ -277,10 +296,14 @@ impl<VertexData: DataType, CellData: DataType, const D: usize>
     /// assert_eq!(backend.vertex_count(), 3);
     /// ```
     #[must_use]
-    pub const fn from_triangulation(
+    pub fn from_triangulation(
         dt: DelaunayTriangulation<AdaptiveKernel<f64>, VertexData, CellData, D>,
     ) -> Self {
-        Self { dt }
+        let interior_facets_by_edge = Self::build_interior_facets_by_edge(&dt);
+        Self {
+            dt,
+            interior_facets_by_edge,
+        }
     }
 
     /// Access the underlying Delaunay triangulation (read-only)
@@ -334,7 +357,7 @@ impl<VertexData: DataType, CellData: DataType, const D: usize>
     /// Returns the high-level topology kind (`Euclidean`, `Toroidal`, etc.) of the
     /// underlying triangulation.
     ///
-    /// This exposes the [`GlobalTopology`](delaunay::topology::traits::GlobalTopology)
+    /// This exposes the [`GlobalTopology`]
     /// metadata attached by [`DelaunayTriangulationBuilder`](delaunay::triangulation::builder::DelaunayTriangulationBuilder) at construction time.
     ///
     /// # Examples
@@ -354,6 +377,26 @@ impl<VertexData: DataType, CellData: DataType, const D: usize>
     #[must_use]
     pub const fn topology_kind(&self) -> TopologyKind {
         self.dt.topology_kind()
+    }
+
+    /// Returns the toroidal fundamental domain for periodic triangulations.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::*;
+    ///
+    /// let tri = CdtTriangulation::from_toroidal_cdt(3, 3).unwrap();
+    /// assert_eq!(tri.geometry().periodic_domain(), Some([1.0, 1.0]));
+    /// ```
+    #[must_use]
+    pub const fn periodic_domain(&self) -> Option<[f64; D]> {
+        match self.dt.global_topology() {
+            GlobalTopology::Toroidal { domain, .. } => Some(domain),
+            GlobalTopology::Euclidean | GlobalTopology::Spherical | GlobalTopology::Hyperbolic => {
+                None
+            }
+        }
     }
 
     /// Returns the vertex payload for `key`, if present.
@@ -742,6 +785,7 @@ impl<VertexData: DataType, CellData: DataType, const D: usize> TriangulationMut
                 coordinates: coords.to_vec(),
                 detail: err.to_string(),
             })?;
+        self.rebuild_interior_facet_index();
         Ok(DelaunayVertexHandle { key })
     }
 
@@ -761,6 +805,7 @@ impl<VertexData: DataType, CellData: DataType, const D: usize> TriangulationMut
                 target: format!("vertex {:?}", vertex.key),
                 detail: err.to_string(),
             })?;
+        self.rebuild_interior_facet_index();
         Ok(info
             .new_cells
             .iter()
@@ -811,6 +856,7 @@ impl<VertexData: DataType, CellData: DataType, const D: usize> TriangulationMut
                 ),
                 detail: err.to_string(),
             })?;
+        self.rebuild_interior_facet_index();
         let inserted: Vec<_> = info.inserted_face_vertices.iter().copied().collect();
         let [v0, v1] = inserted.as_slice() else {
             return Err(DelaunayError::UnexpectedFlipOutput {
@@ -856,6 +902,7 @@ impl<VertexData: DataType, CellData: DataType, const D: usize> TriangulationMut
                     target: format!("face {:?} at point {:?}", face.key, point),
                     detail: err.to_string(),
                 })?;
+        self.rebuild_interior_facet_index();
         let Some(&new_vertex) = info.inserted_face_vertices.first() else {
             return Err(DelaunayError::UnexpectedFlipOutput {
                 operation: "flip_k1_insert",
@@ -1574,6 +1621,37 @@ mod tests {
                 backend.face_count(),
             ),
             counts_before_noops
+        );
+    }
+
+    #[test]
+    fn test_interior_facet_cache_updates_after_edge_flip() {
+        let dt = build_delaunay2_from_cells(
+            &[
+                ([0.0, 0.0], 0),
+                ([1.0, 0.0], 0),
+                ([0.0, 1.0], 1),
+                ([1.0, 1.0], 1),
+            ],
+            &[vec![0, 1, 2], vec![1, 3, 2]],
+        )
+        .expect("explicit square should build");
+        let mut backend = DelaunayBackend::from_triangulation(dt);
+        assert_eq!(backend.interior_facets_by_edge.len(), 1);
+
+        let edge = backend
+            .edges()
+            .find(|edge| backend.can_flip_edge(edge))
+            .expect("square has one interior edge");
+        let old_edge = edge.key;
+        let flip = backend.flip_edge(edge).expect("interior edge should flip");
+
+        assert_eq!(backend.interior_facets_by_edge.len(), 1);
+        assert!(!backend.interior_facets_by_edge.contains_key(&old_edge));
+        assert!(
+            backend
+                .interior_facets_by_edge
+                .contains_key(&flip.new_edge.key)
         );
     }
 

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -14,8 +14,15 @@ use crate::geometry::traits::{
 };
 use delaunay::core::DataType;
 use delaunay::core::edge::EdgeKey;
+use delaunay::core::facet::FacetHandle;
 use delaunay::core::tds::{CellKey, VertexKey};
+use delaunay::core::vertex::Vertex;
 use delaunay::geometry::kernel::AdaptiveKernel;
+use delaunay::geometry::point::Point;
+use delaunay::geometry::traits::coordinate::Coordinate;
+use delaunay::prelude::VertexBuilder;
+use delaunay::prelude::triangulation::flips::BistellarFlips;
+use delaunay::topology::traits::TopologyKind;
 use delaunay::triangulation::DelaunayTriangulation;
 
 /// Delaunay backend wrapping the delaunay crate's triangulation (f64 coordinates).
@@ -23,7 +30,8 @@ use delaunay::triangulation::DelaunayTriangulation;
 /// # Mutation support
 ///
 /// The [`TriangulationMut`] methods (`insert_vertex`, `remove_vertex`, `flip_edge`, etc.)
-/// are not yet implemented and return [`DelaunayError::NotImplemented`]. The `clear()` and
+/// are backed by the upstream Delaunay edit API where possible. `move_vertex()` is not yet
+/// implemented and returns [`DelaunayError::NotImplemented`]. The `clear()` and
 /// `reserve_capacity()` methods are currently no-ops that emit a `log::warn!` diagnostic.
 #[derive(Debug)]
 pub struct DelaunayBackend<VertexData: DataType, CellData: DataType, const D: usize> {
@@ -74,6 +82,7 @@ impl DelaunayFaceHandle {
 
 /// Error type for Delaunay backend operations
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum DelaunayError {
     /// Operation is not yet implemented
     #[error("not implemented: {operation}")]
@@ -89,13 +98,24 @@ pub enum DelaunayError {
         key: VertexKey,
     },
 
-    /// Invalid edge handle (one or both endpoint vertices not found)
-    #[error("invalid edge handle: endpoint vertices {v0:?}, {v1:?} not found in triangulation")]
+    /// Invalid edge handle (the keyed edge is not present in the triangulation).
+    #[error("invalid edge handle: edge {v0:?} -- {v1:?} not found in triangulation")]
     InvalidEdge {
         /// First endpoint vertex key
         v0: VertexKey,
         /// Second endpoint vertex key
         v1: VertexKey,
+    },
+
+    /// The edge exists but is not a valid bistellar k=2 flip target.
+    #[error("non-flippable edge {v0:?} -- {v1:?}: {reason}")]
+    NonFlippableEdge {
+        /// First endpoint vertex key.
+        v0: VertexKey,
+        /// Second endpoint vertex key.
+        v1: VertexKey,
+        /// Why the live edge cannot be flipped.
+        reason: &'static str,
     },
 
     /// Invalid face/cell handle (key not found in triangulation)
@@ -104,11 +124,137 @@ pub enum DelaunayError {
         /// The cell key that was looked up
         key: CellKey,
     },
+
+    /// Coordinate slice length does not match the backend dimension.
+    #[error("coordinate dimension mismatch: got {actual}, expected {expected}")]
+    CoordinateDimensionMismatch {
+        /// Actual number of coordinates supplied.
+        actual: usize,
+        /// Expected coordinate count.
+        expected: usize,
+    },
+
+    /// Vertex construction failed before a backend mutation could be attempted.
+    #[error("failed to build vertex for {operation}: {detail}")]
+    VertexBuildFailed {
+        /// Backend operation that needed a new vertex.
+        operation: &'static str,
+        /// Underlying builder diagnostic.
+        detail: String,
+    },
+
+    /// A Delaunay insertion failed after the vertex was built.
+    #[error("{operation} insertion failed at {coordinates:?}: {detail}")]
+    InsertionFailed {
+        /// Backend operation performing the insertion.
+        operation: &'static str,
+        /// Coordinates of the vertex passed to the insertion routine.
+        coordinates: Vec<f64>,
+        /// Underlying insertion diagnostic.
+        detail: String,
+    },
+
+    /// A bistellar flip failed.
+    #[error("{operation} failed on {target}: {detail}")]
+    FlipFailed {
+        /// Flip operation that failed.
+        operation: &'static str,
+        /// Human-readable target passed to the flip operation.
+        target: String,
+        /// Underlying flip diagnostic.
+        detail: String,
+    },
+
+    /// A successful upstream flip returned data that violates this backend's contract.
+    #[error(
+        "{operation} returned unexpected output for {target}: expected {expected}, got {actual}"
+    )]
+    UnexpectedFlipOutput {
+        /// Flip operation that returned malformed output.
+        operation: &'static str,
+        /// Human-readable target passed to the flip operation.
+        target: String,
+        /// Contract expected by the backend wrapper.
+        expected: &'static str,
+        /// Output shape or detail observed from the upstream result.
+        actual: String,
+    },
 }
 
 impl<VertexData: DataType, CellData: DataType, const D: usize>
     DelaunayBackend<VertexData, CellData, D>
 {
+    /// Builds a backend vertex from a coordinate slice and optional payload.
+    fn build_vertex(
+        coords: &[f64],
+        data: Option<VertexData>,
+        operation: &'static str,
+    ) -> Result<Vertex<f64, VertexData, D>, DelaunayError> {
+        let coords: [f64; D] =
+            coords
+                .try_into()
+                .map_err(|_| DelaunayError::CoordinateDimensionMismatch {
+                    actual: coords.len(),
+                    expected: D,
+                })?;
+        let mut builder = VertexBuilder::<f64, VertexData, D>::default().point(Point::new(coords));
+        if let Some(data) = data {
+            builder = builder.data(data);
+        }
+        builder
+            .build()
+            .map_err(|err| DelaunayError::VertexBuildFailed {
+                operation,
+                detail: err.to_string(),
+            })
+    }
+
+    /// Finds the 2D facet handle corresponding to a live interior edge.
+    fn interior_facet_for_edge(&self, edge: EdgeKey) -> Option<FacetHandle> {
+        if D != 2 {
+            return None;
+        }
+
+        for (cell_key, cell) in self.dt.cells() {
+            let vertices = cell.vertices();
+            let Some(neighbors) = cell.neighbors() else {
+                continue;
+            };
+
+            for (facet_index, neighbor) in neighbors.iter().enumerate() {
+                if neighbor.is_none() {
+                    continue;
+                }
+
+                let facet_vertices: Vec<_> = vertices
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, &key)| (idx != facet_index).then_some(key))
+                    .collect();
+                if facet_vertices.len() == 2
+                    && EdgeKey::new(facet_vertices[0], facet_vertices[1]) == edge
+                {
+                    let facet_index = u8::try_from(facet_index).ok()?;
+                    return Some(FacetHandle::new(cell_key, facet_index));
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Returns whether the keyed edge is present in the triangulation.
+    fn edge_exists(&self, edge: EdgeKey) -> bool {
+        let v0 = edge.v0();
+        let v1 = edge.v1();
+        self.dt.tds().contains_vertex_key(v0)
+            && self.dt.tds().contains_vertex_key(v1)
+            && self
+                .dt
+                .incident_edges(v0)
+                .any(|candidate| candidate == edge)
+    }
+
     /// Create a new Delaunay backend from an existing Delaunay triangulation
     ///
     /// # Examples
@@ -202,7 +348,7 @@ impl<VertexData: DataType, CellData: DataType, const D: usize>
     /// let _kind = backend.topology_kind();
     /// ```
     #[must_use]
-    pub const fn topology_kind(&self) -> delaunay::topology::traits::TopologyKind {
+    pub const fn topology_kind(&self) -> TopologyKind {
         self.dt.topology_kind()
     }
 
@@ -505,22 +651,42 @@ impl<VertexData: DataType, CellData: DataType, const D: usize> TriangulationMut
 {
     fn insert_vertex(
         &mut self,
-        _coords: &[Self::Coordinate],
+        coords: &[Self::Coordinate],
     ) -> Result<Self::VertexHandle, Self::Error> {
-        // TODO: Implement vertex insertion.
-        Err(DelaunayError::NotImplemented {
-            operation: "insert_vertex",
-        })
+        let vertex = Self::build_vertex(coords, None, "insert_vertex")?;
+        let key = self
+            .dt
+            .insert(vertex)
+            .map_err(|err| DelaunayError::InsertionFailed {
+                operation: "insert_vertex",
+                coordinates: coords.to_vec(),
+                detail: err.to_string(),
+            })?;
+        Ok(DelaunayVertexHandle { key })
     }
 
     fn remove_vertex(
         &mut self,
-        _vertex: Self::VertexHandle,
+        vertex: Self::VertexHandle,
     ) -> Result<Vec<Self::FaceHandle>, Self::Error> {
-        // TODO: Implement vertex removal.
-        Err(DelaunayError::NotImplemented {
-            operation: "remove_vertex",
-        })
+        if !self.dt.tds().contains_vertex_key(vertex.key) {
+            return Err(DelaunayError::InvalidVertex { key: vertex.key });
+        }
+
+        let info = self
+            .dt
+            .flip_k1_remove(vertex.key)
+            .map_err(|err| DelaunayError::FlipFailed {
+                operation: "flip_k1_remove",
+                target: format!("vertex {:?}", vertex.key),
+                detail: err.to_string(),
+            })?;
+        Ok(info
+            .new_cells
+            .iter()
+            .copied()
+            .map(|key| DelaunayFaceHandle { key })
+            .collect())
     }
 
     fn move_vertex(
@@ -536,28 +702,97 @@ impl<VertexData: DataType, CellData: DataType, const D: usize> TriangulationMut
 
     fn flip_edge(
         &mut self,
-        _edge: Self::EdgeHandle,
+        edge: Self::EdgeHandle,
     ) -> Result<FlipResult<Self::EdgeHandle, Self::FaceHandle>, Self::Error> {
-        // TODO: Implement edge flip.
-        Err(DelaunayError::NotImplemented {
-            operation: "flip_edge",
-        })
+        let facet = if self.edge_exists(edge.key) {
+            self.interior_facet_for_edge(edge.key).ok_or_else(|| {
+                DelaunayError::NonFlippableEdge {
+                    v0: edge.key.v0(),
+                    v1: edge.key.v1(),
+                    reason: "edge is not an interior 2D facet shared by two cells",
+                }
+            })?
+        } else {
+            return Err(DelaunayError::InvalidEdge {
+                v0: edge.key.v0(),
+                v1: edge.key.v1(),
+            });
+        };
+        let info = self
+            .dt
+            .flip_k2(facet)
+            .map_err(|err| DelaunayError::FlipFailed {
+                operation: "flip_k2",
+                target: format!(
+                    "edge {:?} -- {:?} via facet {:?}",
+                    edge.key.v0(),
+                    edge.key.v1(),
+                    facet
+                ),
+                detail: err.to_string(),
+            })?;
+        let inserted: Vec<_> = info.inserted_face_vertices.iter().copied().collect();
+        let [v0, v1] = inserted.as_slice() else {
+            return Err(DelaunayError::UnexpectedFlipOutput {
+                operation: "flip_k2",
+                target: format!("edge {:?} -- {:?}", edge.key.v0(), edge.key.v1()),
+                expected: "exactly two inserted-face vertices for the replacement edge",
+                actual: format!("{} inserted-face vertices", inserted.len()),
+            });
+        };
+        let affected_faces = info
+            .new_cells
+            .iter()
+            .copied()
+            .map(|key| DelaunayFaceHandle { key })
+            .collect();
+        Ok(FlipResult::new(
+            DelaunayEdgeHandle {
+                key: EdgeKey::new(*v0, *v1),
+            },
+            affected_faces,
+        ))
     }
 
-    fn can_flip_edge(&self, _edge: &Self::EdgeHandle) -> bool {
-        // TODO: Implement flip feasibility check.
-        false
+    fn can_flip_edge(&self, edge: &Self::EdgeHandle) -> bool {
+        self.interior_facet_for_edge(edge.key).is_some()
     }
 
     fn subdivide_face(
         &mut self,
-        _face: Self::FaceHandle,
-        _point: &[Self::Coordinate],
+        face: Self::FaceHandle,
+        point: &[Self::Coordinate],
     ) -> Result<SubdivisionResult<Self::VertexHandle, Self::FaceHandle>, Self::Error> {
-        // TODO: Implement face subdivision.
-        Err(DelaunayError::NotImplemented {
-            operation: "subdivide_face",
-        })
+        if !self.dt.tds().contains_cell_key(face.key) {
+            return Err(DelaunayError::InvalidFace { key: face.key });
+        }
+
+        let vertex = Self::build_vertex(point, None, "subdivide_face")?;
+        let info =
+            self.dt
+                .flip_k1_insert(face.key, vertex)
+                .map_err(|err| DelaunayError::FlipFailed {
+                    operation: "flip_k1_insert",
+                    target: format!("face {:?} at point {:?}", face.key, point),
+                    detail: err.to_string(),
+                })?;
+        let Some(&new_vertex) = info.inserted_face_vertices.first() else {
+            return Err(DelaunayError::UnexpectedFlipOutput {
+                operation: "flip_k1_insert",
+                target: format!("face {:?} at point {:?}", face.key, point),
+                expected: "at least one inserted-face vertex for the inserted point",
+                actual: "no inserted-face vertices".to_string(),
+            });
+        };
+        Ok(SubdivisionResult::new(
+            DelaunayVertexHandle { key: new_vertex },
+            info.new_cells
+                .iter()
+                .copied()
+                .map(|key| DelaunayFaceHandle { key })
+                .collect(),
+            face,
+        ))
     }
 
     fn clear(&mut self) {
@@ -578,9 +813,11 @@ mod tests {
     use std::collections::HashSet;
 
     use crate::geometry::generators::{
-        build_delaunay2_with_data, generate_delaunay2, random_delaunay2, seeded_delaunay2,
+        build_delaunay2_from_cells, build_delaunay2_with_data, generate_delaunay2,
+        random_delaunay2, seeded_delaunay2,
     };
     use crate::util::saturating_usize_to_i32;
+    use slotmap::KeyData;
 
     use super::*;
 
@@ -722,7 +959,7 @@ mod tests {
         let backend = DelaunayBackend::from_triangulation(dt);
 
         // Use a high-generation key that cannot exist in the triangulation's slotmap
-        let bogus_key = VertexKey::from(slotmap::KeyData::from_ffi(u64::MAX));
+        let bogus_key = VertexKey::from(KeyData::from_ffi(u64::MAX));
         let invalid_handle = DelaunayVertexHandle { key: bogus_key };
         let err = backend.vertex_coordinates(&invalid_handle).unwrap_err();
         assert!(
@@ -760,7 +997,7 @@ mod tests {
         let dt = random_delaunay2(3, (0.0, 10.0));
         let backend = DelaunayBackend::from_triangulation(dt);
 
-        let bogus_key = CellKey::from(slotmap::KeyData::from_ffi(u64::MAX));
+        let bogus_key = CellKey::from(KeyData::from_ffi(u64::MAX));
         let invalid_handle = DelaunayFaceHandle { key: bogus_key };
         let err = backend.face_vertices(&invalid_handle).unwrap_err();
         assert!(
@@ -827,8 +1064,8 @@ mod tests {
         let dt = random_delaunay2(3, (0.0, 10.0));
         let backend = DelaunayBackend::from_triangulation(dt);
 
-        let k1 = VertexKey::from(slotmap::KeyData::from_ffi(u64::MAX - 1));
-        let k2 = VertexKey::from(slotmap::KeyData::from_ffi(u64::MAX));
+        let k1 = VertexKey::from(KeyData::from_ffi(u64::MAX - 1));
+        let k2 = VertexKey::from(KeyData::from_ffi(u64::MAX));
         let invalid_handle = DelaunayEdgeHandle {
             key: EdgeKey::new(k1, k2),
         };
@@ -979,7 +1216,7 @@ mod tests {
         let dt = random_delaunay2(3, (0.0, 10.0));
         let backend = DelaunayBackend::from_triangulation(dt);
 
-        let bogus_key = CellKey::from(slotmap::KeyData::from_ffi(u64::MAX));
+        let bogus_key = CellKey::from(KeyData::from_ffi(u64::MAX));
         let invalid_handle = DelaunayFaceHandle { key: bogus_key };
         let err = backend.face_neighbors(&invalid_handle).unwrap_err();
         assert!(
@@ -993,7 +1230,7 @@ mod tests {
         let dt = random_delaunay2(3, (0.0, 10.0));
         let backend = DelaunayBackend::from_triangulation(dt);
 
-        let bogus_key = VertexKey::from(slotmap::KeyData::from_ffi(u64::MAX));
+        let bogus_key = VertexKey::from(KeyData::from_ffi(u64::MAX));
         let invalid_handle = DelaunayVertexHandle { key: bogus_key };
         let err = backend.adjacent_faces(&invalid_handle).unwrap_err();
         assert!(
@@ -1007,7 +1244,7 @@ mod tests {
         let dt = random_delaunay2(3, (0.0, 10.0));
         let backend = DelaunayBackend::from_triangulation(dt);
 
-        let bogus_key = VertexKey::from(slotmap::KeyData::from_ffi(u64::MAX));
+        let bogus_key = VertexKey::from(KeyData::from_ffi(u64::MAX));
         let invalid_handle = DelaunayVertexHandle { key: bogus_key };
         let err = backend.incident_edges(&invalid_handle).unwrap_err();
         assert!(
@@ -1126,7 +1363,7 @@ mod tests {
 
         assert_eq!(
             backend.topology_kind(),
-            delaunay::topology::traits::TopologyKind::Euclidean,
+            TopologyKind::Euclidean,
             "Default builder construction should produce Euclidean topology"
         );
     }
@@ -1152,30 +1389,58 @@ mod tests {
     }
 
     #[test]
-    fn test_mutation_methods_report_not_implemented_contract() {
-        let dt = generate_delaunay2(4, (0.0, 10.0), Some(17)).expect("Builder should succeed");
+    fn test_mutation_methods_use_delaunay_edit_api() {
+        let dt = build_delaunay2_from_cells(
+            &[
+                ([0.0, 0.0], 0),
+                ([1.0, 0.0], 0),
+                ([0.0, 1.0], 1),
+                ([1.0, 1.0], 1),
+            ],
+            &[vec![0, 1, 2], vec![1, 3, 2]],
+        )
+        .expect("explicit square should build");
         let mut backend = DelaunayBackend::from_triangulation(dt);
-        let original_counts = (
-            backend.vertex_count(),
-            backend.edge_count(),
-            backend.face_count(),
-        );
-        let vertex = backend.vertices().next().expect("valid vertex handle");
-        let edge = backend.edges().next().expect("valid edge handle");
-        let face = backend.faces().next().expect("valid face handle");
+        let original_vertex_count = backend.vertex_count();
+        let original_face_count = backend.face_count();
 
-        assert!(matches!(
-            backend.insert_vertex(&[0.0, 0.0]),
-            Err(DelaunayError::NotImplemented {
-                operation: "insert_vertex",
-            })
-        ));
-        assert!(matches!(
-            backend.remove_vertex(vertex.clone()),
-            Err(DelaunayError::NotImplemented {
-                operation: "remove_vertex",
-            })
-        ));
+        let edge = backend
+            .edges()
+            .find(|edge| backend.can_flip_edge(edge))
+            .expect("square has an interior edge");
+        let flip = backend.flip_edge(edge);
+        assert!(flip.is_ok());
+        assert_eq!(backend.vertex_count(), original_vertex_count);
+        assert_eq!(backend.face_count(), original_face_count);
+        assert!(backend.is_valid());
+
+        let dt = build_delaunay2_with_data(&[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.5, 1.0], 1)])
+            .expect("labeled triangle should build");
+        let mut backend = DelaunayBackend::from_triangulation(dt);
+        let original_vertex_count = backend.vertex_count();
+        let original_face_count = backend.face_count();
+        let face = backend.faces().next().expect("valid face handle");
+        let subdivide = backend
+            .subdivide_face(face, &[0.5, 1.0 / 3.0])
+            .expect("face subdivision should use k=1 flip");
+        assert_eq!(backend.vertex_count(), original_vertex_count + 1);
+        assert_eq!(backend.face_count(), original_face_count + 2);
+        assert!(backend.is_valid());
+
+        backend
+            .remove_vertex(subdivide.new_vertex)
+            .expect("degree-3 inserted vertex should be removable");
+        assert_eq!(backend.vertex_count(), original_vertex_count);
+        assert_eq!(backend.face_count(), original_face_count);
+        assert!(backend.is_valid());
+
+        let inserted = backend.insert_vertex(&[0.25, 0.75]);
+        assert!(inserted.is_ok());
+        assert_eq!(backend.vertex_count(), original_vertex_count + 1);
+        assert!(backend.is_valid());
+
+        let vertex = backend.vertices().next().expect("valid vertex handle");
+
         assert!(matches!(
             backend.move_vertex(vertex, &[1.0, 1.0]),
             Err(DelaunayError::NotImplemented {
@@ -1183,19 +1448,43 @@ mod tests {
             })
         ));
         assert!(matches!(
-            backend.flip_edge(edge.clone()),
-            Err(DelaunayError::NotImplemented {
-                operation: "flip_edge",
-            })
-        ));
-        assert!(!backend.can_flip_edge(&edge));
-        assert!(matches!(
-            backend.subdivide_face(face, &[0.5, 0.5]),
-            Err(DelaunayError::NotImplemented {
-                operation: "subdivide_face",
+            backend.insert_vertex(&[0.0]),
+            Err(DelaunayError::CoordinateDimensionMismatch {
+                actual: 1,
+                expected: 2,
             })
         ));
 
+        let bogus_vertex = VertexKey::from(KeyData::from_ffi(u64::MAX));
+        assert!(matches!(
+            backend.remove_vertex(DelaunayVertexHandle { key: bogus_vertex }),
+            Err(DelaunayError::InvalidVertex { key }) if key == bogus_vertex,
+        ));
+
+        let bogus_face = CellKey::from(KeyData::from_ffi(u64::MAX));
+        assert!(matches!(
+            backend.subdivide_face(DelaunayFaceHandle { key: bogus_face }, &[0.25, 0.25]),
+            Err(DelaunayError::InvalidFace { key }) if key == bogus_face,
+        ));
+
+        let dt = build_delaunay2_with_data(&[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.5, 1.0], 1)])
+            .expect("labeled triangle should build");
+        let mut boundary_backend = DelaunayBackend::from_triangulation(dt);
+        let boundary_edge = boundary_backend
+            .edges()
+            .next()
+            .expect("single triangle has boundary edges");
+        assert!(matches!(
+            boundary_backend.flip_edge(boundary_edge),
+            Err(DelaunayError::NonFlippableEdge { reason, .. })
+                if reason.contains("interior 2D facet"),
+        ));
+
+        let counts_before_noops = (
+            backend.vertex_count(),
+            backend.edge_count(),
+            backend.face_count(),
+        );
         backend.clear();
         backend.reserve_capacity(32, 64);
         assert_eq!(
@@ -1204,7 +1493,7 @@ mod tests {
                 backend.edge_count(),
                 backend.face_count(),
             ),
-            original_counts
+            counts_before_noops
         );
     }
 

--- a/src/geometry/backends/mock.rs
+++ b/src/geometry/backends/mock.rs
@@ -6,7 +6,8 @@
 //! CDT algorithms without requiring actual triangulation computations.
 
 use crate::geometry::traits::{
-    FlipResult, GeometryBackend, SubdivisionResult, TriangulationMut, TriangulationQuery,
+    EdgeAdjacentFaces, EdgeAdjacentFacesResult, FlipResult, GeometryBackend, SubdivisionResult,
+    TriangulationMut, TriangulationQuery,
 };
 use std::collections::HashMap;
 
@@ -332,6 +333,28 @@ impl TriangulationQuery for MockBackend {
         self.edges
             .get(&edge.0)
             .map(|&(v1, v2)| (MockVertexHandle(v1), MockVertexHandle(v2)))
+    }
+
+    fn edge_adjacent_faces(
+        &self,
+        edge: &Self::EdgeHandle,
+    ) -> EdgeAdjacentFacesResult<Self::VertexHandle, Self::FaceHandle, Self::Error> {
+        let (v0, v1) = *self.edges.get(&edge.0).ok_or(MockError::Edge(edge.0))?;
+        let adjacent_faces = self.adjacent_face_ids_for_edge(v0, v1);
+        let Ok((opposite_0, opposite_1)) =
+            self.edge_flip_opposites(edge.0, v0, v1, &adjacent_faces)
+        else {
+            return Ok(None);
+        };
+        let [face_0, face_1] = adjacent_faces.as_slice() else {
+            return Ok(None);
+        };
+
+        Ok(Some(EdgeAdjacentFaces::new(
+            (MockVertexHandle(v0), MockVertexHandle(v1)),
+            (MockFaceHandle(*face_0), MockFaceHandle(*face_1)),
+            (MockVertexHandle(opposite_0), MockVertexHandle(opposite_1)),
+        )))
     }
 
     fn adjacent_faces(

--- a/src/geometry/backends/mock.rs
+++ b/src/geometry/backends/mock.rs
@@ -36,6 +36,7 @@ pub struct MockFaceHandle(usize);
 
 /// Mock backend errors
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum MockError {
     /// Invalid vertex handle provided
     #[error("Invalid vertex handle: {0}")]

--- a/src/geometry/operations.rs
+++ b/src/geometry/operations.rs
@@ -236,7 +236,7 @@ impl<T: TriangulationQuery> TriangulationOps for T {}
 mod tests {
     use super::*;
     use crate::geometry::backends::mock::MockBackend;
-    use crate::geometry::traits::{GeometryBackend, TriangulationQuery};
+    use crate::geometry::traits::{EdgeAdjacentFacesResult, GeometryBackend, TriangulationQuery};
     use std::collections::HashSet;
 
     #[derive(Debug, Clone)]
@@ -249,9 +249,11 @@ mod tests {
     #[derive(Debug, PartialEq, Eq, thiserror::Error)]
     enum FixtureError {
         #[error("invalid face")]
-        InvalidFace,
+        Face,
         #[error("invalid vertex")]
-        InvalidVertex,
+        Vertex,
+        #[error("invalid edge")]
+        Edge,
     }
 
     impl GeometryBackend for FixtureBackend {
@@ -302,7 +304,7 @@ mod tests {
             self.vertices
                 .contains(vertex)
                 .then_some(vec![0.0])
-                .ok_or(FixtureError::InvalidVertex)
+                .ok_or(FixtureError::Vertex)
         }
 
         fn face_vertices(
@@ -313,7 +315,7 @@ mod tests {
                 .iter()
                 .find(|(candidate, _)| candidate == face)
                 .and_then(|(_, vertices)| vertices.clone())
-                .ok_or(FixtureError::InvalidFace)
+                .ok_or(FixtureError::Face)
         }
 
         fn edge_endpoints(
@@ -326,6 +328,17 @@ mod tests {
                 .and_then(|(_, endpoints)| *endpoints)
         }
 
+        fn edge_adjacent_faces(
+            &self,
+            edge: &Self::EdgeHandle,
+        ) -> EdgeAdjacentFacesResult<Self::VertexHandle, Self::FaceHandle, Self::Error> {
+            self.edges
+                .iter()
+                .any(|(candidate, _)| candidate == edge)
+                .then_some(None)
+                .ok_or(FixtureError::Edge)
+        }
+
         fn adjacent_faces(
             &self,
             vertex: &Self::VertexHandle,
@@ -333,7 +346,7 @@ mod tests {
             self.vertices
                 .contains(vertex)
                 .then_some(Vec::new())
-                .ok_or(FixtureError::InvalidVertex)
+                .ok_or(FixtureError::Vertex)
         }
 
         fn incident_edges(
@@ -343,7 +356,7 @@ mod tests {
             self.vertices
                 .contains(vertex)
                 .then_some(Vec::new())
-                .ok_or(FixtureError::InvalidVertex)
+                .ok_or(FixtureError::Vertex)
         }
 
         fn face_neighbors(
@@ -354,7 +367,7 @@ mod tests {
                 .iter()
                 .any(|(candidate, _)| candidate == face)
                 .then_some(Vec::new())
-                .ok_or(FixtureError::InvalidFace)
+                .ok_or(FixtureError::Face)
         }
 
         fn is_valid(&self) -> bool {
@@ -399,22 +412,22 @@ mod tests {
         assert_eq!(backend.vertex_coordinates(&0), Ok(vec![0.0]));
         assert!(matches!(
             backend.vertex_coordinates(&99),
-            Err(FixtureError::InvalidVertex)
+            Err(FixtureError::Vertex)
         ));
         assert_eq!(backend.adjacent_faces(&0), Ok(Vec::new()));
         assert!(matches!(
             backend.adjacent_faces(&99),
-            Err(FixtureError::InvalidVertex)
+            Err(FixtureError::Vertex)
         ));
         assert_eq!(backend.incident_edges(&0), Ok(Vec::new()));
         assert!(matches!(
             backend.incident_edges(&99),
-            Err(FixtureError::InvalidVertex)
+            Err(FixtureError::Vertex)
         ));
         assert_eq!(backend.face_neighbors(&0), Ok(Vec::new()));
         assert!(matches!(
             backend.face_neighbors(&99),
-            Err(FixtureError::InvalidFace)
+            Err(FixtureError::Face)
         ));
 
         let hull: HashSet<_> = backend.convex_hull().into_iter().collect();

--- a/src/geometry/traits.rs
+++ b/src/geometry/traits.rs
@@ -101,6 +101,19 @@ pub trait TriangulationQuery: GeometryBackend {
         edge: &Self::EdgeHandle,
     ) -> Option<(Self::VertexHandle, Self::VertexHandle)>;
 
+    /// Get the two faces adjacent to an edge and their opposite vertices.
+    ///
+    /// Returns `Ok(Some(_))` for an interior edge shared by exactly two
+    /// triangular faces, `Ok(None)` for boundary or otherwise non-flippable
+    /// local topology, and `Err` when the edge handle itself is invalid.
+    ///
+    /// # Errors
+    /// Returns error if the edge handle is invalid.
+    fn edge_adjacent_faces(
+        &self,
+        edge: &Self::EdgeHandle,
+    ) -> EdgeAdjacentFacesResult<Self::VertexHandle, Self::FaceHandle, Self::Error>;
+
     /// Get all faces adjacent to a vertex
     ///
     /// # Errors
@@ -163,6 +176,40 @@ impl<E, F> FlipResult<E, F> {
         Self {
             new_edge,
             affected_faces,
+        }
+    }
+}
+
+/// Local topology adjacent to one edge in a 2D triangulation.
+#[derive(Debug, Clone)]
+pub struct EdgeAdjacentFaces<V, F> {
+    /// The two endpoints of the queried edge.
+    pub endpoints: (V, V),
+    /// The two faces sharing the edge.
+    pub faces: (F, F),
+    /// The vertex opposite the edge in each adjacent face.
+    pub opposite_vertices: (V, V),
+}
+
+/// Result type for querying the local faces adjacent to an edge.
+pub type EdgeAdjacentFacesResult<V, F, E> = Result<Option<EdgeAdjacentFaces<V, F>>, E>;
+
+impl<V, F> EdgeAdjacentFaces<V, F> {
+    /// Create a local edge-adjacency record.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::geometry::traits::EdgeAdjacentFaces;
+    ///
+    /// let adjacency = EdgeAdjacentFaces::new(("a", "b"), ("left", "right"), ("c", "d"));
+    /// assert_eq!(adjacency.endpoints, ("a", "b"));
+    /// ```
+    pub const fn new(endpoints: (V, V), faces: (F, F), opposite_vertices: (V, V)) -> Self {
+        Self {
+            endpoints,
+            faces,
+            opposite_vertices,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,9 @@
 //! - Integration with delaunay crate for proper Delaunay triangulations
 //! - 2D Regge Action calculation for CDT
 //! - Foliated 2D triangulation construction and validation
-//! - Planned ergodic moves and Metropolis-Hastings sampling once real CDT
-//!   move kernels are implemented
+//! - Foliation-aware 2D ergodic moves backed by bistellar flips
+//! - Planned Metropolis-Hastings sampling integration once rejected-move
+//!   rollback is implemented
 //!
 //! # Example
 //!
@@ -89,7 +90,7 @@ pub mod cdt {
 
 // Re-exports for convenience
 pub use cdt::action::{ActionConfig, compute_regge_action};
-pub use cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveType};
+pub use cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveStatistics, MoveType};
 pub use cdt::foliation::{CellType, EdgeType, Foliation};
 pub use cdt::metropolis::{
     CdtProposal, CdtTarget, Measurement, MetropolisAlgorithm, MetropolisConfig, MonteCarloStep,
@@ -130,7 +131,7 @@ pub mod prelude {
     pub use crate::cdt::action::{ActionConfig, compute_regge_action};
 
     // Ergodic moves
-    pub use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveType};
+    pub use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveStatistics, MoveType};
 
     // Metropolis simulation
     pub use crate::cdt::metropolis::{
@@ -173,11 +174,28 @@ pub mod prelude {
         pub use crate::geometry::traits::TriangulationQuery;
     }
 
+    /// Focused exports for local CDT move kernels and move statistics.
+    ///
+    /// This prelude intentionally contains only the move API. Combine it with
+    /// `prelude::triangulation::*` and, for explicit Delaunay fixtures,
+    /// `prelude::geometry::*`.
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::*;
+    ///
+    /// let mut stats = MoveStatistics::new();
+    /// stats.record_attempt(MoveType::Move22);
+    /// assert_eq!(stats.moves_22_attempted, 1);
+    /// ```
+    pub mod moves {
+        pub use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveStatistics, MoveType};
+    }
+
     /// Focused exports for running CDT simulations.
     pub mod simulation {
         pub use crate::CdtTriangulation;
         pub use crate::cdt::action::{ActionConfig, compute_regge_action};
-        pub use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveType};
+        pub use crate::cdt::ergodic_moves::MoveType;
         pub use crate::cdt::metropolis::{
             CdtProposal, CdtTarget, Measurement, MetropolisAlgorithm, MetropolisConfig,
             MonteCarloStep, SimulationResultsBackend,

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -73,6 +73,23 @@ enum CdtError {
     UnsupportedOperation,
 }
 
+// ruleid: causal-triangulations.rust.public-error-enums-non-exhaustive
+pub enum MissingNonExhaustiveError {
+    InvalidInput,
+}
+
+// ok: causal-triangulations.rust.public-error-enums-non-exhaustive
+#[non_exhaustive]
+pub enum ExtensibleError {
+    InvalidInput,
+}
+
+// ruleid: causal-triangulations.rust.prefer-focused-prelude-imports-in-public-usage
+use causal_triangulations::geometry::DelaunayBackend2D;
+
+// ok: causal-triangulations.rust.prefer-focused-prelude-imports-in-public-usage
+use causal_triangulations::prelude::geometry::DelaunayBackend2D as PreludeDelaunayBackend2D;
+
 fn stringly_domain_validation_errors() {
     // ruleid: causal-triangulations.rust.no-stringly-domain-validation-errors
     let _ = CdtError::ValidationFailed {

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -78,6 +78,14 @@ pub enum MissingNonExhaustiveError {
     InvalidInput,
 }
 
+mod nested_error_fixtures {
+    #[derive(Debug)]
+    // ruleid: causal-triangulations.rust.public-error-enums-non-exhaustive
+    pub enum NestedMissingNonExhaustiveError {
+        InvalidInput,
+    }
+}
+
 // ok: causal-triangulations.rust.public-error-enums-non-exhaustive
 #[non_exhaustive]
 pub enum ExtensibleError {


### PR DESCRIPTION
- Replace placeholder random move outcomes with Delaunay-backed k=2, k=1 insert, and k=1 remove operations.
- Add causality-aware candidate selection, foliation resynchronization, and structured backend mutation errors.
- Keep EdgeFlip as a 2D Move22 alias while preserving separate move statistics.
- Add focused move preludes, doctests, benchmarks, Semgrep checks, and updated move documentation.
- Mark public error enums non-exhaustive and document orthogonal error guidance.

BREAKING CHANGE: Ergodic move methods now take CdtTriangulation2D instead of dummy Vec<Vec<usize>> fixtures.

Closes #55