### PR TITLE
perf(tooling): add CDT CI performance suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,8 +244,6 @@ jobs:
       - name: Build and test (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          cargo build --verbose --all-targets
-          cargo nextest run --lib --verbose
+          cargo nextest run --workspace --all-targets --verbose --no-run
+          cargo nextest run --workspace --lib --bins --examples --tests --verbose --no-tests pass
           cargo test --doc --verbose
-          cargo nextest run -E 'kind(test)' --verbose
-          cargo nextest run --examples --verbose --no-tests pass

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,7 +21,7 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     env:
-      CARGO_LLVM_COV_VERSION: "0.8.5"
+      CARGO_LLVM_COV_VERSION: "0.8.7"
       JUST_VERSION: "1.50.0"
     steps:
       - name: Checkout repository
@@ -55,7 +55,7 @@ jobs:
           fi
 
           if [ "${installed_version}" != "${CARGO_LLVM_COV_VERSION}" ]; then
-            cargo install cargo-llvm-cov --locked --version "${CARGO_LLVM_COV_VERSION}"
+            cargo install cargo-llvm-cov --locked --force --version "${CARGO_LLVM_COV_VERSION}"
           fi
 
       - name: Install just

--- a/.yamllint
+++ b/.yamllint
@@ -8,7 +8,7 @@ ignore: |
 
 rules:
   line-length:
-    max: 140
+    max: 160
   truthy:
     allowed-values: ['true', 'false', 'on', 'off', 'yes', 'no']
   # Prettier uses a single space before inline comments ("foo: bar # comment").

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 Essential guidance for AI assistants working in this repository.
 
-This file is the **entry point for all coding agents**. Detailed rules are split into additional documents under `docs/dev/`. Agents MUST read the referenced files before making changes.
+This file is the **entry point for all coding agents**. Detailed rules are split into additional documents under `docs/dev/`. Agents MUST read the referenced
+files before making changes.
 
 ---
 
@@ -14,7 +15,8 @@ Before modifying code, agents MUST read:
 - **All files in `docs/dev/*.md`** – repository development rules
 - `docs/code_organization.md` – module layout and architecture
 
-The `docs/dev/` directory contains the authoritative development guidance for this repository. Agents must load every file in that directory before making changes.
+The `docs/dev/` directory contains the authoritative development guidance for this repository. Agents must load every file in that directory before making
+changes.
 
 ---
 
@@ -26,7 +28,8 @@ The `docs/dev/` directory contains the authoritative development guidance for th
 - **ALLOWED**: read‑only git commands (`git --no-pager status`, `git --no-pager diff`, `git --no-pager log`, `git --no-pager show`, `git --no-pager blame`)
 - **ALWAYS** use `git --no-pager` when reading git output
 - Suggest git commands that modify version control state for the user to run manually
-- When suggesting branch names, prefer `{type}/{issue}-descriptor-or-two`, e.g. `fix/307-topology-validation`, `perf/315-bench-profile`, or `doc/329-branch-guidance`. If an environment requires an owner/tool prefix, keep this structure after the prefix, e.g. `codex/fix/307-topology-validation`.
+- When suggesting branch names, prefer `{type}/{issue}-descriptor-or-two`, e.g. `fix/307-topology-validation`, `perf/315-bench-profile`, or
+  `doc/329-branch-guidance`. If an environment requires an owner/tool prefix, keep this structure after the prefix, e.g. `codex/fix/307-topology-validation`.
 
 ### GitHub CLI (`gh`)
 
@@ -46,7 +49,8 @@ When using the `gh` CLI to view issues, PRs, or other GitHub objects:
 
 - **AVOID** plain `gh issue view N` — it may fail with `read:project` scope errors or open a pager.
 
-- To manage **issue dependencies** (Blocks / Is Blocked By), use the GitHub REST API via `gh api`. The endpoint requires the **internal issue ID** (not the issue number).
+- To manage **issue dependencies** (Blocks / Is Blocked By), use the GitHub REST API via `gh api`. The endpoint requires the **internal issue ID** (not the
+  issue number).
 
   To get an issue's internal ID:
 
@@ -70,7 +74,8 @@ When using the `gh` CLI to view issues, PRs, or other GitHub objects:
 
   **Note**: Use `-F` (not `-f`) for `issue_id` so it is sent as an integer. The API returns HTTP 422 if the dependency already exists.
 
-- When updating issues, use explicit `comment`/`edit` commands. For **arbitrary Markdown** (backticks, quotes, special characters), prefer `--body-file -` with a heredoc:
+- When updating issues, use explicit `comment`/`edit` commands. For **arbitrary Markdown** (backticks, quotes, special characters), prefer `--body-file -` with
+  a heredoc:
 
   ```bash
   gh issue comment 42 --repo acgetchell/causal-triangulations --body-file - <<'EOF'
@@ -94,9 +99,12 @@ When using the `gh` CLI to view issues, PRs, or other GitHub objects:
 
 ### Rust Error Handling
 
-- Do not introduce `Box<dyn std::error::Error>`, `Box<dyn Error>`, or `anyhow::Error` as fallible return types in production `src/` code, public doctests, examples, or benchmarks that demonstrate user-facing workflows
-- Prefer `CdtResult<T>` and narrow `CdtError` variants with structured context for distinct I/O, serialization, validation, backend, checkpoint, or output failure modes
-- `&dyn Error` is acceptable for `std::error::Error::source`, tests that verify standard error trait behavior, and lint fixtures that intentionally exercise forbidden generic-error patterns
+- Do not introduce `Box<dyn std::error::Error>`, `Box<dyn Error>`, or `anyhow::Error` as fallible return types in production `src/` code, public doctests,
+  examples, or benchmarks that demonstrate user-facing workflows
+- Prefer `CdtResult<T>` and narrow `CdtError` variants with structured context for distinct I/O, serialization, validation, backend, checkpoint, or output
+  failure modes
+- `&dyn Error` is acceptable for `std::error::Error::source`, tests that verify standard error trait behavior, and lint fixtures that intentionally exercise
+  forbidden generic-error patterns
 - Detailed error-type guidance lives in `docs/dev/rust.md`
 
 ### Rust Import Hygiene
@@ -109,7 +117,8 @@ When using the `gh` CLI to view issues, PRs, or other GitHub objects:
 - Keep `prelude::*` small and focused on common quick-start workflows.
 - Keep scoped preludes minimal and orthogonal; do not duplicate specialized APIs across scoped preludes unless the overlap is intentionally documented.
 - `prelude::observables` is the user-facing analysis surface for measuring triangulations and derived physical observables.
-- `prelude::simulation` is for running, inspecting, and debugging simulations; it may expose telemetry and proposal/result types, but should not become the home for user-facing observable estimators.
+- `prelude::simulation` is for running, inspecting, and debugging simulations; it may expose telemetry and proposal/result types, but should not become the home
+  for user-facing observable estimators.
 - Detailed prelude boundary guidance lives in `docs/dev/rust.md`.
 
 ### Commit Message Generation
@@ -127,14 +136,16 @@ When generating commit messages:
 Commit bodies appear **verbatim** in `CHANGELOG.md` (indented by git‑cliff's template). Write them as clean, readable prose:
 
 - Keep the **subject line** concise — it becomes the changelog entry.
-- The **type** determines the changelog section (`feat` → Added, `fix` → Fixed, `refactor`/`test`/`style` → Changed, `perf` → Performance, `docs` → Documentation, `build`/`chore`/`ci` → Maintenance).
+- The **type** determines the changelog section (`feat` → Added, `fix` → Fixed, `refactor`/`test`/`style` → Changed, `perf` → Performance, `docs` →
+  Documentation, `build`/`chore`/`ci` → Maintenance).
 - Include **PR references** as `(#N)` in the subject — cliff auto‑links them (e.g. `feat: add foo (#42)`).
 - **Avoid headings** `#`–`###` in the body — they conflict with changelog structure (`##` = release, `###` = section). Use `####` if a heading is truly needed.
 - Body text should be **plain prose or simple lists**. Numbered lists and sub‑items are fine but avoid deep nesting.
 
 #### Breaking Changes
 
-Breaking changes **must** use one of these conventional commit markers so that `git‑cliff` can detect them and generate the `### ⚠️ Breaking Changes` section in `CHANGELOG.md`:
+Breaking changes **must** use one of these conventional commit markers so that `git‑cliff` can detect them and generate the `### ⚠️ Breaking Changes` section in
+`CHANGELOG.md`:
 
 - **Bang notation**: `feat!: remove deprecated API` (append `!` after the type/scope)
 - **Footer trailer**: add `BREAKING CHANGE: <description>` as a [git trailer](https://git-scm.com/docs/git-interpret-trailers) at the end of the commit body
@@ -159,7 +170,8 @@ Refer to `docs/dev/commands.md` for full details.
 
 When adding or renaming Cargo examples, update `just examples-validate` markers as needed so CI keeps validating the user-facing example contracts.
 
-For tooling-alignment work, update `docs/dev/tooling-alignment.md` with the comparison and rationale before adding or changing config, workflow, or repository-rule files.
+For tooling-alignment work, update `docs/dev/tooling-alignment.md` with the comparison and rationale before adding or changing config, workflow, or
+repository-rule files.
 
 ---
 
@@ -184,10 +196,16 @@ Key principle:
 - **MSRV**: 1.95.0
 - **Edition**: 2024
 - **Unsafe code**: forbidden (`#![forbid(unsafe_code)]`)
-- **Architecture**: `src/geometry/` is the backend interface layer for the `delaunay` crate; `src/cdt/` is the CDT domain layer. Direct `use delaunay::` imports are restricted to `src/geometry/` (`backends/delaunay.rs` and `generators.rs`); CDT modules use the trait-based abstractions, crate-owned Delaunay handles, generator utilities, and `DelaunayBackend2D` type alias (see `docs/dev/rust.md § Geometry Backend Isolation`)
-- **Modules**: `src/cdt/` (CDT logic: moves, action, Metropolis, foliation, observables, results, triangulation child modules), `src/geometry/` (geometry abstractions and backends), `src/config.rs` (simulation configuration)
-- **Foliation**: `src/cdt/foliation.rs` defines foliation bookkeeping and edge/simplex classification. Time labels are stored as vertex data; `from_cdt_strip` and `from_toroidal_cdt` construct labeled CDT triangulations; `validate_causality` enforces adjacent-slice edges (with circular distance on toroidal time). Design documented in `docs/foliation.md`
-- **Ergodic moves**: `attempt_22_move`, `attempt_13_move`, `attempt_31_move`, `attempt_edge_flip` are Delaunay-backed, foliation-aware move kernels. They mutate through narrow CDT-owned edit operations, roll back failed finalized mutations, and preserve topology/foliation invariants
+- **Architecture**: `src/geometry/` is the backend interface layer for the `delaunay` crate; `src/cdt/` is the CDT domain layer. Direct `use delaunay::` imports
+  are restricted to `src/geometry/` (`backends/delaunay.rs` and `generators.rs`); CDT modules use the trait-based abstractions, crate-owned Delaunay handles,
+  generator utilities, and `DelaunayBackend2D` type alias (see `docs/dev/rust.md § Geometry Backend Isolation`)
+- **Modules**: `src/cdt/` (CDT logic: moves, action, Metropolis, foliation, observables, results, triangulation child modules), `src/geometry/` (geometry
+  abstractions and backends), `src/config.rs` (simulation configuration)
+- **Foliation**: `src/cdt/foliation.rs` defines foliation bookkeeping and edge/simplex classification. Time labels are stored as vertex data; `from_cdt_strip`
+  and `from_toroidal_cdt` construct labeled CDT triangulations; `validate_causality` enforces adjacent-slice edges (with circular distance on toroidal time).
+  Design documented in `docs/foliation.md`
+- **Ergodic moves**: `attempt_22_move`, `attempt_13_move`, `attempt_31_move`, `attempt_edge_flip` are Delaunay-backed, foliation-aware move kernels. They mutate
+  through narrow CDT-owned edit operations, roll back failed finalized mutations, and preserve topology/foliation invariants
 - **Python scripts**: `scripts/` contains benchmark, changelog, and hardware utilities; tests in `scripts/tests/` run via pytest
 - **When adding/removing files**: Update `docs/code_organization.md`
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,11 +2,15 @@
 
 ## Our Principles of Community
 
-The [causal-triangulations][cdt-lib] quantum gravity research library community is founded on the [UC Davis Principles of Community][uc-davis-principles], adapted for our collaborative open-source scientific computing environment. We are committed to fostering an inclusive community that advances quantum gravity research and causal dynamical triangulation methods.
+The [causal-triangulations][cdt-lib] quantum gravity research library community is founded on the [UC Davis Principles of Community][uc-davis-principles],
+adapted for our collaborative open-source scientific computing environment. We are committed to fostering an inclusive community that advances quantum gravity
+research and causal dynamical triangulation methods.
 
 ### We affirm the inherent dignity in all of us
 
-Every person has value and deserves to be treated with respect and courtesy, regardless of their background, experience level, or contributions to the project. We recognize that contributors come from diverse academic, professional, and personal backgrounds, bringing different perspectives that strengthen our community.
+Every person has value and deserves to be treated with respect and courtesy, regardless of their background, experience level, or contributions to the project.
+We recognize that contributors come from diverse academic, professional, and personal backgrounds, bringing different perspectives that strengthen our
+community.
 
 ### We strive for excellence in our teaching and learning, research and scholarship
 
@@ -134,7 +138,8 @@ This Code of Conduct may be updated as the community grows and evolves. Changes 
 
 ## Acknowledgment
 
-These principles are adapted from the [UC Davis Principles of Community][uc-davis-principles], which were developed through a collaborative process involving the entire UC Davis community. We thank UC Davis for providing this thoughtful framework for inclusive community building.
+These principles are adapted from the [UC Davis Principles of Community][uc-davis-principles], which were developed through a collaborative process involving
+the entire UC Davis community. We thank UC Davis for providing this thoughtful framework for inclusive community building.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to Causal Dynamical Triangulations
 
-Thank you for your interest in contributing to the [**causal-triangulations**][cdt-lib] library! This document provides comprehensive guidelines for contributors, from first-time contributors to experienced developers looking to contribute significant features.
+Thank you for your interest in contributing to the [**causal-triangulations**][cdt-lib] library! This document provides comprehensive guidelines for
+contributors, from first-time contributors to experienced developers looking to contribute significant features.
 
 ## Table of Contents
 
@@ -21,7 +22,8 @@ Thank you for your interest in contributing to the [**causal-triangulations**][c
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by our commitment to creating an inclusive and welcoming environment for quantum gravity research and computational physics development.
+This project and everyone participating in it is governed by our commitment to creating an inclusive and welcoming environment for quantum gravity research and
+computational physics development.
 
 Our community is built on the principles of:
 
@@ -148,7 +150,8 @@ This is normal and only happens once.
 
 ## Code Organization
 
-The source/module layout and architecture-sensitive boundaries live in [docs/code_organization.md](docs/code_organization.md). Keep that file current when adding, removing, or moving source files, examples, or architecture-significant modules.
+The source/module layout and architecture-sensitive boundaries live in [docs/code_organization.md](docs/code_organization.md). Keep that file current when
+adding, removing, or moving source files, examples, or architecture-significant modules.
 
 ## Development Workflow
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,18 @@ path = "src/main.rs"
 name = "cdt_benchmarks"
 harness = false
 
+[[bench]]
+name = "ci_performance_suite"
+harness = false
+
 [features]
 slow-tests = [  ]
+
+[profile.perf]
+inherits = "release"
+lto = "thin"
+codegen-units = 1
+debug = "line-tables-only"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ cargo bench triangulation_creation
 cargo bench metropolis_simulation
 cargo bench action_calculations
 
+# CI regression benchmark contract
+just bench-ci
+
 # Performance regression testing
 just perf-check          # Check for performance regressions
 just perf-baseline       # Save performance baseline

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # causal-triangulations
 
-[![Crates.io](https://img.shields.io/crates/v/causal-triangulations.svg)](https://crates.io/crates/causal-triangulations) [![Downloads](https://img.shields.io/crates/d/causal-triangulations.svg)](https://crates.io/crates/causal-triangulations) [![Docs.rs](https://docs.rs/causal-triangulations/badge.svg)](https://docs.rs/causal-triangulations) [![CI](https://github.com/acgetchell/causal-triangulations/actions/workflows/ci.yml/badge.svg)](https://github.com/acgetchell/causal-triangulations/actions/workflows/ci.yml) [![rust-clippy analyze](https://github.com/acgetchell/causal-triangulations/actions/workflows/rust-clippy.yml/badge.svg)](https://github.com/acgetchell/causal-triangulations/actions/workflows/rust-clippy.yml) [![Codecov](https://codecov.io/gh/acgetchell/causal-triangulations/graph/badge.svg?token=CsbOJBypGC)](https://codecov.io/gh/acgetchell/causal-triangulations) [![Audit dependencies](https://github.com/acgetchell/causal-triangulations/actions/workflows/audit.yml/badge.svg)](https://github.com/acgetchell/causal-triangulations/actions/workflows/audit.yml)
+[![Crates.io](https://img.shields.io/crates/v/causal-triangulations.svg)](https://crates.io/crates/causal-triangulations)
+[![Downloads](https://img.shields.io/crates/d/causal-triangulations.svg)](https://crates.io/crates/causal-triangulations)
+[![Docs.rs](https://docs.rs/causal-triangulations/badge.svg)](https://docs.rs/causal-triangulations)
+[![CI][ci-badge]][ci-workflow]
+[![rust-clippy analyze][clippy-badge]][clippy-workflow]
+[![Codecov](https://codecov.io/gh/acgetchell/causal-triangulations/graph/badge.svg?token=CsbOJBypGC)](https://codecov.io/gh/acgetchell/causal-triangulations)
+[![Audit dependencies][audit-badge]][audit-workflow]
 
 Causal Dynamical Triangulations for quantum gravity in [Rust], built on fast Delaunay triangulation primitives.
 
 ## 🌌 Introduction
 
-This library implements **Causal Dynamical Triangulations (CDT)** in [Rust]. CDT is a non-perturbative approach to quantum gravity that constructs discrete spacetime as triangulated manifolds with causal structure, providing a computational framework for studying quantum gravity phenomenology.
+This library implements **Causal Dynamical Triangulations (CDT)** in [Rust]. CDT is a non-perturbative approach to quantum gravity that constructs discrete
+spacetime as triangulated manifolds with causal structure, providing a computational framework for studying quantum gravity phenomenology.
 
 For an introduction to Causal Dynamical Triangulations, see [this paper](https://arxiv.org/abs/hep-th/0105267).
 
@@ -30,9 +37,11 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## 🚧 Project Status
 
-🚧 **Pre-release (0.0.x)** — The 1+1 CDT foundation is implemented and tested, but this crate is still under active development and **not yet ready for production use**. APIs, data structures, and module boundaries may change before v0.1.0.
+🚧 **Pre-release (0.0.x)** — The 1+1 CDT foundation is implemented and tested, but this crate is still under active development and
+**not yet ready for production use**. APIs, data structures, and module boundaries may change before v0.1.0.
 
-The library currently supports validated 1+1 CDT construction, foliation checks, Metropolis sampling, and core observables. Higher-dimensional CDT support, full move-kernel maturity, visualization/export workflows, and advanced ensemble-analysis helpers remain roadmap work.
+The library currently supports validated 1+1 CDT construction, foliation checks, Metropolis sampling, and core observables. Higher-dimensional CDT support, full
+move-kernel maturity, visualization/export workflows, and advanced ensemble-analysis helpers remain roadmap work.
 
 See [`docs/roadmap.md`](docs/roadmap.md) for current direction, near-term candidates, and non-goals.
 
@@ -52,7 +61,8 @@ This crate is part of a broader Rust ecosystem for computational geometry and si
 
 - [`delaunay`](https://crates.io/crates/delaunay) — geometric primitives and triangulations
 - `la-stack` — linear algebra utilities
-- [`markov-chain-monte-carlo`](https://crates.io/crates/markov-chain-monte-carlo) — composable MCMC traits, including delayed-commit proposals for CDT move ordering
+- [`markov-chain-monte-carlo`](https://crates.io/crates/markov-chain-monte-carlo) — composable MCMC traits, including delayed-commit proposals for CDT move
+  ordering
 
 The long-term design separates:
 
@@ -88,7 +98,8 @@ just run-example     # Basic simulation
 ./examples/scripts/performance_test.sh      # Performance benchmarking across system sizes
 ```
 
-`just setup` prints a checklist of external tools used by repository workflows (for example: `uv`, `taplo`, `actionlint`, `shfmt`, `shellcheck`, `jq`) and how to install them.
+`just setup` prints a checklist of external tools used by repository workflows (for example: `uv`, `taplo`, `actionlint`, `shfmt`, `shellcheck`, `jq`) and how
+to install them.
 
 **Just Workflows:**
 
@@ -183,11 +194,13 @@ just perf-report         # Generate detailed performance report
 just perf-trends 7       # Analyze performance trends over 7 days
 ```
 
-See [`benches/README.md`](benches/README.md) for benchmark details and [`docs/PERFORMANCE_TESTING.md`](docs/PERFORMANCE_TESTING.md) for comprehensive performance testing workflow documentation.
+See [`benches/README.md`](benches/README.md) for benchmark details and [`docs/PERFORMANCE_TESTING.md`](docs/PERFORMANCE_TESTING.md) for comprehensive
+performance testing workflow documentation.
 
 ## 🛣️ Roadmap
 
-The high-level roadmap, including 1+1 maturity work, future 2+1 and 3+1 CDT topology tracks, observables, dual/Voronoi geometry, visualization, and non-goals, lives in [`docs/roadmap.md`](docs/roadmap.md).
+The high-level roadmap, including 1+1 maturity work, future 2+1 and 3+1 CDT topology tracks, observables, dual/Voronoi geometry, visualization, and non-goals,
+lives in [`docs/roadmap.md`](docs/roadmap.md).
 
 ## Design notes
 
@@ -225,3 +238,9 @@ This project's license is specified in [LICENSE](LICENSE).
 [Rust]: https://rust-lang.org
 [Delaunay triangulation]: https://crates.io/crates/delaunay
 [Criterion]: https://github.com/bheisler/criterion.rs
+[ci-badge]: https://github.com/acgetchell/causal-triangulations/actions/workflows/ci.yml/badge.svg
+[ci-workflow]: https://github.com/acgetchell/causal-triangulations/actions/workflows/ci.yml
+[clippy-badge]: https://github.com/acgetchell/causal-triangulations/actions/workflows/rust-clippy.yml/badge.svg
+[clippy-workflow]: https://github.com/acgetchell/causal-triangulations/actions/workflows/rust-clippy.yml
+[audit-badge]: https://github.com/acgetchell/causal-triangulations/actions/workflows/audit.yml/badge.svg
+[audit-workflow]: https://github.com/acgetchell/causal-triangulations/actions/workflows/audit.yml

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -11,7 +11,8 @@ layout: "page"
 
 ## How to Cite This Library
 
-If you use this library in your research or project, please cite it using the information provided in our [CITATION.cff](CITATION.cff) file. This file contains structured citation metadata that can be automatically processed by GitHub and other platforms.
+If you use this library in your research or project, please cite it using the information provided in our [CITATION.cff](CITATION.cff) file. This file contains
+structured citation metadata that can be automatically processed by GitHub and other platforms.
 
 **Quick citation:**
 
@@ -28,25 +29,33 @@ This section contains the seminal papers and foundational work that established 
 
 ### Original CDT Framework
 
-- Ambjørn, J., Jurkiewicz, J., and Loll, R. "Dynamically Triangulating Lorentzian Quantum Gravity." _Nuclear Physics B_ 610, no. 1-2 (2001): 347-382. DOI: [10.1016/S0550-3213(01)00297-8](https://doi.org/10.1016/S0550-3213(01)00297-8). arXiv: [hep-th/0105267](https://arxiv.org/abs/hep-th/0105267)
+- Ambjørn, J., Jurkiewicz, J., and Loll, R. "Dynamically Triangulating Lorentzian Quantum Gravity." _Nuclear Physics B_ 610, no. 1-2 (2001): 347-382. DOI:
+  [10.1016/S0550-3213(01)00297-8](https://doi.org/10.1016/S0550-3213(01)00297-8). arXiv: [hep-th/0105267](https://arxiv.org/abs/hep-th/0105267)
 
-- Ambjørn, J., Jurkiewicz, J., and Loll, R. "Emergence of a 4D World from Causal Quantum Gravity." _Physical Review Letters_ 93, no. 13 (2004): 131301. DOI: [10.1103/PhysRevLett.93.131301](https://doi.org/10.1103/PhysRevLett.93.131301). arXiv: [hep-th/0404156](https://arxiv.org/abs/hep-th/0404156)
+- Ambjørn, J., Jurkiewicz, J., and Loll, R. "Emergence of a 4D World from Causal Quantum Gravity." _Physical Review Letters_ 93, no. 13 (2004): 131301. DOI:
+  [10.1103/PhysRevLett.93.131301](https://doi.org/10.1103/PhysRevLett.93.131301). arXiv: [hep-th/0404156](https://arxiv.org/abs/hep-th/0404156)
 
 ### Comprehensive Reviews
 
-- Loll, R. "Quantum Gravity from Causal Dynamical Triangulations: A Review." _Classical and Quantum Gravity_ 37, no. 1 (2020): 013002. DOI: [10.1088/1361-6382/ab57c7](https://doi.org/10.1088/1361-6382/ab57c7). arXiv: [1905.08669](https://arxiv.org/abs/1905.08669)
+- Loll, R. "Quantum Gravity from Causal Dynamical Triangulations: A Review." _Classical and Quantum Gravity_ 37, no. 1 (2020): 013002. DOI:
+  [10.1088/1361-6382/ab57c7](https://doi.org/10.1088/1361-6382/ab57c7). arXiv: [1905.08669](https://arxiv.org/abs/1905.08669)
 
-- Ambjørn, J., Görlich, A., Jurkiewicz, J., and Loll, R. "Nonperturbative Quantum Gravity." _Physics Reports_ 519, no. 4-5 (2012): 127-210. DOI: [10.1016/j.physrep.2012.03.007](https://doi.org/10.1016/j.physrep.2012.03.007). arXiv: [1203.3591](https://arxiv.org/abs/1203.3591)
+- Ambjørn, J., Görlich, A., Jurkiewicz, J., and Loll, R. "Nonperturbative Quantum Gravity." _Physics Reports_ 519, no. 4-5 (2012): 127-210. DOI:
+  [10.1016/j.physrep.2012.03.007](https://doi.org/10.1016/j.physrep.2012.03.007). arXiv: [1203.3591](https://arxiv.org/abs/1203.3591)
 
 ### Volume Profiles and Dimensional Observables
 
-- Ambjørn, J., Jurkiewicz, J., and Loll, R. "Reconstructing the Universe." _Physical Review D_ 72, no. 6 (2005): 064014. DOI: [10.1103/PhysRevD.72.064014](https://doi.org/10.1103/PhysRevD.72.064014). arXiv: [hep-th/0505154](https://arxiv.org/abs/hep-th/0505154)
+- Ambjørn, J., Jurkiewicz, J., and Loll, R. "Reconstructing the Universe." _Physical Review D_ 72, no. 6 (2005): 064014. DOI:
+  [10.1103/PhysRevD.72.064014](https://doi.org/10.1103/PhysRevD.72.064014). arXiv: [hep-th/0505154](https://arxiv.org/abs/hep-th/0505154)
 
-- Ambjørn, J., Jurkiewicz, J., and Loll, R. "The Spectral Dimension of the Universe is Scale Dependent." _Physical Review Letters_ 95, no. 17 (2005): 171301. DOI: [10.1103/PhysRevLett.95.171301](https://doi.org/10.1103/PhysRevLett.95.171301). arXiv: [hep-th/0505113](https://arxiv.org/abs/hep-th/0505113)
+- Ambjørn, J., Jurkiewicz, J., and Loll, R. "The Spectral Dimension of the Universe is Scale Dependent." _Physical Review Letters_ 95, no. 17 (2005): 171301.
+  DOI: [10.1103/PhysRevLett.95.171301](https://doi.org/10.1103/PhysRevLett.95.171301). arXiv: [hep-th/0505113](https://arxiv.org/abs/hep-th/0505113)
 
-- Ambjørn, J., Budd, T., and Watabiki, Y. "Scale-dependent Hausdorff dimensions in 2d gravity." _Physics Letters B_ 736 (2014): 339-343. DOI: [10.1016/j.physletb.2014.07.047](https://doi.org/10.1016/j.physletb.2014.07.047). arXiv: [1406.6251](https://arxiv.org/abs/1406.6251)
+- Ambjørn, J., Budd, T., and Watabiki, Y. "Scale-dependent Hausdorff dimensions in 2d gravity." _Physics Letters B_ 736 (2014): 339-343. DOI:
+  [10.1016/j.physletb.2014.07.047](https://doi.org/10.1016/j.physletb.2014.07.047). arXiv: [1406.6251](https://arxiv.org/abs/1406.6251)
 
-- van der Duin, J., Loll, R., Schiffer, M., and Silva, A. "Quantum gravity and effective topology." _The European Physical Journal C_ 86, no. 2 (2026): 102. DOI: [10.1140/epjc/s10052-026-15322-x](https://doi.org/10.1140/epjc/s10052-026-15322-x)
+- van der Duin, J., Loll, R., Schiffer, M., and Silva, A. "Quantum gravity and effective topology." _The European Physical Journal C_ 86, no. 2 (2026): 102.
+  DOI: [10.1140/epjc/s10052-026-15322-x](https://doi.org/10.1140/epjc/s10052-026-15322-x)
 
 ## Monte Carlo Methods in Quantum Gravity
 
@@ -54,19 +63,24 @@ These references provide the algorithmic foundations for Monte Carlo simulations
 
 ### Metropolis-Hastings Algorithm in CDT
 
-- Ambjørn, J., and Loll, R. "Non-perturbative Lorentzian quantum gravity, causality and topology change." _Nuclear Physics B_ 536, no. 1-2 (1998): 407-434. DOI: [10.1016/S0550-3213(98)00692-0](https://doi.org/10.1016/S0550-3213(98)00692-0). arXiv: [hep-th/9805108](https://arxiv.org/abs/hep-th/9805108)
+- Ambjørn, J., and Loll, R. "Non-perturbative Lorentzian quantum gravity, causality and topology change." _Nuclear Physics B_ 536, no. 1-2 (1998): 407-434. DOI:
+  [10.1016/S0550-3213(98)00692-0](https://doi.org/10.1016/S0550-3213(98)00692-0). arXiv: [hep-th/9805108](https://arxiv.org/abs/hep-th/9805108)
 
 ### Regge Calculus and Discrete Action
 
-- Regge, T. "General Relativity without coordinates." _Il Nuovo Cimento_ 19, no. 3 (1961): 558-571. DOI: [10.1007/BF02733251](https://doi.org/10.1007/BF02733251)
+- Regge, T. "General Relativity without coordinates." _Il Nuovo Cimento_ 19, no. 3 (1961): 558-571. DOI:
+  [10.1007/BF02733251](https://doi.org/10.1007/BF02733251)
 
-- Hamber, H. W. "Quantum Gravitation: The Feynman Path Integral Approach." Berlin: Springer-Verlag, 2009. DOI: [10.1007/978-3-540-85293-3](https://doi.org/10.1007/978-3-540-85293-3)
+- Hamber, H. W. "Quantum Gravitation: The Feynman Path Integral Approach." Berlin: Springer-Verlag, 2009. DOI:
+  [10.1007/978-3-540-85293-3](https://doi.org/10.1007/978-3-540-85293-3)
 
 ### Ergodic Moves and Alexander Moves
 
-- Alexander, J. W. "The combinatorial theory of complexes." _Annals of Mathematics_ 31, no. 2 (1930): 292-320. DOI: [10.2307/1968099](https://doi.org/10.2307/1968099)
+- Alexander, J. W. "The combinatorial theory of complexes." _Annals of Mathematics_ 31, no. 2 (1930): 292-320. DOI:
+  [10.2307/1968099](https://doi.org/10.2307/1968099)
 
-- Pachner, U. "P.L. homeomorphic manifolds are equivalent by elementary shellings." _European Journal of Combinatorics_ 12, no. 2 (1991): 129-145. DOI: [10.1016/S0195-6698(13)80080-7](https://doi.org/10.1016/S0195-6698(13)80080-7)
+- Pachner, U. "P.L. homeomorphic manifolds are equivalent by elementary shellings." _European Journal of Combinatorics_ 12, no. 2 (1991): 129-145. DOI:
+  [10.1016/S0195-6698(13)80080-7](https://doi.org/10.1016/S0195-6698(13)80080-7)
 
 ## Computational Geometry and Delaunay Triangulations
 
@@ -74,13 +88,16 @@ This library leverages computational geometry for efficient triangulation operat
 
 ### Delaunay Triangulation Algorithms
 
-- Bowyer, A. "Computing Dirichlet tessellations." _The Computer Journal_ 24, no. 2 (1981): 162-166. DOI: [10.1093/comjnl/24.2.162](https://doi.org/10.1093/comjnl/24.2.162)
+- Bowyer, A. "Computing Dirichlet tessellations." _The Computer Journal_ 24, no. 2 (1981): 162-166. DOI:
+  [10.1093/comjnl/24.2.162](https://doi.org/10.1093/comjnl/24.2.162)
 
-- Watson, D.F. "Computing the n-dimensional Delaunay tessellation with application to Voronoi polytopes." _The Computer Journal_ 24, no. 2 (1981): 167-172. DOI: [10.1093/comjnl/24.2.167](https://doi.org/10.1093/comjnl/24.2.167)
+- Watson, D.F. "Computing the n-dimensional Delaunay tessellation with application to Voronoi polytopes." _The Computer Journal_ 24, no. 2 (1981): 167-172. DOI:
+  [10.1093/comjnl/24.2.167](https://doi.org/10.1093/comjnl/24.2.167)
 
 ### Computational Geometry References
 
-- de Berg, M., et al. "Computational Geometry: Algorithms and Applications." 3rd ed. Berlin: Springer-Verlag, 2008. DOI: [10.1007/978-3-540-77974-2](https://doi.org/10.1007/978-3-540-77974-2)
+- de Berg, M., et al. "Computational Geometry: Algorithms and Applications." 3rd ed. Berlin: Springer-Verlag, 2008. DOI:
+  [10.1007/978-3-540-77974-2](https://doi.org/10.1007/978-3-540-77974-2)
 
 - The CGAL Project. "CGAL User and Reference Manual." CGAL Editorial Board, 6.0.1 edition, 2024. Available at: <https://doc.cgal.org/6.0.1/Manual/packages.html>
 
@@ -88,15 +105,18 @@ This library leverages computational geometry for efficient triangulation operat
 
 ### Lattice Approaches to Quantum Gravity
 
-- Williams, R. M., and Tuckey, P. A. "Regge calculus: a brief review and bibliography." _Classical and Quantum Gravity_ 9, no. 5 (1992): 1409. DOI: [10.1088/0264-9381/9/5/021](https://doi.org/10.1088/0264-9381/9/5/021)
+- Williams, R. M., and Tuckey, P. A. "Regge calculus: a brief review and bibliography." _Classical and Quantum Gravity_ 9, no. 5 (1992): 1409. DOI:
+  [10.1088/0264-9381/9/5/021](https://doi.org/10.1088/0264-9381/9/5/021)
 
-- Sorkin, R. D. "Causal sets: discrete gravity." In _Lectures on Quantum Gravity_, edited by A. Gomberoff and D. Marolf, 305-327. Boston: Springer, 2005. arXiv: [gr-qc/0309009](https://arxiv.org/abs/gr-qc/0309009)
+- Sorkin, R. D. "Causal sets: discrete gravity." In _Lectures on Quantum Gravity_, edited by A. Gomberoff and D. Marolf, 305-327. Boston: Springer, 2005. arXiv:
+  [gr-qc/0309009](https://arxiv.org/abs/gr-qc/0309009)
 
 ### Spin Foam Models and Loop Quantum Gravity
 
 - Rovelli, C. "Quantum Gravity." Cambridge: Cambridge University Press, 2004. DOI: [10.1017/CBO9780511755804](https://doi.org/10.1017/CBO9780511755804)
 
-- Perez, A. "The Spin Foam Approach to Quantum Gravity." _Living Reviews in Relativity_ 16, no. 1 (2013): 3. DOI: [10.12942/lrr-2013-3](https://doi.org/10.12942/lrr-2013-3). arXiv: [1205.2019](https://arxiv.org/abs/1205.2019)
+- Perez, A. "The Spin Foam Approach to Quantum Gravity." _Living Reviews in Relativity_ 16, no. 1 (2013): 3. DOI:
+  [10.12942/lrr-2013-3](https://doi.org/10.12942/lrr-2013-3). arXiv: [1205.2019](https://arxiv.org/abs/1205.2019)
 
 ## Numerical Methods and Performance
 
@@ -110,7 +130,8 @@ This library leverages computational geometry for efficient triangulation operat
 
 - Boldo, S., and Melquiond, G. "Computer Arithmetic and Formal Proofs." London: ISTE Press, 2017. ISBN: 978-1-78548-254-3
 
-- Muller, J.-M., et al. "Handbook of Floating-Point Arithmetic." 2nd ed. Basel: Birkhäuser, 2018. DOI: [10.1007/978-3-319-76526-6](https://doi.org/10.1007/978-3-319-76526-6)
+- Muller, J.-M., et al. "Handbook of Floating-Point Arithmetic." 2nd ed. Basel: Birkhäuser, 2018. DOI:
+  [10.1007/978-3-319-76526-6](https://doi.org/10.1007/978-3-319-76526-6)
 
 ## Related Software and Libraries
 
@@ -118,10 +139,12 @@ This library leverages computational geometry for efficient triangulation operat
 
 - The CGAL Project. "CGAL: Computational Geometry Algorithms Library." <https://www.cgal.org/>
 
-- Shewchuk, J. R. "Triangle: Engineering a 2D Quality Mesh Generator and Delaunay Triangulator." In _Applied Computational Geometry Towards Geometric Engineering_, 203-222. Berlin: Springer, 1996. DOI: [10.1007/BFb0014497](https://doi.org/10.1007/BFb0014497)
+- Shewchuk, J. R. "Triangle: Engineering a 2D Quality Mesh Generator and Delaunay Triangulator." In
+  _Applied Computational Geometry Towards Geometric Engineering_, 203-222. Berlin: Springer, 1996. DOI: [10.1007/BFb0014497](https://doi.org/10.1007/BFb0014497)
 
 ### Monte Carlo and Statistical Physics
 
 - Newman, M. E. J., and Barkema, G. T. "Monte Carlo Methods in Statistical Physics." Oxford: Oxford University Press, 1999. ISBN: 978-0-19-851797-9
 
-- Landau, D. P., and Binder, K. "A Guide to Monte Carlo Simulations in Statistical Physics." 4th ed. Cambridge: Cambridge University Press, 2014. DOI: [10.1017/CBO9781139696463](https://doi.org/10.1017/CBO9781139696463)
+- Landau, D. P., and Binder, K. "A Guide to Monte Carlo Simulations in Statistical Physics." 4th ed. Cambridge: Cambridge University Press, 2014. DOI:
+  [10.1017/CBO9781139696463](https://doi.org/10.1017/CBO9781139696463)

--- a/benches/README.md
+++ b/benches/README.md
@@ -4,7 +4,8 @@ This document describes the comprehensive benchmarking suite for the Causal Dyna
 
 ## Overview
 
-The benchmarking suite measures performance of key CDT operations using the [criterion](https://crates.io/crates/criterion) benchmarking framework. The benchmarks are designed to track performance across different system sizes and identify performance regressions.
+The benchmarking suite measures performance of key CDT operations using the [criterion](https://crates.io/crates/criterion) benchmarking framework. The
+benchmarks are designed to track performance across different system sizes and identify performance regressions.
 
 ## Running Benchmarks
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -14,6 +14,23 @@ The benchmarking suite measures performance of key CDT operations using the [cri
 cargo bench
 ```
 
+### CI Performance Suite
+
+```bash
+just bench-ci
+```
+
+The `ci_performance_suite` target is the smaller regression contract used by
+the performance tooling. It runs with the Cargo `perf` profile and focuses on
+CDT workflows that should stay comparable across releases:
+
+- generating open-boundary and toroidal CDT triangulations;
+- validating generated triangulations;
+- attempting individual ergodic move types;
+- executing ten random-move sweeps, where each sweep attempts one move per
+  current simplex;
+- running short Metropolis simulations sized as ten initial sweeps.
+
 ### Specific Benchmark Groups
 
 ```bash
@@ -43,6 +60,9 @@ cargo bench cache_operations
 
 # Validation operations
 cargo bench validation
+
+# CI regression contract
+cargo bench --profile perf --bench ci_performance_suite
 ```
 
 ### Output Format
@@ -240,8 +260,8 @@ criterion_group!(
 ### Automated Benchmarking
 
 ```bash
-# Run benchmarks in CI
-cargo bench -- --output-format json > benchmark_results.json
+# Run the CI regression benchmark contract
+just bench-ci
 
 # Performance regression detection
 cargo bench -- --save-baseline main

--- a/benches/ci_performance_suite.rs
+++ b/benches/ci_performance_suite.rs
@@ -1,0 +1,338 @@
+#![forbid(unsafe_code)]
+
+//! CI performance suite for CDT regression checks.
+//!
+//! This harness is the small, durable performance contract for CDT workflows. It
+//! complements the broader `cdt_benchmarks` target by focusing on operations that
+//! should stay fast across releases:
+//!
+//! 1. Open-boundary and toroidal CDT triangulation construction.
+//! 2. Evolved-state validation on generated triangulations.
+//! 3. Individual ergodic move attempts on fresh fixtures.
+//! 4. Ten-sweep random-move workloads, where each sweep attempts one move per
+//!    current simplex.
+//! 5. Short Metropolis runs sized as ten initial sweeps.
+
+use causal_triangulations::prelude::action::ActionConfig;
+use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveStatistics, MoveType};
+use causal_triangulations::prelude::simulation::{MetropolisAlgorithm, MetropolisConfig};
+use causal_triangulations::prelude::triangulation::CdtTriangulation2D;
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+use std::time::Duration;
+
+const SWEEP_COUNT: u32 = 10;
+const BENCH_SEED: u64 = 0xCDA7_2026;
+
+#[derive(Clone, Copy)]
+enum TopologyFixture {
+    OpenStrip,
+    Toroidal,
+}
+
+#[derive(Clone, Copy)]
+struct CdtFixture {
+    name: &'static str,
+    topology: TopologyFixture,
+    vertices_per_slice: u32,
+    time_slices: u32,
+}
+
+struct PreparedFixture {
+    fixture: CdtFixture,
+    triangulation: CdtTriangulation2D,
+    vertices: usize,
+    simplices: usize,
+}
+
+const GENERATION_FIXTURES: &[CdtFixture] = &[
+    CdtFixture {
+        name: "open_strip_small",
+        topology: TopologyFixture::OpenStrip,
+        vertices_per_slice: 12,
+        time_slices: 8,
+    },
+    CdtFixture {
+        name: "open_strip_medium",
+        topology: TopologyFixture::OpenStrip,
+        vertices_per_slice: 20,
+        time_slices: 10,
+    },
+    CdtFixture {
+        name: "open_strip_large",
+        topology: TopologyFixture::OpenStrip,
+        vertices_per_slice: 28,
+        time_slices: 12,
+    },
+    CdtFixture {
+        name: "toroidal_small",
+        topology: TopologyFixture::Toroidal,
+        vertices_per_slice: 8,
+        time_slices: 8,
+    },
+    CdtFixture {
+        name: "toroidal_medium",
+        topology: TopologyFixture::Toroidal,
+        vertices_per_slice: 12,
+        time_slices: 10,
+    },
+];
+
+const SWEEP_FIXTURES: &[CdtFixture] = &[
+    CdtFixture {
+        name: "open_strip_tiny",
+        topology: TopologyFixture::OpenStrip,
+        vertices_per_slice: 4,
+        time_slices: 3,
+    },
+    CdtFixture {
+        name: "open_strip_small",
+        topology: TopologyFixture::OpenStrip,
+        vertices_per_slice: 6,
+        time_slices: 4,
+    },
+    CdtFixture {
+        name: "toroidal_tiny",
+        topology: TopologyFixture::Toroidal,
+        vertices_per_slice: 4,
+        time_slices: 3,
+    },
+];
+
+impl CdtFixture {
+    /// Builds the requested CDT topology for a benchmark fixture.
+    fn build(self) -> CdtTriangulation2D {
+        match self.topology {
+            TopologyFixture::OpenStrip => {
+                CdtTriangulation2D::from_cdt_strip(self.vertices_per_slice, self.time_slices)
+            }
+            TopologyFixture::Toroidal => {
+                CdtTriangulation2D::from_toroidal_cdt(self.vertices_per_slice, self.time_slices)
+            }
+        }
+        .expect("CDT benchmark fixture should build")
+    }
+}
+
+/// Materializes a fixture once so benchmarks can use stable size metadata.
+fn prepare_fixture(fixture: CdtFixture) -> PreparedFixture {
+    let triangulation = fixture.build();
+    let vertices = triangulation.vertex_count();
+    let simplices = triangulation.face_count();
+    PreparedFixture {
+        fixture,
+        triangulation,
+        vertices,
+        simplices,
+    }
+}
+
+/// Converts Criterion throughput element counts without silently truncating.
+fn usize_to_u64(value: usize) -> u64 {
+    u64::try_from(value).expect("benchmark size should fit in u64")
+}
+
+/// Computes the Metropolis step budget for the ten-sweep CI workload.
+fn ten_sweep_step_count(simplices: usize) -> u32 {
+    u32::try_from(sweep_attempt_count(simplices))
+        .expect("benchmark sweep step count should fit in u32")
+}
+
+/// Encodes the CDT convention that one sweep attempts one move per simplex.
+fn sweep_attempt_count(simplices: usize) -> usize {
+    let sweeps = usize::try_from(SWEEP_COUNT).expect("sweep count should fit in usize");
+    simplices
+        .checked_mul(sweeps)
+        .expect("benchmark sweep step count should not overflow")
+}
+
+/// Runs ten random-move sweeps and validates the evolved triangulation.
+fn run_random_move_sweeps(mut triangulation: CdtTriangulation2D, seed: u64) -> MoveStatistics {
+    let mut ergodics = ErgodicsSystem::with_seed(seed);
+
+    for _ in 0..SWEEP_COUNT {
+        let attempts = triangulation.face_count();
+        for _ in 0..attempts {
+            let result = ergodics.attempt_random_move(&mut triangulation);
+            black_box(result);
+        }
+    }
+
+    triangulation
+        .validate()
+        .expect("random sweep workload should preserve CDT invariants");
+    black_box(triangulation.face_count());
+    ergodics.stats
+}
+
+/// Runs a short Metropolis simulation sized to match the ten-sweep workload.
+fn run_metropolis_ten_sweeps(triangulation: CdtTriangulation2D, simplices: usize) -> usize {
+    let steps = ten_sweep_step_count(simplices);
+    let config = MetropolisConfig::new(1.0, steps, 0, steps).with_seed(BENCH_SEED);
+    let results = MetropolisAlgorithm::new(config, ActionConfig::default())
+        .run(triangulation)
+        .expect("ten-sweep Metropolis workload should run");
+    black_box(results.acceptance_rate());
+    results.steps().len()
+}
+
+/// Benchmarks deterministic construction for representative CDT topologies.
+fn bench_cdt_generation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cdt_generation_2d");
+
+    for &fixture in GENERATION_FIXTURES {
+        let prepared = prepare_fixture(fixture);
+        group.throughput(Throughput::Elements(usize_to_u64(prepared.vertices)));
+        group.bench_with_input(
+            BenchmarkId::new(fixture.name, prepared.vertices),
+            &fixture,
+            |b, &fixture| {
+                b.iter(|| {
+                    let triangulation = fixture.build();
+                    black_box(triangulation)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmarks full CDT validation on already-generated triangulations.
+fn bench_cdt_validation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cdt_validation_2d");
+
+    for &fixture in GENERATION_FIXTURES {
+        let prepared = prepare_fixture(fixture);
+        group.throughput(Throughput::Elements(usize_to_u64(prepared.simplices)));
+        group.bench_with_input(
+            BenchmarkId::new(fixture.name, prepared.simplices),
+            &prepared.triangulation,
+            |b, triangulation| {
+                b.iter(|| {
+                    let result = triangulation.validate();
+                    black_box(result)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmarks individual ergodic move attempts on a common fresh fixture.
+fn bench_cdt_move_attempts(c: &mut Criterion) {
+    let prepared = prepare_fixture(CdtFixture {
+        name: "open_strip_medium",
+        topology: TopologyFixture::OpenStrip,
+        vertices_per_slice: 20,
+        time_slices: 10,
+    });
+    let mut group = c.benchmark_group("cdt_move_attempts_2d");
+    group.throughput(Throughput::Elements(usize_to_u64(prepared.simplices)));
+
+    for move_type in [
+        MoveType::Move22,
+        MoveType::Move13Add,
+        MoveType::Move31Remove,
+        MoveType::EdgeFlip,
+    ] {
+        group.bench_with_input(
+            BenchmarkId::new(format!("{move_type:?}"), prepared.simplices),
+            &move_type,
+            |b, &move_type| {
+                b.iter_batched(
+                    || {
+                        (
+                            ErgodicsSystem::with_seed(BENCH_SEED),
+                            prepared.triangulation.clone(),
+                        )
+                    },
+                    |(mut ergodics, mut triangulation)| {
+                        let result = match move_type {
+                            MoveType::Move22 => ergodics.attempt_22_move(&mut triangulation),
+                            MoveType::Move13Add => ergodics.attempt_13_move(&mut triangulation),
+                            MoveType::Move31Remove => ergodics.attempt_31_move(&mut triangulation),
+                            MoveType::EdgeFlip => ergodics.attempt_edge_flip(&mut triangulation),
+                        };
+                        black_box(result)
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmarks short random-move evolution over tiny CI-sized triangulations.
+fn bench_cdt_random_move_sweeps(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cdt_random_move_sweeps_2d");
+
+    for &fixture in SWEEP_FIXTURES {
+        let prepared = prepare_fixture(fixture);
+        group.throughput(Throughput::Elements(usize_to_u64(sweep_attempt_count(
+            prepared.simplices,
+        ))));
+        group.bench_with_input(
+            BenchmarkId::new(prepared.fixture.name, prepared.simplices),
+            &prepared,
+            |b, prepared| {
+                b.iter_batched(
+                    || prepared.triangulation.clone(),
+                    |triangulation| {
+                        let stats = run_random_move_sweeps(triangulation, BENCH_SEED);
+                        black_box(stats.total_attempted())
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmarks the simulation driver with the same ten-sweep sizing contract.
+fn bench_cdt_metropolis_ten_sweeps(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cdt_metropolis_2d");
+
+    for &fixture in &SWEEP_FIXTURES[..2] {
+        let prepared = prepare_fixture(fixture);
+        group.throughput(Throughput::Elements(usize_to_u64(sweep_attempt_count(
+            prepared.simplices,
+        ))));
+        group.bench_with_input(
+            BenchmarkId::new(prepared.fixture.name, prepared.simplices),
+            &prepared,
+            |b, prepared| {
+                b.iter_batched(
+                    || prepared.triangulation.clone(),
+                    |triangulation| {
+                        let steps = run_metropolis_ten_sweeps(triangulation, prepared.simplices);
+                        black_box(steps)
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .measurement_time(Duration::from_secs(2))
+        .warm_up_time(Duration::from_secs(1));
+    targets =
+        bench_cdt_generation,
+        bench_cdt_validation,
+        bench_cdt_move_attempts,
+        bench_cdt_random_move_sweeps,
+        bench_cdt_metropolis_ten_sweeps
+);
+criterion_main!(benches);

--- a/docs/CLI_EXAMPLES.md
+++ b/docs/CLI_EXAMPLES.md
@@ -2,7 +2,8 @@
 
 This document provides examples for using the `cdt` binary, the command-line interface for Causal Dynamical Triangulations simulations.
 
-> **Current simulation status:** examples that pass `--simulate` run the Metropolis-Hastings loop over the 2D CDT move kernels. Omit `--simulate` when you only want triangulation generation and the initial measurement.
+> **Current simulation status:** examples that pass `--simulate` run the Metropolis-Hastings loop over the 2D CDT move kernels. Omit `--simulate` when you only
+> want triangulation generation and the initial measurement.
 
 ## Basic Usage
 
@@ -276,4 +277,5 @@ make run-simulation:
 ./target/release/cdt --version
 ```
 
-This CLI interface provides a way to explore CDT triangulation construction, validate simulation parameters, and run short Monte Carlo simulations from the command line.
+This CLI interface provides a way to explore CDT triangulation construction, validate simulation parameters, and run short Monte Carlo simulations from the
+command line.

--- a/docs/PERFORMANCE_TESTING.md
+++ b/docs/PERFORMANCE_TESTING.md
@@ -278,7 +278,7 @@ Include performance results in your PR description:
 
 ```bash
 # Ensure benchmarks are compiled and run first
-cargo bench
+just bench-ci
 just perf-check
 ```
 
@@ -304,7 +304,7 @@ uv run performance-analysis --no-run
 
 ```bash
 # Run with verbose output
-RUST_BACKTRACE=1 cargo bench -- --verbose
+RUST_BACKTRACE=1 cargo bench --profile perf --bench ci_performance_suite -- --verbose
 
 # Analyze specific benchmark group
 cargo bench triangulation_creation
@@ -368,7 +368,7 @@ just perf-check 5.0   # Strict threshold before completion
 
 ### Components
 
-1. **Criterion Benchmarks** (`benches/cdt_benchmarks.rs`): Core benchmark definitions
+1. **Criterion Benchmarks** (`benches/cdt_benchmarks.rs`, `benches/ci_performance_suite.rs`): Core and CI regression benchmark definitions
 2. **Performance Analyzer** (`scripts/performance_analysis.py`): Analysis and reporting engine
 3. **Justfile Integration**: User-friendly command interface
 4. **GitHub Actions** (`.github/workflows/performance.yml`): CI/CD automation

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,7 @@
 # Releasing causal-triangulations
 
-This guide documents the release flow for `vX.Y.Z`: prepare a dedicated release PR, merge it, create the final annotated tag from the generated changelog, publish to crates.io, and create the GitHub release.
+This guide documents the release flow for `vX.Y.Z`: prepare a dedicated release PR, merge it, create the final annotated tag from the generated changelog,
+publish to crates.io, and create the GitHub release.
 
 The release changelog is generated with `git-cliff --tag` through `just changelog-unreleased`, so no temporary local tag is needed.
 
@@ -67,7 +68,8 @@ rg -n "\bv?[0-9]+\.[0-9]+\.[0-9]+\b" README.md docs/ || true
 just changelog-unreleased "$TAG"
 ```
 
-`just changelog-unreleased` runs `GIT_CLIFF_OFFLINE=true git-cliff --tag "$TAG" -o CHANGELOG.md`, then `postprocess-changelog`, then `archive-changelog`. The root changelog keeps Unreleased plus the active minor series; older completed minor series live under `docs/archive/changelog/`.
+`just changelog-unreleased` runs `GIT_CLIFF_OFFLINE=true git-cliff --tag "$TAG" -o CHANGELOG.md`, then `postprocess-changelog`, then `archive-changelog`. The
+root changelog keeps Unreleased plus the active minor series; older completed minor series live under `docs/archive/changelog/`.
 
 4. Validate the release branch
 
@@ -155,8 +157,10 @@ cargo publish
 6. Create the GitHub release with notes from the tag annotation
 
 ```bash
-gh release create "$TAG" --notes-from-tag
+gh release create "$TAG" --title "$TAG" --notes-from-tag
 ```
+
+Always set the GitHub release title to the exact tag string, including the leading `v`.
 
 ---
 

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -163,16 +163,20 @@ causal-triangulations/
 
 The crate is split into two intentionally different layers:
 
-- `src/geometry/` is the backend interface layer. It is the only layer that talks directly to the `delaunay` crate, wrapping upstream types behind crate-owned traits, opaque handles, generators, and backend adapters.
-- `src/cdt/` is the CDT domain layer. It owns causal triangulation semantics: foliation, topology and causality checks, ergodic moves, Regge action, Metropolis sampling, measurements, and observables.
+- `src/geometry/` is the backend interface layer. It is the only layer that talks directly to the `delaunay` crate, wrapping upstream types behind crate-owned
+  traits, opaque handles, generators, and backend adapters.
+- `src/cdt/` is the CDT domain layer. It owns causal triangulation semantics: foliation, topology and causality checks, ergodic moves, Regge action, Metropolis
+  sampling, measurements, and observables.
 
-Code outside `src/geometry/` must not import `delaunay::` directly. CDT modules should depend on `TriangulationQuery` / `TriangulationMut`, crate-owned Delaunay handle wrappers, `DelaunayBackend2D`, and generator functions from `crate::geometry`.
+Code outside `src/geometry/` must not import `delaunay::` directly. CDT modules should depend on `TriangulationQuery` / `TriangulationMut`, crate-owned Delaunay
+handle wrappers, `DelaunayBackend2D`, and generator functions from `crate::geometry`.
 
 ## Key Modules
 
 ### `cdt/foliation.rs` — Foliation
 
-Assigns each vertex to a discrete time slice, enabling classification of edges as spacelike or timelike and triangles as up or down. See `docs/foliation.md` for design details.
+Assigns each vertex to a discrete time slice, enabling classification of edges as spacelike or timelike and triangles as up or down. See `docs/foliation.md` for
+design details.
 
 - `Foliation` — aggregate bookkeeping (per-slice vertex counts, total slices)
 - `EdgeType` — `Spacelike` (same slice) or `Timelike` (adjacent slices)
@@ -181,15 +185,21 @@ Assigns each vertex to a discrete time slice, enabling classification of edges a
 
 ### `cdt/triangulation.rs` — Foliation integration
 
-This is CDT domain logic layered over the geometry backend interface. It may use `DelaunayBackend2D` and crate-owned Delaunay handles, but it does not reach through to upstream `delaunay::` APIs directly.
+This is CDT domain logic layered over the geometry backend interface. It may use `DelaunayBackend2D` and crate-owned Delaunay handles, but it does not reach
+through to upstream `delaunay::` APIs directly.
 
-- Owns the `CdtTriangulation` wrapper, `CdtMetadata`, `SimulationEvent`, metadata validation, cached simplex-count accessors, and common backend-agnostic wrapper methods
-- `from_cdt_strip(vertices_per_slice, num_slices)` — Delaunay-built open-boundary 1+1 CDT strip with strict Up/Down simplex classification and upstream Level 1–4 Delaunay validation before wrapping
-- `from_toroidal_cdt(vertices_per_slice, num_slices)` — periodic Delaunay S¹×S¹ toroidal CDT (χ = 0) with upstream Level 1–4 validation before wrapping; requires `vertices_per_slice ≥ 3` and `num_slices ≥ 3`
+- Owns the `CdtTriangulation` wrapper, `CdtMetadata`, `SimulationEvent`, metadata validation, cached simplex-count accessors, and common backend-agnostic
+  wrapper methods
+- `from_cdt_strip(vertices_per_slice, num_slices)` — Delaunay-built open-boundary 1+1 CDT strip with strict Up/Down simplex classification and upstream Level
+  1–4 Delaunay validation before wrapping
+- `from_toroidal_cdt(vertices_per_slice, num_slices)` — periodic Delaunay S¹×S¹ toroidal CDT (χ = 0) with upstream Level 1–4 validation before wrapping;
+  requires `vertices_per_slice ≥ 3` and `num_slices ≥ 3`
 - `assign_foliation_by_y(num_slices)` — bin existing vertices into time slices
 - Query methods: `time_label`, `edge_type`, `vertices_at_time`, `slice_sizes`, `has_foliation`
-- Validation: constructors require upstream Delaunay Level 1–4 validation for initial meshes; `validate()` is the post-move/final-state contract and requires upstream structural validity plus CDT topology, foliation, causality, and strict Up/Down simplex classification
-- Mutable backend access is not exposed. CDT code mutates Delaunay state only through narrow crate-internal operations (`flip_edge`, `subdivide_face`, `remove_vertex`, `set_vertex_data`) that invalidate cached counts and foliation synchronization bookkeeping on success.
+- Validation: constructors require upstream Delaunay Level 1–4 validation for initial meshes; `validate()` is the post-move/final-state contract and requires
+  upstream structural validity plus CDT topology, foliation, causality, and strict Up/Down simplex classification
+- Mutable backend access is not exposed. CDT code mutates Delaunay state only through narrow crate-internal operations (`flip_edge`, `subdivide_face`,
+  `remove_vertex`, `set_vertex_data`) that invalidate cached counts and foliation synchronization bookkeeping on success.
 
 The implementation is split into child modules under `src/cdt/triangulation/`:
 
@@ -203,24 +213,33 @@ The implementation is split into child modules under `src/cdt/triangulation/`:
 - `OpenBoundary` (default) — finite strip with boundary, χ ∈ {1, 2}
 - `Toroidal` — periodic in space and time, S¹×S¹, χ = 0
 - Wired through `CdtConfig.topology`, `CdtConfigOverrides.topology`, the CLI `--topology` flag, and `CdtMetadata.topology`
-- `run_simulation()` dispatches on topology: `Toroidal` → `from_toroidal_cdt`, `OpenBoundary` → `from_cdt_strip`; `vertices` is the total vertex count and must divide evenly across `timeslices`
+- `run_simulation()` dispatches on topology: `Toroidal` → `from_toroidal_cdt`, `OpenBoundary` → `from_cdt_strip`; `vertices` is the total vertex count and must
+  divide evenly across `timeslices`
 
 ### `cdt/metropolis.rs` — Metropolis move ordering
 
-`MetropolisAlgorithm::run()` proposes a move type, computes `ΔS` from the move's simplex-count delta, accepts or rejects the proposal, and only mutates the triangulation after acceptance. Accepted applications that fail are rolled back from a triangulation snapshot and retried at another random local site; retry exhaustion is recorded as a rejection, while hard backend failures remain structured errors. Toroidal move finalization rejects and rolls back candidate sites that would violate χ = 0 or the closed-S¹ per-slice foliation invariant. See `docs/metropolis.md` for the detailed ordering.
+`MetropolisAlgorithm::run()` proposes a move type, computes `ΔS` from the move's simplex-count delta, accepts or rejects the proposal, and only mutates the
+triangulation after acceptance. Accepted applications that fail are rolled back from a triangulation snapshot and retried at another random local site; retry
+exhaustion is recorded as a rejection, while hard backend failures remain structured errors. Toroidal move finalization rejects and rolls back candidate sites
+that would violate χ = 0 or the closed-S¹ per-slice foliation invariant. See `docs/metropolis.md` for the detailed ordering.
 
 ### `cdt/results.rs` — Simulation outputs
 
 - `Measurement` records per-step action, simplex counts, and optional per-slice volume profiles.
 - `SimulationResultsBackend` owns the final triangulation, Monte Carlo step telemetry, move statistics, and measurement history.
-- Result methods summarize acceptance rate, average action, post-thermalization volume profiles, sample volume fluctuations, and final-state Hausdorff/spectral dimension estimates.
+- Result methods summarize acceptance rate, average action, post-thermalization volume profiles, sample volume fluctuations, and final-state Hausdorff/spectral
+  dimension estimates.
 
 ### `cdt/observables.rs` — User-facing estimators
 
-- `estimate_hausdorff_dimension` — estimates Hausdorff dimension from combinatorial dual-graph geodesic ball growth, returning `None` when the triangulation is too small or live face adjacency cannot be resolved
-- `estimate_spectral_dimension` — estimates spectral dimension from dual-graph diffusion return probability, returning `None` when the graph is too small or lacks enough positive return-probability samples for a fit
-- `CdtTriangulation::volume_profile` measures per-slice triangle counts on a triangulation; `SimulationResultsBackend` provides aggregate volume-profile summaries for simulation outputs
-- Import triangulation-focused analysis APIs through `prelude::observables`; use `prelude::simulation` when constructing or inspecting simulation result containers
+- `estimate_hausdorff_dimension` — estimates Hausdorff dimension from combinatorial dual-graph geodesic ball growth, returning `None` when the triangulation is
+  too small or live face adjacency cannot be resolved
+- `estimate_spectral_dimension` — estimates spectral dimension from dual-graph diffusion return probability, returning `None` when the graph is too small or
+  lacks enough positive return-probability samples for a fit
+- `CdtTriangulation::volume_profile` measures per-slice triangle counts on a triangulation; `SimulationResultsBackend` provides aggregate volume-profile
+  summaries for simulation outputs
+- Import triangulation-focused analysis APIs through `prelude::observables`; use `prelude::simulation` when constructing or inspecting simulation result
+  containers
 
 ### `geometry/traits.rs` — Backend-neutral interface
 
@@ -241,15 +260,18 @@ The implementation is split into child modules under `src/cdt/triangulation/`:
 
 - `generate_delaunay2` — builds a 2D Delaunay triangulation with optional seed
 - `build_delaunay2_with_data` — builds from coordinate + vertex-data pairs
-- `build_delaunay2_from_simplices` / `build_delaunay2_with_topology` — builds from explicit simplex connectivity (no Delaunay point insertion); the latter also accepts `TopologyGuarantee` and `GlobalTopology` metadata for supported explicit topologies
-- `build_toroidal_delaunay2` — API-compatibility wrapper for explicit toroidal meshes; with `delaunay` v0.7.8 it validates the domain and reports the upstream explicit-toroidal topology limitation
+- `build_delaunay2_from_simplices` / `build_delaunay2_with_topology` — builds from explicit simplex connectivity (no Delaunay point insertion); the latter also
+  accepts `TopologyGuarantee` and `GlobalTopology` metadata for supported explicit topologies
+- `build_toroidal_delaunay2` — API-compatibility wrapper for explicit toroidal meshes; with `delaunay` v0.7.8 it validates the domain and reports the upstream
+  explicit-toroidal topology limitation
 - `build_periodic_toroidal_delaunay2` — builds true periodic toroidal Delaunay meshes through the upstream image-point constructor
 - `random_delaunay2`, `seeded_delaunay2` — convenience wrappers
 - `DelaunayTriangulation2D` — type alias for the concrete 2D triangulation type
 
 Together with `backends/delaunay.rs`, this module is the only place that directly imports from the `delaunay` crate.
 
-The toroidal CDT constructor builds from labeled lattice vertices and delegates to the upstream periodic image-point constructor, then validates the resulting Delaunay triangulation before CDT foliation, causality, topology, and simplex-classification checks run.
+The toroidal CDT constructor builds from labeled lattice vertices and delegates to the upstream periodic image-point constructor, then validates the resulting
+Delaunay triangulation before CDT foliation, causality, topology, and simplex-classification checks run.
 
 ### `util.rs` — Numeric helpers
 
@@ -260,6 +282,7 @@ The toroidal CDT constructor builds from labeled lattice vertices and delegates 
 
 ## Key Dependencies
 
-- `delaunay` (v0.7.8) — geometry backend (Delaunay triangulations, vertex data for time labels, checked TDS reconstruction with topology context, `set_vertex_data_by_key` for O(1) label mutation)
+- `delaunay` (v0.7.8) — geometry backend (Delaunay triangulations, vertex data for time labels, checked TDS reconstruction with topology context,
+  `set_vertex_data_by_key` for O(1) label mutation)
 - `markov-chain-monte-carlo` (v0.3) — MCMC framework (`DelayedProposal`, `Chain::step_delayed`, `Target`)
 - `num-traits` — `ToPrimitive` and `NumCast` for checked or saturating numeric conversions

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -30,7 +30,8 @@ causal-triangulations/
 │   └── dependabot.yml
 ├── benches/
 │   ├── README.md
-│   └── cdt_benchmarks.rs
+│   ├── cdt_benchmarks.rs
+│   └── ci_performance_suite.rs
 ├── docs/
 │   ├── dev/
 │   │   ├── commands.md

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -27,7 +27,8 @@ These commands ensure:
 
 This repository standardizes development tasks through the `justfile`.
 
-Agents should **prefer running `just` commands instead of invoking the underlying tools directly**. The justfile ensures the correct flags, configuration, and tool ordering are used.
+Agents should **prefer running `just` commands instead of invoking the underlying tools directly**. The justfile ensures the correct flags, configuration, and
+tool ordering are used.
 
 Examples:
 
@@ -37,7 +38,8 @@ Examples:
 
 Direct tool invocation should only be used when a corresponding `just` command does not exist.
 
-Rust unit, integration, CLI, slow, example, and release test recipes run with `cargo nextest`. Documentation tests intentionally remain on `cargo test --doc` because nextest does not run rustdoc doctests.
+Rust unit, integration, CLI, slow, example, and release test recipes run with `cargo nextest`. Documentation tests intentionally remain on `cargo test --doc`
+because nextest does not run rustdoc doctests.
 
 ---
 
@@ -121,7 +123,8 @@ This runs the normal CI command and then feature-gated slow/stress tests.
 
 Repository-owned Semgrep rules live in `semgrep.yaml`. They encode focused project invariants that are not already covered by Rust, Clippy, Ruff, or ShellCheck.
 
-When adding or changing a Semgrep rule, add a matching fixture under `tests/semgrep/` and keep `just semgrep-test` passing. Rules ported from `markov-chain-monte-carlo` must be adapted to CDT naming, paths, and architecture constraints rather than copied mechanically.
+When adding or changing a Semgrep rule, add a matching fixture under `tests/semgrep/` and keep `just semgrep-test` passing. Rules ported from
+`markov-chain-monte-carlo` must be adapted to CDT naming, paths, and architecture constraints rather than copied mechanically.
 
 Commands:
 
@@ -165,11 +168,14 @@ Examples must:
 - run successfully
 - demonstrate correct API usage
 
-`just examples-validate` additionally checks stable output markers for user-facing Cargo examples. Keep those markers semantic rather than exact numeric values so simulation output can evolve without making the example contract brittle.
+`just examples-validate` additionally checks stable output markers for user-facing Cargo examples. Keep those markers semantic rather than exact numeric values
+so simulation output can evolve without making the example contract brittle.
 
-The example runner compiles all Cargo examples once with `cargo build --release --examples`, then executes the compiled binaries directly. This preserves example coverage while avoiding repeated Cargo invocations for each example.
+The example runner compiles all Cargo examples once with `cargo build --release --examples`, then executes the compiled binaries directly. This preserves
+example coverage while avoiding repeated Cargo invocations for each example.
 
-When adding or renaming a Cargo example, update `scripts/run_all_examples.sh` `validate_example_output()` with stable semantic output markers, or intentionally document why success-only validation is sufficient for that example.
+When adding or renaming a Cargo example, update `scripts/run_all_examples.sh` `validate_example_output()` with stable semantic output markers, or intentionally
+document why success-only validation is sufficient for that example.
 
 ---
 
@@ -209,9 +215,9 @@ Compatibility aliases remain available as granular recipes:
 
 ## Markdown Formatting
 
-Markdown files are checked and fixed with `rumdl`. The current config keeps
-legacy long-line and generated-reference behavior out of the migration so the
-tooling change does not become a broad documentation rewrite.
+Markdown files are checked and fixed with `rumdl`. The repository uses a
+160-column Markdown width, and `just markdown-check` also runs a raw line-length
+guard so constructs that `rumdl` exempts from MD013 still respect that limit.
 
 Commands:
 
@@ -279,7 +285,8 @@ jq empty file.json
 
 Workflows must pass `actionlint`.
 
-The repository has separate workflows for full CI, dependency audit, Codecov coverage, repository-rule SARIF upload, Clippy SARIF, performance checks, and CodeQL analysis. Do not add another external analysis workflow unless it has a distinct signal and required secrets are configured for this repository.
+The repository has separate workflows for full CI, dependency audit, Codecov coverage, repository-rule SARIF upload, Clippy SARIF, performance checks, and
+CodeQL analysis. Do not add another external analysis workflow unless it has a distinct signal and required secrets are configured for this repository.
 
 External GitHub Actions must use full commit-SHA pins, stay within the
 repository-owned allowlist in `semgrep.yaml`, and keep a readable version

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -314,6 +314,12 @@ Benchmark harnesses can be smoke-tested without producing baseline-quality perfo
 just bench-smoke
 ```
 
+The smaller CI regression benchmark contract runs through the `perf` Cargo profile:
+
+```bash
+just bench-ci
+```
+
 To compile benchmarks and release-profile integration tests without running them:
 
 ```bash
@@ -388,7 +394,8 @@ Regenerate with:
 just changelog
 ```
 
-This runs `git-cliff`, applies the Python postprocessor, and archives completed minor release series under `docs/archive/changelog/`.
+This runs `git-cliff`, applies the Python postprocessor, archives completed minor release series under `docs/archive/changelog/`, and
+formats generated changelog files with `rumdl`.
 
 For release PRs, generate the changelog for a version before the final tag exists with:
 

--- a/docs/dev/python.md
+++ b/docs/dev/python.md
@@ -2,7 +2,8 @@
 
 Guidance for Python automation under `scripts/`.
 
-The Rust library is the primary product, but the Python benchmark, changelog, hardware, coverage, and workflow utilities are part of the trusted development loop. Keep them typed and predictable so failures are visible in CI instead of being hidden behind loose mocks or broad exception handling.
+The Rust library is the primary product, but the Python benchmark, changelog, hardware, coverage, and workflow utilities are part of the trusted development
+loop. Keep them typed and predictable so failures are visible in CI instead of being hidden behind loose mocks or broad exception handling.
 
 ---
 
@@ -59,17 +60,21 @@ Structured results keep tests close to production behavior and give `ty` real at
 ## Exceptions
 
 - Catch specific recoverable error families in production code. Avoid `except Exception`.
-- In tests, raise concrete exceptions that match the production recovery path (`OSError`, `RuntimeError`, `subprocess.CalledProcessError`, `subprocess.TimeoutExpired`, etc.).
+- In tests, raise concrete exceptions that match the production recovery path (`OSError`, `RuntimeError`, `subprocess.CalledProcessError`,
+  `subprocess.TimeoutExpired`, etc.).
 - Do not use raw `Exception` in mocks just to force a fallback branch; doing so weakens the contract that the production code is meant to enforce.
 
 ---
 
 ## Test Helpers
 
-Put reusable typed test helpers near the top of the test module or in `scripts/tests/conftest.py` when they are shared. Prefer one helper that returns the real structured type over repeating partially configured mocks throughout a file.
+Put reusable typed test helpers near the top of the test module or in `scripts/tests/conftest.py` when they are shared. Prefer one helper that returns the real
+structured type over repeating partially configured mocks throughout a file.
 
 ## Parser and File-Format Contracts
 
-When a script both writes and parses a text format, add a focused round-trip test that writes representative records and parses them back. The test should cover stable identifiers, optional sections, units, and numeric forms such as scientific notation when those values can be emitted by production code.
+When a script both writes and parses a text format, add a focused round-trip test that writes representative records and parses them back. The test should cover
+stable identifiers, optional sections, units, and numeric forms such as scientific notation when those values can be emitted by production code.
 
-For parser refactors, keep malformed-input regression tests for behavior that callers depend on, such as skipping incomplete sections or failing loudly on invalid numerical data.
+For parser refactors, keep malformed-input regression tests for behavior that callers depend on, such as skipping incomplete sections or failing loudly on
+invalid numerical data.

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -70,7 +70,9 @@ Avoid unnecessary allocations and cloning in public APIs. Prefer returning refer
 
 Only return owned values (`Vec`, `String`, etc.) when necessary.
 
-Do not expose broad mutable access to invariant-heavy CDT wrappers. Prefer narrow mutation methods that perform one operation, invalidate derived caches/bookkeeping, and return a typed `Result`. Tests that need invalid legacy states should use local helpers inside the test module rather than test-only constructors or methods on production impl blocks.
+Do not expose broad mutable access to invariant-heavy CDT wrappers. Prefer narrow mutation methods that perform one operation, invalidate derived
+caches/bookkeeping, and return a typed `Result`. Tests that need invalid legacy states should use local helpers inside the test module rather than test-only
+constructors or methods on production impl blocks.
 
 ---
 
@@ -80,7 +82,9 @@ Public APIs must **not panic**.
 
 Use explicit error propagation.
 
-Production `src/` code must not use bare `unwrap()` or explicit `panic!`. Use `?`, typed errors, `Option`, or an intentional fallback instead. Tests, doctests, examples, and benchmark setup may fail fast when a broken fixture should stop execution immediately; prefer `expect("reason")` over bare `unwrap()` in user-facing examples so failures remain diagnosable.
+Production `src/` code must not use bare `unwrap()` or explicit `panic!`. Use `?`, typed errors, `Option`, or an intentional fallback instead. Tests, doctests,
+examples, and benchmark setup may fail fast when a broken fixture should stop execution immediately; prefer `expect("reason")` over bare `unwrap()` in
+user-facing examples so failures remain diagnosable.
 
 ### Fallible public functions
 
@@ -132,20 +136,28 @@ Errors should be defined **within the module where they are used**.
 
 Avoid large centralized error enums.
 
-Error variants must be narrow, orthogonal, and purpose-specific. Do not collapse distinct failure modes into one catch-all variant when callers, tests, or debugging would need to distinguish them. Prefer a new variant over stringly typed detail when the distinction is part of the recovery or diagnostic path.
+Error variants must be narrow, orthogonal, and purpose-specific. Do not collapse distinct failure modes into one catch-all variant when callers, tests, or
+debugging would need to distinguish them. Prefer a new variant over stringly typed detail when the distinction is part of the recovery or diagnostic path.
 
 Each variant should carry the structured context needed to debug the failure without parsing the `Display` string:
 
 - the operation being attempted, when the same error can occur from multiple operations
 - the relevant handle, key, index, coordinate, or configuration field
 - the expected invariant and the actual value when reporting validation failures
-- the source error as a typed source when possible, or as a string only at crate/backend boundaries where the upstream type is not part of this crate's public contract
+- the source error as a typed source when possible, or as a string only at crate/backend boundaries where the upstream type is not part of this crate's public
+  contract
 
-Keep error layers orthogonal. Invalid input or handles, unsupported operations, topology/causality violations, backend mutation failures, and internal postcondition failures should use different variants. Wrapping is appropriate only when crossing abstraction layers, and wrappers must preserve the lower-level detail.
+Keep error layers orthogonal. Invalid input or handles, unsupported operations, topology/causality violations, backend mutation failures, and internal
+postcondition failures should use different variants. Wrapping is appropriate only when crossing abstraction layers, and wrappers must preserve the lower-level
+detail.
 
 Public error enums must be `#[non_exhaustive]` so new variants remain additive.
 
-Do not use `Box<dyn std::error::Error>`, `Box<dyn Error>`, or `anyhow::Error` as fallible return types in production `src/` code, public doctests, examples, or benchmarks that demonstrate user-facing workflows. Prefer the crate's typed `CdtResult<T>` and add a narrow `CdtError` variant when a distinct I/O, serialization, validation, backend, or checkpoint failure mode is otherwise only representable as a generic error. `&dyn Error` is acceptable for implementing `std::error::Error::source`, for tests that explicitly verify the standard error trait implementation, and for lint fixtures that exercise the forbidden pattern.
+Do not use `Box<dyn std::error::Error>`, `Box<dyn Error>`, or `anyhow::Error` as fallible return types in production `src/` code, public doctests, examples, or
+benchmarks that demonstrate user-facing workflows. Prefer the crate's typed `CdtResult<T>` and add a narrow `CdtError` variant when a distinct I/O,
+serialization, validation, backend, or checkpoint failure mode is otherwise only representable as a generic error. `&dyn Error` is acceptable for implementing
+`std::error::Error::source`, for tests that explicitly verify the standard error trait implementation, and for lint fixtures that exercise the forbidden
+pattern.
 
 Example:
 
@@ -166,7 +178,8 @@ Always import types at the top of the module rather than using fully‑qualified
 
 Group imports from the same module into a single `use` statement with braces.
 
-Do not put test-only imports in the production module preamble. Move `#[cfg(test)]` imports into the relevant `tests` module so normal builds do not carry test-only style noise at the top of implementation files.
+Do not put test-only imports in the production module preamble. Move `#[cfg(test)]` imports into the relevant `tests` module so normal builds do not carry
+test-only style noise at the top of implementation files.
 
 If a test module already has `use super::*;`, do not re‑import items that are already brought into scope by the parent module's imports.
 
@@ -184,9 +197,11 @@ Modules are declared from `src/lib.rs` (and `src/main.rs` for binaries), includi
 
 All public items must have documentation.
 
-Public functions and methods should include a `# Examples` section with a runnable doctest demonstrating basic usage. Doctests serve as both documentation and regression tests.
+Public functions and methods should include a `# Examples` section with a runnable doctest demonstrating basic usage. Doctests serve as both documentation and
+regression tests.
 
-Private helper functions should have a `///` doc comment that explains why the helper exists, especially when it encodes an invariant, isolates validation, or keeps a mutation path consistent.
+Private helper functions should have a `///` doc comment that explains why the helper exists, especially when it encodes an invariant, isolates validation, or
+keeps a mutation path consistent.
 
 After Rust changes, verify documentation builds:
 
@@ -198,27 +213,34 @@ just doc-check
 
 ## Re-exports
 
-Types that are part of the crate's **stable public API** (documented, intended for external consumption) should be re-exported from the crate root (`src/lib.rs`). Internal-use public types (e.g., backend-specific handles) should not be re-exported to avoid API bloat.
+Types that are part of the crate's **stable public API** (documented, intended for external consumption) should be re-exported from the crate root
+(`src/lib.rs`). Internal-use public types (e.g., backend-specific handles) should not be re-exported to avoid API bloat.
 
 When adding a new public API type, add a corresponding `pub use` line in the re-export block at the top of `lib.rs`.
 
-The broad `prelude::*` must stay small. It should cover common quick-start workflows such as CDT construction, basic configuration, simulation startup, query traits, and error handling. Do not use it as a dumping ground for every public type.
+The broad `prelude::*` must stay small. It should cover common quick-start workflows such as CDT construction, basic configuration, simulation startup, query
+traits, and error handling. Do not use it as a dumping ground for every public type.
 
-Focused preludes under `prelude::` must remain small, orthogonal, and purpose-specific. Use them in doctests, integration tests, examples, and benchmarks instead of deep module paths when demonstrating public workflows. Avoid duplicating specialized APIs across scoped preludes unless the overlap is deliberate and documented:
+Focused preludes under `prelude::` must remain small, orthogonal, and purpose-specific. Use them in doctests, integration tests, examples, and benchmarks
+instead of deep module paths when demonstrating public workflows. Avoid duplicating specialized APIs across scoped preludes unless the overlap is deliberate and
+documented:
 
 - `prelude::geometry` for backend construction, geometry generators, and geometry traits
 - `prelude::triangulation` for CDT wrappers, foliation classification, topology metadata, and triangulation queries
 - `prelude::moves` for local ergodic move kernels, move results, move types, and move statistics
 - `prelude::action` for standalone action configuration and Regge action calculations
 - `prelude::errors` for crate error types and typed error-category enums needed to pattern-match failures
-- `prelude::simulation` for Metropolis/action simulation workflows, proposal types, simulation result types, and telemetry needed to inspect or debug simulations
-- `prelude::observables` for user-facing analysis APIs that measure triangulations or derived physical observables, such as volume profiles, Hausdorff-dimension estimators, and spectral-dimension estimators
+- `prelude::simulation` for Metropolis/action simulation workflows, proposal types, simulation result types, and telemetry needed to inspect or debug
+  simulations
+- `prelude::observables` for user-facing analysis APIs that measure triangulations or derived physical observables, such as volume profiles, Hausdorff-dimension
+  estimators, and spectral-dimension estimators
 - `prelude::testing` for fixture-only helpers such as the mock backend and its typed error categories
 
 Keep the simulation and observables boundaries crisp:
 
 - Export user-facing observable estimators from `prelude::observables`, not `prelude::simulation`.
-- Keep simulation telemetry, proposal adapters, and result containers in `prelude::simulation`; do not export them from `prelude::observables` merely because an observable can be computed from them.
+- Keep simulation telemetry, proposal adapters, and result containers in `prelude::simulation`; do not export them from `prelude::observables` merely because an
+  observable can be computed from them.
 - Examples and doctests for measurements should prefer `prelude::observables::*`; examples and doctests for running MCMC should prefer `prelude::simulation::*`.
 
 ---
@@ -292,7 +314,9 @@ Before adding a dependency, consider:
 
 ## Geometry Backend Isolation
 
-`src/geometry/` is the backend interface layer. It is responsible for wrapping the upstream `delaunay` crate behind this crate's traits, opaque handles, generators, and backend adapters. `src/cdt/` is the CDT domain layer: it owns foliation, topology, causality, moves, action, simulation, results, and observables.
+`src/geometry/` is the backend interface layer. It is responsible for wrapping the upstream `delaunay` crate behind this crate's traits, opaque handles,
+generators, and backend adapters. `src/cdt/` is the CDT domain layer: it owns foliation, topology, causality, moves, action, simulation, results, and
+observables.
 
 Direct `use delaunay::` imports are **restricted** to the `src/geometry/` subtree:
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -113,7 +113,8 @@ All Python tests should:
 
 ### Rust Test Runner
 
-Runnable Rust tests use `cargo nextest` through the repository `just` recipes. Rustdoc doctests remain on `cargo test --doc` because nextest does not execute doctests. Use the `just` recipes instead of calling Cargo directly so this split stays consistent locally and in CI.
+Runnable Rust tests use `cargo nextest` through the repository `just` recipes. Rustdoc doctests remain on `cargo test --doc` because nextest does not execute
+doctests. Use the `just` recipes instead of calling Cargo directly so this split stays consistent locally and in CI.
 
 ---
 

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -1,6 +1,7 @@
 # Tooling Alignment
 
-This note records the issue #112 comparison between `causal-triangulations` and the sibling `markov-chain-monte-carlo` repository. Keep it current when changing repository tooling so future updates can be deliberate rather than copied wholesale.
+This note records the issue #112 comparison between `causal-triangulations` and the sibling `markov-chain-monte-carlo` repository. Keep it current when changing
+repository tooling so future updates can be deliberate rather than copied wholesale.
 
 ## Current Parity
 
@@ -14,27 +15,39 @@ Both repositories now have explicit local configuration for the core Rust and Py
 - `rumdl.toml`, `dprint.json`, `.yamllint`, `typos.toml`, and `clippy.toml` define documentation and configuration checks.
 - `justfile` is the single local entry point for formatting, linting, tests, coverage, Semgrep, changelog, and setup commands.
 
+Non-Rust repository tooling is normalized to a 160-column width: Ruff for Python support scripts, `rumdl` plus the Markdown raw line-length guard, `yamllint`,
+`dprint`/`pretty_yaml`, and the generated changelog postprocessor all use 160 columns. Rust remains on the narrower `rustfmt` `max_width = 100` setting because
+wide Rust signatures, trait bounds, and method chains become harder to scan at 160 columns.
+
 ## Python Tooling
 
-CDT's Python tooling is broader than MCMC's. MCMC currently has changelog and tag helpers; CDT also has benchmark, hardware, coverage, archive, and performance-analysis scripts. The shared script patterns have already been ported here:
+CDT's Python tooling is broader than MCMC's. MCMC currently has changelog and tag helpers; CDT also has benchmark, hardware, coverage, archive, and
+performance-analysis scripts. The shared script patterns have already been ported here:
 
 - secure subprocess wrappers in `scripts/subprocess_utils.py`;
 - typed `subprocess.CompletedProcess[str]` helpers in tests;
 - Ruff, Ty, pytest, and uv-managed development dependencies in `pyproject.toml`;
-- Python Semgrep rules and fixtures for broad exception catches across all `scripts/**/*.py`, raw `Exception` in tests, ad hoc subprocess mocks, and missing return annotations.
+- Python Semgrep rules and fixtures for broad exception catches across all `scripts/**/*.py`, raw `Exception` in tests, ad hoc subprocess mocks, and missing
+  return annotations.
 
-The broad-exception Semgrep rule now covers the full Python support-script tree. `scripts/benchmark_utils.py`, `scripts/hardware_utils.py`, and `scripts/performance_analysis.py` use typed recoverable exception boundaries, so new broad `except Exception` recovery paths are treated as tooling regressions rather than accepted legacy cleanup.
+The broad-exception Semgrep rule now covers the full Python support-script tree. `scripts/benchmark_utils.py`, `scripts/hardware_utils.py`, and
+`scripts/performance_analysis.py` use typed recoverable exception boundaries, so new broad `except Exception` recovery paths are treated as tooling regressions
+rather than accepted legacy cleanup.
 
 ## Intentional Differences
 
 Some differences remain because CDT has different workflows and project invariants:
 
-- CDT runs examples through `scripts/run_all_examples.sh`, which discovers current examples dynamically, builds release examples once, applies a timeout while running the compiled binaries, and checks stable semantic output markers in `--validate` mode without requiring exact numeric output.
+- CDT runs examples through `scripts/run_all_examples.sh`, which discovers current examples dynamically, builds release examples once, applies a timeout while
+  running the compiled binaries, and checks stable semantic output markers in `--validate` mode without requiring exact numeric output.
 - CDT keeps `archive-changelog` so completed release series move under `docs/archive/changelog/`; MCMC does not yet archive old changelog sections.
 - CDT keeps a dedicated `performance.yml` workflow and local `perf-*` recipes. MCMC does not have matching CDT benchmark-baseline tooling.
-- CDT exposes feature-gated long-running Rust checks through the `slow-tests` Cargo feature and the `just test-slow` recipe, keeping normal CI fast while giving stabilization work a named path for heavier integration coverage.
-- CDT has a repository rule SARIF workflow for the local Semgrep rules. A Codacy workflow was not ported because it depends on project-specific `CODACY_PROJECT_TOKEN` setup and would duplicate the existing repository-rule SARIF signal until Codacy is configured for this repository.
-- CDT Semgrep rules include geometry-backend isolation, foliation/topology validation, focused prelude imports, Python support-script discipline, and typed error policies. These are repository-specific and should not be weakened while porting generic rules.
+- CDT exposes feature-gated long-running Rust checks through the `slow-tests` Cargo feature and the `just test-slow` recipe, keeping normal CI fast while giving
+  stabilization work a named path for heavier integration coverage.
+- CDT has a repository rule SARIF workflow for the local Semgrep rules. A Codacy workflow was not ported because it depends on project-specific
+  `CODACY_PROJECT_TOKEN` setup and would duplicate the existing repository-rule SARIF signal until Codacy is configured for this repository.
+- CDT Semgrep rules include geometry-backend isolation, foliation/topology validation, focused prelude imports, Python support-script discipline, and typed
+  error policies. These are repository-specific and should not be weakened while porting generic rules.
 - CDT and MCMC both require Python `>=3.12` for repository-managed support tooling.
 
 ## Ported Updates
@@ -44,26 +57,37 @@ The useful updates ported from MCMC are:
 - explicit `rustfmt.toml` formatting configuration;
 - explicit uv package mode and pytest 9 minimum in `pyproject.toml`;
 - CodeQL analysis for GitHub Actions and Rust, using `build-mode: none` for Rust;
-- the MCMC-style `cliff.toml` template and `just changelog-unreleased <version>` flow, adapted to keep CDT's changelog archive step and avoid temporary local release tags;
+- the MCMC-style `cliff.toml` template and `just changelog-unreleased <version>` flow, adapted to keep CDT's changelog archive step and avoid temporary local
+  release tags;
 - a Semgrep rule that rejects `NaN` and infinity defaults after failed floating-point conversions, with a regression fixture under `tests/semgrep/`.
-- production-only Rust Semgrep rules that reject bare `unwrap()` and explicit `panic!` in non-test `src/` code while preserving idiomatic fail-fast usage in tests, doctests, examples, and benchmark setup.
+- production-only Rust Semgrep rules that reject bare `unwrap()` and explicit `panic!` in non-test `src/` code while preserving idiomatic fail-fast usage in
+  tests, doctests, examples, and benchmark setup.
 - an `examples-validate` recipe that runs Cargo examples and verifies stable output markers for the user-facing example contracts.
 
 The useful Semgrep updates ported from the sibling `delaunay` repository are:
 
-- a silent numeric-conversion fallback rule, adapted to CDT `src/` paths and cleaned up in observable/result aggregation code so conversion failures use explicit branches instead of `unwrap_or` sentinels;
-- preventive Rust rules for `partial_cmp(...).unwrap_or(...)`, function-local imports in production source, and `#[allow(clippy::...)]` suppressions, each kept repository-owned with CDT rule IDs and fixtures.
+- a silent numeric-conversion fallback rule, adapted to CDT `src/` paths and cleaned up in observable/result aggregation code so conversion failures use
+  explicit branches instead of `unwrap_or` sentinels;
+- preventive Rust rules for `partial_cmp(...).unwrap_or(...)`, function-local imports in production source, and `#[allow(clippy::...)]` suppressions, each kept
+  repository-owned with CDT rule IDs and fixtures.
 
 The useful `justfile` updates ported from `delaunay` are:
 
 - `ci-slow`, a named CI-plus-slow-tests workflow using CDT's existing `slow-tests` feature gate;
-- `cargo nextest` for runnable Rust unit, integration, CLI, slow, example, and release test recipes, while keeping rustdoc doctests on `cargo test --doc` because nextest does not execute doctests;
-- single-pass release example builds in `scripts/run_all_examples.sh`, which preserve semantic output validation while avoiding repeated `cargo run --example` invocations;
-- `bench-smoke`, adapted to CDT's `cdt_benchmarks` harness and Criterion's minimal sample settings so benchmark harnesses can be smoke-tested without producing baseline-quality numbers;
+- `cargo nextest` for runnable Rust unit, integration, CLI, slow, example, and release test recipes, while keeping rustdoc doctests on `cargo test --doc`
+  because nextest does not execute doctests;
+- single-pass release example builds in `scripts/run_all_examples.sh`, which preserve semantic output validation while avoiding repeated `cargo run --example`
+  invocations;
+- `bench-smoke`, adapted to CDT's `cdt_benchmarks` harness and Criterion's minimal sample settings so benchmark harnesses can be smoke-tested without producing
+  baseline-quality numbers;
 - `bench-test-compile`, which layers release-profile integration-test compilation on top of the existing warning-denying benchmark compile check;
-- opt-in release hygiene recipes `unused-deps` and `publish-check`, kept outside the default `lint` and `ci` paths so they are available before releases without making routine validation slower or more tool-dependent;
+- opt-in release hygiene recipes `unused-deps` and `publish-check`, kept outside the default `lint` and `ci` paths so they are available before releases without
+  making routine validation slower or more tool-dependent;
 - `rumdl` Markdown checking, `dprint`/`pretty_yaml` YAML formatting, check/fix aliases, and a corrected rename/copy note in `spell-check`.
-- repository-owned Semgrep rules that keep user-facing `just check` examples before `just fix` examples and enforce SHA-pinned, allowlisted GitHub Actions with readable version comments. Dependabot remains the update path for pinned external actions, with review focused on preserving both the SHA and readable version comment.
+- repository-owned Semgrep rules that keep user-facing `just check` examples before `just fix` examples and enforce SHA-pinned, allowlisted GitHub Actions with
+  readable version comments. Dependabot remains the update path for pinned external actions, with review focused on preserving both the SHA and readable version
+  comment.
+- Delaunay's non-Rust 160-column tooling policy, adapted for CDT while intentionally leaving Rust formatting at `rustfmt`'s 100-column width.
 
 ## CI Shape Evaluation
 
@@ -111,7 +135,9 @@ larger Delaunay profiling and same-machine comparison helpers remain deferred.
 
 These were evaluated but not ported in this pass:
 
-- `codacy.yml`: defer until the repository has an intentional Codacy project token and a decision about whether Codacy should upload repository-owned OpenGrep/Semgrep findings in addition to `.github/workflows/semgrep-sarif.yml`.
-- Delaunay's hot-path `FastHashMap`/`FastHashSet` rule: defer because CDT does not currently define equivalent hash aliases or the same `src/core` hot-path layout.
-- Delaunay's `profiling_suite` and same-machine baseline recipes: defer because CDT's `ci_performance_suite` now provides the portable regression contract, while deeper profiling still needs CDT-specific benchmark interpretation.
-- Delaunay's broader Markdown cleanup: defer because CDT intentionally keeps legacy long-line and generated-reference behavior out of the `rumdl` migration.
+- `codacy.yml`: defer until the repository has an intentional Codacy project token and a decision about whether Codacy should upload repository-owned
+  OpenGrep/Semgrep findings in addition to `.github/workflows/semgrep-sarif.yml`.
+- Delaunay's hot-path `FastHashMap`/`FastHashSet` rule: defer because CDT does not currently define equivalent hash aliases or the same `src/core` hot-path
+  layout.
+- Delaunay's `profiling_suite` and same-machine baseline recipes: defer because CDT's `ci_performance_suite` now provides the portable regression contract,
+  while deeper profiling still needs CDT-specific benchmark interpretation.

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -65,11 +65,53 @@ The useful `justfile` updates ported from `delaunay` are:
 - `rumdl` Markdown checking, `dprint`/`pretty_yaml` YAML formatting, check/fix aliases, and a corrected rename/copy note in `spell-check`.
 - repository-owned Semgrep rules that keep user-facing `just check` examples before `just fix` examples and enforce SHA-pinned, allowlisted GitHub Actions with readable version comments. Dependabot remains the update path for pinned external actions, with review focused on preserving both the SHA and readable version comment.
 
+## CI Shape Evaluation
+
+Issue #131 evaluated larger CI-shape changes after the lower-risk speedups from
+issue #130. Recent successful PR CI runs on May 22, 2026 showed the macOS and
+Windows matrix legs often determining wall-clock duration:
+
+- `perf/130-ci-speedups` (#137): Ubuntu completed in about 3m31s, macOS in
+  about 3m52s, and Windows in about 3m40s.
+- `feat/checked-delaunay-api` (#128): Ubuntu completed in about 4m28s, macOS
+  in about 4m56s, and Windows in about 6m10s.
+
+The repository intentionally keeps the existing `build (ubuntu-latest)`,
+`build (macos-latest)`, and `build (windows-latest)` required check contexts,
+and keeps Rust target coverage on all three platforms. A broader split that
+would run the comprehensive repository/tooling path only on Linux was rejected
+because it would weaken the current macOS build signal.
+
+The adopted change is smaller: the Windows leg now uses
+`cargo nextest run --workspace --all-targets --no-run` instead of an initial
+`cargo build --all-targets`, then runs lib, binary, example, and integration
+test targets through one nextest invocation. That keeps the full Rust target
+compile surface on Windows, including benchmark compilation, while avoiding
+accidental Criterion benchmark execution in the test job. Rustdoc doctests
+remain on `cargo test --doc` because nextest does not execute doctests.
+
+The May 2026 Delaunay tooling refresh was reviewed for portable pieces. CDT
+adopted `cargo-llvm-cov` 0.8.7 in both local setup and Codecov, added `rumdl`
+formatting to generated changelog recipes, and ported archive heading
+normalization so historical changelog archives are cleaned even when a release
+only rewrites the active minor series. Delaunay's profiling, Codacy SARIF
+filtering, and benchmark-comparison machinery remained deferred from that pass
+because CDT needed a different benchmark contract and has no configured Codacy
+workflow.
+
+The follow-up benchmark alignment introduced a CDT-specific
+`ci_performance_suite` rather than copying Delaunay's dimensional construction
+contract. CDT's suite covers generated open-boundary and toroidal
+triangulations, validation, individual ergodic move attempts, ten-sweep
+random-move workloads, and ten-sweep Metropolis runs. The suite uses a local
+`perf` profile and feeds the existing performance-analysis scripts, while the
+larger Delaunay profiling and same-machine comparison helpers remain deferred.
+
 ## Deferred Updates
 
 These were evaluated but not ported in this pass:
 
 - `codacy.yml`: defer until the repository has an intentional Codacy project token and a decision about whether Codacy should upload repository-owned OpenGrep/Semgrep findings in addition to `.github/workflows/semgrep-sarif.yml`.
 - Delaunay's hot-path `FastHashMap`/`FastHashSet` rule: defer because CDT does not currently define equivalent hash aliases or the same `src/core` hot-path layout.
-- Delaunay's `ci_performance_suite`, `profiling_suite`, `[profile.perf]`, and same-machine baseline recipes: defer because CDT currently has a single `cdt_benchmarks` harness plus the existing `performance-analysis` workflow, so porting those recipes would require a CDT-specific benchmark contract rather than a justfile-only change.
+- Delaunay's `profiling_suite` and same-machine baseline recipes: defer because CDT's `ci_performance_suite` now provides the portable regression contract, while deeper profiling still needs CDT-specific benchmark interpretation.
 - Delaunay's broader Markdown cleanup: defer because CDT intentionally keeps legacy long-line and generated-reference behavior out of the `rumdl` migration.

--- a/docs/foliation.md
+++ b/docs/foliation.md
@@ -4,7 +4,8 @@ Per-vertex time labels, edge classification, and causal validation for 1+1 CDT.
 
 ## Background
 
-In Causal Dynamical Triangulations (Ambjørn, Jurkiewicz, Loll 2001), spacetime is built from simplices arranged in a **foliation** — a layered structure where each time slice is a spatial manifold and adjacent slices are connected by timelike edges.
+In Causal Dynamical Triangulations (Ambjørn, Jurkiewicz, Loll 2001), spacetime is built from simplices arranged in a **foliation** — a layered structure where
+each time slice is a spatial manifold and adjacent slices are connected by timelike edges.
 
 For the periodic 1+1 CDT cases:
 
@@ -13,13 +14,17 @@ For the periodic 1+1 CDT cases:
 - **Edge classification**: spacelike (both endpoints at same t) or timelike (endpoints at t and t±1)
 - **Causality constraint**: no edge may span more than one time slice (|Δt| ≤ 1)
 
-This implementation also supports open-boundary strip variants. `from_toroidal_cdt()` builds the periodic S¹ × S¹ toroidal case, while `from_cdt_strip()` builds open spatial-interval strip geometries over discrete time. Both constructor families use the same edge classification and causality constraint, but their topology metadata and boundary expectations differ.
+This implementation also supports open-boundary strip variants. `from_toroidal_cdt()` builds the periodic S¹ × S¹ toroidal case, while `from_cdt_strip()` builds
+open spatial-interval strip geometries over discrete time. Both constructor families use the same edge classification and causality constraint, but their
+topology metadata and boundary expectations differ.
 
 ## Architecture
 
-Foliation is CDT domain logic. The implementation stores labels in the Delaunay-backed geometry through crate-owned wrapper APIs, but direct interaction with upstream `delaunay::` types remains confined to the `src/geometry/` backend interface layer.
+Foliation is CDT domain logic. The implementation stores labels in the Delaunay-backed geometry through crate-owned wrapper APIs, but direct interaction with
+upstream `delaunay::` types remains confined to the `src/geometry/` backend interface layer.
 
-Time labels are stored **directly as vertex data** in the Delaunay triangulation, using the `Vertex<f64, u32, 2>` type parameter. This mirrors CGAL's `vertex->info()` used in CDT-plusplus. The `Foliation` struct tracks only aggregate bookkeeping.
+Time labels are stored **directly as vertex data** in the Delaunay triangulation, using the `Vertex<f64, u32, 2>` type parameter. This mirrors CGAL's
+`vertex->info()` used in CDT-plusplus. The `Foliation` struct tracks only aggregate bookkeeping.
 
 ```text
 CdtTriangulation<B>
@@ -31,11 +36,14 @@ CdtTriangulation<B>
     └── num_slices: u32
 ```
 
-Vertex data is set at construction time via `VertexBuilder::data(t)`. For post-construction labeling (e.g., `assign_foliation_by_y`), labels are written in-place through CDT-owned helper paths — an O(1) operation per vertex that does not affect geometry or topology. Public callers do not receive mutable backend access; CDT mutation paths are narrow so cache and foliation synchronization state are invalidated consistently.
+Vertex data is set at construction time via `VertexBuilder::data(t)`. For post-construction labeling (e.g., `assign_foliation_by_y`), labels are written
+in-place through CDT-owned helper paths — an O(1) operation per vertex that does not affect geometry or topology. Public callers do not receive mutable backend
+access; CDT mutation paths are narrow so cache and foliation synchronization state are invalidated consistently.
 
 ## Time Label Assignment
 
-For `from_cdt_strip()` and `from_toroidal_cdt()`, time labels are assigned directly while building vertices. Vertex `(i, t)` receives label `t`, so each slice starts with exactly `vertices_per_slice` vertices. The constructors require their Delaunay-built simplices to span adjacent slices before returning.
+For `from_cdt_strip()` and `from_toroidal_cdt()`, time labels are assigned directly while building vertices. Vertex `(i, t)` receives label `t`, so each slice
+starts with exactly `vertices_per_slice` vertices. The constructors require their Delaunay-built simplices to span adjacent slices before returning.
 
 `assign_foliation_by_y()` uses band-based bucketing and writes labels through the same CDT-owned label-write path.
 
@@ -49,14 +57,18 @@ The open-boundary strip constructor places vertices in a lightly perturbed layer
 
 Parameters: `vertices_per_slice ≥ 4`, `num_slices ≥ 2`.
 
-The toroidal constructor places vertices on a unit lattice in an `N × T` periodic domain and uses the upstream periodic image-point Delaunay constructor. It then checks the requested `V = N·T`, `E = 3·N·T`, `F = 2·N·T` toroidal counts and strict CDT classification.
+The toroidal constructor places vertices on a unit lattice in an `N × T` periodic domain and uses the upstream periodic image-point Delaunay constructor. It
+then checks the requested `V = N·T`, `E = 3·N·T`, `F = 2·N·T` toroidal counts and strict CDT classification.
 
 ## Initialization vs Evolution Validation
 
 Initial CDT constructors are stricter than post-move validation:
 
-- **Initialization**: `from_cdt_strip()` and `from_toroidal_cdt()` must pass upstream Delaunay Level 1-4 validation before returning. This certifies the starting mesh as a valid, well-behaved PL-manifold and Delaunay triangulation.
-- **After ergodic moves / simulation completion**: `CdtTriangulation::validate()` requires upstream structural validity plus CDT topology, foliation, causality, and simplex-classification invariants. It intentionally does not require Level 4 Delaunay-ness, because the CDT move kernels are not expected to preserve the Delaunay empty-circumsphere predicate.
+- **Initialization**: `from_cdt_strip()` and `from_toroidal_cdt()` must pass upstream Delaunay Level 1-4 validation before returning. This certifies the
+  starting mesh as a valid, well-behaved PL-manifold and Delaunay triangulation.
+- **After ergodic moves / simulation completion**: `CdtTriangulation::validate()` requires upstream structural validity plus CDT topology, foliation, causality,
+  and simplex-classification invariants. It intentionally does not require Level 4 Delaunay-ness, because the CDT move kernels are not expected to preserve the
+  Delaunay empty-circumsphere predicate.
 
 If the move set is ever changed to preserve Delaunay-ness, final-state validation should be tightened to include Level 4 as well.
 
@@ -76,9 +88,12 @@ Classification is done by `classify_edge(t0, t1)`, which reads time labels from 
 - `Up` (2,1) — two vertices at time _t_, one at _t + 1_. The spacelike base is in the lower slice.
 - `Down` (1,2) — one vertex at time _t_, two at _t + 1_. The spacelike base is in the upper slice.
 
-Classification is done by `classify_simplex(t0, t1, t2)`. Triangles that don’t span exactly one time slice (e.g., all vertices at the same time, or spanning >1 slice) return `None`.
+Classification is done by `classify_simplex(t0, t1, t2)`. Triangles that don’t span exactly one time slice (e.g., all vertices at the same time, or spanning >1
+slice) return `None`.
 
-Simplex types are encoded as `i32` simplex data (`Up = 1`, `Down = -1`) and can be bulk-written via `classify_all_simplices()` using `set_simplex_data`. For foliated triangulations this bulk path is strict: every face must classify as `Up` or `Down`, otherwise `classify_all_simplices()` and `validate_simplex_classification()` return a validation error.
+Simplex types are encoded as `i32` simplex data (`Up = 1`, `Down = -1`) and can be bulk-written via `classify_all_simplices()` using `set_simplex_data`. For
+foliated triangulations this bulk path is strict: every face must classify as `Up` or `Down`, otherwise `classify_all_simplices()` and
+`validate_simplex_classification()` return a validation error.
 
 ## Validation
 
@@ -91,10 +106,12 @@ Structural checks:
 1. Every vertex has a time label (labeled count = vertex count)
 2. Every time slice is non-empty
 3. `slice_sizes` sum is consistent with labeled count
-4. For toroidal topology, every spatial slice is one closed S¹ ring: each vertex has exactly two spacelike neighbors in its slice, and the slice subgraph is a single connected cycle
+4. For toroidal topology, every spatial slice is one closed S¹ ring: each vertex has exactly two spacelike neighbors in its slice, and the slice subgraph is a
+   single connected cycle
 5. For toroidal topology, timelike edges connect each slice to both neighboring time slices modulo `T`
 
-Ergodic moves resynchronize foliation bookkeeping from live vertex labels after mutation. On toroidal triangulations, the move kernel immediately reruns `validate_topology()` and `validate_foliation()` before recording success; failures are rolled back and returned as ordinary local-site rejections.
+Ergodic moves resynchronize foliation bookkeeping from live vertex labels after mutation. On toroidal triangulations, the move kernel immediately reruns
+`validate_topology()` and `validate_foliation()` before recording success; failures are rolled back and returned as ordinary local-site rejections.
 
 ### `validate_causality_delaunay()`
 
@@ -121,4 +138,5 @@ Strict simplex-classification check:
 
 ## Regression Coverage
 
-- `tests/integration_tests.rs::test_toroidal_metropolis_accepts_periodic_moves_and_preserves_topology` runs a seeded toroidal Metropolis simulation, requires at least one accepted periodic move, and checks final topology, foliation, causality, simplex classification, and χ = 0.
+- `tests/integration_tests.rs::test_toroidal_metropolis_accepts_periodic_moves_and_preserves_topology` runs a seeded toroidal Metropolis simulation, requires at
+  least one accepted periodic move, and checks final topology, foliation, causality, simplex classification, and χ = 0.

--- a/docs/metropolis.md
+++ b/docs/metropolis.md
@@ -11,10 +11,19 @@ For each step:
    - `(3,1)`: `ΔN0 = -1`, `ΔN1 = -3`, `ΔN2 = -2`
 3. Accept the proposed move if `ΔS <= 0`, or with probability `exp(-ΔS / T)`.
 4. Only after acceptance, apply the move through the ergodic move kernel.
-5. If an accepted application fails at its chosen local site, the move kernel restores its pre-mutation triangulation snapshot and the simulation retries at another randomly selected site for a bounded number of attempts. For toroidal triangulations, this includes candidate edits that would violate χ = 0 or break a spatial slice's closed-S¹ ring after mutation.
-6. If all retries fail because no local site is valid, record the step as rejected and continue; the triangulation has been restored to its pre-application state.
-7. If a backend edit reports a hard mutation failure, return `CdtError::MetropolisMoveApplicationFailed` with the step, move type, retry count, and lower-level failure.
+5. If an accepted application fails at its chosen local site, the move kernel restores its pre-mutation triangulation snapshot and the simulation retries at
+   another randomly selected site for a bounded number of attempts. For toroidal triangulations, this includes candidate edits that would violate χ = 0 or break
+   a spatial slice's closed-S¹ ring after mutation.
+6. If all retries fail because no local site is valid, record the step as rejected and continue; the triangulation has been restored to its pre-application
+   state.
+7. If a backend edit reports a hard mutation failure, return `CdtError::MetropolisMoveApplicationFailed` with the step, move type, retry count, and lower-level
+   failure.
 
-This ordering avoids mutating the triangulation for Metropolis-rejected moves. Rollback is still required for accepted moves because a backend edit can fail after a site has been selected or after partial invariant refresh work. Ergodic kernels snapshot lazily, after candidate selection and immediately before mutation, so ordinary local-site rejections avoid cloning the triangulation. Exhausted local-site retries are ordinary proposal rejections because the selected move type did not bind to a realizable local site within the bounded search. The recorded `SimulationResultsBackend::move_stats` counts Metropolis-level attempted and applied moves, while `ErgodicsSystem::stats` remains local to the lower-level move kernel.
+This ordering avoids mutating the triangulation for Metropolis-rejected moves. Rollback is still required for accepted moves because a backend edit can fail
+after a site has been selected or after partial invariant refresh work. Ergodic kernels snapshot lazily, after candidate selection and immediately before
+mutation, so ordinary local-site rejections avoid cloning the triangulation. Exhausted local-site retries are ordinary proposal rejections because the selected
+move type did not bind to a realizable local site within the bounded search. The recorded `SimulationResultsBackend::move_stats` counts Metropolis-level
+attempted and applied moves, while `ErgodicsSystem::stats` remains local to the lower-level move kernel.
 
-The integration test `test_toroidal_metropolis_accepts_periodic_moves_and_preserves_topology` covers this contract by running a seeded S¹×S¹ simulation, requiring at least one accepted periodic move, and checking final topology, foliation, causality, simplex classification, and Euler characteristic.
+The integration test `test_toroidal_metropolis_accepts_periodic_moves_and_preserves_topology` covers this contract by running a seeded S¹×S¹ simulation,
+requiring at least one accepted periodic move, and checking final topology, foliation, causality, simplex classification, and Euler characteristic.

--- a/docs/moves.md
+++ b/docs/moves.md
@@ -1,8 +1,10 @@
 # Ergodic Moves
 
-Ergodic moves are the local Monte Carlo updates that allow the triangulation to explore the space of geometries. This module implements the standard ergodic moves for 2D Causal Dynamical Triangulations (see `src/cdt/ergodic_moves.rs`).
+Ergodic moves are the local Monte Carlo updates that allow the triangulation to explore the space of geometries. This module implements the standard ergodic
+moves for 2D Causal Dynamical Triangulations (see `src/cdt/ergodic_moves.rs`).
 
-For public examples, doctests, benchmarks, and integration tests, import the focused move API with `use causal_triangulations::prelude::moves::*;`. Combine it with `prelude::triangulation::*` for CDT wrappers and `prelude::geometry::*` when constructing explicit Delaunay fixtures.
+For public examples, doctests, benchmarks, and integration tests, import the focused move API with `use causal_triangulations::prelude::moves::*;`. Combine it
+with `prelude::triangulation::*` for CDT wrappers and `prelude::geometry::*` when constructing explicit Delaunay fixtures.
 
 ## Types
 
@@ -10,9 +12,12 @@ For public examples, doctests, benchmarks, and integration tests, import the foc
 
 Enumerates the available move types:
 
-- `Move22` — (2,2) move: flip the shared edge between two triangles, preserving vertex count; causality-aware — the CDT layer validates and rejects moves that break causal layering
-- `Move13Add` — (1,3) move: insert a new vertex by subdividing one triangle into three; when the triangulation is foliated, the inserted vertex receives the time label that keeps all replacement triangles causal
-- `Move31Remove` — (3,1) move: remove a degree-3 vertex by merging three triangles into one when the replacement triangle is causal and the removal does not empty a time slice
+- `Move22` — (2,2) move: flip the shared edge between two triangles, preserving vertex count; causality-aware — the CDT layer validates and rejects moves that
+  break causal layering
+- `Move13Add` — (1,3) move: insert a new vertex by subdividing one triangle into three; when the triangulation is foliated, the inserted vertex receives the
+  time label that keeps all replacement triangles causal
+- `Move31Remove` — (3,1) move: remove a degree-3 vertex by merging three triangles into one when the replacement triangle is causal and the removal does not
+  empty a time slice
 - `EdgeFlip` — API-compatible alias for the 2D k=2 edge flip used by `Move22`; it records separate statistics but uses the same causal prechecks
 
 ### `MoveResult`
@@ -22,12 +27,16 @@ Returned by each `attempt_*` method:
 - `Success` — move was applied
 - `CausalityViolation` — rejected because the move would break causal layering
 - `GeometricViolation` — rejected because no geometrically valid candidate move exists
-- `Rejected(CdtError)` — rejected for another reason, with details; backend mutation failures are reported as `CdtError::BackendMutationFailed` rather than collapsed into `GeometricViolation`
-- `HardFailure(CdtError)` — the move already mutated geometry but then failed a required post-mutation synchronization step; this is distinct from `Rejected(CdtError)`, which reports reversible rejection reasons before an accepted mutation is finalized. See the `MoveResult` enum and `HardFailure(CdtError)` variant in `src/cdt/ergodic_moves.rs`.
+- `Rejected(CdtError)` — rejected for another reason, with details; backend mutation failures are reported as `CdtError::BackendMutationFailed` rather than
+  collapsed into `GeometricViolation`
+- `HardFailure(CdtError)` — the move already mutated geometry but then failed a required post-mutation synchronization step; this is distinct from
+  `Rejected(CdtError)`, which reports reversible rejection reasons before an accepted mutation is finalized. See the `MoveResult` enum and
+  `HardFailure(CdtError)` variant in `src/cdt/ergodic_moves.rs`.
 
 ### `MoveStatistics`
 
-Tracks per-move-type attempt and acceptance counts. Fields: `moves_22_attempted` / `moves_22_accepted`, `moves_13_attempted` / `moves_13_accepted`, `moves_31_attempted` / `moves_31_accepted`, `edge_flips_attempted` / `edge_flips_accepted`.
+Tracks per-move-type attempt and acceptance counts. Fields: `moves_22_attempted` / `moves_22_accepted`, `moves_13_attempted` / `moves_13_accepted`,
+`moves_31_attempted` / `moves_31_accepted`, `edge_flips_attempted` / `edge_flips_accepted`.
 
 Key methods:
 
@@ -48,7 +57,9 @@ Owns a `MoveStatistics` instance and a thread-local RNG. Public API:
 - `attempt_edge_flip(&mut CdtTriangulation2D) -> MoveResult`
 - `attempt_random_move(&mut CdtTriangulation2D) -> MoveResult` — delegates to one of the above
 
-Accepted moves mutate the triangulation through narrow CDT-owned edit operations, then rebuild CDT foliation bookkeeping from live vertex labels and refresh simplex classifications. On toroidal triangulations, move finalization also rechecks χ = 0 and the closed-S¹ per-slice foliation invariant before recording success. The raw mutable backend is not exposed as part of the CDT API.
+Accepted moves mutate the triangulation through narrow CDT-owned edit operations, then rebuild CDT foliation bookkeeping from live vertex labels and refresh
+simplex classifications. On toroidal triangulations, move finalization also rechecks χ = 0 and the closed-S¹ per-slice foliation invariant before recording
+success. The raw mutable backend is not exposed as part of the CDT API.
 
 ## Architecture
 
@@ -56,13 +67,20 @@ Move validation follows a two-layer design:
 
 - **`delaunay` crate** — pure geometric operations (`flip_k2`, `flip_k1_insert`, `flip_k1_remove`) with no physics constraints
 - **Geometry backend interface layer (`src/geometry/`)** — wraps upstream Delaunay operations behind crate-owned traits and handles
-- **CDT domain layer (`src/cdt/`)** — chooses candidate sites, checks causality and time-slice integrity, and resynchronizes foliation metadata after accepted moves
+- **CDT domain layer (`src/cdt/`)** — chooses candidate sites, checks causality and time-slice integrity, and resynchronizes foliation metadata after accepted
+  moves
 
-Move code lives in the CDT domain layer. It may call `DelaunayBackend2D` methods and trait-backed mutation hooks, but it must not import upstream `delaunay::` APIs directly.
+Move code lives in the CDT domain layer. It may call `DelaunayBackend2D` methods and trait-backed mutation hooks, but it must not import upstream `delaunay::`
+APIs directly.
 
-Public `attempt_*` methods snapshot only after a valid local site has been selected and mutation is about to begin; ordinary geometric or causal rejections do not clone the triangulation. If a selected mutation or required post-mutation synchronization fails, the method restores that snapshot before returning the non-success `MoveResult`. Toroidal post-move topology or closed-ring foliation failures are treated as rollbackable local-site rejections, because the candidate site was geometrically editable but would break the periodic CDT contract.
+Public `attempt_*` methods snapshot only after a valid local site has been selected and mutation is about to begin; ordinary geometric or causal rejections do
+not clone the triangulation. If a selected mutation or required post-mutation synchronization fails, the method restores that snapshot before returning the
+non-success `MoveResult`. Toroidal post-move topology or closed-ring foliation failures are treated as rollbackable local-site rejections, because the candidate
+site was geometrically editable but would break the periodic CDT contract.
 
-The Metropolis loop accepts or rejects a move type before calling these mutating kernels. If an accepted application fails at its selected site, the simulation retries at another random site from the restored triangulation. Exhausting those retries is recorded as a rejected proposal; hard backend mutation failures still return `CdtError::MetropolisMoveApplicationFailed`. See `docs/metropolis.md`.
+The Metropolis loop accepts or rejects a move type before calling these mutating kernels. If an accepted application fails at its selected site, the simulation
+retries at another random site from the restored triangulation. Exhausting those retries is recorded as a rejected proposal; hard backend mutation failures
+still return `CdtError::MetropolisMoveApplicationFailed`. See `docs/metropolis.md`.
 
 ## Planned Work
 

--- a/docs/moves.md
+++ b/docs/moves.md
@@ -66,7 +66,8 @@ success. The raw mutable backend is not exposed as part of the CDT API.
 Move validation follows a two-layer design:
 
 - **`delaunay` crate** — pure geometric operations (`flip_k2`, `flip_k1_insert`, `flip_k1_remove`) with no physics constraints
-- **Geometry backend interface layer (`src/geometry/`)** — wraps upstream Delaunay operations behind crate-owned traits and handles
+- **Geometry backend interface layer (`src/geometry/`)** — wraps upstream Delaunay operations behind crate-owned traits, handles conversion, validation, and
+  error translation between the upstream library and our internal geometry types
 - **CDT domain layer (`src/cdt/`)** — chooses candidate sites, checks causality and time-slice integrity, and resynchronizes foliation metadata after accepted
   moves
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,8 @@
 # Roadmap
 
-This roadmap records likely directions for the `causal-triangulations` crate. It is not a stability promise; release scope depends on scientific need, API maturity, and validation quality. Concrete implementation tasks should be tracked as GitHub issues; keep this document focused on release direction, candidate themes, and non-goals.
+This roadmap records likely directions for the `causal-triangulations` crate. It is not a stability promise; release scope depends on scientific need, API
+maturity, and validation quality. Concrete implementation tasks should be tracked as GitHub issues; keep this document focused on release direction, candidate
+themes, and non-goals.
 
 ## v0.1.0 CDT Foundations
 
@@ -32,8 +34,10 @@ Likely follow-up work before broadening the dimensional surface:
 
 The next CDT dimensions should advance as explicit topology tracks rather than a generic higher-dimensional bucket:
 
-- 2+1 CDT with spherical spatial slices (S²) and toroidal spatial slices (T²), including constructor fixtures, foliation validation, local move kernels, Metropolis sampling, and topology-specific regression tests
-- 3+1 CDT with spherical spatial slices (S³) and toroidal spatial slices (T³), following the same staged path after the required geometry-backend operations and invariants are available
+- 2+1 CDT with spherical spatial slices (S²) and toroidal spatial slices (T²), including constructor fixtures, foliation validation, local move kernels,
+  Metropolis sampling, and topology-specific regression tests
+- 3+1 CDT with spherical spatial slices (S³) and toroidal spatial slices (T³), following the same staged path after the required geometry-backend operations and
+  invariants are available
 - Periodic-time variants where the topology contract is well defined and the backend can validate the corresponding Euler/Poincaré-style invariants cleanly
 - Dimension-specific action terms, simplex-count bookkeeping, volume profiles, and acceptance diagnostics
 
@@ -45,7 +49,8 @@ CDT observables should remain user-facing analysis APIs and should grow in locks
 - Add geodesic-distance distributions, shell-volume curves, two-point functions, and finite-size scaling helpers
 - Add curvature-oriented Regge observables when the local simplex data is sufficiently validated
 - Keep the current Hausdorff- and spectral-dimension estimators available on combinatorial dual adjacency graphs
-- Reuse Voronoi tessellation support from the `delaunay` crate when it lands, so observables can opt into full dual/Voronoi regions rather than rebuilding only face- or simplex-adjacency graphs
+- Reuse Voronoi tessellation support from the `delaunay` crate when it lands, so observables can opt into full dual/Voronoi regions rather than rebuilding only
+  face- or simplex-adjacency graphs
 - Preserve a clear distinction between combinatorial dual graphs, geometric Voronoi tessellations, and visualization/export representations
 
 ## Visualization and Workflow Support
@@ -68,4 +73,6 @@ Exploratory directions:
 
 ## Non-Goals
 
-The crate should remain a focused CDT physics library layered over a geometry backend. General-purpose mesh editing, a replacement Delaunay implementation, publication plotting, broad MCMC diagnostics, and domain-specific downstream analyses belong in separate crates or tools unless they are needed to validate core CDT behavior.
+The crate should remain a focused CDT physics library layered over a geometry backend. General-purpose mesh editing, a replacement Delaunay implementation,
+publication plotting, broad MCMC diagnostics, and domain-specific downstream analyses belong in separate crates or tools unless they are needed to validate core
+CDT behavior.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,18 +1,24 @@
 # Testing Overview
 
-This document summarizes the repository's current test coverage and the main gaps to keep in mind when adding features. Command details and CI expectations live in `docs/dev/testing.md` and `docs/dev/commands.md`.
+This document summarizes the repository's current test coverage and the main gaps to keep in mind when adding features. Command details and CI expectations live
+in `docs/dev/testing.md` and `docs/dev/commands.md`.
 
 ## Current Coverage
 
 - **Library unit tests**: `cargo test --lib` currently runs the core Rust test suite across CDT, geometry, configuration, and utility modules.
-- **Integration tests**: `tests/integration_tests.rs`, `tests/cli.rs`, `tests/proptest_foliation.rs`, and `tests/proptest_metropolis.rs` cover public workflows, CLI validation, foliation invariants, and Metropolis scoring.
+- **Integration tests**: `tests/integration_tests.rs`, `tests/cli.rs`, `tests/proptest_foliation.rs`, and `tests/proptest_metropolis.rs` cover public workflows,
+  CLI validation, foliation invariants, and Metropolis scoring.
 - **Python support-script tests**: `scripts/tests/` covers benchmark, changelog, coverage, hardware, tag, and subprocess utilities.
 - **Documentation tests**: public doctests run through `just test-doc` and as part of the broader CI path.
 - **Examples and benchmark compilation**: `just ci` compiles benchmarks and runs all example programs.
 
-The issue #105 toroidal regression is covered by `tests/integration_tests.rs::test_toroidal_metropolis_accepts_periodic_moves_and_preserves_topology`, which runs a seeded S¹×S¹ Metropolis simulation, requires at least one accepted periodic move, and verifies topology, foliation, causality, simplex classification, and χ = 0 at the end.
+The issue #105 toroidal regression is covered by `tests/integration_tests.rs::test_toroidal_metropolis_accepts_periodic_moves_and_preserves_topology`, which
+runs a seeded S¹×S¹ Metropolis simulation, requires at least one accepted periodic move, and verifies topology, foliation, causality, simplex classification,
+and χ = 0 at the end.
 
-Open-boundary simulation entrypoints are covered by crate-root tests that require `run_simulation()` to build a foliated regular CDT strip, preserve adjacent-slice causality, classify simplices, and report a non-empty volume profile. Configuration tests also reject open-boundary totals that cannot be split into equal-size spatial slices.
+Open-boundary simulation entrypoints are covered by crate-root tests that require `run_simulation()` to build a foliated regular CDT strip, preserve
+adjacent-slice causality, classify simplices, and report a non-empty volume profile. Configuration tests also reject open-boundary totals that cannot be split
+into equal-size spatial slices.
 
 ## Remaining Gaps
 

--- a/dprint.json
+++ b/dprint.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dprint.dev/schemas/v0.json",
-  "lineWidth": 120,
+  "lineWidth": 160,
   "indentWidth": 2,
   "useTabs": false,
   "newLineKind": "lf",

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -2,7 +2,8 @@
 
 This directory contains shell scripts that demonstrate how to use the `cdt` command-line binary for simulation-oriented scenarios.
 
-> **Current simulation status:** scripts that pass `--simulate` run the Metropolis-Hastings loop over the 2D CDT move kernels. Remove `--simulate` only when you want triangulation construction without Monte Carlo steps.
+> **Current simulation status:** scripts that pass `--simulate` run the Metropolis-Hastings loop over the 2D CDT move kernels. Remove `--simulate` only when you
+> want triangulation construction without Monte Carlo steps.
 
 ## Available Scripts
 

--- a/justfile
+++ b/justfile
@@ -353,6 +353,21 @@ markdown-check: _ensure-rumdl
     done < <(git ls-files -z '*.md')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 -n100 rumdl check
+        violations=0
+        for file in "${files[@]}"; do
+            line_number=0
+            while IFS= read -r line || [[ -n "$line" ]]; do
+                line_number=$((line_number + 1))
+                if [ "${#line}" -gt 160 ]; then
+                    printf '%s:%d: line length %d exceeds 160\n' "$file" "$line_number" "${#line}" >&2
+                    violations=$((violations + 1))
+                fi
+            done < "$file"
+        done
+        if [ "$violations" -gt 0 ]; then
+            echo "Markdown raw line-length check failed." >&2
+            exit 1
+        fi
     else
         echo "No markdown files found to check."
     fi

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@
 # Use bash with strict error handling for all recipes
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
-cargo_llvm_cov_version := "0.8.5"
+cargo_llvm_cov_version := "0.8.7"
 cargo_nextest_version := "0.9.136"
 
 # Common cargo-llvm-cov arguments for all coverage runs.
@@ -124,9 +124,13 @@ action-lint: _ensure-actionlint
 bench:
     cargo bench --workspace
 
+bench-ci:
+    cargo bench --profile perf --bench ci_performance_suite
+
 # Smoke-test benchmark harnesses with minimal samples; not for performance data.
 bench-smoke:
     cargo bench --workspace --bench cdt_benchmarks -- --sample-size 10 --measurement-time 1 --warm-up-time 1 --noplot
+    cargo bench --workspace --bench ci_performance_suite -- --sample-size 10 --measurement-time 1 --warm-up-time 1 --noplot
 
 # Compile benchmarks without running them, treating warnings as errors.
 # This catches bench/release-profile-only warnings (e.g. debug_assertions-gated unused vars)
@@ -145,20 +149,34 @@ build:
 build-release:
     cargo build --release
 
-# Changelog management (git-cliff + post-processing + archiving)
-changelog: _ensure-git-cliff python-sync
+# Changelog management (git-cliff + post-processing + archiving + rumdl formatting)
+changelog: _ensure-git-cliff _ensure-rumdl python-sync
     #!/usr/bin/env bash
     set -euo pipefail
     GIT_CLIFF_OFFLINE=true git-cliff -o CHANGELOG.md
     uv run postprocess-changelog
     uv run archive-changelog
+    archive_files=()
+    if [ -d docs/archive/changelog ]; then
+        while IFS= read -r -d '' file; do
+            archive_files+=("$file")
+        done < <(find docs/archive/changelog -name '*.md' -print0)
+    fi
+    rumdl fmt --silent CHANGELOG.md "${archive_files[@]}"
 
-changelog-unreleased version: _ensure-git-cliff python-sync
+changelog-unreleased version: _ensure-git-cliff _ensure-rumdl python-sync
     #!/usr/bin/env bash
     set -euo pipefail
     GIT_CLIFF_OFFLINE=true git-cliff --tag {{version}} -o CHANGELOG.md
     uv run postprocess-changelog
     uv run archive-changelog
+    archive_files=()
+    if [ -d docs/archive/changelog ]; then
+        while IFS= read -r -d '' file; do
+            archive_files+=("$file")
+        done < <(find docs/archive/changelog -name '*.md' -print0)
+    fi
+    rumdl fmt --silent CHANGELOG.md "${archive_files[@]}"
 
 tag version: python-sync
     uv run tag-release {{version}}
@@ -283,6 +301,7 @@ help-workflows:
     @echo ""
     @echo "Benchmark System:"
     @echo "  just bench              # Run all benchmarks"
+    @echo "  just bench-ci           # Run CI regression benchmarks with the perf profile"
     @echo "  just bench-smoke        # Smoke-test benchmark harnesses with minimal samples"
     @echo "  just bench-compile      # Compile benchmarks without running"
     @echo "  just bench-test-compile # Compile benches + release integration tests without running"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ py-modules = [
 ]
 
 [tool.ruff]
-line-length = 150
+line-length = 160
 target-version = "py312"
 src = [ "scripts" ]
 

--- a/rumdl.toml
+++ b/rumdl.toml
@@ -1,6 +1,10 @@
 [global]
+line-length = 160
 disable = [
-    "MD013",
     "MD034",
     "MD057",
 ]
+
+[MD013]
+line-length = 160
+reflow = true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,7 @@
 # Scripts Directory
 
-This directory contains Python and shell tooling used by the CDT repository. Where possible, we keep these scripts aligned with the newer versions in the `delaunay` repo so both projects can eventually share a single PyPI package (runnable via `uvx`).
+This directory contains Python and shell tooling used by the CDT repository. Where possible, we keep these scripts aligned with the newer versions in the
+`delaunay` repo so both projects can eventually share a single PyPI package (runnable via `uvx`).
 
 ## Prerequisites
 
@@ -28,11 +29,13 @@ uv run tag-release v0.1.0 --help
 just tag v0.1.0
 ```
 
-`just changelog` runs `git-cliff`, applies markdown hygiene, and archives completed minor release series under `docs/archive/changelog/`. Use `just changelog-unreleased vX.Y.Z` while preparing a release PR before the final tag exists.
+`just changelog` runs `git-cliff`, applies markdown hygiene, and archives completed minor release series under `docs/archive/changelog/`. Use
+`just changelog-unreleased vX.Y.Z` while preparing a release PR before the final tag exists.
 
 ### Benchmark utilities
 
-`benchmark-utils` is a shared baseline/compare tool (ported from `delaunay`). It’s safe to use in CDT, but some subcommands assume baseline formats and benchmark layouts that are still being unified across repos.
+`benchmark-utils` is a shared baseline/compare tool (ported from `delaunay`). It’s safe to use in CDT, but some subcommands assume baseline formats and
+benchmark layouts that are still being unified across repos.
 
 ```bash
 uv run benchmark-utils generate-baseline

--- a/scripts/archive_changelog.py
+++ b/scripts/archive_changelog.py
@@ -26,7 +26,7 @@ import re
 import sys
 from pathlib import Path
 
-from postprocess_changelog import postprocess_text
+from postprocess_changelog import normalize_entry_headings_text, postprocess_text
 
 # Matches ``## [X.Y.Z]`` or ``## [Unreleased]``
 _VERSION_HEADING_RE = re.compile(r"^## \[")
@@ -262,6 +262,18 @@ def write_archive(
     return path
 
 
+def _postprocess_existing_archives(archive_dir: Path) -> None:
+    """Normalize historical archive files that are not regenerated this run."""
+    if not archive_dir.is_dir():
+        return
+
+    for path in archive_dir.glob("*.md"):
+        text = path.read_text(encoding="utf-8")
+        normalized = normalize_entry_headings_text(text)
+        if normalized != text:
+            path.write_text(normalized, encoding="utf-8")
+
+
 def build_root(
     preamble: str,
     unreleased: str,
@@ -328,6 +340,7 @@ def archive_changelog(
     preamble, unreleased, version_blocks = parse_changelog(text)
 
     if not version_blocks:
+        _postprocess_existing_archives(archive_dir)
         return  # nothing to archive
 
     groups = group_by_minor(version_blocks)
@@ -343,6 +356,7 @@ def archive_changelog(
         archived_minors.append(minor)
 
     if not archived_minors:
+        _postprocess_existing_archives(archive_dir)
         return  # only one minor series — nothing to archive yet
 
     # Compute relative path from changelog location to archive dir.
@@ -386,6 +400,7 @@ def archive_changelog(
             root_text = root_text.rstrip("\n") + "\n\n" + defs_text + "\n"
 
     changelog_path.write_text(root_text, encoding="utf-8")
+    _postprocess_existing_archives(archive_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -443,9 +443,7 @@ def format_benchmark_tables(
             # Format time and throughput
             time_str = format_time_value(bench.time_mean, bench.time_unit) if bench.time_unit else "N/A"
             throughput_str = (
-                format_throughput_value(bench.throughput_mean, bench.throughput_unit)
-                if bench.throughput_unit and bench.throughput_mean is not None
-                else "N/A"
+                format_throughput_value(bench.throughput_mean, bench.throughput_unit) if bench.throughput_unit and bench.throughput_mean is not None else "N/A"
             )
 
             if include_simplices:

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -768,9 +768,7 @@ class PerformanceSummaryGenerator:
         sorted_dims = sorted(
             cases_by_dimension.keys(),
             key=lambda d: (
-                int(str(d).strip().removesuffix("D").removesuffix("d"))
-                if str(d).strip().removesuffix("D").removesuffix("d").isdigit()
-                else sys.maxsize
+                int(str(d).strip().removesuffix("D").removesuffix("d")) if str(d).strip().removesuffix("D").removesuffix("d").isdigit() else sys.maxsize
             ),
         )
 
@@ -1323,8 +1321,7 @@ class CriterionParser:
     @staticmethod
     def _process_fallback_discovery(criterion_dir: Path) -> list[BenchmarkData]:
         """Recursively discover estimates.json files when structured search fails."""
-        results = []
-        seen: set[str] = set()
+        results_by_key: dict[str, tuple[str, BenchmarkData]] = {}
 
         for estimates_file in criterion_dir.rglob("estimates.json"):
             parent_name = estimates_file.parent.name
@@ -1346,16 +1343,24 @@ class CriterionParser:
             benchmark_id = CriterionParser._benchmark_id_from_estimates_path(estimates_file, dim_dir, points_dir)
             key = benchmark_id or f"{points}_{dimension}"
 
-            # Prefer "new" over "base" when duplicates exist
-            if key in seen and parent_name == "base":
+            # Prefer "new" over "base" when duplicates exist.
+            existing = results_by_key.get(key)
+            if existing is not None and parent_name == "base":
                 continue
 
             bd = CriterionParser.parse_estimates_json(estimates_file, points, dimension, benchmark_id)
-            if bd:
-                seen.add(key)
-                results.append(bd)
+            if not bd:
+                continue
 
-        return results
+            if existing is not None:
+                existing_parent_name, _existing_bd = existing
+                if parent_name == "new" and existing_parent_name == "base":
+                    results_by_key[key] = (parent_name, bd)
+                continue
+
+            results_by_key[key] = (parent_name, bd)
+
+        return [bd for _parent_name, bd in results_by_key.values()]
 
     @staticmethod
     def _benchmark_id_from_estimates_path(estimates_file: Path, dim_dir: Path, points_dir: Path) -> str:
@@ -1783,8 +1788,7 @@ class PerformanceComparator:
             average_regression_found = average_change > self.regression_threshold
             if average_regression_found:
                 f.write(
-                    f"🚨 OVERALL REGRESSION: Average performance decreased by {average_change:.1f}% "
-                    f"(exceeds {self.regression_threshold}% threshold)\n",
+                    f"🚨 OVERALL REGRESSION: Average performance decreased by {average_change:.1f}% (exceeds {self.regression_threshold}% threshold)\n",
                 )
                 logger.warning(
                     "Average regression detected: average_change=%.2f%% threshold=%.2f%% benchmarks=%s",
@@ -1794,8 +1798,7 @@ class PerformanceComparator:
                 )
             elif average_change < -self.regression_threshold:
                 f.write(
-                    f"🎉 OVERALL IMPROVEMENT: Average performance improved by {abs(average_change):.1f}% "
-                    f"(exceeds {self.regression_threshold}% threshold)\n",
+                    f"🎉 OVERALL IMPROVEMENT: Average performance improved by {abs(average_change):.1f}% (exceeds {self.regression_threshold}% threshold)\n",
                 )
                 logger.info(
                     "Average improvement detected: average_change=%.2f%% threshold=%.2f%% benchmarks=%s",
@@ -1847,8 +1850,7 @@ class PerformanceComparator:
         f.write(f"Current Time: [{benchmark.time_low}, {benchmark.time_mean}, {benchmark.time_high}] {benchmark.time_unit}\n")
         if benchmark.throughput_mean is not None:
             f.write(
-                f"Current Throughput: [{benchmark.throughput_low}, {benchmark.throughput_mean}, "
-                f"{benchmark.throughput_high}] {benchmark.throughput_unit}\n",
+                f"Current Throughput: [{benchmark.throughput_low}, {benchmark.throughput_mean}, {benchmark.throughput_high}] {benchmark.throughput_unit}\n",
             )
 
     def _write_baseline_benchmark_data(self, f, benchmark: BenchmarkData) -> None:
@@ -1856,8 +1858,7 @@ class PerformanceComparator:
         f.write(f"Baseline Time: [{benchmark.time_low}, {benchmark.time_mean}, {benchmark.time_high}] {benchmark.time_unit}\n")
         if benchmark.throughput_mean is not None:
             f.write(
-                f"Baseline Throughput: [{benchmark.throughput_low}, {benchmark.throughput_mean}, "
-                f"{benchmark.throughput_high}] {benchmark.throughput_unit}\n",
+                f"Baseline Throughput: [{benchmark.throughput_low}, {benchmark.throughput_mean}, {benchmark.throughput_high}] {benchmark.throughput_unit}\n",
             )
 
     def _write_time_comparison(self, f, current: BenchmarkData, baseline: BenchmarkData) -> tuple[float | None, bool]:

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -35,6 +35,7 @@ from packaging.version import InvalidVersion, Version
 logger = logging.getLogger(__name__)
 
 DEFAULT_REGRESSION_THRESHOLD = 7.5
+TRUSTED_BENCH_PROFILE = "perf"
 
 if TYPE_CHECKING:
     from benchmark_models import (
@@ -1225,7 +1226,12 @@ class CriterionParser:
     """Parse Criterion benchmark output and JSON data."""
 
     @staticmethod
-    def parse_estimates_json(estimates_path: Path, points: int, dimension: str) -> BenchmarkData | None:
+    def parse_estimates_json(
+        estimates_path: Path,
+        points: int,
+        dimension: str,
+        benchmark_id: str = "",
+    ) -> BenchmarkData | None:
         """
         Parse Criterion estimates.json file to extract benchmark data.
 
@@ -1265,7 +1271,7 @@ class CriterionParser:
             thrpt_high = points * 1000 / max(low_us, eps)  # Higher time = lower throughput
 
             return (
-                BenchmarkData(points, dimension)
+                BenchmarkData(points, dimension, benchmark_id=benchmark_id)
                 # Baseline timing values are rounded to 2 decimal places for consistency
                 # This standardizes storage format and avoids spurious precision differences
                 .with_timing(round(low_us, 2), round(mean_us, 2), round(high_us, 2), "µs")
@@ -1309,13 +1315,16 @@ class CriterionParser:
         if not estimates_file:
             return None
 
-        return CriterionParser.parse_estimates_json(estimates_file, point_count, f"{dim}D")
+        benchmark_dir = point_dir.parent
+        group_dir = benchmark_dir.parent
+        benchmark_id = f"{group_dir.name}/{benchmark_dir.name}/{point_dir.name}"
+        return CriterionParser.parse_estimates_json(estimates_file, point_count, f"{dim}D", benchmark_id)
 
     @staticmethod
     def _process_fallback_discovery(criterion_dir: Path) -> list[BenchmarkData]:
         """Recursively discover estimates.json files when structured search fails."""
         results = []
-        seen: set[tuple[int, str]] = set()
+        seen: set[str] = set()
 
         for estimates_file in criterion_dir.rglob("estimates.json"):
             parent_name = estimates_file.parent.name
@@ -1334,18 +1343,38 @@ class CriterionParser:
 
             points = int(points_dir.name)
             dimension = f"{dim_match.group(1)}D"
-            key = (points, dimension)
+            benchmark_id = CriterionParser._benchmark_id_from_estimates_path(estimates_file, dim_dir, points_dir)
+            key = benchmark_id or f"{points}_{dimension}"
 
             # Prefer "new" over "base" when duplicates exist
             if key in seen and parent_name == "base":
                 continue
 
-            bd = CriterionParser.parse_estimates_json(estimates_file, points, dimension)
+            bd = CriterionParser.parse_estimates_json(estimates_file, points, dimension, benchmark_id)
             if bd:
                 seen.add(key)
                 results.append(bd)
 
         return results
+
+    @staticmethod
+    def _benchmark_id_from_estimates_path(estimates_file: Path, dim_dir: Path, points_dir: Path) -> str:
+        """Return a stable Criterion benchmark id from a discovered estimates file."""
+        try:
+            relative = estimates_file.relative_to(dim_dir)
+        except ValueError:
+            return ""
+
+        parts = list(relative.parts)
+        if len(parts) < 4:
+            return ""
+        if parts[-2:] != [estimates_file.parent.name, estimates_file.name]:
+            return ""
+
+        benchmark_parts = parts[:-2]
+        if not benchmark_parts or benchmark_parts[-1] != points_dir.name:
+            return ""
+        return f"{dim_dir.name}/{'/'.join(benchmark_parts)}"
 
     @staticmethod
     def find_criterion_results(target_dir: Path) -> list[BenchmarkData]:
@@ -1371,9 +1400,9 @@ class CriterionParser:
                 continue
 
             # Iterate all nested benchmark targets under the <Nd> group
-            for benchmark_dir in (p for p in dim_dir.iterdir() if p.is_dir()):
+            for benchmark_dir in sorted(p for p in dim_dir.iterdir() if p.is_dir()):
                 # Find point count directories
-                for point_dir in benchmark_dir.iterdir():
+                for point_dir in sorted(benchmark_dir.iterdir()):
                     benchmark_data = CriterionParser._process_point_directory(point_dir, dim)
                     if benchmark_data:
                         results.append(benchmark_data)
@@ -1383,7 +1412,7 @@ class CriterionParser:
             results = CriterionParser._process_fallback_discovery(criterion_dir)
 
         # Sort by dimension, then by point count
-        results.sort(key=lambda x: (int(x.dimension.rstrip("D")), x.points))
+        results.sort(key=lambda x: (int(x.dimension.rstrip("D")), x.points or -1, x.benchmark_id))
         return results
 
 
@@ -1418,14 +1447,22 @@ class BaselineGenerator:
             # Run fresh benchmark - using secure subprocess wrapper
             if dev_mode:
                 run_cargo_command(
-                    ["bench", "--bench", "ci_performance_suite", "--", *DEV_MODE_BENCH_ARGS],
+                    [
+                        "bench",
+                        "--profile",
+                        TRUSTED_BENCH_PROFILE,
+                        "--bench",
+                        "ci_performance_suite",
+                        "--",
+                        *DEV_MODE_BENCH_ARGS,
+                    ],
                     cwd=self.project_root,
                     timeout=bench_timeout,
                     capture_output=True,
                 )
             else:
                 run_cargo_command(
-                    ["bench", "--bench", "ci_performance_suite"],
+                    ["bench", "--profile", TRUSTED_BENCH_PROFILE, "--bench", "ci_performance_suite"],
                     cwd=self.project_root,
                     timeout=bench_timeout,
                     capture_output=True,
@@ -1536,14 +1573,22 @@ class PerformanceComparator:
             # Run fresh benchmark - using secure subprocess wrapper
             if dev_mode:
                 run_cargo_command(
-                    ["bench", "--bench", "ci_performance_suite", "--", *DEV_MODE_BENCH_ARGS],
+                    [
+                        "bench",
+                        "--profile",
+                        TRUSTED_BENCH_PROFILE,
+                        "--bench",
+                        "ci_performance_suite",
+                        "--",
+                        *DEV_MODE_BENCH_ARGS,
+                    ],
                     cwd=self.project_root,
                     timeout=bench_timeout,
                     capture_output=True,
                 )
             else:
                 run_cargo_command(
-                    ["bench", "--bench", "ci_performance_suite"],
+                    ["bench", "--profile", TRUSTED_BENCH_PROFILE, "--bench", "ci_performance_suite"],
                     cwd=self.project_root,
                     timeout=bench_timeout,
                     capture_output=True,

--- a/scripts/performance_analysis.py
+++ b/scripts/performance_analysis.py
@@ -195,7 +195,14 @@ class PerformanceAnalyzer:
         print("🏃 Running benchmarks...")
         try:
             result = run_cargo_command(
-                ["bench", "--message-format=json"],
+                [
+                    "bench",
+                    "--profile",
+                    "perf",
+                    "--bench",
+                    "ci_performance_suite",
+                    "--message-format=json",
+                ],
                 cwd=self.project_root,
                 check=False,
                 timeout=600,  # 10 minute timeout

--- a/scripts/postprocess_changelog.py
+++ b/scripts/postprocess_changelog.py
@@ -38,8 +38,11 @@ _TOKEN_RE = re.compile(
 )
 
 
-# Version section heading: ## [X.Y.Z] or ## [Unreleased]
-_VERSION_RE = re.compile(r"^## \[")
+# Version section heading: ## [X.Y.Z], ## [vX.Y.Z], or ## [Unreleased]
+_VERSION_RE = re.compile(
+    r"^## \[(?:v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?|Unreleased)\]"
+    r"(?:\s+-\s+\d{4}-\d{2}-\d{2})?\s*$"
+)
 
 # PR link: [#123](https://github.com/.../pull/123)
 _PR_LINK_RE = re.compile(r"\[#(\d+)\]\(https://github\.com/[^)]+/pull/\d+\)")

--- a/scripts/postprocess_changelog.py
+++ b/scripts/postprocess_changelog.py
@@ -65,6 +65,25 @@ _INDENTED_ATX_HEADING_RE = re.compile(r"^(?P<indent>\s+)#{1,6}\s+(?P<title>.*?)(
 # generated commits. Treat them as prose headings inside the parent entry.
 _SQUASH_HEADING_RE = re.compile(r"^(?P<indent>\s*)-\s+(?P<prefix>[A-Za-z]+(?:\([^)]+\))?!?):\s+(?P<title>.+?)\s*$")
 
+# Changelog section headings that may appear at column zero under a version
+# heading. Other accidental ``##``/``###`` headings from commit bodies are
+# demoted to entry-level headings so they cannot split the generated hierarchy.
+_CHANGELOG_SECTION_HEADINGS = {
+    "Added",
+    "Changed",
+    "Deprecated",
+    "Dependencies",
+    "Documentation",
+    "Fixed",
+    "Maintenance",
+    "Merged Pull Requests",
+    "Performance",
+    "Removed",
+    "Security",
+    "⚠️ Breaking Changes",
+}
+_ENTRY_HEADING_RE = re.compile(r"^(?P<level>#{2,6})\s+(?P<title>.*?)(?:\s+#+\s*)?$")
+
 # This label set is intentionally broad, including release labels such as
 # "added", "fixed", "changed", "removed", and "deprecated". Rewriting is
 # only allowed when _is_isolated_body_heading accepts the line; do not relax
@@ -432,6 +451,38 @@ def _normalize_indented_heading(line: str) -> str:
     return f"{match.group('indent')}**{title}**"
 
 
+def _normalize_entry_heading(line: str) -> str:
+    """Demote accidental column-zero commit-body headings to entry headings."""
+    match = _ENTRY_HEADING_RE.match(line)
+    if match is None:
+        return line
+
+    level = match.group("level")
+    title = match.group("title").strip()
+    if not title or level.startswith("####"):
+        return line
+    if level == "##" and (_VERSION_RE.match(line) or title == "Archives"):
+        return line
+    if level == "###" and title in _CHANGELOG_SECTION_HEADINGS:
+        return line
+    return f"#### {title}"
+
+
+def normalize_entry_headings_text(text: str) -> str:
+    """Normalize accidental entry headings in an existing changelog document."""
+    result: list[str] = []
+    in_code_block = False
+
+    for line in text.split("\n"):
+        if line.lstrip().startswith("```"):
+            result.append(line)
+            in_code_block = not in_code_block
+            continue
+        result.append(line if in_code_block else _normalize_entry_heading(line))
+
+    return "\n".join(result).rstrip("\n") + "\n"
+
+
 def _process_code_fence(line: str, result: list[str], in_code_block: bool, next_line: str | None) -> tuple[bool, bool]:
     """Handle fenced-code transitions and append the line when consumed."""
     stripped = line.lstrip()
@@ -481,6 +532,7 @@ def _normalize_body_line(line: str, lines: list[str], idx: int, result: list[str
     is_isolated_body_heading = _is_isolated_body_heading(lines, idx)
     line = _deindent_orphan(line, lines, idx)
     line = _normalize_indented_heading(line)
+    line = _normalize_entry_heading(line)
 
     if is_isolated_body_heading:
         line = _normalize_squash_heading(line, nested=current_entry_summary is not None)

--- a/scripts/tests/test_archive_changelog.py
+++ b/scripts/tests/test_archive_changelog.py
@@ -353,6 +353,30 @@ class TestArchiveChangelog:
         archive_changelog(changelog, tmp_path / "archive")
         assert changelog.read_text(encoding="utf-8") == "# Changelog\n\nNo versions yet.\n"
 
+    def test_existing_archives_are_postprocessed(self, tmp_path: Path) -> None:
+        """Older archive files are normalized even when they are not regenerated."""
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text(_PREAMBLE + _UNRELEASED + _V072 + _V071, encoding="utf-8")
+        archive_dir = tmp_path / "docs" / "archive" / "changelog"
+        archive_dir.mkdir(parents=True)
+        archive = archive_dir / "0.5.md"
+        archive.write_text(
+            "# Changelog - 0.5.x\n\n"
+            "## [0.5.3] - 2025-10-31\n\n"
+            "### Fixed\n\n"
+            "- Handle degenerate configurations [#116](https://github.com/acgetchell/causal-triangulations/pull/116)\n"
+            "  [`a6ec3fa`](https://github.com/acgetchell/causal-triangulations/commit/a6ec3fadeadbeef)\n\n"
+            "## Duplicate Vertex Handling\n\n"
+            "- Add duplicate coordinate detection\n",
+            encoding="utf-8",
+        )
+
+        archive_changelog(changelog, archive_dir)
+
+        content = archive.read_text(encoding="utf-8")
+        assert "\n## Duplicate Vertex Handling" not in content
+        assert "#### Duplicate Vertex Handling" in content
+
     def test_distributes_link_defs(self, tmp_path: Path) -> None:
         """Reference-style link definitions are distributed to the correct files."""
         changelog = tmp_path / "CHANGELOG.md"

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -268,6 +268,57 @@ class TestCriterionParser:
         actual_order = [(b.dimension, b.points) for b in ci_suite_results]
         assert actual_order == expected_order
 
+    def test_process_point_directory_preserves_benchmark_id(self, tmp_path: Path) -> None:
+        estimates = tmp_path / "target" / "criterion" / "cdt_generation_2d" / "open_strip_medium" / "200" / "new" / "estimates.json"
+        estimates.parent.mkdir(parents=True)
+        estimates.write_text(
+            json.dumps(
+                {
+                    "mean": {
+                        "point_estimate": 25_000.0,
+                        "confidence_interval": {
+                            "lower_bound": 20_000.0,
+                            "upper_bound": 30_000.0,
+                        },
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = CriterionParser._process_point_directory(estimates.parents[1], "2")
+
+        assert result is not None
+        assert result.benchmark_id == "cdt_generation_2d/open_strip_medium/200"
+        assert result.comparison_key == "cdt_generation_2d/open_strip_medium/200"
+
+    def test_find_criterion_results_keeps_same_size_workloads_separate(self, tmp_path: Path) -> None:
+        criterion_dir = tmp_path / "target" / "criterion" / "cdt_move_attempts_2d"
+        for workload, mean in [("Move22", 10_000.0), ("EdgeFlip", 20_000.0)]:
+            estimates = criterion_dir / workload / "342" / "new" / "estimates.json"
+            estimates.parent.mkdir(parents=True)
+            estimates.write_text(
+                json.dumps(
+                    {
+                        "mean": {
+                            "point_estimate": mean,
+                            "confidence_interval": {
+                                "lower_bound": mean * 0.9,
+                                "upper_bound": mean * 1.1,
+                            },
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+        results = CriterionParser.find_criterion_results(tmp_path / "target")
+
+        assert [result.benchmark_id for result in results] == [
+            "cdt_move_attempts_2d/EdgeFlip/342",
+            "cdt_move_attempts_2d/Move22/342",
+        ]
+
 
 class TestPerformanceComparator:
     """Test cases for PerformanceComparator class."""

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -319,6 +319,32 @@ class TestCriterionParser:
             "cdt_move_attempts_2d/Move22/342",
         ]
 
+    def test_fallback_discovery_prefers_new_over_base_for_same_key(self, tmp_path: Path) -> None:
+        criterion_dir = tmp_path / "target" / "criterion"
+        for parent_name, mean in [("base", 30_000.0), ("new", 10_000.0)]:
+            estimates = criterion_dir / "cdt_generation_2d" / "open_strip_medium" / "200" / parent_name / "estimates.json"
+            estimates.parent.mkdir(parents=True)
+            estimates.write_text(
+                json.dumps(
+                    {
+                        "mean": {
+                            "point_estimate": mean,
+                            "confidence_interval": {
+                                "lower_bound": mean * 0.9,
+                                "upper_bound": mean * 1.1,
+                            },
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+        results = CriterionParser._process_fallback_discovery(criterion_dir)
+
+        assert len(results) == 1
+        assert results[0].benchmark_id == "cdt_generation_2d/open_strip_medium/200"
+        assert results[0].time_mean == 10.0
+
 
 class TestPerformanceComparator:
     """Test cases for PerformanceComparator class."""

--- a/scripts/tests/test_postprocess_changelog.py
+++ b/scripts/tests/test_postprocess_changelog.py
@@ -414,6 +414,18 @@ class TestIndentedHeadingNormalization:
     def test_archives_heading_is_preserved(self) -> None:
         assert _normalize_entry_heading("## Archives") == "## Archives"
 
+    def test_bracketed_entry_heading_becomes_level_four(self) -> None:
+        assert _normalize_entry_heading("## [Notes]") == "#### [Notes]"
+
+    def test_bracketed_version_like_entry_heading_becomes_level_four(self) -> None:
+        assert _normalize_entry_heading("## [1.2.3 Notes]") == "#### [1.2.3 Notes]"
+
+    def test_release_heading_is_preserved(self) -> None:
+        assert _normalize_entry_heading("## [v1.2.3] - 2026-05-22") == "## [v1.2.3] - 2026-05-22"
+
+    def test_prerelease_heading_is_preserved(self) -> None:
+        assert _normalize_entry_heading("## [1.2.3-rc.1+build.7]") == "## [1.2.3-rc.1+build.7]"
+
     def test_contextual_category_heading_becomes_level_four(self) -> None:
         assert _normalize_entry_heading("### Fixed: Add rollback") == "#### Fixed: Add rollback"
 

--- a/scripts/tests/test_postprocess_changelog.py
+++ b/scripts/tests/test_postprocess_changelog.py
@@ -10,12 +10,14 @@ from postprocess_changelog import (
     _is_duplicate_squash_heading,
     _is_isolated_body_heading,
     _max_pr_number,
+    _normalize_entry_heading,
     _normalize_indented_heading,
     _normalize_squash_heading,
     _plain_summary,
     _process_code_fence,
     _reflow_line,
     _squash_heading_parts,
+    normalize_entry_headings_text,
     postprocess,
     postprocess_text,
 )
@@ -403,6 +405,18 @@ class TestIndentedHeadingNormalization:
     def test_column_zero_changelog_heading_is_preserved(self) -> None:
         assert _normalize_indented_heading("### Added") == "### Added"
 
+    def test_column_zero_entry_heading_becomes_level_four(self) -> None:
+        assert _normalize_entry_heading("## Duplicate Vertex Handling") == "#### Duplicate Vertex Handling"
+
+    def test_column_zero_category_heading_is_preserved(self) -> None:
+        assert _normalize_entry_heading("### Fixed") == "### Fixed"
+
+    def test_archives_heading_is_preserved(self) -> None:
+        assert _normalize_entry_heading("## Archives") == "## Archives"
+
+    def test_contextual_category_heading_becomes_level_four(self) -> None:
+        assert _normalize_entry_heading("### Fixed: Add rollback") == "#### Fixed: Add rollback"
+
     def test_normalized_heading_is_idempotent(self) -> None:
         assert _normalize_indented_heading("  **Title**") == "  **Title**"
 
@@ -431,6 +445,47 @@ class TestIndentedHeadingNormalization:
         assert "  **Correctness Fixes**" in result
         assert "  **API Design**" in result
         assert "### Performance" in result
+
+    def test_full_pipeline_normalizes_unindented_commit_body_headings(self, tmp_path: Path) -> None:
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(
+            "# Changelog\n\n"
+            "## [1.0.0]\n\n"
+            "### Fixed\n\n"
+            "- Handle degenerate configurations [#116](https://github.com/acgetchell/causal-triangulations/pull/116)\n"
+            f"  {_commit()}\n\n"
+            "## Duplicate Vertex Handling\n\n"
+            "  - Add duplicate coordinate detection\n\n"
+            "### Fixed: Add rollback on cell creation failure\n\n"
+            "  Add rollback mechanisms when cell creation fails.\n",
+            encoding="utf-8",
+        )
+
+        postprocess(f)
+
+        result = f.read_text(encoding="utf-8")
+        assert "\n## Duplicate Vertex Handling" not in result
+        assert "\n### Fixed: Add rollback on cell creation failure" not in result
+        assert "#### Duplicate Vertex Handling" in result
+        assert "#### Fixed: Add rollback on cell creation failure" in result
+        assert "### Fixed" in result
+
+    def test_existing_archive_normalization_preserves_fenced_headings(self) -> None:
+        text = (
+            "# Changelog - 0.5.x\n\n"
+            "## [0.5.3] - 2025-10-31\n\n"
+            "### Fixed\n\n"
+            "```markdown\n"
+            "## Example Heading\n"
+            "### Fixed: Example\n"
+            "```\n\n"
+            "## Duplicate Vertex Handling\n"
+        )
+
+        result = normalize_entry_headings_text(text)
+
+        assert "```markdown\n## Example Heading\n### Fixed: Example\n```" in result
+        assert "#### Duplicate Vertex Handling" in result
 
 
 class TestSquashHeadingNormalization:


### PR DESCRIPTION
- Add a perf-profile Criterion suite for CDT generation, validation, move attempts, ten-sweep random-move workloads, and short Metropolis runs.
- Wire benchmark analysis and baseline comparison tooling to use stable Criterion benchmark IDs from the new suite.
- Keep Linux, macOS, and Windows CI coverage while speeding Windows Rust validation with nextest.
- Align coverage and changelog tooling with the Delaunay refresh, including cargo-llvm-cov 0.8.7 and archive heading normalization.

Closes #131 