### PR TITLE
perf(ci): speed up Rust validation workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ env:
   RUST_BACKTRACE: 1
   ACTIONLINT_VERSION: "1.7.10"
   DPRINT_VERSION: "0.51.1"
+  NEXTEST_VERSION: "0.9.136"
   SHFMT_VERSION: "3.12.0"
   TYPOS_VERSION: "1.43.5"
   UV_VERSION: "0.9.21"
@@ -60,6 +61,11 @@ jobs:
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
         with:
           tool: just
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
+        with:
+          tool: cargo-nextest@${{ env.NEXTEST_VERSION }}
 
       - name: Install uv (for Python scripts and yamllint/ruff)
         if: matrix.os != 'windows-latest'
@@ -232,7 +238,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           cargo build --verbose --all-targets
-          cargo test --lib --verbose
+          cargo nextest run --lib --verbose
           cargo test --doc --verbose
-          cargo test --tests --verbose
-          cargo test --examples --verbose
+          cargo nextest run -E 'kind(test)' --verbose
+          cargo nextest run --examples --verbose --no-tests pass

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -37,6 +37,8 @@ Examples:
 
 Direct tool invocation should only be used when a corresponding `just` command does not exist.
 
+Rust unit, integration, CLI, slow, example, and release test recipes run with `cargo nextest`. Documentation tests intentionally remain on `cargo test --doc` because nextest does not run rustdoc doctests.
+
 ---
 
 ## Formatting
@@ -164,6 +166,8 @@ Examples must:
 - demonstrate correct API usage
 
 `just examples-validate` additionally checks stable output markers for user-facing Cargo examples. Keep those markers semantic rather than exact numeric values so simulation output can evolve without making the example contract brittle.
+
+The example runner compiles all Cargo examples once with `cargo build --release --examples`, then executes the compiled binaries directly. This preserves example coverage while avoiding repeated Cargo invocations for each example.
 
 When adding or renaming a Cargo example, update `scripts/run_all_examples.sh` `validate_example_output()` with stable semantic output markers, or intentionally document why success-only validation is sufficient for that example.
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -111,6 +111,10 @@ All Python tests should:
 - use type hints
 - include `-> None` return annotations on test functions
 
+### Rust Test Runner
+
+Runnable Rust tests use `cargo nextest` through the repository `just` recipes. Rustdoc doctests remain on `cargo test --doc` because nextest does not execute doctests. Use the `just` recipes instead of calling Cargo directly so this split stays consistent locally and in CI.
+
 ---
 
 ## Floating-Point Comparisons
@@ -225,8 +229,8 @@ The `ci` recipe runs `check bench-compile test-all examples-validate`, which enf
 
 - **check** (via `lint`): formatting, clippy, documentation builds, markdown, spelling, config validation (JSON, TOML, YAML, GitHub Actions)
 - **bench-compile**: benchmarks compile without warnings under `-D warnings`
-- **test-all**: unit tests, doc tests, integration tests, and Python tests (pytest)
-- **examples-validate**: all Cargo examples run successfully and user-facing examples emit stable output markers
+- **test-all**: unit tests and integration tests via nextest, rustdoc doctests via `cargo test --doc`, and Python tests via pytest
+- **examples-validate**: Cargo examples build once, then the compiled binaries run successfully with stable output markers
 
 ---
 

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -29,7 +29,7 @@ The broad-exception Semgrep rule now covers the full Python support-script tree.
 
 Some differences remain because CDT has different workflows and project invariants:
 
-- CDT runs examples through `scripts/run_all_examples.sh`, which discovers current examples dynamically and applies a timeout. Its `--validate` mode checks stable semantic output markers for known Cargo examples without requiring exact numeric output.
+- CDT runs examples through `scripts/run_all_examples.sh`, which discovers current examples dynamically, builds release examples once, applies a timeout while running the compiled binaries, and checks stable semantic output markers in `--validate` mode without requiring exact numeric output.
 - CDT keeps `archive-changelog` so completed release series move under `docs/archive/changelog/`; MCMC does not yet archive old changelog sections.
 - CDT keeps a dedicated `performance.yml` workflow and local `perf-*` recipes. MCMC does not have matching CDT benchmark-baseline tooling.
 - CDT exposes feature-gated long-running Rust checks through the `slow-tests` Cargo feature and the `just test-slow` recipe, keeping normal CI fast while giving stabilization work a named path for heavier integration coverage.
@@ -57,6 +57,8 @@ The useful Semgrep updates ported from the sibling `delaunay` repository are:
 The useful `justfile` updates ported from `delaunay` are:
 
 - `ci-slow`, a named CI-plus-slow-tests workflow using CDT's existing `slow-tests` feature gate;
+- `cargo nextest` for runnable Rust unit, integration, CLI, slow, example, and release test recipes, while keeping rustdoc doctests on `cargo test --doc` because nextest does not execute doctests;
+- single-pass release example builds in `scripts/run_all_examples.sh`, which preserve semantic output validation while avoiding repeated `cargo run --example` invocations;
 - `bench-smoke`, adapted to CDT's `cdt_benchmarks` harness and Criterion's minimal sample settings so benchmark harnesses can be smoke-tested without producing baseline-quality numbers;
 - `bench-test-compile`, which layers release-profile integration-test compilation on top of the existing warning-denying benchmark compile check;
 - opt-in release hygiene recipes `unused-deps` and `publish-check`, kept outside the default `lint` and `ci` paths so they are available before releases without making routine validation slower or more tool-dependent;

--- a/justfile
+++ b/justfile
@@ -7,6 +7,7 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
 cargo_llvm_cov_version := "0.8.5"
+cargo_nextest_version := "0.9.136"
 
 # Common cargo-llvm-cov arguments for all coverage runs.
 # Excludes benches/examples from reports while allowing integration tests to
@@ -36,6 +37,15 @@ _ensure-cargo-machete:
     if ! cargo machete --version >/dev/null 2>&1; then
         echo "❌ 'cargo-machete' not found. Install with:"
         echo "   cargo install --locked cargo-machete"
+        exit 1
+    fi
+
+_ensure-cargo-nextest:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! cargo nextest --version >/dev/null 2>&1; then
+        echo "❌ 'cargo-nextest' not found. See 'just setup-tools' or install:"
+        echo "   cargo install --locked cargo-nextest --version {{cargo_nextest_version}}"
         exit 1
     fi
 
@@ -131,9 +141,9 @@ bench-smoke:
 bench-compile:
     RUSTFLAGS='-D warnings' cargo bench --workspace --no-run
 
-# Compile benchmarks and release-profile integration tests without running.
-bench-test-compile: bench-compile
-    cargo test --tests --release --no-run
+# Compile benchmarks and release-profile Rust test binaries without running.
+bench-test-compile: bench-compile _ensure-cargo-nextest
+    cargo nextest run --tests --release --no-run
 
 # Build commands
 build:
@@ -179,8 +189,9 @@ check: lint
 check-fast:
     cargo check
 
-# CI simulation: comprehensive validation (matches .github/workflows/ci.yml)
-# Runs: checks + all tests (Rust + Python) + validated examples + bench compile
+# CI simulation: comprehensive validation (matches .github/workflows/ci.yml).
+# Rust unit/integration tests use nextest; doctests remain on cargo test because
+# nextest does not execute rustdoc doctests.
 ci: check bench-compile test-all examples-validate
     @echo "🎯 CI checks complete!"
 
@@ -544,7 +555,7 @@ setup-tools:
         else
             echo "Install required tools via your system package manager, or ensure they are on PATH."
         fi
-        echo "Required tools: uv, jq, taplo, yamllint, shfmt, shellcheck, actionlint, git-cliff, dprint, typos, cargo-llvm-cov, cargo-machete"
+        echo "Required tools: uv, jq, taplo, yamllint, shfmt, shellcheck, actionlint, git-cliff, dprint, typos, cargo-llvm-cov, cargo-nextest, cargo-machete"
         echo ""
     fi
 
@@ -604,6 +615,14 @@ setup-tools:
         echo "  ✓ cargo-llvm-cov ${cargo_llvm_cov_version}"
     fi
 
+    cargo_nextest_version="{{cargo_nextest_version}}"
+    if ! cargo nextest --version >/dev/null 2>&1 || [[ "$(cargo nextest --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$cargo_nextest_version" ]]; then
+        echo "  ⏳ Installing cargo-nextest ${cargo_nextest_version} (cargo)..."
+        cargo install --locked cargo-nextest --version "${cargo_nextest_version}"
+    else
+        echo "  ✓ cargo-nextest ${cargo_nextest_version}"
+    fi
+
     if ! cargo machete --version >/dev/null 2>&1; then
         echo "  ⏳ Installing cargo-machete (cargo)..."
         cargo install --locked cargo-machete
@@ -638,6 +657,12 @@ setup-tools:
         echo "  ✓ cargo machete"
     else
         echo "  ✗ cargo machete"
+        missing=1
+    fi
+    if cargo nextest --version >/dev/null 2>&1; then
+        echo "  ✓ cargo nextest"
+    else
+        echo "  ✗ cargo nextest"
         missing=1
     fi
     if [ "$missing" -ne 0 ]; then
@@ -729,36 +754,38 @@ spell-check: _ensure-typos
         echo "No modified files to spell-check."
     fi
 
-# Testing: fast tests (lib + doc)
+# Testing: fast tests (lib via nextest + rustdoc doctests via cargo test)
 test: test-lib test-doc
 
-# Testing: comprehensive suite (lib + doc + integration + Python)
+# Testing: comprehensive suite (Rust runnable tests via nextest + doctests + Python)
 test-all: test test-integration test-python
     @echo "✅ All tests passed!"
 
-test-lib:
-    cargo test --lib --verbose
+test-lib: _ensure-cargo-nextest
+    cargo nextest run --lib --verbose
 
+# Doctests must stay on cargo test; nextest does not run rustdoc doctests.
 test-doc:
     cargo test --doc --verbose
 
-test-integration:
-    cargo test --tests --verbose
+test-integration: _ensure-cargo-nextest
+    cargo nextest run -E 'kind(test)' --verbose
 
-test-slow:
-    cargo test --tests --features slow-tests --verbose
+test-slow: _ensure-cargo-nextest
+    cargo nextest run -E 'kind(test)' --features slow-tests --verbose
 
-test-examples:
-    cargo test --examples --verbose
+test-examples: _ensure-cargo-nextest
+    cargo nextest run --examples --verbose --no-tests pass
 
-test-cli:
-    cargo test --test cli --verbose
+test-cli: _ensure-cargo-nextest
+    cargo nextest run --test cli --verbose
 
 test-python: _ensure-uv
     uv run python -m pytest
 
-test-release:
-    cargo test --release
+test-release: _ensure-cargo-nextest
+    cargo nextest run --release --workspace
+    cargo test --doc --release
 
 # File validation
 validate-json: _ensure-jq

--- a/scripts/run_all_examples.sh
+++ b/scripts/run_all_examples.sh
@@ -21,7 +21,7 @@ DESCRIPTION:
     Automatically discovers and runs Cargo examples in examples/:
       - examples/<name>.rs
       - examples/<name>/main.rs
-    All examples run in release mode (--release).
+    All examples are built once in release mode, then executed directly.
 
 OPTIONS:
     -h, --help       Show this help message and exit
@@ -39,6 +39,7 @@ EXAMPLES:
 
 NOTES:
     - All examples run in release mode for better performance
+    - Cargo examples are compiled once before execution to avoid repeated Cargo work
     - Examples are discovered automatically from the examples/ directory
     - Output is shown in real-time as examples execute
     - Script exits with error code if any example fails
@@ -130,17 +131,34 @@ elif command -v gtimeout >/dev/null 2>&1; then
 	TIMEOUT_CMD="gtimeout"
 fi
 
-run_cargo_example() {
+case "$(uname -s 2>/dev/null || true)" in
+MINGW* | MSYS* | CYGWIN*) EXE_SUFFIX=".exe" ;;
+*) EXE_SUFFIX="" ;;
+esac
+
+TARGET_DIR="${CARGO_TARGET_DIR:-${PROJECT_ROOT}/target}"
+EXAMPLES_BIN_DIR="${TARGET_DIR}/release/examples"
+
+echo "Building release examples once..."
+cargo build --release --examples
+echo
+
+run_compiled_example() {
 	local example="$1"
+	local binary="${EXAMPLES_BIN_DIR}/${example}${EXE_SUFFIX}"
+
+	if [[ ! -x "$binary" ]]; then
+		error_exit "Compiled example binary not found or not executable: $binary"
+	fi
 
 	if [[ -n "$TIMEOUT_CMD" ]]; then
 		DURATION="${EXAMPLE_TIMEOUT:-600s}"
 		# If DURATION has no unit suffix, assume seconds
 		case "$DURATION" in *[a-zA-Z]) ;; *) DURATION="${DURATION}s" ;; esac
 		"$TIMEOUT_CMD" --preserve-status --signal=TERM --kill-after=10s "$DURATION" \
-			cargo run --release --example "$example"
+			"$binary"
 	else
-		cargo run --release --example "$example"
+		"$binary"
 	fi
 }
 
@@ -191,7 +209,7 @@ validate_example_output() {
 for example in "${all_examples[@]}"; do
 	echo "=== Running $example ==="
 	if [[ "$VALIDATE_OUTPUT" == true ]]; then
-		if output=$(run_cargo_example "$example" 2>&1); then
+		if output=$(run_compiled_example "$example" 2>&1); then
 			printf '%s\n' "$output"
 			validate_example_output "$example" "$output"
 		else
@@ -199,7 +217,7 @@ for example in "${all_examples[@]}"; do
 			error_exit "Example $example failed!"
 		fi
 	else
-		run_cargo_example "$example" || error_exit "Example $example failed!"
+		run_compiled_example "$example" || error_exit "Example $example failed!"
 	fi
 done
 


### PR DESCRIPTION
- Run runnable Rust unit, integration, CLI, slow, example, and release test recipes with cargo nextest while keeping rustdoc doctests on cargo test.
- Build release examples once and execute the compiled binaries for validated example runs.
- Install pinned cargo-nextest in CI and document the validation split.

Closes #130