### PR TITLE
feat(cdt)!: complete 1+1 toroidal CDT sampling

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,29 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "causal-triangulations: A Causal Dynamical Triangulation library for quantum gravity research"
+version: 0.0.1
+url: "https://github.com/acgetchell/causal-triangulations"
+repository-code: "https://github.com/acgetchell/causal-triangulations"
+authors:
+  - family-names: "Getchell"
+    given-names: "Adam"
+    email: "adam@adamgetchell.org"
+    orcid: "https://orcid.org/0000-0002-0797-0021"
+keywords:
+  - "causal-dynamical-triangulations"
+  - "quantum-gravity"
+  - "simulation"
+  - "spacetime"
+  - "triangulation"
+abstract: >-
+  Rust crate providing Causal Dynamical Triangulations for quantum gravity
+  research. The library implements validated 1+1 CDT construction, foliation
+  checks, Metropolis-Hastings sampling over causal local moves, Regge action
+  calculation, simulation outputs, checkpoints, and observables including volume
+  profiles, Hausdorff-dimension estimates, and spectral-dimension estimates.
+  It builds on Delaunay triangulation primitives, keeps geometry and CDT domain
+  logic separated, and provides a command-line binary plus focused public APIs
+  for simulation and analysis workflows. Written in safe Rust with no unsafe
+  code.
+license: BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ unfixed-volume simulations controlled by the cosmological constant are a standar
 In an unfixed-volume ensemble, the cosmological constant is the coupling that controls volume growth or shrinkage because it is conjugate to the lattice
 volume term in the action. Use `--cosmological-constant` to tune that behavior. Values too far from the useful finite-volume regime can drive runs toward
 minimum-volume configurations or toward rapid growth; this is expected physics for the unfixed ensemble, not volume fixing.
+Automated λ-scan utilities for finding practical finite-volume windows are planned as [#143](https://github.com/acgetchell/causal-triangulations/issues/143);
+for v0.1.0, tune `--cosmological-constant` manually and inspect the reported volume and acceptance diagnostics.
 
 Higher-dimensional CDT studies often use explicit approximate volume fixing for finite-size numerical work. For example, Ambjørn et al. discuss quadratic
 volume fixing in [The Semiclassical Limit of Causal Dynamical Triangulations](https://arxiv.org/abs/1102.3929), and the toroidal phase-structure study uses

--- a/README.md
+++ b/README.md
@@ -235,6 +235,23 @@ This includes foundational work on:
 - Computational geometry and Delaunay triangulations
 - Discrete approaches to general relativity
 
+## 🤖 AI Agents
+
+This repository contains an `AGENTS.md` file, which defines the canonical rules and invariants for all AI coding assistants and autonomous agents working on
+this codebase.
+
+AI tools (including ChatGPT, Claude, CodeRabbit, Codex, and WARP) are expected to read and follow `AGENTS.md` when proposing or applying changes.
+
+Portions of this library were developed with the assistance of these AI tools:
+
+- [ChatGPT]
+- [Claude]
+- [CodeRabbit]
+- [Codex]
+- [WARP]
+
+> All code was written and/or reviewed and validated by the author.
+
 ## 📝 License
 
 This project's license is specified in [LICENSE](LICENSE).
@@ -244,6 +261,11 @@ This project's license is specified in [LICENSE](LICENSE).
 [Rust]: https://rust-lang.org
 [Delaunay triangulation]: https://crates.io/crates/delaunay
 [Criterion]: https://github.com/bheisler/criterion.rs
+[ChatGPT]: https://openai.com/chatgpt
+[Claude]: https://www.anthropic.com/claude
+[CodeRabbit]: https://coderabbit.ai/
+[Codex]: https://openai.com/codex/
+[WARP]: https://www.warp.dev
 [ci-badge]: https://github.com/acgetchell/causal-triangulations/actions/workflows/ci.yml/badge.svg
 [ci-workflow]: https://github.com/acgetchell/causal-triangulations/actions/workflows/ci.yml
 [clippy-badge]: https://github.com/acgetchell/causal-triangulations/actions/workflows/rust-clippy.yml/badge.svg

--- a/README.md
+++ b/README.md
@@ -55,6 +55,68 @@ See [`docs/roadmap.md`](docs/roadmap.md) for current direction, near-term candid
 - **Zero-cost abstractions** for performance-critical geometry operations
 - **Rich ecosystem** for scientific computing and parallel processing
 
+## 📋 Running The Binary
+
+The crate installs a `cdt` binary. Use it to construct an initial 1+1 CDT triangulation, optionally run the Metropolis move loop, and write analysis-friendly
+CSV/JSON output.
+
+```bash
+# Build the binary
+cargo build --release
+
+# Show all supported options
+./target/release/cdt --help
+
+# Build an open-boundary triangulation and record the initial measurement
+./target/release/cdt --vertices-per-slice 4 --timeslices 5 --output-json open-boundary-summary.json
+
+# Run a periodic toroidal simulation and write both output formats
+./target/release/cdt \
+  --vertices-per-slice 8 \
+  --timeslices 6 \
+  --topology toroidal \
+  --steps 200 \
+  --thermalization-steps 20 \
+  --measurement-frequency 10 \
+  --temperature 1.5 \
+  --seed 105 \
+  --simulate \
+  --output-csv toroidal-measurements.csv \
+  --output-json toroidal-summary.json
+```
+
+Prefer `--vertices-per-slice` for regular initial data; the binary computes the total initial vertex count as `vertices_per_slice × timeslices`. `--vertices`
+is still accepted when you already know the total, but it must divide evenly by `--timeslices`. Open-boundary runs require at least 4 vertices per slice and
+toroidal runs require at least 3 vertices per slice. Without `--simulate`, the binary only builds the initial triangulation and writes the step-0 measurement.
+
+### Ensemble And Volume Behavior
+
+Current simulations do not apply volume fixing. Volume-changing moves may change the total number of vertices and simplices during a run, so the sampled
+ensemble is the unfixed-volume ensemble defined by the configured CDT action and Metropolis-Hastings proposal rules. This is intentional for now: in 1+1 CDT,
+unfixed-volume simulations controlled by the cosmological constant are a standard toy-model setting, as in Israel and Lindner,
+[Quantum gravity on a laptop: 1+1 Dimensional Causal Dynamical Triangulation simulation](https://doi.org/10.1016/j.rinp.2012.10.001).
+
+In an unfixed-volume ensemble, the cosmological constant is the coupling that controls volume growth or shrinkage because it is conjugate to the lattice
+volume term in the action. Use `--cosmological-constant` to tune that behavior. Values too far from the useful finite-volume regime can drive runs toward
+minimum-volume configurations or toward rapid growth; this is expected physics for the unfixed ensemble, not volume fixing.
+
+Higher-dimensional CDT studies often use explicit approximate volume fixing for finite-size numerical work. For example, Ambjørn et al. discuss quadratic
+volume fixing in [The Semiclassical Limit of Causal Dynamical Triangulations](https://arxiv.org/abs/1102.3929), and the toroidal phase-structure study uses
+quadratic volume fixing in [The phase structure of Causal Dynamical Triangulations with toroidal spatial topology](https://arxiv.org/abs/1802.10434). This
+crate may add such a mode later, but it should be opt-in because it samples a modified action rather than the current bare unfixed-volume ensemble.
+
+### Ready-to-Use Scripts
+
+The `examples/scripts/` directory contains research workflows:
+
+- **`basic_simulation.sh`** - Simple simulation command
+- **`parameter_sweep.sh`** - Temperature sweep setup
+- **`performance_test.sh`** - Construction and simulation timing across system sizes
+
+For detailed documentation, sample output, and usage instructions for each script, see [examples/scripts/README.md](examples/scripts/README.md).
+
+For comprehensive CLI documentation and advanced usage patterns, see [`docs/CLI_EXAMPLES.md`](docs/CLI_EXAMPLES.md).
+
 ## 🧩 Ecosystem
 
 This crate is part of a broader Rust ecosystem for computational geometry and simulation:
@@ -71,6 +133,43 @@ The long-term design separates:
 - **Physics** (CDT-specific dynamics and observables)
 
 Within this crate, `src/geometry/` is the backend interface layer over `delaunay`, while `src/cdt/` is the CDT domain layer.
+
+## 📋 Benchmarking
+
+Comprehensive performance benchmarks using [Criterion]:
+
+```bash
+# Run all benchmarks
+cargo bench
+
+# Specific benchmark categories
+cargo bench triangulation_creation
+cargo bench metropolis_simulation
+cargo bench action_calculations
+
+# CI regression benchmark contract
+just bench-ci
+
+# Performance regression testing
+just perf-check          # Check for performance regressions
+just perf-baseline       # Save performance baseline
+just perf-report         # Generate detailed performance report
+just perf-trends 7       # Analyze performance trends over 7 days
+```
+
+See [`benches/README.md`](benches/README.md) for benchmark details and [`docs/PERFORMANCE_TESTING.md`](docs/PERFORMANCE_TESTING.md) for comprehensive
+performance testing workflow documentation.
+
+## 🛣️ Roadmap
+
+The high-level roadmap, including 1+1 maturity work, future 2+1 and 3+1 CDT topology tracks, observables, dual/Voronoi geometry, visualization, and non-goals,
+lives in [`docs/roadmap.md`](docs/roadmap.md).
+
+## Design notes
+
+- **Separation of concerns**: geometry primitives (Delaunay/Voronoi) are decoupled from CDT dynamics.
+- **Foliation‑aware data model**: explicit time labels; space‑like vs time‑like edges encoded in types.
+- **Testing**: unit + property tests for invariants (e.g., move reversibility, manifoldness).
 
 ## 🤝 How to Contribute
 
@@ -114,99 +213,6 @@ to install them.
 - `just changelog-unreleased v0.1.0` - Generate a release changelog before the final tag exists
 - `just tag v0.1.0` - Create an annotated git tag from changelog content
 - `just perf-help` - Show performance analysis commands (`perf-baseline`, `perf-check`, etc.)
-
-## 📋 Examples
-
-### Library Usage
-
-See [`examples/basic_cdt.rs`](examples/basic_cdt.rs) for a complete working example:
-
-```rust
-use causal_triangulations::prelude::action::ActionConfig;
-use causal_triangulations::prelude::errors::CdtResult;
-use causal_triangulations::prelude::simulation::{MetropolisAlgorithm, MetropolisConfig};
-use causal_triangulations::prelude::triangulation::CdtTriangulation;
-
-fn main() -> CdtResult<()> {
-    // Create a foliated open-boundary CDT strip.
-    let triangulation = CdtTriangulation::from_cdt_strip(8, 4)?;
-
-    // Configure and run the Monte Carlo simulation.
-    let metropolis_config = MetropolisConfig::new(1.0, 1000, 100, 10);
-    let action_config = ActionConfig::default();
-    let algorithm = MetropolisAlgorithm::new(metropolis_config, action_config);
-
-    let results = algorithm.run(triangulation)?;
-    println!("Acceptance rate: {:.3}", results.acceptance_rate());
-    println!("Average action: {:.3}", results.average_action());
-    Ok(())
-}
-```
-
-### Command Line Interface
-
-```bash
-# Build the binary
-cargo build --release
-
-# Build a triangulation and record the initial measurement
-./target/release/cdt --vertices 20 --timeslices 10 --steps 2000
-
-# Configure a parameter sweep with simulation enabled
-./target/release/cdt \
-  --vertices 50 --timeslices 12 \
-  --temperature 1.5 --coupling-0 0.8 \
-  --steps 5000 --simulate
-```
-
-### Ready-to-Use Scripts
-
-The `examples/scripts/` directory contains research workflows:
-
-- **`basic_simulation.sh`** - Simple simulation command
-- **`parameter_sweep.sh`** - Temperature sweep setup
-- **`performance_test.sh`** - Construction and simulation timing across system sizes
-
-For detailed documentation, sample output, and usage instructions for each script, see [examples/scripts/README.md](examples/scripts/README.md).
-
-For comprehensive CLI documentation and advanced usage patterns, see [`docs/CLI_EXAMPLES.md`](docs/CLI_EXAMPLES.md).
-
-## 📋 Benchmarking
-
-Comprehensive performance benchmarks using [Criterion]:
-
-```bash
-# Run all benchmarks
-cargo bench
-
-# Specific benchmark categories
-cargo bench triangulation_creation
-cargo bench metropolis_simulation
-cargo bench action_calculations
-
-# CI regression benchmark contract
-just bench-ci
-
-# Performance regression testing
-just perf-check          # Check for performance regressions
-just perf-baseline       # Save performance baseline
-just perf-report         # Generate detailed performance report
-just perf-trends 7       # Analyze performance trends over 7 days
-```
-
-See [`benches/README.md`](benches/README.md) for benchmark details and [`docs/PERFORMANCE_TESTING.md`](docs/PERFORMANCE_TESTING.md) for comprehensive
-performance testing workflow documentation.
-
-## 🛣️ Roadmap
-
-The high-level roadmap, including 1+1 maturity work, future 2+1 and 3+1 CDT topology tracks, observables, dual/Voronoi geometry, visualization, and non-goals,
-lives in [`docs/roadmap.md`](docs/roadmap.md).
-
-## Design notes
-
-- **Separation of concerns**: geometry primitives (Delaunay/Voronoi) are decoupled from CDT dynamics.
-- **Foliation‑aware data model**: explicit time labels; space‑like vs time‑like edges encoded in types.
-- **Testing**: unit + property tests for invariants (e.g., move reversibility, manifoldness).
 
 For comprehensive guidelines on contributing, development environment setup, testing, and code organization, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -1,13 +1,4 @@
----
-title: "References and Citations"
-description: "Academic references and bibliographic citations used throughout the causal-triangulations library"
-keywords: ["references", "citations", "causal dynamical triangulations", "quantum gravity", "bibliography"]
-author: "Adam Getchell"
-date: "2026-05-06"
-category: "Documentation"
-tags: ["academic", "research", "citations", "physics", "quantum gravity"]
-layout: "page"
----
+# References and Citations
 
 ## How to Cite This Library
 
@@ -23,9 +14,53 @@ GitHub. https://github.com/acgetchell/causal-triangulations
 
 For BibTeX, APA, or other citation formats, please refer to the [CITATION.cff](CITATION.cff) file or use GitHub's "Cite this repository" feature.
 
+## AI-Assisted Development Tools
+
+- **ChatGPT**: OpenAI. <https://openai.com/chatgpt>.
+- **Claude**: Anthropic. <https://www.anthropic.com/claude>.
+- **CodeRabbit**: CodeRabbit AI, Inc. <https://coderabbit.ai/>.
+- **Codex**: OpenAI. <https://openai.com/codex/>.
+- **WARP**: Warp Dev, Inc. <https://www.warp.dev/>.
+
+All AI-generated output was reviewed and/or edited by the maintainer.
+No generated content was used without human oversight.
+
+## Computational Geometry and Delaunay Triangulations
+
+This library delegates Delaunay construction, validation, periodic triangulation support, and local geometric edit primitives to the `delaunay` crate. Refer to
+that crate and its bibliography for detailed computational-geometry citations:
+
+- Getchell, Adam. "delaunay: A d-dimensional Delaunay triangulation library." Zenodo, 2026. DOI:
+  [10.5281/zenodo.16931097](https://doi.org/10.5281/zenodo.16931097). Repository: <https://github.com/acgetchell/delaunay>
+
+## Discrete Approaches to General Relativity
+
+### Lattice Approaches to Quantum Gravity
+
+- Sorkin, R. D. "Causal sets: discrete gravity." In _Lectures on Quantum Gravity_, edited by A. Gomberoff and D. Marolf, 305-327. Boston: Springer, 2005. arXiv:
+  [gr-qc/0309009](https://arxiv.org/abs/gr-qc/0309009)
+
+- Williams, R. M., and Tuckey, P. A. "Regge calculus: a brief review and bibliography." _Classical and Quantum Gravity_ 9, no. 5 (1992): 1409. DOI:
+  [10.1088/0264-9381/9/5/021](https://doi.org/10.1088/0264-9381/9/5/021)
+
+### Spin Foam Models and Loop Quantum Gravity
+
+- Perez, A. "The Spin Foam Approach to Quantum Gravity." _Living Reviews in Relativity_ 16, no. 1 (2013): 3. DOI:
+  [10.12942/lrr-2013-3](https://doi.org/10.12942/lrr-2013-3). arXiv: [1205.2019](https://arxiv.org/abs/1205.2019)
+
+- Rovelli, C. "Quantum Gravity." Cambridge: Cambridge University Press, 2004. DOI: [10.1017/CBO9780511755804](https://doi.org/10.1017/CBO9780511755804)
+
 ## Foundational Causal Dynamical Triangulations Theory
 
 This section contains the seminal papers and foundational work that established CDT as a non-perturbative approach to quantum gravity.
+
+### Comprehensive Reviews
+
+- Ambjørn, J., Görlich, A., Jurkiewicz, J., and Loll, R. "Nonperturbative Quantum Gravity." _Physics Reports_ 519, no. 4-5 (2012): 127-210. DOI:
+  [10.1016/j.physrep.2012.03.007](https://doi.org/10.1016/j.physrep.2012.03.007). arXiv: [1203.3591](https://arxiv.org/abs/1203.3591)
+
+- Loll, R. "Quantum Gravity from Causal Dynamical Triangulations: A Review." _Classical and Quantum Gravity_ 37, no. 1 (2020): 013002. DOI:
+  [10.1088/1361-6382/ab57c7](https://doi.org/10.1088/1361-6382/ab57c7). arXiv: [1905.08669](https://arxiv.org/abs/1905.08669)
 
 ### Original CDT Framework
 
@@ -35,24 +70,24 @@ This section contains the seminal papers and foundational work that established 
 - Ambjørn, J., Jurkiewicz, J., and Loll, R. "Emergence of a 4D World from Causal Quantum Gravity." _Physical Review Letters_ 93, no. 13 (2004): 131301. DOI:
   [10.1103/PhysRevLett.93.131301](https://doi.org/10.1103/PhysRevLett.93.131301). arXiv: [hep-th/0404156](https://arxiv.org/abs/hep-th/0404156)
 
-### Comprehensive Reviews
+### Volume Profiles, Topology, and Dimensional Observables
 
-- Loll, R. "Quantum Gravity from Causal Dynamical Triangulations: A Review." _Classical and Quantum Gravity_ 37, no. 1 (2020): 013002. DOI:
-  [10.1088/1361-6382/ab57c7](https://doi.org/10.1088/1361-6382/ab57c7). arXiv: [1905.08669](https://arxiv.org/abs/1905.08669)
+- Ambjørn, J., Budd, T., and Watabiki, Y. "Scale-dependent Hausdorff dimensions in 2d gravity." _Physics Letters B_ 736 (2014): 339-343. DOI:
+  [10.1016/j.physletb.2014.07.047](https://doi.org/10.1016/j.physletb.2014.07.047). arXiv: [1406.6251](https://arxiv.org/abs/1406.6251)
 
-- Ambjørn, J., Görlich, A., Jurkiewicz, J., and Loll, R. "Nonperturbative Quantum Gravity." _Physics Reports_ 519, no. 4-5 (2012): 127-210. DOI:
-  [10.1016/j.physrep.2012.03.007](https://doi.org/10.1016/j.physrep.2012.03.007). arXiv: [1203.3591](https://arxiv.org/abs/1203.3591)
+- Ambjørn, J., Gizbert-Studnicki, J., Görlich, A., Jurkiewicz, J., and Németh, D. "The phase structure of causal dynamical triangulations with toroidal spatial
+  topology." _Journal of High Energy Physics_ 2018, no. 6 (2018): 111. DOI: [10.1007/JHEP06(2018)111](https://doi.org/10.1007/JHEP06(2018)111). arXiv:
+  [1802.10434](https://arxiv.org/abs/1802.10434)
 
-### Volume Profiles and Dimensional Observables
+- Ambjørn, J., Görlich, A. T., Jurkiewicz, J., Loll, R., Gizbert-Studnicki, J., and Trześniewski, T. "The semiclassical limit of causal dynamical
+  triangulations." _Nuclear Physics B_ 849, no. 1 (2011): 144-165. DOI:
+  [10.1016/j.nuclphysb.2011.03.019](https://doi.org/10.1016/j.nuclphysb.2011.03.019). arXiv: [1102.3929](https://arxiv.org/abs/1102.3929)
 
 - Ambjørn, J., Jurkiewicz, J., and Loll, R. "Reconstructing the Universe." _Physical Review D_ 72, no. 6 (2005): 064014. DOI:
   [10.1103/PhysRevD.72.064014](https://doi.org/10.1103/PhysRevD.72.064014). arXiv: [hep-th/0505154](https://arxiv.org/abs/hep-th/0505154)
 
 - Ambjørn, J., Jurkiewicz, J., and Loll, R. "The Spectral Dimension of the Universe is Scale Dependent." _Physical Review Letters_ 95, no. 17 (2005): 171301.
   DOI: [10.1103/PhysRevLett.95.171301](https://doi.org/10.1103/PhysRevLett.95.171301). arXiv: [hep-th/0505113](https://arxiv.org/abs/hep-th/0505113)
-
-- Ambjørn, J., Budd, T., and Watabiki, Y. "Scale-dependent Hausdorff dimensions in 2d gravity." _Physics Letters B_ 736 (2014): 339-343. DOI:
-  [10.1016/j.physletb.2014.07.047](https://doi.org/10.1016/j.physletb.2014.07.047). arXiv: [1406.6251](https://arxiv.org/abs/1406.6251)
 
 - van der Duin, J., Loll, R., Schiffer, M., and Silva, A. "Quantum gravity and effective topology." _The European Physical Journal C_ 86, no. 2 (2026): 102.
   DOI: [10.1140/epjc/s10052-026-15322-x](https://doi.org/10.1140/epjc/s10052-026-15322-x)
@@ -61,18 +96,13 @@ This section contains the seminal papers and foundational work that established 
 
 These references provide the algorithmic foundations for Monte Carlo simulations in discrete quantum gravity.
 
-### Metropolis-Hastings Algorithm in CDT
+### CDT Simulation Implementation and Ensembles
 
-- Ambjørn, J., and Loll, R. "Non-perturbative Lorentzian quantum gravity, causality and topology change." _Nuclear Physics B_ 536, no. 1-2 (1998): 407-434. DOI:
-  [10.1016/S0550-3213(98)00692-0](https://doi.org/10.1016/S0550-3213(98)00692-0). arXiv: [hep-th/9805108](https://arxiv.org/abs/hep-th/9805108)
+- Brunekreef, J., Görlich, A., and Loll, R. "Simulating CDT quantum gravity." _Computer Physics Communications_ 300 (2024): 109170. DOI:
+  [10.1016/j.cpc.2024.109170](https://doi.org/10.1016/j.cpc.2024.109170). arXiv: [2310.16744](https://arxiv.org/abs/2310.16744)
 
-### Regge Calculus and Discrete Action
-
-- Regge, T. "General Relativity without coordinates." _Il Nuovo Cimento_ 19, no. 3 (1961): 558-571. DOI:
-  [10.1007/BF02733251](https://doi.org/10.1007/BF02733251)
-
-- Hamber, H. W. "Quantum Gravitation: The Feynman Path Integral Approach." Berlin: Springer-Verlag, 2009. DOI:
-  [10.1007/978-3-540-85293-3](https://doi.org/10.1007/978-3-540-85293-3)
+- Israel, N. S., and Lindner, J. F. "Quantum gravity on a laptop: 1+1 Dimensional Causal Dynamical Triangulation simulation." _Results in Physics_ 2 (2012):
+  164-169. DOI: [10.1016/j.rinp.2012.10.001](https://doi.org/10.1016/j.rinp.2012.10.001)
 
 ### Ergodic Moves and Alexander Moves
 
@@ -82,49 +112,31 @@ These references provide the algorithmic foundations for Monte Carlo simulations
 - Pachner, U. "P.L. homeomorphic manifolds are equivalent by elementary shellings." _European Journal of Combinatorics_ 12, no. 2 (1991): 129-145. DOI:
   [10.1016/S0195-6698(13)80080-7](https://doi.org/10.1016/S0195-6698(13)80080-7)
 
-## Computational Geometry and Delaunay Triangulations
+### Generic MCMC Framework
 
-This library leverages computational geometry for efficient triangulation operations.
+This library delegates generic Markov-chain stepping, delayed-commit proposal APIs, log-space transition handling, and future reusable MCMC algorithm
+improvements to the `markov-chain-monte-carlo` crate. Refer to that crate and its bibliography for detailed generic MCMC and statistical-physics citations:
 
-### Delaunay Triangulation Algorithms
+- Getchell, Adam. "markov-chain-monte-carlo: A composable MCMC framework for Rust." Zenodo, 2026. DOI:
+  [10.5281/zenodo.20033111](https://doi.org/10.5281/zenodo.20033111). Repository: <https://github.com/acgetchell/markov-chain-monte-carlo>
 
-- Bowyer, A. "Computing Dirichlet tessellations." _The Computer Journal_ 24, no. 2 (1981): 162-166. DOI:
-  [10.1093/comjnl/24.2.162](https://doi.org/10.1093/comjnl/24.2.162)
+### Metropolis-Hastings Algorithm in CDT
 
-- Watson, D.F. "Computing the n-dimensional Delaunay tessellation with application to Voronoi polytopes." _The Computer Journal_ 24, no. 2 (1981): 167-172. DOI:
-  [10.1093/comjnl/24.2.167](https://doi.org/10.1093/comjnl/24.2.167)
+- Ambjørn, J., and Loll, R. "Non-perturbative Lorentzian quantum gravity, causality and topology change." _Nuclear Physics B_ 536, no. 1-2 (1998): 407-434.
+  DOI: [10.1016/S0550-3213(98)00692-0](https://doi.org/10.1016/S0550-3213(98)00692-0). arXiv: [hep-th/9805108](https://arxiv.org/abs/hep-th/9805108)
 
-### Computational Geometry References
+- Hastings, W. K. "Monte Carlo sampling methods using Markov chains and their applications." _Biometrika_ 57, no. 1 (1970): 97-109. DOI:
+  [10.1093/biomet/57.1.97](https://doi.org/10.1093/biomet/57.1.97)
 
-- de Berg, M., et al. "Computational Geometry: Algorithms and Applications." 3rd ed. Berlin: Springer-Verlag, 2008. DOI:
-  [10.1007/978-3-540-77974-2](https://doi.org/10.1007/978-3-540-77974-2)
+### Regge Calculus and Discrete Action
 
-- The CGAL Project. "CGAL User and Reference Manual." CGAL Editorial Board, 6.0.1 edition, 2024. Available at: <https://doc.cgal.org/6.0.1/Manual/packages.html>
+- Hamber, H. W. "Quantum Gravitation: The Feynman Path Integral Approach." Berlin: Springer-Verlag, 2009. DOI:
+  [10.1007/978-3-540-85293-3](https://doi.org/10.1007/978-3-540-85293-3)
 
-## Discrete Approaches to General Relativity
-
-### Lattice Approaches to Quantum Gravity
-
-- Williams, R. M., and Tuckey, P. A. "Regge calculus: a brief review and bibliography." _Classical and Quantum Gravity_ 9, no. 5 (1992): 1409. DOI:
-  [10.1088/0264-9381/9/5/021](https://doi.org/10.1088/0264-9381/9/5/021)
-
-- Sorkin, R. D. "Causal sets: discrete gravity." In _Lectures on Quantum Gravity_, edited by A. Gomberoff and D. Marolf, 305-327. Boston: Springer, 2005. arXiv:
-  [gr-qc/0309009](https://arxiv.org/abs/gr-qc/0309009)
-
-### Spin Foam Models and Loop Quantum Gravity
-
-- Rovelli, C. "Quantum Gravity." Cambridge: Cambridge University Press, 2004. DOI: [10.1017/CBO9780511755804](https://doi.org/10.1017/CBO9780511755804)
-
-- Perez, A. "The Spin Foam Approach to Quantum Gravity." _Living Reviews in Relativity_ 16, no. 1 (2013): 3. DOI:
-  [10.12942/lrr-2013-3](https://doi.org/10.12942/lrr-2013-3). arXiv: [1205.2019](https://arxiv.org/abs/1205.2019)
+- Regge, T. "General Relativity without coordinates." _Il Nuovo Cimento_ 19, no. 3 (1961): 558-571. DOI:
+  [10.1007/BF02733251](https://doi.org/10.1007/BF02733251)
 
 ## Numerical Methods and Performance
-
-### High-Performance Scientific Computing
-
-- Press, W. H., et al. "Numerical Recipes: The Art of Scientific Computing." 3rd ed. Cambridge: Cambridge University Press, 2007. ISBN: 978-0-521-88068-8
-
-- Golub, G. H., and Van Loan, C. F. "Matrix Computations." 4th ed. Baltimore: Johns Hopkins University Press, 2013. ISBN: 978-1-4214-0794-4
 
 ### Formal Verification in Scientific Computing
 
@@ -133,18 +145,8 @@ This library leverages computational geometry for efficient triangulation operat
 - Muller, J.-M., et al. "Handbook of Floating-Point Arithmetic." 2nd ed. Basel: Birkhäuser, 2018. DOI:
   [10.1007/978-3-319-76526-6](https://doi.org/10.1007/978-3-319-76526-6)
 
-## Related Software and Libraries
+### High-Performance Scientific Computing
 
-### Computational Geometry Libraries
+- Golub, G. H., and Van Loan, C. F. "Matrix Computations." 4th ed. Baltimore: Johns Hopkins University Press, 2013. ISBN: 978-1-4214-0794-4
 
-- The CGAL Project. "CGAL: Computational Geometry Algorithms Library." <https://www.cgal.org/>
-
-- Shewchuk, J. R. "Triangle: Engineering a 2D Quality Mesh Generator and Delaunay Triangulator." In
-  _Applied Computational Geometry Towards Geometric Engineering_, 203-222. Berlin: Springer, 1996. DOI: [10.1007/BFb0014497](https://doi.org/10.1007/BFb0014497)
-
-### Monte Carlo and Statistical Physics
-
-- Newman, M. E. J., and Barkema, G. T. "Monte Carlo Methods in Statistical Physics." Oxford: Oxford University Press, 1999. ISBN: 978-0-19-851797-9
-
-- Landau, D. P., and Binder, K. "A Guide to Monte Carlo Simulations in Statistical Physics." 4th ed. Cambridge: Cambridge University Press, 2014. DOI:
-  [10.1017/CBO9781139696463](https://doi.org/10.1017/CBO9781139696463)
+- Press, W. H., et al. "Numerical Recipes: The Art of Scientific Computing." 3rd ed. Cambridge: Cambridge University Press, 2007. ISBN: 978-0-521-88068-8

--- a/docs/CLI_EXAMPLES.md
+++ b/docs/CLI_EXAMPLES.md
@@ -13,17 +13,19 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 ```bash
 # Basic 2D CDT triangulation with default parameters
-./target/release/cdt --vertices 10 --timeslices 5
+./target/release/cdt --vertices-per-slice 4 --timeslices 5
 
 # Run with custom simulation settings
-./target/release/cdt --vertices 20 --timeslices 10 --temperature 1.5 --steps 2000 --simulate
+./target/release/cdt --vertices-per-slice 4 --timeslices 10 --temperature 1.5 --steps 2000 --simulate
 ```
 
 ## Command Line Arguments
 
 ### Required Arguments
 
-- `--vertices <N>`: Number of vertices in the triangulation (minimum 3)
+- `--vertices-per-slice <N>`: Vertices on each initial spatial slice. Prefer this for regular CDT initial data; the binary computes
+  `total vertices = vertices-per-slice × timeslices`.
+- `--vertices <N>`: Total initial vertex count. Use this only when the total is already known; it must divide evenly by `--timeslices`.
 - `--timeslices <N>`: Number of time slices in the CDT foliation (minimum 1)
 
 ### Optional Simulation Parameters
@@ -50,12 +52,12 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 ```bash
 # Quick triangulation-generation test with minimal parameters
-./target/release/cdt --vertices 5 --timeslices 2
+./target/release/cdt --vertices-per-slice 4 --timeslices 2
 ```
 
 **Expected Output:**
 
-- Creates a 5-vertex, 2-timeslice triangulation
+- Creates an 8-vertex, 2-timeslice open-boundary triangulation
 - Does not run Monte Carlo steps unless `--simulate` is passed
 - Reports the initial triangulation measurement
 
@@ -63,7 +65,7 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 ```bash
 ./target/release/cdt \
-  --vertices 50 \
+  --vertices-per-slice 5 \
   --timeslices 10 \
   --temperature 1.2 \
   --steps 5000 \
@@ -79,7 +81,7 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 ```bash
 # High temperature configuration
 ./target/release/cdt \
-  --vertices 30 \
+  --vertices-per-slice 4 \
   --timeslices 8 \
   --temperature 10.0 \
   --steps 3000 \
@@ -93,7 +95,7 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 ```bash
 # Low temperature configuration
 ./target/release/cdt \
-  --vertices 25 \
+  --vertices-per-slice 4 \
   --timeslices 12 \
   --temperature 0.5 \
   --steps 8000 \
@@ -108,7 +110,7 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 ```bash
 # Modified coupling constants
 ./target/release/cdt \
-  --vertices 40 \
+  --vertices-per-slice 5 \
   --timeslices 8 \
   --coupling-0 0.8 \
   --coupling-2 1.2 \
@@ -122,7 +124,7 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 ```bash
 # Generate triangulation without running Monte Carlo simulation
-./target/release/cdt --vertices 100 --timeslices 20
+./target/release/cdt --vertices-per-slice 5 --timeslices 20
 ```
 
 **Use Case:** Generate initial configurations for other analysis tools
@@ -140,7 +142,7 @@ Create a script to run parameter sweeps:
 for temp in 0.5 1.0 1.5 2.0 2.5; do
     echo "Running simulation at temperature $temp"
     ./target/release/cdt \
-        --vertices 30 \
+        --vertices-per-slice 4 \
         --timeslices 10 \
         --temperature $temp \
         --steps 2000 \
@@ -154,7 +156,7 @@ done
 ```bash
 # Large simulation for performance testing
 ./target/release/cdt \
-  --vertices 200 \
+  --vertices-per-slice 8 \
   --timeslices 25 \
   --steps 10000 \
   --measurement-frequency 100 \
@@ -167,16 +169,16 @@ Enable detailed logging:
 
 ```bash
 # Set log level for detailed triangulation output
-RUST_LOG=debug ./target/release/cdt --vertices 10 --timeslices 5
+RUST_LOG=debug ./target/release/cdt --vertices-per-slice 4 --timeslices 5
 
 # Show detailed simulation logging
-RUST_LOG=debug ./target/release/cdt --vertices 10 --timeslices 5 --simulate
+RUST_LOG=debug ./target/release/cdt --vertices-per-slice 4 --timeslices 5 --simulate
 
 # Log only errors and warnings
-RUST_LOG=warn ./target/release/cdt --vertices 50 --timeslices 10 --simulate
+RUST_LOG=warn ./target/release/cdt --vertices-per-slice 5 --timeslices 10 --simulate
 
 # Save output to file
-./target/release/cdt --vertices 25 --timeslices 8 --simulate > simulation.log 2>&1
+./target/release/cdt --vertices-per-slice 4 --timeslices 8 --simulate > simulation.log 2>&1
 ```
 
 ## Expected Output Format
@@ -185,11 +187,11 @@ RUST_LOG=warn ./target/release/cdt --vertices 50 --timeslices 10 --simulate
 
 ```text
 [INFO] Dimensionality: 2
-[INFO] Number of vertices: 10
+[INFO] Number of vertices: 20
 [INFO] Number of timeslices: 5
 [INFO] Topology: OpenBoundary
 [INFO] Using trait-based backend system
-[INFO] Triangulation created with 10 vertices, <edge-count> edges, <face-count> faces
+[INFO] Triangulation created with 20 vertices, <edge-count> edges, <face-count> faces
 [INFO] CDT simulation completed successfully
 ```
 
@@ -197,11 +199,11 @@ RUST_LOG=warn ./target/release/cdt --vertices 50 --timeslices 10 --simulate
 
 ```bash
 # Invalid parameters
-./target/release/cdt --vertices 2 --timeslices 1
-# Error: vertices must be >= 3
+./target/release/cdt --vertices-per-slice 2 --timeslices 2
+# Error: vertices must be >= 4 · timeslices (8) for open-boundary topology
 
 # Unsupported dimension
-./target/release/cdt --vertices 10 --timeslices 5 --dimension 4
+./target/release/cdt --vertices-per-slice 4 --timeslices 5 --dimension 4
 # Error: unsupported dimension
 ```
 
@@ -246,7 +248,7 @@ RUST_LOG=warn ./target/release/cdt --vertices 50 --timeslices 10 --simulate
    - Consider reducing measurement frequency
 
 4. **Parameter validation errors**
-   - Check minimum values (vertices ≥ 3, timeslices ≥ 1)
+   - Check minimum values (open-boundary vertices per slice ≥ 4, toroidal vertices per slice ≥ 3)
    - Verify dimension is 2
 
 ## Integration with Other Tools
@@ -255,7 +257,7 @@ RUST_LOG=warn ./target/release/cdt --vertices 50 --timeslices 10 --simulate
 
 ```bash
 # Pipe triangulation-only output to analysis tools
-./target/release/cdt --vertices 50 --timeslices 10 | \
+./target/release/cdt --vertices-per-slice 5 --timeslices 10 | \
   python analysis_script.py
 ```
 
@@ -264,7 +266,7 @@ RUST_LOG=warn ./target/release/cdt --vertices 50 --timeslices 10 --simulate
 ```bash
 # Use in makefiles or CI/CD
 make run-simulation: 
- ./target/release/cdt --vertices $(VERTICES) --timeslices $(SLICES)
+ ./target/release/cdt --vertices-per-slice $(VERTICES_PER_SLICE) --timeslices $(SLICES)
 ```
 
 ## Help and Documentation

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -125,6 +125,7 @@ causal-triangulations/
 │   │           └── rust_style.rs
 │   ├── cli.rs
 │   ├── integration_tests.rs
+│   ├── large_scale_debug.rs
 │   ├── physics_integration.rs
 │   ├── proptest_foliation.rs
 │   ├── proptest_metropolis.rs
@@ -218,10 +219,11 @@ The implementation is split into child modules under `src/cdt/triangulation/`:
 
 ### `cdt/metropolis.rs` — Metropolis move ordering
 
-`MetropolisAlgorithm::run()` proposes a move type, computes `ΔS` from the move's simplex-count delta, accepts or rejects the proposal, and only mutates the
-triangulation after acceptance. Accepted applications that fail are rolled back from a triangulation snapshot and retried at another random local site; retry
-exhaustion is recorded as a rejection, while hard backend failures remain structured errors. Toroidal move finalization rejects and rolls back candidate sites
-that would violate χ = 0 or the closed-S¹ per-slice foliation invariant. See `docs/metropolis.md` for the detailed ordering.
+`MetropolisAlgorithm::run()` proposes a move type, plans a concrete local transition on a cloned triangulation, computes `ΔS` and the forward/reverse
+Metropolis-Hastings site-count ratio, accepts or rejects the concrete proposal, and only replaces the live triangulation after acceptance. Planning failures are
+rolled back inside the move kernels; retry exhaustion is recorded as a rejection, while hard backend failures remain structured errors. Toroidal move
+finalization rejects and rolls back candidate sites that would violate χ = 0 or the closed-S¹ per-slice foliation invariant. See `docs/metropolis.md` for the
+detailed ordering.
 
 ### `cdt/results.rs` — Simulation outputs
 

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -141,6 +141,7 @@ causal-triangulations/
 ├── CHANGELOG.md
 ├── CODE_OF_CONDUCT.md
 ├── CONTRIBUTING.md
+├── CITATION.cff
 ├── Cargo.lock
 ├── Cargo.toml
 ├── LICENSE

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -250,8 +250,8 @@ just shell-fix         # Format (mutating)
 
 ## YAML Validation
 
-YAML files are checked with `yamllint` and formatted with `dprint` using the
-Rust-native `pretty_yaml` plugin.
+YAML and `CITATION.cff` files are checked with `yamllint` and formatted with
+`dprint` using the Rust-native `pretty_yaml` plugin.
 
 Commands:
 
@@ -262,6 +262,18 @@ just yaml-fix          # Format (mutating)
 
 Compatibility aliases remain available as granular recipes:
 `just yaml-lint` and `just yaml-fmt-check`.
+
+---
+
+## CITATION.cff Validation
+
+Citation metadata should pass both YAML style linting and CFF schema validation.
+
+Run:
+
+```bash
+just citation-check
+```
 
 ---
 

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -327,6 +327,47 @@ The smaller CI regression benchmark contract runs through the `perf` Cargo profi
 just bench-ci
 ```
 
+For manual large-scale toroidal 1+1 CDT move-kernel debugging, run the parameterized slow-test harness through the `perf` Cargo profile:
+
+```bash
+just debug-large-scale-1p1 512 16 10
+```
+
+Named scale probes are also available:
+
+```bash
+just debug-large-scale-1p1-512
+just debug-large-scale-1p1-1024
+```
+
+The arguments are total vertices, timeslices, and sweeps. The umbrella recipe runs the curated large-scale debug case set:
+
+```bash
+just perf-large-scale-debug
+```
+
+The umbrella recipe currently runs `512/16/10` and `1024/32/1` cases. It is intentionally manual and long-running; use the parameterized
+`debug-large-scale-1p1` recipe directly when you only need a smaller smoke probe.
+
+These debug recipes do not enable volume fixing. Volume drift in the reported final vertex and simplex counts is expected when `(1,3)` and `(3,1)` moves are
+accepted. Treat these runs as unfixed-volume move-kernel stress tests, not as fixed-volume CDT production ensembles. Future fixed-volume recipes should be
+explicitly labeled because quadratic volume fixing samples a modified ensemble; see Ambjørn et al.,
+[The Semiclassical Limit of Causal Dynamical Triangulations](https://arxiv.org/abs/1102.3929), and
+[The phase structure of Causal Dynamical Triangulations with toroidal spatial topology](https://arxiv.org/abs/1802.10434).
+
+For unfixed-volume debug runs, the cosmological constant is the volume-control coupling. If a large-scale recipe grows or shrinks too aggressively, tune the
+action parameters rather than interpreting the run as a failed fixed-volume simulation.
+
+The recipes set per-case environment variables, and the Rust harness also accepts these variables directly:
+
+| Variable | Description |
+| -------- | ----------- |
+| `CDT_LARGE_DEBUG_VERTICES` / `CDT_LARGE_DEBUG_VERTICES_1P1` | Total vertex count |
+| `CDT_LARGE_DEBUG_TIMESLICES` / `CDT_LARGE_DEBUG_TIMESLICES_1P1` | Number of periodic time slices |
+| `CDT_LARGE_DEBUG_SWEEPS` / `CDT_LARGE_DEBUG_SWEEPS_1P1` | Sweep count; one sweep attempts one move per current simplex |
+| `CDT_LARGE_DEBUG_SEED` / `CDT_LARGE_DEBUG_SEED_1P1` | RNG seed, decimal or `0x` hexadecimal |
+| `CDT_LARGE_DEBUG_MAX_RUNTIME_SECS` | Optional wall-clock cap checked between sweeps; `0` disables it |
+
 To compile benchmarks and release-profile integration tests without running them:
 
 ```bash

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -83,6 +83,8 @@ The useful `justfile` updates ported from `delaunay` are:
 - `bench-test-compile`, which layers release-profile integration-test compilation on top of the existing warning-denying benchmark compile check;
 - opt-in release hygiene recipes `unused-deps` and `publish-check`, kept outside the default `lint` and `ci` paths so they are available before releases without
   making routine validation slower or more tool-dependent;
+- `citation-check`, using `cffconvert` through `uvx`, and inclusion of `CITATION.cff` in YAML/CFF formatting and linting so research-software citation metadata
+  is schema-validated before release;
 - `rumdl` Markdown checking, `dprint`/`pretty_yaml` YAML formatting, check/fix aliases, and a corrected rename/copy note in `spell-check`.
 - repository-owned Semgrep rules that keep user-facing `just check` examples before `just fix` examples and enforce SHA-pinned, allowlisted GitHub Actions with
   readable version comments. Dependabot remains the update path for pinned external actions, with review focused on preserving both the SHA and readable version

--- a/docs/metropolis.md
+++ b/docs/metropolis.md
@@ -5,25 +5,26 @@
 For each step:
 
 1. Select a move type with `ErgodicsSystem::select_random_move()`.
-2. Compute the proposed action change from the move type's simplex-count delta:
+2. Build a concrete delayed proposal for that move type by selecting and applying a realizable local site on a cloned triangulation. If no concrete site exists,
+   record the step as a rejected proposal and continue without changing the live triangulation.
+3. Compute the proposed action change from the concrete proposal's simplex-count delta:
    - `(2,2)` / edge flip: `ΔN0 = 0`, `ΔN1 = 0`, `ΔN2 = 0`
    - `(1,3)`: `ΔN0 = +1`, `ΔN1 = +3`, `ΔN2 = +2`
    - `(3,1)`: `ΔN0 = -1`, `ΔN1 = -3`, `ΔN2 = -2`
-3. Accept the proposed move if `ΔS <= 0`, or with probability `exp(-ΔS / T)`.
-4. Only after acceptance, apply the move through the ergodic move kernel.
-5. If an accepted application fails at its chosen local site, the move kernel restores its pre-mutation triangulation snapshot and the simulation retries at
-   another randomly selected site for a bounded number of attempts. For toroidal triangulations, this includes candidate edits that would violate χ = 0 or break
-   a spatial slice's closed-S¹ ring after mutation.
-6. If all retries fail because no local site is valid, record the step as rejected and continue; the triangulation has been restored to its pre-application
-   state.
-7. If a backend edit reports a hard mutation failure, return `CdtError::MetropolisMoveApplicationFailed` with the step, move type, retry count, and lower-level
-   failure.
+4. Count the forward sites for the selected move type and the reverse sites for the inverse move type on the proposed state.
+5. Accept with the Metropolis-Hastings probability
+   `min(1, exp(-ΔS / T + log(q(current | proposed) / q(proposed | current))))`. For equal move-family weights this adds
+   `log(forward_site_count / reverse_site_count)` to the ordinary action term, so `(1,3)` and `(3,1)` proposals account for their different site
+   multiplicities.
+6. Only after acceptance, replace the live triangulation with the planned proposed state.
+7. If proposal planning hits a hard backend or invariant failure, return `CdtError::MetropolisMoveApplicationFailed` with the step, move type, retry count, and
+   lower-level failure.
 
-This ordering avoids mutating the triangulation for Metropolis-rejected moves. Rollback is still required for accepted moves because a backend edit can fail
-after a site has been selected or after partial invariant refresh work. Ergodic kernels snapshot lazily, after candidate selection and immediately before
-mutation, so ordinary local-site rejections avoid cloning the triangulation. Exhausted local-site retries are ordinary proposal rejections because the selected
-move type did not bind to a realizable local site within the bounded search. The recorded `SimulationResultsBackend::move_stats` counts Metropolis-level
-attempted and applied moves, while `ErgodicsSystem::stats` remains local to the lower-level move kernel.
+This ordering avoids mutating the live triangulation for Metropolis-rejected moves while still binding each proposal to a concrete local transition before the
+acceptance draw. Rollback remains inside the move kernels while planning on the cloned state because a backend edit can fail after a site has been selected or
+after partial invariant refresh work. Exhausted local-site retries are ordinary proposal rejections because the selected move type did not bind to a realizable
+local site within the bounded search. The recorded `SimulationResultsBackend::move_stats` counts Metropolis-level attempted and applied moves, while
+`ErgodicsSystem::stats` remains local to the lower-level move kernel.
 
 The integration test `test_toroidal_metropolis_accepts_periodic_moves_and_preserves_topology` covers this contract by running a seeded S¹×S¹ simulation,
 requiring at least one accepted periodic move, and checking final topology, foliation, causality, simplex classification, and Euler characteristic.

--- a/docs/metropolis.md
+++ b/docs/metropolis.md
@@ -26,5 +26,37 @@ after partial invariant refresh work. Exhausted local-site retries are ordinary 
 local site within the bounded search. The recorded `SimulationResultsBackend::move_stats` counts Metropolis-level attempted and applied moves, while
 `ErgodicsSystem::stats` remains local to the lower-level move kernel.
 
+## Proposal-Ratio Correction
+
+The proposal-ratio correction is not computed from the number of moves accepted during a run. It is a property of the concrete proposal distribution at the
+current step:
+
+```text
+q(current | proposed) / q(proposed | current)
+```
+
+For the current sampler, move families are selected with equal probability. Once a move family is selected, the kernel chooses uniformly among its valid local
+application sites. For a concrete transition from `current` to `proposed`:
+
+```text
+q(proposed | current) = P(forward move family) * 1 / N_forward
+q(current | proposed) = P(reverse move family) * 1 / N_reverse
+```
+
+The equal move-family probabilities cancel for inverse move pairs, leaving:
+
+```text
+q(current | proposed) / q(proposed | current) = N_forward / N_reverse
+log_q_ratio = log(N_forward) - log(N_reverse)
+```
+
+`N_forward` is the number of valid local sites for the selected move type in the current triangulation. `N_reverse` is the number of valid local sites for the
+inverse move type in the proposed triangulation. For example, a `(1,3)` proposal counts valid `(1,3)` sites before the move and valid reverse `(3,1)` sites
+after the move. This corrects proposal asymmetry for detailed balance without adding volume fixing or changing the target action.
+
+This is the ordinary Metropolis-Hastings proposal-ratio correction: it uses the actual proposal kernel, not empirical acceptance counts from the run. Hastings'
+original Markov-chain sampling paper gives the general acceptance rule, and Brunekreef, Görlich, and Loll describe CDT Monte Carlo moves together with their
+detailed-balance equations. See [REFERENCES.md](../REFERENCES.md) for the full citations.
+
 The integration test `test_toroidal_metropolis_accepts_periodic_moves_and_preserves_topology` covers this contract by running a seeded S¹×S¹ simulation,
 requiring at least one accepted periodic move, and checking final topology, foliation, causality, simplex classification, and Euler characteristic.

--- a/docs/moves.md
+++ b/docs/moves.md
@@ -84,9 +84,10 @@ not clone the triangulation. If a selected mutation or required post-mutation sy
 non-success `MoveResult`. Toroidal post-move topology or closed-ring foliation failures are treated as rollbackable local-site rejections, because the candidate
 site was geometrically editable but would break the periodic CDT contract.
 
-The Metropolis loop accepts or rejects a move type before calling these mutating kernels. If an accepted application fails at its selected site, the simulation
-retries at another random site from the restored triangulation. Exhausting those retries is recorded as a rejected proposal; hard backend mutation failures
-still return `CdtError::MetropolisMoveApplicationFailed`. See `docs/metropolis.md`.
+The Metropolis loop first clones the current triangulation and plans a concrete move on that cloned triangulation; see `src/cdt/metropolis.rs`. It then performs
+the accept/reject decision from the proposed move metadata; see `docs/metropolis.md`. Only accepted proposals swap the cloned, mutated state into the live
+simulation. Failed applications on the cloned state are retried from the restored clone state, exhausted retries are recorded as rejected proposals, and hard
+backend mutation or invariant-refresh failures still return `CdtError::MetropolisMoveApplicationFailed`.
 
 ## Ensemble And Volume Fixing
 
@@ -112,5 +113,4 @@ fixing yet; if added, it should be explicit and opt-in.
 ## Planned Work
 
 - [ ] Weight `select_random_move()` by available application sites per move type to remove uniform-sampling chain bias
-- [ ] Weight accepted move-site retries by available local sites instead of bounded random retries
 - [ ] Broaden per-kernel toroidal move-site tests around periodic boundary simplices

--- a/docs/moves.md
+++ b/docs/moves.md
@@ -14,10 +14,12 @@ Enumerates the available move types:
 
 - `Move22` — (2,2) move: flip the shared edge between two triangles, preserving vertex count; causality-aware — the CDT layer validates and rejects moves that
   break causal layering
-- `Move13Add` — (1,3) move: insert a new vertex by subdividing one triangle into three; when the triangulation is foliated, the inserted vertex receives the
-  time label that keeps all replacement triangles causal
-- `Move31Remove` — (3,1) move: remove a degree-3 vertex by merging three triangles into one when the replacement triangle is causal and the removal does not
-  empty a time slice
+- `Move13Add` — (1,3) move: insert a new vertex by adding local CDT volume; open-boundary and unfoliated runs subdivide one triangle into three, while
+  toroidal foliated runs split a spacelike link by subdividing an adjacent face and flipping the original spacelike link away. Inserted vertices receive the
+  time label needed to keep the replacement simplices causal.
+- `Move31Remove` — (3,1) move: remove a vertex by collapsing local CDT volume; open-boundary and unfoliated runs remove a degree-3 vertex when the replacement
+  triangle is causal and no time slice is emptied, while toroidal foliated runs use the inverse flip-then-collapse path for degree-4 spacelike-link-split
+  configurations.
 - `EdgeFlip` — API-compatible alias for the 2D k=2 edge flip used by `Move22`; it records separate statistics but uses the same causal prechecks
 
 ### `MoveResult`
@@ -35,15 +37,18 @@ Returned by each `attempt_*` method:
 
 ### `MoveStatistics`
 
-Tracks per-move-type attempt and acceptance counts. Fields: `moves_22_attempted` / `moves_22_accepted`, `moves_13_attempted` / `moves_13_accepted`,
-`moves_31_attempted` / `moves_31_accepted`, `edge_flips_attempted` / `edge_flips_accepted`.
+Tracks per-move-type attempts, accepted moves, and hard failures. Attempts count every selected proposal. Accepted counts include only moves that committed and
+validated successfully. Hard failures are distinct from ordinary proposal rejections: they remain in the attempt denominator, do not increment accepted counts,
+and are reported through the `*_hard_failed` fields and `total_hard_failures()`.
 
 Key methods:
 
 - `record_attempt(MoveType)` — increment the attempt counter
-- `record_success(MoveType)` — increment the acceptance counter
-- `acceptance_rate(MoveType) -> f64` — ratio for a single move type
-- `total_acceptance_rate() -> f64` — ratio across all move types
+- `record_success(MoveType)` — increment the committed-and-validated acceptance counter
+- `record_hard_failure(MoveType)` — increment post-mutation invariant failure telemetry without treating the move as accepted
+- `acceptance_rate(MoveType) -> f64` — accepted / attempted ratio for a single move type
+- `total_acceptance_rate() -> f64` — accepted / attempted ratio across all move types
+- `total_hard_failures() -> u64` — total hard failures across all move types
 
 ### `ErgodicsSystem`
 
@@ -82,6 +87,27 @@ site was geometrically editable but would break the periodic CDT contract.
 The Metropolis loop accepts or rejects a move type before calling these mutating kernels. If an accepted application fails at its selected site, the simulation
 retries at another random site from the restored triangulation. Exhausting those retries is recorded as a rejected proposal; hard backend mutation failures
 still return `CdtError::MetropolisMoveApplicationFailed`. See `docs/metropolis.md`.
+
+## Ensemble And Volume Fixing
+
+Current CDT simulations do not add a volume-fixing term. The `(1,3)` and `(3,1)` kernels are genuine volume-changing proposals, so accepted moves may change
+the total number of vertices and simplices over time. The resulting Markov chain should therefore be interpreted as sampling the unfixed-volume ensemble
+specified by the configured action, cosmological term, proposal probabilities, and Metropolis-Hastings acceptance rule.
+
+This is a valid 1+1 CDT setting rather than an implementation accident. Israel and Lindner use a 1+1 CDT Monte Carlo model where add/remove moves satisfy
+detailed balance and the cosmological constant controls whether the universe size is stable, shrinking, or diverging:
+[Quantum gravity on a laptop: 1+1 Dimensional Causal Dynamical Triangulation simulation](https://doi.org/10.1016/j.rinp.2012.10.001).
+
+For unfixed-volume runs, tune the cosmological constant rather than expecting the move kernels to preserve volume. The cosmological constant is conjugate to
+the lattice volume term, so changing it changes the relative acceptance of volume-increasing and volume-decreasing trajectories through the ordinary action
+difference. The current binary exposes this as `--cosmological-constant`, and programmatic callers set it through `ActionConfig`.
+
+Approximate volume fixing is also standard in higher-dimensional CDT when the scientific goal is a finite-size ensemble at a chosen lattice volume. In that
+case the fixing term is part of the sampled action, for example a quadratic penalty around a target volume, and detailed balance is with respect to the
+modified ensemble. See Ambjørn et al.,
+[The Semiclassical Limit of Causal Dynamical Triangulations](https://arxiv.org/abs/1102.3929), and the toroidal topology study,
+[The phase structure of Causal Dynamical Triangulations with toroidal spatial topology](https://arxiv.org/abs/1802.10434). This crate does not implement volume
+fixing yet; if added, it should be explicit and opt-in.
 
 ## Planned Work
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,29 +13,44 @@ The v0.1.0 foundation work focuses on making the crate a usable, validated 1+1 C
 - [x] Explicit toroidal S¹×S¹ CDT construction with χ = 0 validation
 - [x] Per-vertex foliation labels, causality checks, and strict Up/Down simplex classification
 - [x] Real 2D ergodic move kernels over Delaunay backend edit operations
-- [x] Proposal-before-mutation Metropolis loop with rollback and bounded local-site retries
+- [x] Concrete delayed-proposal Metropolis-Hastings loop with forward/reverse local-site weighting
 - [x] Toroidal Metropolis regression coverage requiring accepted periodic moves while preserving topology and foliation
 - [x] CLI and configuration support for open-boundary and toroidal topology selection
 - [x] Volume-profile, Hausdorff-dimension, and spectral-dimension observables on the combinatorial dual graph
 - [x] Repository validation loop covering Rust, Python support scripts, Semgrep rules, documentation, examples, and benchmarks
+- [ ] Support variable spatial volume profiles for 1+1 CDT initial geometries
+  ([#141](https://github.com/acgetchell/causal-triangulations/issues/141))
+- [ ] Track release-readiness gates for the first public release
+  ([#140](https://github.com/acgetchell/causal-triangulations/issues/140))
 
 ## 1+1 Maturity
 
 Likely follow-up work before broadening the dimensional surface:
 
 - Weight move-type selection by available application sites to reduce uniform-sampling bias
-- Weight or enumerate accepted move-site retries so proposals bind to concrete local moves before acceptance
 - Broaden per-kernel toroidal tests around spatial and temporal wrap-around simplices
 - Accept fixed triangle simplices directly in explicit-simplex generator APIs to remove per-triangle `Vec` adaptation
 - Add manual foliation assignment APIs with the same validation and synchronization guarantees as constructor-assigned labels
 - Add tutorial-style examples for open-boundary strips, toroidal runs, observables, and interpreting Metropolis acceptance behavior
+
+## v0.1.1 Ensemble Controls
+
+The post-v0.1.0 1+1 track should keep the default ensemble scientifically explicit while adding opt-in controls for finite-volume numerical workflows:
+
+- Add optional CDT volume fixing for bounded large-scale simulations
+  ([#142](https://github.com/acgetchell/causal-triangulations/issues/142)). Volume fixing should be opt-in and documented as a modified action, not the default
+  unfixed-volume ensemble.
+- Add λ scan utilities for unfixed-volume 1+1 CDT runs
+  ([#143](https://github.com/acgetchell/causal-triangulations/issues/143)). These should help users tune the cosmological constant, which is conjugate to the
+  lattice volume term and controls volume growth or shrinkage in unfixed-volume runs.
 
 ## Higher-Dimensional CDT Tracks
 
 The next CDT dimensions should advance as explicit topology tracks rather than a generic higher-dimensional bucket:
 
 - 2+1 CDT with spherical spatial slices (S²) and toroidal spatial slices (T²), including constructor fixtures, foliation validation, local move kernels,
-  Metropolis sampling, and topology-specific regression tests
+  Metropolis sampling, and topology-specific regression tests. The current v0.2.0 scoped issue is 2+1 toroidal CDT triangulations
+  ([#144](https://github.com/acgetchell/causal-triangulations/issues/144)).
 - 3+1 CDT with spherical spatial slices (S³) and toroidal spatial slices (T³), following the same staged path after the required geometry-backend operations and
   invariants are available
 - Periodic-time variants where the topology contract is well defined and the backend can validate the corresponding Euler/Poincaré-style invariants cleanly

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,7 +25,6 @@ into equal-size spatial slices.
 ### Ergodic Move Sampling
 
 - Weight move-type selection by available application sites instead of sampling move types uniformly.
-- Weight or enumerate accepted move-site retries so proposals bind to concrete local moves before Metropolis acceptance.
 - Add focused per-kernel toroidal fixtures for spatial and temporal wrap-around simplices.
 - Exercise more negative cases where a geometrically editable site must be rejected because it would break CDT invariants.
 

--- a/dprint.json
+++ b/dprint.json
@@ -8,7 +8,8 @@
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm"
   ],
   "includes": [
-    "**/*.{yaml,yml}"
+    "**/*.{yaml,yml}",
+    "CITATION.cff"
   ],
   "excludes": [
     "target/**",

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -144,7 +144,7 @@ cargo build --release
 
 # Run with custom parameters. Remove --simulate for a successful triangulation-only run.
 RUST_LOG=info ./target/release/cdt \
-    --vertices 25 \
+    --vertices-per-slice 4 \
     --timeslices 10 \
     --temperature 1.5 \
     --steps 3000 \
@@ -222,11 +222,11 @@ Triangulation-only logs contain:
 
 ```text
 [INFO] Dimensionality: 2
-[INFO] Number of vertices: 20
+[INFO] Number of vertices: 32
 [INFO] Number of timeslices: 8
 [INFO] Topology: OpenBoundary
 [INFO] Using trait-based backend system
-[INFO] Triangulation created with 20 vertices, <edge-count> edges, <face-count> faces
+[INFO] Triangulation created with 32 vertices, <edge-count> edges, <face-count> faces
 [INFO] CDT simulation completed successfully
 ```
 

--- a/examples/scripts/basic_simulation.sh
+++ b/examples/scripts/basic_simulation.sh
@@ -22,11 +22,11 @@ echo
 
 # Run a basic simulation with logging
 echo "Running basic CDT simulation..."
-echo "Parameters: 10 vertices, 5 timeslices, 1000 MC steps"
+echo "Parameters: 4 vertices/slice, 5 timeslices, 1000 MC steps"
 echo
 
 RUST_LOG=info ./target/release/cdt \
-	--vertices 10 \
+	--vertices-per-slice 4 \
 	--timeslices 5 \
 	--temperature 1.0 \
 	--steps 1000 \

--- a/examples/scripts/parameter_sweep.sh
+++ b/examples/scripts/parameter_sweep.sh
@@ -9,7 +9,7 @@ echo "=== CDT Parameter Sweep Example ==="
 echo
 
 # Configuration
-VERTICES=20
+VERTICES_PER_SLICE=4
 TIMESLICES=8
 STEPS=2000
 OUTPUT_DIR="sweep_results"
@@ -28,7 +28,7 @@ echo
 
 # Run parameter sweep
 echo "Starting parameter sweep over ${#TEMPERATURES[@]} temperature values..."
-echo "Fixed parameters: $VERTICES vertices, $TIMESLICES timeslices, $STEPS steps"
+echo "Fixed parameters: $VERTICES_PER_SLICE vertices/slice, $TIMESLICES timeslices, $STEPS steps"
 echo
 
 for temp in "${TEMPERATURES[@]}"; do
@@ -39,7 +39,7 @@ for temp in "${TEMPERATURES[@]}"; do
 
 	# Run simulation and save output
 	RUST_LOG=info ./target/release/cdt \
-		--vertices $VERTICES \
+		--vertices-per-slice $VERTICES_PER_SLICE \
 		--timeslices $TIMESLICES \
 		--temperature "$temp" \
 		--steps $STEPS \

--- a/examples/scripts/performance_test.sh
+++ b/examples/scripts/performance_test.sh
@@ -9,10 +9,10 @@ echo
 
 # System size configurations to test
 declare -a TEST_CONFIGS=(
-	"10 5 1000"   # Small: 10 vertices, 5 slices, 1000 steps
-	"20 8 2000"   # Medium: 20 vertices, 8 slices, 2000 steps
-	"50 10 3000"  # Large: 50 vertices, 10 slices, 3000 steps
-	"100 15 5000" # Extra Large: 100 vertices, 15 slices, 5000 steps
+	"4 5 1000"  # Small: 4 vertices/slice, 5 slices, 1000 steps
+	"4 8 2000"  # Medium: 4 vertices/slice, 8 slices, 2000 steps
+	"5 10 3000" # Large: 5 vertices/slice, 10 slices, 3000 steps
+	"8 15 5000" # Extra Large: 8 vertices/slice, 15 slices, 5000 steps
 )
 
 declare -a SIZE_NAMES=("Small" "Medium" "Large" "Extra Large")
@@ -30,24 +30,24 @@ echo
 
 results_file="performance_results.txt"
 echo "# CDT Performance Test Results - $(date)" >"$results_file"
-echo "# Format: Size | Vertices | Slices | Steps | Runtime (s) | Memory (MB)" >>"$results_file"
+echo "# Format: Size | Vertices/Slice | Slices | Steps | Runtime (s) | Memory (MB)" >>"$results_file"
 echo
 
 for i in "${!TEST_CONFIGS[@]}"; do
 	read -ra config <<<"${TEST_CONFIGS[$i]}"
-	vertices=${config[0]}
+	vertices_per_slice=${config[0]}
 	slices=${config[1]}
 	steps=${config[2]}
 	size_name=${SIZE_NAMES[$i]}
 
-	echo "Testing $size_name configuration: $vertices vertices, $slices slices, $steps steps"
+	echo "Testing $size_name configuration: $vertices_per_slice vertices/slice, $slices slices, $steps steps"
 
 	# Measure execution time and memory usage
 	start_time=$(date +%s.%N)
 
 	# Run simulation with minimal logging to reduce I/O overhead
 	RUST_LOG=error ./target/release/cdt \
-		--vertices "$vertices" \
+		--vertices-per-slice "$vertices_per_slice" \
 		--timeslices "$slices" \
 		--steps "$steps" \
 		--thermalization-steps $((steps / 10)) \
@@ -64,7 +64,7 @@ for i in "${!TEST_CONFIGS[@]}"; do
 	echo "  ✓ Completed in ${runtime_formatted}s"
 
 	# Log results
-	echo "$size_name | $vertices | $slices | $steps | $runtime_formatted | N/A" >>"$results_file"
+	echo "$size_name | $vertices_per_slice | $slices | $steps | $runtime_formatted | N/A" >>"$results_file"
 done
 
 echo

--- a/justfile
+++ b/justfile
@@ -209,6 +209,10 @@ ci-baseline tag="ci":
 ci-slow: ci test-slow
     @echo "✅ CI + slow tests passed!"
 
+# Validate CITATION.cff against the Citation File Format schema.
+citation-check: _ensure-uv
+    uvx --from cffconvert==2.0.0 cffconvert --validate -i CITATION.cff
+
 # Clean build artifacts
 clean:
     cargo clean
@@ -340,8 +344,8 @@ lint: lint-code lint-docs lint-config
 # Code linting: Rust (fmt-check, clippy, docs, Semgrep) + Python (ruff, ty) + Shell scripts
 lint-code: fmt-check clippy doc-check semgrep semgrep-test python-lint shell-lint
 
-# Configuration validation: JSON, TOML, YAML, GitHub Actions workflows
-lint-config: validate-json toml-check yaml-check action-lint
+# Configuration validation: JSON, TOML, YAML/CFF, GitHub Actions workflows
+lint-config: validate-json toml-check yaml-check citation-check action-lint
 
 # Documentation linting: Markdown + spell checking
 lint-docs: markdown-check spell-check
@@ -829,7 +833,7 @@ test-examples: _ensure-cargo-nextest
     cargo nextest run --examples --verbose --no-tests pass
 
 test-integration: _ensure-cargo-nextest
-    cargo nextest run -E 'kind(test)' --verbose
+    cargo nextest run --tests --verbose
 
 test-lib: _ensure-cargo-nextest
     cargo nextest run --lib --verbose
@@ -842,7 +846,7 @@ test-release: _ensure-cargo-nextest
     cargo test --doc --release
 
 test-slow: _ensure-cargo-nextest
-    cargo nextest run -E 'kind(test)' --features slow-tests --verbose
+    cargo nextest run --tests --features slow-tests --verbose
 
 toml-check: toml-fmt-check toml-lint
 
@@ -915,9 +919,9 @@ yaml-fix: _ensure-dprint
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '*.yml' '*.yaml')
+    done < <(git ls-files -z '*.yml' '*.yaml' 'CITATION.cff')
     if [ "${#files[@]}" -gt 0 ]; then
-        echo "📝 dprint fmt (YAML, ${#files[@]} files)"
+        echo "📝 dprint fmt (YAML/CFF, ${#files[@]} files)"
         dprint fmt --incremental=false "${files[@]}"
     else
         echo "No YAML files found to format."
@@ -929,9 +933,9 @@ yaml-fmt-check: _ensure-dprint
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '*.yml' '*.yaml')
+    done < <(git ls-files -z '*.yml' '*.yaml' 'CITATION.cff')
     if [ "${#files[@]}" -gt 0 ]; then
-        echo "🔍 dprint check (YAML, ${#files[@]} files)"
+        echo "🔍 dprint check (YAML/CFF, ${#files[@]} files)"
         dprint check --incremental=false "${files[@]}"
     else
         echo "No YAML files found to check."
@@ -943,9 +947,9 @@ yaml-lint: _ensure-yamllint
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '*.yml' '*.yaml')
+    done < <(git ls-files -z '*.yml' '*.yaml' 'CITATION.cff')
     if [ "${#files[@]}" -gt 0 ]; then
-        echo "🔍 yamllint (${#files[@]} files)"
+        echo "🔍 yamllint (${#files[@]} YAML/CFF files)"
         yamllint --strict -c .yamllint "${files[@]}"
     else
         echo "No YAML files found to lint."

--- a/justfile
+++ b/justfile
@@ -49,10 +49,10 @@ _ensure-cargo-nextest:
         exit 1
     fi
 
-_ensure-jq:
+_ensure-dprint:
     #!/usr/bin/env bash
     set -euo pipefail
-    command -v jq >/dev/null || { echo "❌ 'jq' not found. See 'just setup' or install: brew install jq"; exit 1; }
+    command -v dprint >/dev/null || { echo "❌ 'dprint' not found. See 'just setup' or install: brew install dprint"; exit 1; }
 
 _ensure-git-cliff:
     #!/usr/bin/env bash
@@ -63,10 +63,10 @@ _ensure-git-cliff:
         exit 1
     }
 
-_ensure-dprint:
+_ensure-jq:
     #!/usr/bin/env bash
     set -euo pipefail
-    command -v dprint >/dev/null || { echo "❌ 'dprint' not found. See 'just setup' or install: brew install dprint"; exit 1; }
+    command -v jq >/dev/null || { echo "❌ 'jq' not found. See 'just setup' or install: brew install jq"; exit 1; }
 
 _ensure-rumdl:
     #!/usr/bin/env bash
@@ -127,16 +127,16 @@ bench:
 bench-ci:
     cargo bench --profile perf --bench ci_performance_suite
 
-# Smoke-test benchmark harnesses with minimal samples; not for performance data.
-bench-smoke:
-    cargo bench --workspace --bench cdt_benchmarks -- --sample-size 10 --measurement-time 1 --warm-up-time 1 --noplot
-    cargo bench --workspace --bench ci_performance_suite -- --sample-size 10 --measurement-time 1 --warm-up-time 1 --noplot
-
 # Compile benchmarks without running them, treating warnings as errors.
 # This catches bench/release-profile-only warnings (e.g. debug_assertions-gated unused vars)
 # that won't show up in normal debug-profile `cargo test` / `cargo clippy` runs.
 bench-compile:
     RUSTFLAGS='-D warnings' cargo bench --workspace --no-run
+
+# Smoke-test benchmark harnesses with minimal samples; not for performance data.
+bench-smoke:
+    cargo bench --workspace --bench cdt_benchmarks -- --sample-size 10 --measurement-time 1 --warm-up-time 1 --noplot
+    cargo bench --workspace --bench ci_performance_suite -- --sample-size 10 --measurement-time 1 --warm-up-time 1 --noplot
 
 # Compile benchmarks and release-profile Rust test binaries without running.
 bench-test-compile: bench-compile _ensure-cargo-nextest
@@ -164,6 +164,9 @@ changelog: _ensure-git-cliff _ensure-rumdl python-sync
     fi
     rumdl fmt --silent CHANGELOG.md "${archive_files[@]}"
 
+changelog-tag version:
+    just tag {{version}}
+
 changelog-unreleased version: _ensure-git-cliff _ensure-rumdl python-sync
     #!/usr/bin/env bash
     set -euo pipefail
@@ -177,15 +180,6 @@ changelog-unreleased version: _ensure-git-cliff _ensure-rumdl python-sync
         done < <(find docs/archive/changelog -name '*.md' -print0)
     fi
     rumdl fmt --silent CHANGELOG.md "${archive_files[@]}"
-
-tag version: python-sync
-    uv run tag-release {{version}}
-
-tag-force version: python-sync
-    uv run tag-release {{version}} --force
-
-changelog-tag version:
-    just tag {{version}}
 
 changelog-update: changelog
     @echo "📝 Changelog updated successfully!"
@@ -243,6 +237,15 @@ coverage-ci: _ensure-cargo-llvm-cov
 
 coverage-report *args: _ensure-uv
     uv run coverage_report {{args}}
+
+debug-large-scale-1p1 vertices="512" timeslices="16" sweeps="10" max_secs="1800" seed="0xCD710139": _ensure-cargo-nextest
+    CDT_LARGE_DEBUG_VERTICES_1P1={{ vertices }} CDT_LARGE_DEBUG_TIMESLICES_1P1={{ timeslices }} CDT_LARGE_DEBUG_SWEEPS_1P1={{ sweeps }} CDT_LARGE_DEBUG_SEED_1P1={{ seed }} CDT_LARGE_DEBUG_MAX_RUNTIME_SECS={{ max_secs }} cargo nextest run --cargo-profile perf --features slow-tests --test large_scale_debug debug_large_scale_1p1 -- --exact --nocapture
+
+debug-large-scale-1p1-1024 max_secs="1800":
+    just debug-large-scale-1p1 1024 32 1 {{ max_secs }}
+
+debug-large-scale-1p1-512 max_secs="1800":
+    just debug-large-scale-1p1 512 16 10 {{ max_secs }}
 
 # Default recipe shows available commands
 default:
@@ -302,6 +305,8 @@ help-workflows:
     @echo "Benchmark System:"
     @echo "  just bench              # Run all benchmarks"
     @echo "  just bench-ci           # Run CI regression benchmarks with the perf profile"
+    @echo "  just debug-large-scale-1p1 # Run one toroidal 1+1 CDT debug case"
+    @echo "  just perf-large-scale-debug # Run curated large-scale CDT debug cases"
     @echo "  just bench-smoke        # Smoke-test benchmark harnesses with minimal samples"
     @echo "  just bench-compile      # Compile benchmarks without running"
     @echo "  just bench-test-compile # Compile benches + release integration tests without running"
@@ -392,6 +397,55 @@ markdown-fix: _ensure-rumdl
 
 markdown-lint: markdown-check
 
+perf-baseline tag="": _ensure-uv
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tag_value="{{tag}}"
+    if [ -n "$tag_value" ]; then
+        uv run performance-analysis --save-baseline --tag "$tag_value"
+    else
+        uv run performance-analysis --save-baseline
+    fi
+
+perf-check threshold="10.0": _ensure-uv
+    uv run performance-analysis --threshold {{threshold}}
+
+perf-compare file: _ensure-uv
+    uv run performance-analysis --compare "{{file}}"
+
+perf-help:
+    @echo "Performance Analysis Commands:"
+    @echo "  just perf-baseline [tag]    # Save current performance as baseline (optionally tagged)"
+    @echo "  just perf-check [threshold] # Check for regressions (default: 10% threshold)"
+    @echo "  just perf-report [file]     # Generate performance report"
+    @echo "  just perf-trends [days]     # Analyze trends over N days (default: 7)"
+    @echo "  just perf-compare <file>    # Compare with specific baseline file"
+    @echo ""
+    @echo "Examples:"
+    @echo "  just perf-baseline v1.0.0   # Save tagged baseline"
+    @echo "  just perf-check 5.0         # Check with 5% threshold"
+    @echo "  just perf-report my_report.md # Save report to specific file"
+    @echo "  just perf-trends 30         # Analyze last 30 days"
+
+perf-large-scale-debug max_secs="1800":
+    just debug-large-scale-1p1-512 {{ max_secs }}
+    just debug-large-scale-1p1-1024 {{ max_secs }}
+
+perf-report file="": _ensure-uv
+    #!/usr/bin/env bash
+    set -euo pipefail
+    file_value="{{file}}"
+    if [ -n "$file_value" ]; then
+        uv run performance-analysis --report "$file_value"
+    else
+        timestamp=$(date +"%Y%m%d_%H%M%S")
+        uv run performance-analysis --report "performance_report_${timestamp}.md"
+        echo "📄 Report saved to: performance_report_${timestamp}.md"
+    fi
+
+perf-trends days="7": _ensure-uv
+    uv run performance-analysis --trends {{days}}
+
 publish-check: _ensure-jq
     #!/usr/bin/env bash
     set -euo pipefail
@@ -450,54 +504,6 @@ publish-check: _ensure-jq
     echo ""
     echo "✅ Publish check passed!"
 
-perf-baseline tag="": _ensure-uv
-    #!/usr/bin/env bash
-    set -euo pipefail
-    tag_value="{{tag}}"
-    if [ -n "$tag_value" ]; then
-        uv run performance-analysis --save-baseline --tag "$tag_value"
-    else
-        uv run performance-analysis --save-baseline
-    fi
-
-perf-check threshold="10.0": _ensure-uv
-    uv run performance-analysis --threshold {{threshold}}
-
-perf-compare file: _ensure-uv
-    uv run performance-analysis --compare "{{file}}"
-
-perf-help:
-    @echo "Performance Analysis Commands:"
-    @echo "  just perf-baseline [tag]    # Save current performance as baseline (optionally tagged)"
-    @echo "  just perf-check [threshold] # Check for regressions (default: 10% threshold)"
-    @echo "  just perf-report [file]     # Generate performance report"
-    @echo "  just perf-trends [days]     # Analyze trends over N days (default: 7)"
-    @echo "  just perf-compare <file>    # Compare with specific baseline file"
-    @echo ""
-    @echo "Examples:"
-    @echo "  just perf-baseline v1.0.0   # Save tagged baseline"
-    @echo "  just perf-check 5.0         # Check with 5% threshold"
-    @echo "  just perf-report my_report.md # Save report to specific file"
-    @echo "  just perf-trends 30         # Analyze last 30 days"
-
-perf-report file="": _ensure-uv
-    #!/usr/bin/env bash
-    set -euo pipefail
-    file_value="{{file}}"
-    if [ -n "$file_value" ]; then
-        uv run performance-analysis --report "$file_value"
-    else
-        timestamp=$(date +"%Y%m%d_%H%M%S")
-        uv run performance-analysis --report "performance_report_${timestamp}.md"
-        echo "📄 Report saved to: performance_report_${timestamp}.md"
-    fi
-
-perf-trends days="7": _ensure-uv
-    uv run performance-analysis --trends {{days}}
-
-python-sync: _ensure-uv
-    uv sync --group dev
-
 python-check: _ensure-uv
     uv run ruff format --check scripts/
     uv run ruff check scripts/
@@ -510,8 +516,25 @@ python-fix: _ensure-uv
 
 python-lint: python-check
 
+python-sync: _ensure-uv
+    uv sync --group dev
+
 python-typecheck: _ensure-uv
     uv run ty check scripts/
+
+# Running the binary
+run *args:
+    cargo run --bin cdt {{args}}
+
+run-example:
+    cargo run --bin cdt -- -v 32 -t 3
+
+run-release *args:
+    cargo run --release --bin cdt {{args}}
+
+# Run example simulation script
+run-simulation:
+    ./examples/scripts/basic_simulation.sh
 
 # Repository-owned Semgrep rules for project-specific diagnostics.
 semgrep: _ensure-uv
@@ -537,20 +560,6 @@ semgrep-test: _ensure-uv
     done < <(find tests/semgrep -type f ! -name '*.fixed' -print0)
 
     uv run semgrep scan --test --strict --config "$config_dir" tests/semgrep
-
-# Running the binary
-run *args:
-    cargo run --bin cdt {{args}}
-
-run-example:
-    cargo run --bin cdt -- -v 32 -t 3
-
-run-release *args:
-    cargo run --release --bin cdt {{args}}
-
-# Run example simulation script
-run-simulation:
-    ./examples/scripts/basic_simulation.sh
 
 # cspell:ignore oldname newname
 
@@ -738,6 +747,8 @@ shell-check: _ensure-shellcheck _ensure-shfmt
         echo "No shell files found to check."
     fi
 
+shell-fix: shell-fmt
+
 # Shell scripts: format (mutating)
 shell-fmt: _ensure-shfmt
     #!/usr/bin/env bash
@@ -755,8 +766,6 @@ shell-fmt: _ensure-shfmt
     # Note: justfiles are not shell scripts and are excluded from shellcheck
 
 shell-lint: shell-check
-
-shell-fix: shell-fmt
 
 # Spell check (typos)
 spell-check: _ensure-typos
@@ -796,6 +805,12 @@ spell-check: _ensure-typos
         echo "No modified files to spell-check."
     fi
 
+tag version: python-sync
+    uv run tag-release {{version}}
+
+tag-force version: python-sync
+    uv run tag-release {{version}} --force
+
 # Testing: fast tests (lib via nextest + rustdoc doctests via cargo test)
 test: test-lib test-doc
 
@@ -803,24 +818,21 @@ test: test-lib test-doc
 test-all: test test-integration test-python
     @echo "✅ All tests passed!"
 
-test-lib: _ensure-cargo-nextest
-    cargo nextest run --lib --verbose
+test-cli: _ensure-cargo-nextest
+    cargo nextest run --test cli --verbose
 
 # Doctests must stay on cargo test; nextest does not run rustdoc doctests.
 test-doc:
     cargo test --doc --verbose
 
-test-integration: _ensure-cargo-nextest
-    cargo nextest run -E 'kind(test)' --verbose
-
-test-slow: _ensure-cargo-nextest
-    cargo nextest run -E 'kind(test)' --features slow-tests --verbose
-
 test-examples: _ensure-cargo-nextest
     cargo nextest run --examples --verbose --no-tests pass
 
-test-cli: _ensure-cargo-nextest
-    cargo nextest run --test cli --verbose
+test-integration: _ensure-cargo-nextest
+    cargo nextest run -E 'kind(test)' --verbose
+
+test-lib: _ensure-cargo-nextest
+    cargo nextest run --lib --verbose
 
 test-python: _ensure-uv
     uv run python -m pytest
@@ -829,19 +841,12 @@ test-release: _ensure-cargo-nextest
     cargo nextest run --release --workspace
     cargo test --doc --release
 
-# File validation
-validate-json: _ensure-jq
-    #!/usr/bin/env bash
-    set -euo pipefail
-    files=()
-    while IFS= read -r -d '' file; do
-        files+=("$file")
-    done < <(git ls-files -z '*.json')
-    if [ "${#files[@]}" -gt 0 ]; then
-        printf '%s\0' "${files[@]}" | xargs -0 -n1 jq empty
-    else
-        echo "No JSON files found to validate."
-    fi
+test-slow: _ensure-cargo-nextest
+    cargo nextest run -E 'kind(test)' --features slow-tests --verbose
+
+toml-check: toml-fmt-check toml-lint
+
+toml-fix: toml-fmt
 
 toml-fmt: _ensure-taplo
     #!/usr/bin/env bash
@@ -885,12 +890,22 @@ toml-lint: _ensure-taplo
         echo "No TOML files found to lint."
     fi
 
-toml-check: toml-fmt-check toml-lint
-
-toml-fix: toml-fmt
-
 unused-deps: _ensure-cargo-machete
     cargo machete
+
+# File validation
+validate-json: _ensure-jq
+    #!/usr/bin/env bash
+    set -euo pipefail
+    files=()
+    while IFS= read -r -d '' file; do
+        files+=("$file")
+    done < <(git ls-files -z '*.json')
+    if [ "${#files[@]}" -gt 0 ]; then
+        printf '%s\0' "${files[@]}" | xargs -0 -n1 jq empty
+    else
+        echo "No JSON files found to validate."
+    fi
 
 yaml-check: yaml-fmt-check yaml-lint
 

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -607,6 +607,28 @@ rules:
       - pattern-regex: '(?ms)^\s*(?:@echo\s+"?\s*)?just\s+toml-fix\b[^\n]*(?:\n\s*(?:#[^\n]*)?)*?\n\s*(?:@echo\s+"?\s*)?just\s+toml-check\b' # yamllint disable-line rule:line-length
       - pattern-regex: '(?ms)^\s*(?:@echo\s+"?\s*)?just\s+shell-fix\b[^\n]*(?:\n\s*(?:#[^\n]*)?)*?\n\s*(?:@echo\s+"?\s*)?just\s+shell-check\b' # yamllint disable-line rule:line-length
 
+  - id: causal-triangulations.cli.prefer-vertices-per-slice-in-user-facing-runs
+    languages:
+      - regex
+    severity: WARNING
+    message: "Use --vertices-per-slice in user-facing cdt commands; reserve --vertices for compatibility prose and low-level tests."
+    metadata:
+      category: maintainability
+      rationale: >-
+        User-facing binary examples should model the spatial-slice parameter
+        users actually choose, leaving the total vertex count as a derived value.
+    paths:
+      include:
+        - "/README.md"
+        - "/docs/**/*.md"
+        - "/examples/scripts/**/*.md"
+        - "/examples/scripts/**/*.sh"
+        - "/tests/semgrep/docs/**/*.sh"
+    pattern-either:
+      - pattern-regex: '(?m)^\s*(?:RUST_LOG=\S+\s+)?(?:\./target/(?:debug|release)/)?cdt\b[^\n]*\s--vertices(?:\s|=)' # yamllint disable-line rule:line-length
+      - pattern-regex: '(?m)^\s*cargo\s+run\b[^\n]*--bin\s+cdt\b[^\n]*--\s+[^\n]*--vertices(?:\s|=)' # yamllint disable-line rule:line-length
+      - pattern-regex: '(?m)^\s*--vertices(?:\s|=)'
+
   - id: causal-triangulations.github-actions.external-action-sha-pinned
     languages:
       - regex

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -11,10 +11,13 @@
 use crate::config::CdtTopology;
 use crate::errors::{BackendMutationOperation, CdtError};
 use crate::geometry::CdtTriangulation2D;
-use crate::geometry::backends::delaunay::{DelaunayFaceHandle, DelaunayVertexHandle};
+use crate::geometry::backends::delaunay::{
+    DelaunayEdgeHandle, DelaunayFaceHandle, DelaunayVertexHandle,
+};
 use crate::geometry::traits::{EdgeAdjacentFaces, TriangulationQuery};
 use rand::{RngExt, SeedableRng, rngs::Xoshiro256PlusPlus};
 use serde::{Deserialize, Serialize};
+use std::array;
 use std::fmt::Display;
 
 /// Types of ergodic moves available in 2D CDT.
@@ -22,9 +25,9 @@ use std::fmt::Display;
 pub enum MoveType {
     /// (2,2) move: Flip edge between two triangles
     Move22,
-    /// (1,3) move: Add vertex by subdividing triangle
+    /// (1,3) move: Add a vertex by subdividing local CDT volume
     Move13Add,
-    /// (3,1) move: Remove vertex by merging triangles
+    /// (3,1) move: Remove a vertex by collapsing local CDT volume
     Move31Remove,
     /// Edge flip: API-compatible alias for the 2D (2,2) move
     EdgeFlip,
@@ -33,7 +36,7 @@ pub enum MoveType {
 /// Result of attempting an ergodic move.
 #[derive(Debug, Clone, PartialEq)]
 pub enum MoveResult {
-    /// Move was successfully applied
+    /// Move was successfully applied and validated as the next CDT state
     Success,
     /// Move was rejected due to causality constraints
     CausalityViolation,
@@ -41,29 +44,50 @@ pub enum MoveResult {
     GeometricViolation,
     /// Move was rejected for other reasons
     Rejected(CdtError),
-    /// Move mutated geometry but failed a required post-mutation invariant refresh
+    /// Move mutated geometry but failed a required post-mutation invariant refresh.
+    ///
+    /// Hard failures are rolled back by public move attempts and are tracked
+    /// separately from ordinary proposal rejections in [`MoveStatistics`].
     HardFailure(CdtError),
 }
 
 /// Statistics tracking for ergodic moves.
+///
+/// Attempts count every selected move proposal. Accepted counts include only
+/// moves that committed and validated successfully. Hard-failure counts record
+/// proposals that mutated the backend but failed post-mutation CDT invariants;
+/// those failures remain in the attempt denominator but are not counted as
+/// accepted moves.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MoveStatistics {
     /// Number of (2,2) moves attempted
     pub moves_22_attempted: u64,
     /// Number of (2,2) moves accepted
     pub moves_22_accepted: u64,
+    /// Number of (2,2) moves that mutated state but failed post-mutation invariants.
+    #[serde(default)]
+    pub moves_22_hard_failed: u64,
     /// Number of (1,3) moves attempted
     pub moves_13_attempted: u64,
     /// Number of (1,3) moves accepted
     pub moves_13_accepted: u64,
+    /// Number of (1,3) moves that mutated state but failed post-mutation invariants.
+    #[serde(default)]
+    pub moves_13_hard_failed: u64,
     /// Number of (3,1) moves attempted
     pub moves_31_attempted: u64,
     /// Number of (3,1) moves accepted
     pub moves_31_accepted: u64,
+    /// Number of (3,1) moves that mutated state but failed post-mutation invariants.
+    #[serde(default)]
+    pub moves_31_hard_failed: u64,
     /// Number of edge flips attempted
     pub edge_flips_attempted: u64,
     /// Number of edge flips accepted
     pub edge_flips_accepted: u64,
+    /// Number of edge flips that mutated state but failed post-mutation invariants.
+    #[serde(default)]
+    pub edge_flips_hard_failed: u64,
 }
 
 impl MoveStatistics {
@@ -102,7 +126,7 @@ impl MoveStatistics {
         }
     }
 
-    /// Records a successful move.
+    /// Records a successful move that committed and validated.
     ///
     /// # Examples
     ///
@@ -122,7 +146,39 @@ impl MoveStatistics {
         }
     }
 
+    /// Records a move that mutated state but failed a post-mutation invariant.
+    ///
+    /// Hard failures are distinct from ordinary proposal rejections and are not
+    /// counted as accepted moves. Call this after the corresponding
+    /// [`Self::record_attempt`] so acceptance-rate denominators continue to
+    /// reflect all selected proposals.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
+    ///
+    /// let mut stats = MoveStatistics::new();
+    /// stats.record_attempt(MoveType::Move31Remove);
+    /// stats.record_hard_failure(MoveType::Move31Remove);
+    /// assert_eq!(stats.moves_31_accepted, 0);
+    /// assert_eq!(stats.moves_31_hard_failed, 1);
+    /// ```
+    pub const fn record_hard_failure(&mut self, move_type: MoveType) {
+        match move_type {
+            MoveType::Move22 => self.moves_22_hard_failed += 1,
+            MoveType::Move13Add => self.moves_13_hard_failed += 1,
+            MoveType::Move31Remove => self.moves_31_hard_failed += 1,
+            MoveType::EdgeFlip => self.edge_flips_hard_failed += 1,
+        }
+    }
+
     /// Calculates acceptance rate for a specific move type.
+    ///
+    /// The returned ratio is accepted attempts divided by all attempts for that
+    /// move type. Ordinary rejections and hard failures both remain in the
+    /// denominator; hard failures are additionally visible through
+    /// [`Self::total_hard_failures`] and the per-move hard-failure fields.
     ///
     /// # Examples
     ///
@@ -154,6 +210,11 @@ impl MoveStatistics {
     }
 
     /// Calculates overall acceptance rate.
+    ///
+    /// This is the total number of committed, validated moves divided by total
+    /// attempts across all move types. Hard failures are not accepted moves, so
+    /// they lower this rate and are separately reported by
+    /// [`Self::total_hard_failures`].
     ///
     /// # Examples
     ///
@@ -188,6 +249,9 @@ impl MoveStatistics {
 
     /// Returns the total number of attempted moves across all move types.
     ///
+    /// This includes proposals that were later accepted, rejected, or recorded
+    /// as hard failures.
+    ///
     /// # Examples
     ///
     /// ```
@@ -208,6 +272,9 @@ impl MoveStatistics {
 
     /// Returns the total number of accepted moves across all move types.
     ///
+    /// This counts only moves that committed and validated successfully. It does
+    /// not include ordinary rejections or hard failures.
+    ///
     /// # Examples
     ///
     /// ```
@@ -224,6 +291,30 @@ impl MoveStatistics {
             + self.moves_13_accepted
             + self.moves_31_accepted
             + self.edge_flips_accepted
+    }
+
+    /// Returns the total number of hard failures across all move types.
+    ///
+    /// A hard failure means a proposal mutated backend state before a required
+    /// post-mutation CDT invariant check failed. Public move attempts roll back
+    /// the triangulation before returning [`MoveResult::HardFailure`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
+    ///
+    /// let mut stats = MoveStatistics::new();
+    /// stats.record_hard_failure(MoveType::Move13Add);
+    /// stats.record_hard_failure(MoveType::EdgeFlip);
+    /// assert_eq!(stats.total_hard_failures(), 2);
+    /// ```
+    #[must_use]
+    pub const fn total_hard_failures(&self) -> u64 {
+        self.moves_22_hard_failed
+            + self.moves_13_hard_failed
+            + self.moves_31_hard_failed
+            + self.edge_flips_hard_failed
     }
 }
 
@@ -249,6 +340,18 @@ pub struct ErgodicsSystem {
 enum InsertionLabel {
     Unfoliated,
     Label(u32),
+}
+
+struct ToroidalInsertionCandidate {
+    edge: DelaunayEdgeHandle,
+    face: DelaunayFaceHandle,
+    point: [f64; 2],
+    label: u32,
+}
+
+struct ToroidalRemovalCandidate {
+    vertex: DelaunayVertexHandle,
+    flip_edge: DelaunayEdgeHandle,
 }
 
 impl ErgodicsSystem {
@@ -345,14 +448,22 @@ impl ErgodicsSystem {
     /// ```
     pub fn attempt_22_move(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
         self.stats.record_attempt(MoveType::Move22);
-        self.attempt_causal_edge_flip(triangulation, MoveType::Move22)
+        let result = self.attempt_causal_edge_flip(triangulation, MoveType::Move22);
+        self.record_hard_failure_if_needed(MoveType::Move22, result)
     }
 
     /// Attempts a (1,3) move on the triangulation.
     ///
-    /// A (1,3) move inserts a vertex at the selected triangle centroid. For a
-    /// foliated triangle, the inserted vertex receives the unique time label
-    /// that keeps all three replacement triangles causal.
+    /// On open-boundary and unfoliated triangulations, a (1,3) move inserts a
+    /// vertex at the selected triangle centroid. For a foliated triangle, the
+    /// inserted vertex receives the unique time label that keeps all three
+    /// replacement triangles causal.
+    ///
+    /// On toroidal foliated triangulations, the same public move type is
+    /// realized as a spacelike-link split: the kernel subdivides one adjacent
+    /// face, labels the inserted vertex on the split link's time slice, flips
+    /// the original spacelike link away, and finalizes only if the periodic
+    /// topology and closed-S¹ slice invariants still hold.
     ///
     /// # Examples
     ///
@@ -378,7 +489,8 @@ impl ErgodicsSystem {
     /// ```
     pub fn attempt_13_move(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
         self.stats.record_attempt(MoveType::Move13Add);
-        self.attempt_13_move_mutating(triangulation)
+        let result = self.attempt_13_move_mutating(triangulation);
+        self.record_hard_failure_if_needed(MoveType::Move13Add, result)
     }
 
     /// Rollback boundary for an accepted (1,3) move application.
@@ -388,6 +500,12 @@ impl ErgodicsSystem {
     /// every early return must pass a `MoveResult` through `rollback_if_failed`
     /// or restore state itself.
     fn attempt_13_move_mutating(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
+        if matches!(triangulation.metadata().topology, CdtTopology::Toroidal)
+            && triangulation.has_foliation()
+        {
+            return self.attempt_toroidal_13_move_mutating(triangulation);
+        }
+
         let mut geometric_candidate_seen = false;
         let mut causal_candidate_count = 0;
         let mut selected_candidate = None;
@@ -451,11 +569,90 @@ impl ErgodicsSystem {
         rollback_if_failed(triangulation, snapshot, result)
     }
 
+    /// Applies the toroidal volume-add move as a spacelike-link split.
+    ///
+    /// The backend only exposes primitive bistellar edits, so this composes a
+    /// face subdivision with an immediate flip of the original spacelike link.
+    /// The intermediate same-slice triangle is never finalized as CDT state.
+    fn attempt_toroidal_13_move_mutating(
+        &mut self,
+        triangulation: &mut CdtTriangulation2D,
+    ) -> MoveResult {
+        let mut geometric_candidate_seen = false;
+        let mut causal_candidate_count = 0;
+        let mut selected_candidate = None;
+
+        let geometry = triangulation.geometry();
+        for edge in geometry.edges() {
+            let Ok(Some(adjacent)) = geometry.edge_adjacent_faces(&edge) else {
+                continue;
+            };
+            geometric_candidate_seen = true;
+
+            let Some(candidate) = toroidal_insertion_candidate(triangulation, edge, &adjacent)
+            else {
+                continue;
+            };
+
+            causal_candidate_count += 1;
+            if self.rng.random_range(0..causal_candidate_count) == 0 {
+                selected_candidate = Some(candidate);
+            }
+        }
+
+        let Some(candidate) = selected_candidate else {
+            if !geometric_candidate_seen {
+                return MoveResult::GeometricViolation;
+            }
+            return MoveResult::CausalityViolation;
+        };
+
+        let snapshot = triangulation.clone();
+        let subdivision_target = format!("face {:?}", candidate.face.simplex_key());
+        let subdivision = triangulation.subdivide_face(candidate.face, &candidate.point);
+        let subdivision = match subdivision {
+            Ok(subdivision) => subdivision,
+            Err(err) => {
+                let result = reject_backend(
+                    BackendMutationOperation::SubdivideFace,
+                    subdivision_target,
+                    &err,
+                );
+                return rollback_if_failed(triangulation, snapshot, result);
+            }
+        };
+
+        if let Err(err) =
+            triangulation.set_vertex_data(&subdivision.new_vertex, Some(candidate.label))
+        {
+            let result = MoveResult::HardFailure(CdtError::BackendMutationFailed {
+                operation: BackendMutationOperation::SetVertexData,
+                target: format!("vertex {:?}", subdivision.new_vertex.vertex_key()),
+                detail: err.to_string(),
+            });
+            return rollback_if_failed(triangulation, snapshot, result);
+        }
+
+        let flip_target = format!("{:?}", candidate.edge);
+        let flip_result = triangulation.flip_edge(candidate.edge);
+        let result = match flip_result {
+            Ok(_) => self.finish_mutated_move(triangulation, MoveType::Move13Add),
+            Err(err) => reject_backend(BackendMutationOperation::FlipEdge, flip_target, &err),
+        };
+        rollback_if_failed(triangulation, snapshot, result)
+    }
+
     /// Attempts a (3,1) move on the triangulation.
     ///
-    /// A (3,1) move removes a degree-3 vertex if its neighbouring vertices can
-    /// form one causal replacement triangle and the removal does not empty a
-    /// time slice.
+    /// On open-boundary and unfoliated triangulations, a (3,1) move removes a
+    /// degree-3 vertex if its neighbouring vertices can form one causal
+    /// replacement triangle and the removal does not empty a time slice.
+    ///
+    /// On toroidal foliated triangulations, this inverse volume move targets a
+    /// degree-4 local configuration produced by a spacelike-link split. The
+    /// kernel flips a timelike support edge so the removable vertex becomes
+    /// degree 3, then collapses it and finalizes only if the periodic topology
+    /// and closed-S¹ slice invariants still hold.
     ///
     /// # Examples
     ///
@@ -485,7 +682,8 @@ impl ErgodicsSystem {
     /// ```
     pub fn attempt_31_move(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
         self.stats.record_attempt(MoveType::Move31Remove);
-        self.attempt_31_move_mutating(triangulation)
+        let result = self.attempt_31_move_mutating(triangulation);
+        self.record_hard_failure_if_needed(MoveType::Move31Remove, result)
     }
 
     /// Rollback boundary for an accepted (3,1) move application.
@@ -494,6 +692,12 @@ impl ErgodicsSystem {
     /// bookkeeping. Once the snapshot exists, every early return must pass a
     /// `MoveResult` through `rollback_if_failed` or restore state itself.
     fn attempt_31_move_mutating(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
+        if matches!(triangulation.metadata().topology, CdtTopology::Toroidal)
+            && triangulation.has_foliation()
+        {
+            return self.attempt_toroidal_31_move_mutating(triangulation);
+        }
+
         let mut geometric_candidate_seen = false;
         let mut causal_candidate_count = 0;
         let mut selected_vertex = None;
@@ -538,6 +742,48 @@ impl ErgodicsSystem {
         rollback_if_failed(triangulation, snapshot, result)
     }
 
+    /// Applies the toroidal inverse volume move as flip-then-collapse.
+    fn attempt_toroidal_31_move_mutating(
+        &mut self,
+        triangulation: &mut CdtTriangulation2D,
+    ) -> MoveResult {
+        let mut candidate_count = 0_usize;
+        let mut selected_candidate = None;
+
+        for vertex in triangulation.geometry().vertices() {
+            let Some(candidate) = toroidal_removal_candidate(triangulation, vertex) else {
+                continue;
+            };
+
+            candidate_count += 1;
+            if self.rng.random_range(0..candidate_count) == 0 {
+                selected_candidate = Some(candidate);
+            }
+        }
+
+        let Some(candidate) = selected_candidate else {
+            return MoveResult::GeometricViolation;
+        };
+
+        let snapshot = triangulation.clone();
+        let flip_target = format!("{:?}", candidate.flip_edge);
+        let flip_result = triangulation.flip_edge(candidate.flip_edge);
+        if let Err(err) = flip_result {
+            let result = reject_backend(BackendMutationOperation::FlipEdge, flip_target, &err);
+            return rollback_if_failed(triangulation, snapshot, result);
+        }
+
+        let removal_target = format!("vertex {:?}", candidate.vertex.vertex_key());
+        let removal = triangulation.remove_vertex(candidate.vertex);
+        let result = match removal {
+            Ok(_) => self.finish_mutated_move(triangulation, MoveType::Move31Remove),
+            Err(err) => {
+                reject_backend(BackendMutationOperation::RemoveVertex, removal_target, &err)
+            }
+        };
+        rollback_if_failed(triangulation, snapshot, result)
+    }
+
     /// Attempts an edge flip move on the triangulation.
     ///
     /// In 2D this is the same bistellar k=2 operation as [`Self::attempt_22_move`].
@@ -570,7 +816,8 @@ impl ErgodicsSystem {
     /// ```
     pub fn attempt_edge_flip(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
         self.stats.record_attempt(MoveType::EdgeFlip);
-        self.attempt_causal_edge_flip(triangulation, MoveType::EdgeFlip)
+        let result = self.attempt_causal_edge_flip(triangulation, MoveType::EdgeFlip);
+        self.record_hard_failure_if_needed(MoveType::EdgeFlip, result)
     }
 
     /// Attempts a random ergodic move on the triangulation.
@@ -668,6 +915,18 @@ impl ErgodicsSystem {
 
         self.stats.record_success(move_type);
         MoveResult::Success
+    }
+
+    /// Records hard-failure telemetry without treating it as acceptance.
+    const fn record_hard_failure_if_needed(
+        &mut self,
+        move_type: MoveType,
+        result: MoveResult,
+    ) -> MoveResult {
+        if matches!(result, MoveResult::HardFailure(_)) {
+            self.stats.record_hard_failure(move_type);
+        }
+        result
     }
 }
 
@@ -809,8 +1068,8 @@ fn flip_is_causal(
 ///
 /// The candidate label must keep all three replacement triangles valid CDT
 /// triangles; unfoliated triangulations return a marker that skips labeling.
-/// Toroidal triangulations reject `(1,3)` subdivisions before mutation because
-/// the local subdivision is not compatible with the closed spatial slice
+/// Toroidal triangulations use a separate spacelike-link split path, because a
+/// bare face subdivision is not compatible with the closed spatial slice
 /// invariant.
 fn insertion_label(
     triangulation: &CdtTriangulation2D,
@@ -819,11 +1078,83 @@ fn insertion_label(
     if !triangulation.has_foliation() {
         return Some(InsertionLabel::Unfoliated);
     }
-    if matches!(triangulation.metadata().topology, CdtTopology::Toroidal) {
+
+    causal_insertion_label(triangulation, face)
+}
+
+/// Returns the previous and next labels around the toroidal time circle.
+const fn toroidal_neighbor_labels(
+    triangulation: &CdtTriangulation2D,
+    label: u32,
+) -> Option<(u32, u32)> {
+    let total = triangulation.time_slices();
+    if total < 3 || label >= total {
+        return None;
+    }
+    let previous = if label == 0 { total - 1 } else { label - 1 };
+    let next = (label + 1) % total;
+    Some((previous, next))
+}
+
+/// Checks whether two labels are the previous and next toroidal slices.
+const fn labels_are_toroidal_neighbors(
+    triangulation: &CdtTriangulation2D,
+    base: u32,
+    first: u32,
+    second: u32,
+) -> bool {
+    let Some((previous, next)) = toroidal_neighbor_labels(triangulation, base) else {
+        return false;
+    };
+    (first == previous && second == next) || (first == next && second == previous)
+}
+
+/// Selects a valid toroidal `(1,3)` candidate around one spacelike link.
+fn toroidal_insertion_candidate(
+    triangulation: &CdtTriangulation2D,
+    edge: DelaunayEdgeHandle,
+    adjacent: &EdgeAdjacentFaces<DelaunayVertexHandle, DelaunayFaceHandle>,
+) -> Option<ToroidalInsertionCandidate> {
+    let (endpoint_0, endpoint_1) = &adjacent.endpoints;
+    let endpoint_0_label = triangulation
+        .geometry()
+        .vertex_data_by_key(endpoint_0.vertex_key())?;
+    let endpoint_1_label = triangulation
+        .geometry()
+        .vertex_data_by_key(endpoint_1.vertex_key())?;
+    if endpoint_0_label != endpoint_1_label {
         return None;
     }
 
-    causal_insertion_label(triangulation, face)
+    let (opposite_0, opposite_1) = &adjacent.opposite_vertices;
+    let opposite_0_label = triangulation
+        .geometry()
+        .vertex_data_by_key(opposite_0.vertex_key())?;
+    let opposite_1_label = triangulation
+        .geometry()
+        .vertex_data_by_key(opposite_1.vertex_key())?;
+    if !labels_are_toroidal_neighbors(
+        triangulation,
+        endpoint_0_label,
+        opposite_0_label,
+        opposite_1_label,
+    ) {
+        return None;
+    }
+    if !cdt_vertex_triple(triangulation, [endpoint_0, endpoint_1, opposite_0])
+        || !cdt_vertex_triple(triangulation, [endpoint_0, endpoint_1, opposite_1])
+    {
+        return None;
+    }
+
+    let face = adjacent.faces.0.clone();
+    let point = centroid(triangulation, &face)?;
+    Some(ToroidalInsertionCandidate {
+        edge,
+        face,
+        point,
+        label: endpoint_0_label,
+    })
 }
 
 /// Finds a CDT-valid inserted vertex label without topology-specific guards.
@@ -895,19 +1226,18 @@ fn centroid(triangulation: &CdtTriangulation2D, face: &DelaunayFaceHandle) -> Op
 
 /// Computes a centroid in one periodic image, then wraps it back into the domain.
 fn toroidal_centroid(coords: &[[f64; 2]], domain: [f64; 2]) -> Option<[f64; 2]> {
-    let [reference, rest @ ..] = coords else {
+    let [reference, coord_1, coord_2] = coords else {
         return None;
     };
-    if rest.len() != 2
-        || domain
-            .iter()
-            .any(|period| !period.is_finite() || *period <= 0.0)
+    if domain
+        .iter()
+        .any(|period| !period.is_finite() || *period <= 0.0)
     {
         return None;
     }
 
     let mut centroid = *reference;
-    for coord in rest {
+    for coord in [coord_1, coord_2] {
         for axis in 0..2 {
             let period = domain[axis];
             let mut unwrapped = coord[axis];
@@ -925,6 +1255,130 @@ fn toroidal_centroid(coords: &[[f64; 2]], domain: [f64; 2]) -> Option<[f64; 2]> 
         centroid[axis] = (centroid[axis] / 3.0).rem_euclid(domain[axis]);
     }
     Some(centroid)
+}
+
+/// Returns the other endpoint of an edge if `vertex` is incident to it.
+fn other_endpoint(
+    triangulation: &CdtTriangulation2D,
+    edge: &DelaunayEdgeHandle,
+    vertex: &DelaunayVertexHandle,
+) -> Option<DelaunayVertexHandle> {
+    let (first, second) = triangulation.geometry().edge_endpoints(edge)?;
+    if &first == vertex {
+        Some(second)
+    } else if &second == vertex {
+        Some(first)
+    } else {
+        None
+    }
+}
+
+/// Returns true when a live edge connects the two vertices.
+fn edge_exists_between(
+    triangulation: &CdtTriangulation2D,
+    first: &DelaunayVertexHandle,
+    second: &DelaunayVertexHandle,
+) -> bool {
+    triangulation
+        .geometry()
+        .incident_edges(first)
+        .is_ok_and(|edges| {
+            edges.into_iter().any(|edge| {
+                triangulation
+                    .geometry()
+                    .edge_endpoints(&edge)
+                    .is_some_and(|(left, right)| &left == second || &right == second)
+            })
+        })
+}
+
+/// Checks whether two opposite vertices match an unordered pair.
+fn opposites_match_pair(
+    adjacent: &EdgeAdjacentFaces<DelaunayVertexHandle, DelaunayFaceHandle>,
+    first: &DelaunayVertexHandle,
+    second: &DelaunayVertexHandle,
+) -> bool {
+    let (opposite_0, opposite_1) = &adjacent.opposite_vertices;
+    (opposite_0 == first && opposite_1 == second) || (opposite_0 == second && opposite_1 == first)
+}
+
+/// Selects a valid toroidal inverse `(3,1)` candidate.
+fn toroidal_removal_candidate(
+    triangulation: &CdtTriangulation2D,
+    vertex: DelaunayVertexHandle,
+) -> Option<ToroidalRemovalCandidate> {
+    let label = triangulation
+        .geometry()
+        .vertex_data_by_key(vertex.vertex_key())?;
+    let slice = usize::try_from(label).ok()?;
+    if triangulation
+        .slice_sizes()
+        .get(slice)
+        .is_none_or(|&count| count <= 3)
+    {
+        return None;
+    }
+
+    let incident_edges = triangulation.geometry().incident_edges(&vertex).ok()?;
+    if incident_edges.len() != 4 {
+        return None;
+    }
+
+    let mut spacelike_neighbors: [Option<DelaunayVertexHandle>; 2] = array::from_fn(|_| None);
+    let mut timelike_neighbors: [Option<(DelaunayVertexHandle, DelaunayEdgeHandle, u32)>; 2] =
+        array::from_fn(|_| None);
+    let mut spacelike_count = 0;
+    let mut timelike_count = 0;
+    for edge in incident_edges {
+        let neighbor = other_endpoint(triangulation, &edge, &vertex)?;
+        let neighbor_label = triangulation
+            .geometry()
+            .vertex_data_by_key(neighbor.vertex_key())?;
+        match time_dist(triangulation, label, neighbor_label) {
+            0 => {
+                let slot = spacelike_neighbors.get_mut(spacelike_count)?;
+                *slot = Some(neighbor);
+                spacelike_count += 1;
+            }
+            1 => {
+                let slot = timelike_neighbors.get_mut(timelike_count)?;
+                *slot = Some((neighbor, edge, neighbor_label));
+                timelike_count += 1;
+            }
+            _ => return None,
+        }
+    }
+
+    let [Some(space_0), Some(space_1)] = spacelike_neighbors else {
+        return None;
+    };
+    let [
+        Some((_, time_edge_0, time_label_0)),
+        Some((_, time_edge_1, time_label_1)),
+    ] = timelike_neighbors
+    else {
+        return None;
+    };
+    if !labels_are_toroidal_neighbors(triangulation, label, time_label_0, time_label_1) {
+        return None;
+    }
+    if edge_exists_between(triangulation, &space_0, &space_1) {
+        return None;
+    }
+
+    for edge in [&time_edge_0, &time_edge_1] {
+        let Ok(Some(adjacent)) = triangulation.geometry().edge_adjacent_faces(edge) else {
+            continue;
+        };
+        if opposites_match_pair(&adjacent, &space_0, &space_1) {
+            return Some(ToroidalRemovalCandidate {
+                vertex,
+                flip_edge: edge.clone(),
+            });
+        }
+    }
+
+    None
 }
 
 /// Collects the three distinct neighboring vertices around a removable vertex.
@@ -998,10 +1452,92 @@ fn removal_candidate_is_causal(
         .is_some_and(|&count| count > 1)
 }
 
+/// Counts concrete local sites that can realize `move_type` from `triangulation`.
+///
+/// The Metropolis-Hastings proposal ratio uses this to account for asymmetric
+/// forward and reverse site multiplicities for volume-changing CDT moves.
+pub(crate) fn proposal_site_count(
+    triangulation: &CdtTriangulation2D,
+    move_type: MoveType,
+) -> usize {
+    match move_type {
+        MoveType::Move22 | MoveType::EdgeFlip => edge_flip_site_count(triangulation),
+        MoveType::Move13Add => insertion_site_count(triangulation),
+        MoveType::Move31Remove => removal_site_count(triangulation),
+    }
+}
+
+fn edge_flip_site_count(triangulation: &CdtTriangulation2D) -> usize {
+    let geometry = triangulation.geometry();
+    geometry
+        .edges()
+        .filter(|edge| {
+            let Ok(Some(adjacent)) = geometry.edge_adjacent_faces(edge) else {
+                return false;
+            };
+            flip_is_causal(triangulation, &adjacent)
+        })
+        .count()
+}
+
+fn insertion_site_count(triangulation: &CdtTriangulation2D) -> usize {
+    if is_toroidal_foliated(triangulation) {
+        return toroidal_insertion_site_count(triangulation);
+    }
+
+    triangulation
+        .geometry()
+        .faces()
+        .filter(|face| {
+            centroid(triangulation, face).is_some()
+                && insertion_label(triangulation, face).is_some()
+        })
+        .count()
+}
+
+fn toroidal_insertion_site_count(triangulation: &CdtTriangulation2D) -> usize {
+    let geometry = triangulation.geometry();
+    geometry
+        .edges()
+        .filter(|edge| {
+            let Ok(Some(adjacent)) = geometry.edge_adjacent_faces(edge) else {
+                return false;
+            };
+            toroidal_insertion_candidate(triangulation, edge.clone(), &adjacent).is_some()
+        })
+        .count()
+}
+
+fn removal_site_count(triangulation: &CdtTriangulation2D) -> usize {
+    if is_toroidal_foliated(triangulation) {
+        return triangulation
+            .geometry()
+            .vertices()
+            .filter(|vertex| toroidal_removal_candidate(triangulation, vertex.clone()).is_some())
+            .count();
+    }
+
+    triangulation
+        .geometry()
+        .vertices()
+        .filter(|vertex| {
+            let Some(neighbors) = neighbors3(triangulation, vertex) else {
+                return false;
+            };
+            removal_candidate_is_causal(triangulation, vertex, &neighbors)
+        })
+        .count()
+}
+
+fn is_toroidal_foliated(triangulation: &CdtTriangulation2D) -> bool {
+    matches!(triangulation.metadata().topology, CdtTopology::Toroidal)
+        && triangulation.has_foliation()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::errors::CdtValidationCheck;
+    use crate::errors::{CdtValidationCheck, CdtValidationFailure};
     use crate::geometry::DelaunayBackend2D;
     use crate::geometry::generators::{build_delaunay2_from_simplices, build_delaunay2_with_data};
     use approx::assert_relative_eq;
@@ -1058,19 +1594,70 @@ mod tests {
         ] {
             assert_relative_eq!(stats.acceptance_rate(move_type), 0.0);
             stats.record_attempt(move_type);
+            stats.record_hard_failure(move_type);
+            assert_relative_eq!(stats.acceptance_rate(move_type), 0.0);
+            stats.record_attempt(move_type);
             stats.record_success(move_type);
-            assert_relative_eq!(stats.acceptance_rate(move_type), 1.0);
+            assert_relative_eq!(stats.acceptance_rate(move_type), 0.5);
         }
 
-        assert_eq!(stats.moves_22_attempted, 1);
-        assert_eq!(stats.moves_13_attempted, 1);
-        assert_eq!(stats.moves_31_attempted, 1);
-        assert_eq!(stats.edge_flips_attempted, 1);
+        assert_eq!(stats.moves_22_attempted, 2);
+        assert_eq!(stats.moves_13_attempted, 2);
+        assert_eq!(stats.moves_31_attempted, 2);
+        assert_eq!(stats.edge_flips_attempted, 2);
         assert_eq!(stats.moves_22_accepted, 1);
         assert_eq!(stats.moves_13_accepted, 1);
         assert_eq!(stats.moves_31_accepted, 1);
         assert_eq!(stats.edge_flips_accepted, 1);
-        assert_relative_eq!(stats.total_acceptance_rate(), 1.0);
+        assert_eq!(stats.moves_22_hard_failed, 1);
+        assert_eq!(stats.moves_13_hard_failed, 1);
+        assert_eq!(stats.moves_31_hard_failed, 1);
+        assert_eq!(stats.edge_flips_hard_failed, 1);
+        assert_eq!(stats.total_hard_failures(), 4);
+        assert_relative_eq!(stats.total_acceptance_rate(), 0.5);
+    }
+
+    #[test]
+    fn hard_failure_result_updates_stats_without_acceptance() {
+        let mut system = ErgodicsSystem::new();
+        system.stats.record_attempt(MoveType::Move13Add);
+
+        let result = system.record_hard_failure_if_needed(
+            MoveType::Move13Add,
+            MoveResult::HardFailure(CdtError::ValidationFailed {
+                check: CdtValidationCheck::ErgodicMoveCandidateGeometry,
+                failure: CdtValidationFailure::ErgodicMoveCandidateGeometry {
+                    detail: "simulated hard failure".to_string(),
+                },
+            }),
+        );
+
+        assert!(matches!(result, MoveResult::HardFailure(_)));
+        assert_eq!(system.stats.moves_13_attempted, 1);
+        assert_eq!(system.stats.moves_13_accepted, 0);
+        assert_eq!(system.stats.moves_13_hard_failed, 1);
+        assert_relative_eq!(system.stats.acceptance_rate(MoveType::Move13Add), 0.0);
+    }
+
+    #[test]
+    fn move_statistics_defaults_hard_failures_for_legacy_payloads() {
+        let stats: MoveStatistics = serde_json::from_str(
+            r#"{
+                "moves_22_attempted": 1,
+                "moves_22_accepted": 1,
+                "moves_13_attempted": 2,
+                "moves_13_accepted": 0,
+                "moves_31_attempted": 3,
+                "moves_31_accepted": 0,
+                "edge_flips_attempted": 4,
+                "edge_flips_accepted": 1
+            }"#,
+        )
+        .expect("legacy move statistics should deserialize");
+
+        assert_eq!(stats.total_attempted(), 10);
+        assert_eq!(stats.total_accepted(), 2);
+        assert_eq!(stats.total_hard_failures(), 0);
     }
 
     #[test]
@@ -1169,7 +1756,9 @@ mod tests {
             snapshot,
             MoveResult::HardFailure(CdtError::ValidationFailed {
                 check: CdtValidationCheck::ErgodicMoveCandidateGeometry,
-                detail: "simulated post-mutation failure".to_string(),
+                failure: CdtValidationFailure::ErgodicMoveCandidateGeometry {
+                    detail: "simulated post-mutation failure".to_string(),
+                },
             }),
         );
 
@@ -1281,35 +1870,8 @@ mod tests {
         );
     }
 
-    /// Builds a backend-mutated toroidal subdivision fixture for testing `(3,1)` rollback support.
-    ///
-    /// The public `(1,3)` kernel now rejects this candidate after final invariant validation,
-    /// but the inverse `(3,1)` path still needs direct coverage against a periodic subdivision.
-    fn subdivide_first_toroidal_candidate(triangulation: &mut CdtTriangulation2D) {
-        let candidate = triangulation.geometry().faces().find_map(|face| {
-            let point = centroid(triangulation, &face)?;
-            let label = causal_insertion_label(triangulation, &face)?;
-            Some((face, point, label))
-        });
-        let Some((face, point, label)) = candidate else {
-            panic!("periodic toroidal fixture should contain a causal subdivision candidate");
-        };
-
-        let subdivision = triangulation
-            .subdivide_face(face, &point)
-            .expect("periodic toroidal subdivision should reach the backend");
-        if let InsertionLabel::Label(label) = label {
-            triangulation
-                .set_vertex_data(&subdivision.new_vertex, Some(label))
-                .expect("subdivision vertex label should be writable");
-        }
-        triangulation
-            .synchronize_foliation_from_live_labels()
-            .expect("subdivided fixture should rebuild foliation bookkeeping");
-    }
-
     #[test]
-    fn periodic_toroidal_move_13_rejects_invalid_s1_subdivision_before_mutation() {
+    fn periodic_toroidal_move_13_splits_spacelike_link() {
         let mut system = ErgodicsSystem::with_seed(7);
         let mut triangulation =
             CdtTriangulation2D::from_toroidal_cdt(8, 8).expect("build toroidal CDT");
@@ -1321,31 +1883,37 @@ mod tests {
 
         let result = system.attempt_13_move(&mut triangulation);
 
-        assert!(
-            matches!(result, MoveResult::CausalityViolation),
-            "periodic toroidal Move13Add should reject closed-S1 subdivision candidates before mutation, got {result:?}"
+        assert_eq!(
+            result,
+            MoveResult::Success,
+            "periodic toroidal Move13Add should split a spacelike link, got {result:?}"
         );
-        assert_eq!(system.stats.moves_13_accepted, 0);
+        assert_eq!(system.stats.moves_13_accepted, 1);
         assert_eq!(
             (
                 triangulation.vertex_count(),
                 triangulation.edge_count(),
                 triangulation.face_count(),
             ),
-            counts_before,
-            "rejected periodic toroidal subdivision should leave simplex counts unchanged"
+            (
+                counts_before.0 + 1,
+                counts_before.1 + 3,
+                counts_before.2 + 2
+            ),
+            "accepted periodic toroidal insertion should apply the CDT volume-move count delta"
         );
         triangulation
             .validate()
-            .expect("rejected periodic toroidal Move13Add should preserve evolved CDT invariants");
+            .expect("accepted periodic toroidal Move13Add should preserve evolved CDT invariants");
     }
 
     #[test]
-    fn periodic_toroidal_move_31_succeeds_after_offset_support() {
-        let mut system = ErgodicsSystem::with_seed(7);
+    fn periodic_toroidal_move_31_reverses_link_split() {
+        let mut system = ErgodicsSystem::with_seed(0);
         let mut triangulation =
             CdtTriangulation2D::from_toroidal_cdt(8, 8).expect("build toroidal CDT");
-        subdivide_first_toroidal_candidate(&mut triangulation);
+        let insert = system.attempt_13_move(&mut triangulation);
+        assert_eq!(insert, MoveResult::Success);
         let counts_before = (
             triangulation.vertex_count(),
             triangulation.edge_count(),
@@ -1373,9 +1941,56 @@ mod tests {
             ),
             "accepted periodic toroidal removal should reverse a local 1,3 subdivision"
         );
+        assert!(
+            triangulation
+                .volume_profile()
+                .iter()
+                .all(|&count| count >= 3),
+            "accepted periodic toroidal removal must preserve nonempty closed spatial slices"
+        );
         triangulation.validate().expect(
             "accepted periodic toroidal Move31Remove should preserve evolved CDT invariants",
         );
+    }
+
+    #[test]
+    fn periodic_toroidal_move_31_rejects_minimal_slice_removal() {
+        let mut system = ErgodicsSystem::with_seed(7);
+        let mut triangulation =
+            CdtTriangulation2D::from_toroidal_cdt(3, 3).expect("build minimal toroidal CDT");
+        let counts_before = (
+            triangulation.vertex_count(),
+            triangulation.edge_count(),
+            triangulation.face_count(),
+        );
+        let profile_before = triangulation.volume_profile();
+
+        let result = system.attempt_31_move(&mut triangulation);
+
+        assert_eq!(
+            result,
+            MoveResult::GeometricViolation,
+            "minimal periodic toroidal slices should not expose removable volume candidates"
+        );
+        assert_eq!(system.stats.moves_31_attempted, 1);
+        assert_eq!(system.stats.moves_31_accepted, 0);
+        assert_eq!(
+            (
+                triangulation.vertex_count(),
+                triangulation.edge_count(),
+                triangulation.face_count(),
+            ),
+            counts_before,
+            "rejected minimal toroidal removal must preserve simplex counts"
+        );
+        assert_eq!(
+            triangulation.volume_profile(),
+            profile_before,
+            "rejected minimal toroidal removal must preserve closed spatial slices"
+        );
+        triangulation
+            .validate()
+            .expect("rejected minimal toroidal removal should preserve CDT invariants");
     }
 
     #[test]

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -14,7 +14,7 @@ use crate::geometry::CdtTriangulation2D;
 use crate::geometry::backends::delaunay::{
     DelaunayEdgeHandle, DelaunayFaceHandle, DelaunayVertexHandle,
 };
-use crate::geometry::traits::{EdgeAdjacentFaces, TriangulationQuery};
+use crate::geometry::traits::{EdgeAdjacentFaces, TriangulationMut, TriangulationQuery};
 use rand::{RngExt, SeedableRng, rngs::Xoshiro256PlusPlus};
 use serde::{Deserialize, Serialize};
 use std::array;
@@ -519,6 +519,9 @@ impl ErgodicsSystem {
             let Some(label) = insertion_label(triangulation, &face) else {
                 continue;
             };
+            if !insertion_candidate_is_committable(triangulation, &face, &point, label) {
+                continue;
+            }
 
             causal_candidate_count += 1;
             if self.rng.random_range(0..causal_candidate_count) == 0 {
@@ -593,6 +596,9 @@ impl ErgodicsSystem {
             else {
                 continue;
             };
+            if !toroidal_insertion_candidate_is_committable(triangulation, &candidate) {
+                continue;
+            }
 
             causal_candidate_count += 1;
             if self.rng.random_range(0..causal_candidate_count) == 0 {
@@ -711,6 +717,9 @@ impl ErgodicsSystem {
             if !removal_candidate_is_causal(triangulation, &vertex, &neighbors) {
                 continue;
             }
+            if !removal_candidate_is_committable(triangulation, &vertex, &neighbors) {
+                continue;
+            }
 
             causal_candidate_count += 1;
             if self.rng.random_range(0..causal_candidate_count) == 0 {
@@ -754,6 +763,9 @@ impl ErgodicsSystem {
             let Some(candidate) = toroidal_removal_candidate(triangulation, vertex) else {
                 continue;
             };
+            if !toroidal_removal_candidate_is_committable(triangulation, &candidate) {
+                continue;
+            }
 
             candidate_count += 1;
             if self.rng.random_range(0..candidate_count) == 0 {
@@ -872,12 +884,7 @@ impl ErgodicsSystem {
                 continue;
             };
             geometric_candidate_seen = true;
-            if !flip_is_causal(triangulation, &adjacent) {
-                continue;
-            }
-            if !candidate_mutation_succeeds(triangulation, |candidate| {
-                candidate.flip_edge(edge.clone()).is_ok()
-            }) {
+            if !edge_flip_candidate_is_committable(triangulation, &edge, &adjacent) {
                 continue;
             }
 
@@ -1069,6 +1076,21 @@ fn flip_is_causal(
         && cdt_vertex_triple(triangulation, [endpoint_1, opposite_0, opposite_1])
 }
 
+/// Checks whether a k=2 edge flip passes the cheap deterministic edit guards.
+fn edge_flip_candidate_is_committable(
+    triangulation: &CdtTriangulation2D,
+    edge: &DelaunayEdgeHandle,
+    adjacent: &EdgeAdjacentFaces<DelaunayVertexHandle, DelaunayFaceHandle>,
+) -> bool {
+    let (opposite_0, opposite_1) = &adjacent.opposite_vertices;
+    triangulation.geometry().can_flip_edge(edge)
+        && flip_is_causal(triangulation, adjacent)
+        && !edge_exists_between(triangulation, opposite_0, opposite_1)
+        && candidate_mutation_succeeds(triangulation, |candidate| {
+            candidate.flip_edge(edge.clone()).is_ok()
+        })
+}
+
 /// Finds the inserted vertex label that makes a `(1,3)` subdivision causal.
 ///
 /// The candidate label must keep all three replacement triangles valid CDT
@@ -1085,6 +1107,27 @@ fn insertion_label(
     }
 
     causal_insertion_label(triangulation, face)
+}
+
+/// Checks coordinate-level backend preconditions for face subdivision.
+fn insertion_candidate_is_committable(
+    triangulation: &CdtTriangulation2D,
+    face: &DelaunayFaceHandle,
+    point: &[f64; 2],
+    label: InsertionLabel,
+) -> bool {
+    point.iter().all(|coordinate| coordinate.is_finite())
+        && candidate_mutation_succeeds(triangulation, |candidate| {
+            let Ok(subdivision) = candidate.subdivide_face(face.clone(), point) else {
+                return false;
+            };
+            if let InsertionLabel::Label(label) = label {
+                return candidate
+                    .set_vertex_data(&subdivision.new_vertex, Some(label))
+                    .is_ok();
+            }
+            true
+        })
 }
 
 /// Returns the previous and next labels around the toroidal time circle.
@@ -1160,6 +1203,27 @@ fn toroidal_insertion_candidate(
         point,
         label: endpoint_0_label,
     })
+}
+
+/// Checks backend-local preconditions for the toroidal spacelike-link split.
+fn toroidal_insertion_candidate_is_committable(
+    triangulation: &CdtTriangulation2D,
+    candidate: &ToroidalInsertionCandidate,
+) -> bool {
+    candidate
+        .point
+        .iter()
+        .all(|coordinate| coordinate.is_finite())
+        && candidate_mutation_succeeds(triangulation, |dry_run| {
+            let Ok(subdivision) = dry_run.subdivide_face(candidate.face.clone(), &candidate.point)
+            else {
+                return false;
+            };
+            dry_run
+                .set_vertex_data(&subdivision.new_vertex, Some(candidate.label))
+                .is_ok()
+                && dry_run.flip_edge(candidate.edge.clone()).is_ok()
+        })
 }
 
 /// Finds a CDT-valid inserted vertex label without topology-specific guards.
@@ -1297,6 +1361,22 @@ fn edge_exists_between(
         })
 }
 
+/// Returns true when a live face already spans exactly the three vertices.
+fn face_exists_with_vertices(
+    triangulation: &CdtTriangulation2D,
+    vertices: &[DelaunayVertexHandle; 3],
+) -> bool {
+    triangulation.geometry().faces().any(|face| {
+        triangulation
+            .geometry()
+            .face_vertices(&face)
+            .is_ok_and(|face_vertices| {
+                face_vertices.len() == 3
+                    && vertices.iter().all(|vertex| face_vertices.contains(vertex))
+            })
+    })
+}
+
 /// Checks whether two opposite vertices match an unordered pair.
 fn opposites_match_pair(
     adjacent: &EdgeAdjacentFaces<DelaunayVertexHandle, DelaunayFaceHandle>,
@@ -1384,6 +1464,30 @@ fn toroidal_removal_candidate(
     }
 
     None
+}
+
+/// Checks whether collapsing a degree-3 vertex would duplicate an existing face.
+fn removal_candidate_is_committable(
+    triangulation: &CdtTriangulation2D,
+    vertex: &DelaunayVertexHandle,
+    neighbors: &[DelaunayVertexHandle; 3],
+) -> bool {
+    !face_exists_with_vertices(triangulation, neighbors)
+        && candidate_mutation_succeeds(triangulation, |candidate| {
+            candidate.remove_vertex(vertex.clone()).is_ok()
+        })
+}
+
+/// Checks backend-local preconditions for the toroidal flip-then-collapse move.
+fn toroidal_removal_candidate_is_committable(
+    triangulation: &CdtTriangulation2D,
+    candidate: &ToroidalRemovalCandidate,
+) -> bool {
+    triangulation.geometry().can_flip_edge(&candidate.flip_edge)
+        && candidate_mutation_succeeds(triangulation, |dry_run| {
+            dry_run.flip_edge(candidate.flip_edge.clone()).is_ok()
+                && dry_run.remove_vertex(candidate.vertex.clone()).is_ok()
+        })
 }
 
 /// Collects the three distinct neighboring vertices around a removable vertex.
@@ -1482,10 +1586,7 @@ fn edge_flip_site_count(triangulation: &CdtTriangulation2D) -> usize {
             let Ok(Some(adjacent)) = geometry.edge_adjacent_faces(edge) else {
                 return false;
             };
-            flip_is_causal(triangulation, &adjacent)
-                && candidate_mutation_succeeds(triangulation, |candidate| {
-                    candidate.flip_edge(edge.clone()).is_ok()
-                })
+            edge_flip_candidate_is_committable(triangulation, edge, &adjacent)
         })
         .count()
 }
@@ -1506,17 +1607,7 @@ fn insertion_site_count(triangulation: &CdtTriangulation2D) -> usize {
                 return false;
             };
 
-            candidate_mutation_succeeds(triangulation, |candidate| {
-                let Ok(subdivision) = candidate.subdivide_face(face.clone(), &point) else {
-                    return false;
-                };
-                if let InsertionLabel::Label(label) = label {
-                    return candidate
-                        .set_vertex_data(&subdivision.new_vertex, Some(label))
-                        .is_ok();
-                }
-                true
-            })
+            insertion_candidate_is_committable(triangulation, face, &point, label)
         })
         .count()
 }
@@ -1533,15 +1624,7 @@ fn toroidal_insertion_site_count(triangulation: &CdtTriangulation2D) -> usize {
             else {
                 return false;
             };
-            candidate_mutation_succeeds(triangulation, |candidate| {
-                let Ok(subdivision) = candidate.subdivide_face(insert.face, &insert.point) else {
-                    return false;
-                };
-                candidate
-                    .set_vertex_data(&subdivision.new_vertex, Some(insert.label))
-                    .is_ok()
-                    && candidate.flip_edge(insert.edge).is_ok()
-            })
+            toroidal_insertion_candidate_is_committable(triangulation, &insert)
         })
         .count()
 }
@@ -1555,10 +1638,7 @@ fn removal_site_count(triangulation: &CdtTriangulation2D) -> usize {
                 let Some(remove) = toroidal_removal_candidate(triangulation, vertex.clone()) else {
                     return false;
                 };
-                candidate_mutation_succeeds(triangulation, |candidate| {
-                    candidate.flip_edge(remove.flip_edge).is_ok()
-                        && candidate.remove_vertex(remove.vertex).is_ok()
-                })
+                toroidal_removal_candidate_is_committable(triangulation, &remove)
             })
             .count();
     }
@@ -1571,20 +1651,17 @@ fn removal_site_count(triangulation: &CdtTriangulation2D) -> usize {
                 return false;
             };
             removal_candidate_is_causal(triangulation, vertex, &neighbors)
-                && candidate_mutation_succeeds(triangulation, |candidate| {
-                    candidate.remove_vertex(vertex.clone()).is_ok()
-                })
+                && removal_candidate_is_committable(triangulation, vertex, &neighbors)
         })
         .count()
 }
 
-/// Tests a candidate mutation on a clone before counting or sampling the site.
+/// Tests a candidate mutation on a cloned triangulation before counting or sampling it.
 ///
-/// Proposal-site accounting must count only local sites that can actually
-/// commit through the same backend mutation path as the executor. Running the
-/// operation on a cloned triangulation keeps the live state unchanged while
-/// filtering out sites that pass CDT-local guards but would still be rejected by
-/// the geometry backend.
+/// Metropolis-Hastings site counts must include only sites that can actually
+/// commit through the same backend mutation path as the executor. Cheap local
+/// guards run first where possible, and this dry-run catches remaining backend
+/// constraints without mutating the live state.
 fn candidate_mutation_succeeds(
     triangulation: &CdtTriangulation2D,
     operation: impl FnOnce(&mut CdtTriangulation2D) -> bool,
@@ -1886,6 +1963,64 @@ mod tests {
     }
 
     #[test]
+    fn proposal_site_count_matches_open_boundary_move_availability() {
+        let mut system = ErgodicsSystem::new();
+        let mut triangulation = single_triangle();
+
+        assert_eq!(proposal_site_count(&triangulation, MoveType::Move22), 0);
+        assert_eq!(proposal_site_count(&triangulation, MoveType::EdgeFlip), 0);
+        assert_eq!(proposal_site_count(&triangulation, MoveType::Move13Add), 1);
+        assert_eq!(
+            proposal_site_count(&triangulation, MoveType::Move31Remove),
+            0
+        );
+
+        let insert = system.attempt_13_move(&mut triangulation);
+        assert_eq!(insert, MoveResult::Success);
+        assert_eq!(proposal_site_count(&triangulation, MoveType::Move13Add), 3);
+        assert_eq!(
+            proposal_site_count(&triangulation, MoveType::Move31Remove),
+            1
+        );
+
+        let removal = system.attempt_31_move(&mut triangulation);
+        assert_eq!(removal, MoveResult::Success);
+        assert_eq!(proposal_site_count(&triangulation, MoveType::Move13Add), 1);
+        assert_eq!(
+            proposal_site_count(&triangulation, MoveType::Move31Remove),
+            0
+        );
+    }
+
+    #[test]
+    fn removal_committable_guard_rejects_existing_replacement_face() {
+        let triangulation = single_triangle();
+        let face = triangulation
+            .geometry()
+            .faces()
+            .next()
+            .expect("triangle fixture should have one face");
+        let vertices = triangulation
+            .geometry()
+            .face_vertices(&face)
+            .expect("triangle face should resolve vertices");
+        let [v0, v1, v2] = vertices.as_slice() else {
+            panic!("triangle fixture face should have exactly three vertices");
+        };
+        let replacement_vertices = [v0.clone(), v1.clone(), v2.clone()];
+
+        assert!(face_exists_with_vertices(
+            &triangulation,
+            &replacement_vertices
+        ));
+        assert!(!removal_candidate_is_committable(
+            &triangulation,
+            v0,
+            &replacement_vertices
+        ));
+    }
+
+    #[test]
     fn move_31_removes_degree_three() {
         let mut system = ErgodicsSystem::new();
         let mut triangulation = single_triangle();
@@ -2015,6 +2150,33 @@ mod tests {
         triangulation.validate().expect(
             "accepted periodic toroidal Move31Remove should preserve evolved CDT invariants",
         );
+    }
+
+    #[test]
+    fn proposal_site_count_tracks_toroidal_inverse_sites() {
+        let mut system = ErgodicsSystem::with_seed(0);
+        let mut triangulation =
+            CdtTriangulation2D::from_toroidal_cdt(8, 8).expect("build toroidal CDT");
+
+        assert!(
+            proposal_site_count(&triangulation, MoveType::Move31Remove) > 0,
+            "initial toroidal CDT should expose committable inverse-volume sites"
+        );
+        assert!(proposal_site_count(&triangulation, MoveType::Move13Add) > 0);
+
+        let insert = system.attempt_13_move(&mut triangulation);
+        assert_eq!(insert, MoveResult::Success);
+
+        assert!(
+            proposal_site_count(&triangulation, MoveType::Move31Remove) > 0,
+            "a toroidal spacelike-link split should expose at least one committable inverse site"
+        );
+
+        let removal = system.attempt_31_move(&mut triangulation);
+        assert_eq!(removal, MoveResult::Success);
+        triangulation
+            .validate()
+            .expect("proposal-counted toroidal inverse move should preserve CDT invariants");
     }
 
     #[test]

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -875,6 +875,11 @@ impl ErgodicsSystem {
             if !flip_is_causal(triangulation, &adjacent) {
                 continue;
             }
+            if !candidate_mutation_succeeds(triangulation, |candidate| {
+                candidate.flip_edge(edge.clone()).is_ok()
+            }) {
+                continue;
+            }
 
             causal_candidate_count += 1;
             if self.rng.random_range(0..causal_candidate_count) == 0 {
@@ -1456,6 +1461,8 @@ fn removal_candidate_is_causal(
 ///
 /// The Metropolis-Hastings proposal ratio uses this to account for asymmetric
 /// forward and reverse site multiplicities for volume-changing CDT moves.
+/// Counts include only sites that pass the same deterministic pre-mutation
+/// guards as the mutating executor.
 pub(crate) fn proposal_site_count(
     triangulation: &CdtTriangulation2D,
     move_type: MoveType,
@@ -1476,6 +1483,9 @@ fn edge_flip_site_count(triangulation: &CdtTriangulation2D) -> usize {
                 return false;
             };
             flip_is_causal(triangulation, &adjacent)
+                && candidate_mutation_succeeds(triangulation, |candidate| {
+                    candidate.flip_edge(edge.clone()).is_ok()
+                })
         })
         .count()
 }
@@ -1489,8 +1499,24 @@ fn insertion_site_count(triangulation: &CdtTriangulation2D) -> usize {
         .geometry()
         .faces()
         .filter(|face| {
-            centroid(triangulation, face).is_some()
-                && insertion_label(triangulation, face).is_some()
+            let Some(point) = centroid(triangulation, face) else {
+                return false;
+            };
+            let Some(label) = insertion_label(triangulation, face) else {
+                return false;
+            };
+
+            candidate_mutation_succeeds(triangulation, |candidate| {
+                let Ok(subdivision) = candidate.subdivide_face(face.clone(), &point) else {
+                    return false;
+                };
+                if let InsertionLabel::Label(label) = label {
+                    return candidate
+                        .set_vertex_data(&subdivision.new_vertex, Some(label))
+                        .is_ok();
+                }
+                true
+            })
         })
         .count()
 }
@@ -1503,7 +1529,19 @@ fn toroidal_insertion_site_count(triangulation: &CdtTriangulation2D) -> usize {
             let Ok(Some(adjacent)) = geometry.edge_adjacent_faces(edge) else {
                 return false;
             };
-            toroidal_insertion_candidate(triangulation, edge.clone(), &adjacent).is_some()
+            let Some(insert) = toroidal_insertion_candidate(triangulation, edge.clone(), &adjacent)
+            else {
+                return false;
+            };
+            candidate_mutation_succeeds(triangulation, |candidate| {
+                let Ok(subdivision) = candidate.subdivide_face(insert.face, &insert.point) else {
+                    return false;
+                };
+                candidate
+                    .set_vertex_data(&subdivision.new_vertex, Some(insert.label))
+                    .is_ok()
+                    && candidate.flip_edge(insert.edge).is_ok()
+            })
         })
         .count()
 }
@@ -1513,7 +1551,15 @@ fn removal_site_count(triangulation: &CdtTriangulation2D) -> usize {
         return triangulation
             .geometry()
             .vertices()
-            .filter(|vertex| toroidal_removal_candidate(triangulation, vertex.clone()).is_some())
+            .filter(|vertex| {
+                let Some(remove) = toroidal_removal_candidate(triangulation, vertex.clone()) else {
+                    return false;
+                };
+                candidate_mutation_succeeds(triangulation, |candidate| {
+                    candidate.flip_edge(remove.flip_edge).is_ok()
+                        && candidate.remove_vertex(remove.vertex).is_ok()
+                })
+            })
             .count();
     }
 
@@ -1525,8 +1571,26 @@ fn removal_site_count(triangulation: &CdtTriangulation2D) -> usize {
                 return false;
             };
             removal_candidate_is_causal(triangulation, vertex, &neighbors)
+                && candidate_mutation_succeeds(triangulation, |candidate| {
+                    candidate.remove_vertex(vertex.clone()).is_ok()
+                })
         })
         .count()
+}
+
+/// Tests a candidate mutation on a clone before counting or sampling the site.
+///
+/// Proposal-site accounting must count only local sites that can actually
+/// commit through the same backend mutation path as the executor. Running the
+/// operation on a cloned triangulation keeps the live state unchanged while
+/// filtering out sites that pass CDT-local guards but would still be rejected by
+/// the geometry backend.
+fn candidate_mutation_succeeds(
+    triangulation: &CdtTriangulation2D,
+    operation: impl FnOnce(&mut CdtTriangulation2D) -> bool,
+) -> bool {
+    let mut candidate = triangulation.clone();
+    operation(&mut candidate)
 }
 
 fn is_toroidal_foliated(triangulation: &CdtTriangulation2D) -> bool {

--- a/src/cdt/metropolis.rs
+++ b/src/cdt/metropolis.rs
@@ -247,11 +247,14 @@ impl Target<CdtTriangulation2D> for CdtTarget {
     }
 }
 
-/// Delayed CDT move proposal selected before mutating a triangulation.
+/// Concrete delayed CDT move proposal selected before committing live state.
 ///
-/// A plan records the selected [`MoveType`] and its count-level action delta
-/// before any triangulation mutation occurs. The delayed proposal API scores
-/// this plan first, then applies it only if the Metropolis step accepts it.
+/// A plan records the selected [`MoveType`], the action before and after the
+/// move, and a cloned triangulation containing the proposed mutation. Planning
+/// may mutate that clone to realize a concrete local site, but it never mutates
+/// the live simulation state. The delayed proposal API scores this plan with
+/// the Metropolis-Hastings forward/reverse proposal-site ratio, then commits
+/// the cloned state only if the Metropolis step accepts it.
 ///
 /// # Examples
 ///
@@ -294,6 +297,7 @@ pub struct CdtProposalPlan {
     action_before: f64,
     action_after: Option<f64>,
     delta_action: Option<f64>,
+    forward_site_count: usize,
     proposed_state: CdtTriangulation2D,
 }
 
@@ -310,17 +314,17 @@ impl CdtProposalPlan {
         self.action_before
     }
 
-    /// Returns the proposed action if the move's simplex-count delta is valid.
+    /// Returns the action of the concrete proposed state, if one was realized.
     ///
-    /// A value of `None` means the selected move cannot be scored from the
-    /// current simplex counts, so [`DelayedProposal::proposed_log_prob`] treats
-    /// the plan as impossible.
+    /// A value of `None` means the selected move could not be scored or
+    /// realized, so [`DelayedProposal::proposed_log_prob`] treats the plan as
+    /// impossible.
     #[must_use]
     pub const fn action_after(&self) -> Option<f64> {
         self.action_after
     }
 
-    /// Returns the proposal action change, if it can be evaluated.
+    /// Returns the concrete proposal action change, if it can be evaluated.
     #[must_use]
     pub const fn delta_action(&self) -> Option<f64> {
         self.delta_action
@@ -385,7 +389,7 @@ enum CdtProposalSiteRejection {
     CausalityViolation,
     /// The selected local site was geometrically invalid.
     GeometricViolation,
-    /// A move kernel rejected the selected local site with a typed CDT error.
+    /// The selected local site was rejected by the backend mutation kernel.
     Kernel(CdtError),
 }
 
@@ -478,10 +482,12 @@ impl Error for CdtProposalError {
 
 /// Delayed-commit CDT proposal distribution.
 ///
-/// This adapter exposes CDT's accept-before-mutation move ordering through the
-/// [`DelayedProposal`] API. Use the same [`ActionConfig`] as the matching
-/// [`CdtTarget`] or [`MetropolisAlgorithm`] so that proposal planning and target
-/// scoring agree.
+/// This adapter exposes CDT's clone-plan-commit move ordering through the
+/// [`DelayedProposal`] API. It plans a concrete local move on a cloned
+/// triangulation, scores the proposed state with the same [`ActionConfig`] as
+/// the matching [`CdtTarget`] or [`MetropolisAlgorithm`], corrects for
+/// forward/reverse proposal-site counts, and commits the clone only after
+/// acceptance.
 ///
 /// # Examples
 ///
@@ -1690,25 +1696,19 @@ fn validate_move_counter_bounds(move_stats: &MoveStatistics) -> CdtResult<()> {
     ];
 
     for (move_type, attempted, accepted, hard_failed) in counters {
+        if hard_failed != 0 {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeReason::MoveStatisticsInvariant,
+                format!(
+                    "{move_type:?} hard-failure move count must be zero in resumable checkpoints"
+                ),
+            ));
+        }
+
         if accepted > attempted {
             return Err(checkpoint_resume_failed(
                 CheckpointResumeReason::MoveStatisticsInvariant,
                 format!("{move_type:?} accepted move count exceeds attempted move count"),
-            ));
-        }
-
-        let finalized_or_hard_failed = accepted.checked_add(hard_failed).ok_or_else(|| {
-            checkpoint_resume_failed(
-                CheckpointResumeReason::MoveStatisticsInvariant,
-                format!("{move_type:?} accepted plus hard-failure count exceeds u64::MAX"),
-            )
-        })?;
-        if finalized_or_hard_failed > attempted {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeReason::MoveStatisticsInvariant,
-                format!(
-                    "{move_type:?} accepted plus hard-failure count exceeds attempted move count"
-                ),
             ));
         }
     }
@@ -1848,6 +1848,10 @@ fn propose_concrete_plan(
     if proposed_delta_action(action_config, simplex_counts(state), move_type).is_none() {
         return Ok(None);
     }
+    let forward_site_count = proposal_site_count(state, move_type);
+    if forward_site_count == 0 {
+        return Ok(None);
+    }
 
     let mut proposed_state = state.clone();
     let action_after = match apply_accepted_move(
@@ -1867,12 +1871,13 @@ fn propose_concrete_plan(
         action_before,
         action_after: Some(action_after),
         delta_action: Some(delta_action),
+        forward_site_count,
         proposed_state,
     }))
 }
 
-fn concrete_log_q_ratio(state: &CdtTriangulation2D, plan: &CdtProposalPlan) -> f64 {
-    let forward_sites = proposal_site_count(state, plan.move_type);
+fn concrete_log_q_ratio(_state: &CdtTriangulation2D, plan: &CdtProposalPlan) -> f64 {
+    let forward_sites = plan.forward_site_count;
     if forward_sites == 0 {
         return f64::NEG_INFINITY;
     }
@@ -2565,10 +2570,11 @@ mod tests {
     }
 
     #[test]
-    fn chain_counters_rejects_hard_failures_above_attempted() {
+    fn chain_counters_rejects_nonzero_hard_failures() {
         let stats = MoveStatistics {
-            moves_22_attempted: 1,
-            moves_22_hard_failed: 2,
+            moves_22_attempted: 3,
+            moves_22_accepted: 1,
+            moves_22_hard_failed: 1,
             ..MoveStatistics::new()
         };
         let Err(CdtError::CheckpointResumeFailed { reason, detail }) = chain_counters(&stats)
@@ -2577,7 +2583,8 @@ mod tests {
         };
 
         assert_eq!(reason, CheckpointResumeReason::MoveStatisticsInvariant);
-        assert!(detail.contains("accepted plus hard-failure count exceeds attempted move count"));
+        assert!(detail.contains("Move22"));
+        assert!(detail.contains("hard-failure move count must be zero"));
     }
 
     #[test]
@@ -3024,6 +3031,7 @@ mod tests {
             action_before: 1.0,
             action_after: None,
             delta_action: None,
+            forward_site_count: 0,
             proposed_state: triangulation.clone(),
         };
 
@@ -3071,6 +3079,7 @@ mod tests {
             action_before,
             action_after: Some(action_after),
             delta_action: Some(action_after - action_before),
+            forward_site_count: proposal_site_count(&triangulation, MoveType::Move13Add),
             proposed_state,
         };
         let mut rng = StdRng::seed_from_u64(11);

--- a/src/cdt/metropolis.rs
+++ b/src/cdt/metropolis.rs
@@ -11,11 +11,15 @@
 //! randomly selected local site.
 
 use crate::cdt::action::ActionConfig;
-use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveStatistics, MoveType};
+use crate::cdt::ergodic_moves::{
+    ErgodicsSystem, MoveResult, MoveStatistics, MoveType, proposal_site_count,
+};
 use crate::cdt::results::{Measurement, SimulationResultsBackend};
 use crate::cdt::triangulation::SimulationEvent;
 use crate::config::validate_schedule;
-use crate::errors::{CdtError, CdtResult, CheckpointResumeReason};
+use crate::errors::{
+    CdtError, CdtResult, CheckpointResumeReason, MetropolisMoveApplicationFailure,
+};
 use crate::geometry::CdtTriangulation2D;
 use crate::util::saturating_usize_to_u32;
 use markov_chain_monte_carlo::{Chain, ChainCheckpoint, DelayedProposal, Target};
@@ -575,21 +579,15 @@ impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
     ) -> Result<Option<Self::Plan>, Self::Error> {
         let move_type = self.moves.select_random_move();
         let action_before = action_for(&self.action_config, state);
-        if proposed_delta_action(&self.action_config, simplex_counts(state), move_type).is_none() {
-            cold_path();
-            return Ok(None);
-        }
-
-        let mut proposed_state = state.clone();
-        let action_after = match apply_accepted_move(
-            &mut proposed_state,
+        let plan = match propose_concrete_plan(
+            state,
             &mut self.moves,
             &self.action_config,
             move_type,
             action_before,
         ) {
-            Ok(AcceptedMoveResult::Applied { action_after }) => action_after,
-            Ok(AcceptedMoveResult::NoApplicableSite { .. }) => {
+            Ok(Some(plan)) => plan,
+            Ok(None) => {
                 cold_path();
                 return Ok(None);
             }
@@ -602,15 +600,7 @@ impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
                 });
             }
         };
-        let delta_action = action_after - action_before;
-
-        Ok(Some(CdtProposalPlan {
-            move_type,
-            action_before,
-            action_after: Some(action_after),
-            delta_action: Some(delta_action),
-            proposed_state,
-        }))
+        Ok(Some(plan))
     }
 
     fn proposed_log_prob<T: Target<CdtTriangulation2D>>(
@@ -622,6 +612,14 @@ impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
         Ok(plan
             .action_after
             .map_or(f64::NEG_INFINITY, |_| target.log_prob(&plan.proposed_state)))
+    }
+
+    fn log_q_ratio(
+        &self,
+        state: &CdtTriangulation2D,
+        plan: &Self::Plan,
+    ) -> Result<f64, Self::Error> {
+        Ok(concrete_log_q_ratio(state, plan))
     }
 
     fn info(&self, plan: &Self::Plan) -> Self::Info {
@@ -1324,7 +1322,7 @@ fn run_one_step(
         });
 
     let action_before = state.current_action;
-    let delta_action = proposed_delta_action(
+    let mut delta_action = proposed_delta_action(
         &algorithm.action_config,
         simplex_counts(&state.triangulation),
         move_type,
@@ -1332,49 +1330,51 @@ fn run_one_step(
 
     let mut accepted = false;
     let mut action_after = None;
-    if let Some(delta) = delta_action
-        && metropolis_accept(
-            delta,
-            algorithm.config.temperature,
-            &mut state.acceptance_rng,
-        )
-    {
-        match apply_accepted_move(
-            &mut state.triangulation,
+
+    let plan = if delta_action.is_some() {
+        match propose_concrete_plan(
+            &state.triangulation,
             &mut state.ergodics,
             &algorithm.action_config,
             move_type,
             action_before,
         ) {
-            Ok(AcceptedMoveResult::Applied {
-                action_after: applied_action,
-            }) => {
-                accepted = true;
-                action_after = Some(applied_action);
-                state.current_action = applied_action;
-                state.move_stats.record_success(move_type);
-                state
-                    .triangulation
-                    .record_event(SimulationEvent::MoveAccepted {
-                        move_type: format!("{move_type:?}"),
-                        step: step.into(),
-                        action_change: applied_action - action_before,
-                    });
-                validate_evolved_cdt_if_due(state)?;
-            }
-            Ok(AcceptedMoveResult::NoApplicableSite { .. }) => {
-                // A move type can be Metropolis-accepted even when bounded
-                // random local-site selection finds no realizable site. That
-                // is an ordinary proposal rejection, not a fatal simulation error.
-            }
+            Ok(plan) => plan,
             Err(err) => {
+                state.move_stats.record_hard_failure(move_type);
                 return Err(accepted_move_error(
                     step,
                     move_type,
                     err.attempt,
-                    err.source.to_string(),
+                    err.source,
                 ));
             }
+        }
+    } else {
+        None
+    };
+
+    if let Some(plan) = plan {
+        delta_action = plan.delta_action;
+        let log_alpha = -(plan.action_after.expect("planned moves have actions") - action_before)
+            / algorithm.config.temperature
+            + concrete_log_q_ratio(&state.triangulation, &plan);
+
+        if metropolis_accept_log_alpha(log_alpha, &mut state.acceptance_rng) {
+            let applied_action = plan.action_after.expect("planned moves have actions");
+            state.triangulation = plan.proposed_state;
+            accepted = true;
+            action_after = Some(applied_action);
+            state.current_action = applied_action;
+            state.move_stats.record_success(move_type);
+            state
+                .triangulation
+                .record_event(SimulationEvent::MoveAccepted {
+                    move_type: format!("{move_type:?}"),
+                    step: step.into(),
+                    action_change: applied_action - action_before,
+                });
+            validate_evolved_cdt_if_due(state)?;
         }
     }
 
@@ -1648,14 +1648,99 @@ fn validate_checkpoint_measurements(checkpoint: &CdtMcmcCheckpoint) -> CdtResult
     Ok(())
 }
 
+/// Sums move counters without allowing invalid serialized telemetry to wrap.
+fn checked_move_counter_sum(counter_name: &str, counters: [u64; 4]) -> CdtResult<u64> {
+    counters.into_iter().try_fold(0_u64, |total, count| {
+        total.checked_add(count).ok_or_else(|| {
+            checkpoint_resume_failed(
+                CheckpointResumeReason::MoveStatisticsInvariant,
+                format!("{counter_name} move count exceeds u64::MAX"),
+            )
+        })
+    })
+}
+
+/// Rejects per-move counter states that cannot be produced by the sampler.
+fn validate_move_counter_bounds(move_stats: &MoveStatistics) -> CdtResult<()> {
+    let counters = [
+        (
+            MoveType::Move22,
+            move_stats.moves_22_attempted,
+            move_stats.moves_22_accepted,
+            move_stats.moves_22_hard_failed,
+        ),
+        (
+            MoveType::Move13Add,
+            move_stats.moves_13_attempted,
+            move_stats.moves_13_accepted,
+            move_stats.moves_13_hard_failed,
+        ),
+        (
+            MoveType::Move31Remove,
+            move_stats.moves_31_attempted,
+            move_stats.moves_31_accepted,
+            move_stats.moves_31_hard_failed,
+        ),
+        (
+            MoveType::EdgeFlip,
+            move_stats.edge_flips_attempted,
+            move_stats.edge_flips_accepted,
+            move_stats.edge_flips_hard_failed,
+        ),
+    ];
+
+    for (move_type, attempted, accepted, hard_failed) in counters {
+        if accepted > attempted {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeReason::MoveStatisticsInvariant,
+                format!("{move_type:?} accepted move count exceeds attempted move count"),
+            ));
+        }
+
+        let finalized_or_hard_failed = accepted.checked_add(hard_failed).ok_or_else(|| {
+            checkpoint_resume_failed(
+                CheckpointResumeReason::MoveStatisticsInvariant,
+                format!("{move_type:?} accepted plus hard-failure count exceeds u64::MAX"),
+            )
+        })?;
+        if finalized_or_hard_failed > attempted {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeReason::MoveStatisticsInvariant,
+                format!(
+                    "{move_type:?} accepted plus hard-failure count exceeds attempted move count"
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 /// Converts CDT move statistics into generic MCMC chain counters.
 ///
 /// Accepted and rejected counts are derived from proposal accounting, with
 /// overflow and impossible accepted-above-attempted states reported as
 /// checkpoint resume errors instead of panicking.
 fn chain_counters(move_stats: &MoveStatistics) -> CdtResult<(usize, usize)> {
-    let attempted = move_stats.total_attempted();
-    let accepted = move_stats.total_accepted();
+    validate_move_counter_bounds(move_stats)?;
+    let attempted = checked_move_counter_sum(
+        "attempted",
+        [
+            move_stats.moves_22_attempted,
+            move_stats.moves_13_attempted,
+            move_stats.moves_31_attempted,
+            move_stats.edge_flips_attempted,
+        ],
+    )?;
+    let accepted = checked_move_counter_sum(
+        "accepted",
+        [
+            move_stats.moves_22_accepted,
+            move_stats.moves_13_accepted,
+            move_stats.moves_31_accepted,
+            move_stats.edge_flips_accepted,
+        ],
+    )?;
     let rejected = attempted.checked_sub(accepted).ok_or_else(|| {
         checkpoint_resume_failed(
             CheckpointResumeReason::MoveStatisticsInvariant,
@@ -1753,12 +1838,83 @@ fn proposed_delta_action(
     Some(action_after - action_before)
 }
 
+fn propose_concrete_plan(
+    state: &CdtTriangulation2D,
+    moves: &mut ErgodicsSystem,
+    action_config: &ActionConfig,
+    move_type: MoveType,
+    action_before: f64,
+) -> Result<Option<CdtProposalPlan>, MoveApplicationError> {
+    if proposed_delta_action(action_config, simplex_counts(state), move_type).is_none() {
+        return Ok(None);
+    }
+
+    let mut proposed_state = state.clone();
+    let action_after = match apply_accepted_move(
+        &mut proposed_state,
+        moves,
+        action_config,
+        move_type,
+        action_before,
+    )? {
+        AcceptedMoveResult::Applied { action_after } => action_after,
+        AcceptedMoveResult::NoApplicableSite { .. } => return Ok(None),
+    };
+    let delta_action = action_after - action_before;
+
+    Ok(Some(CdtProposalPlan {
+        move_type,
+        action_before,
+        action_after: Some(action_after),
+        delta_action: Some(delta_action),
+        proposed_state,
+    }))
+}
+
+fn concrete_log_q_ratio(state: &CdtTriangulation2D, plan: &CdtProposalPlan) -> f64 {
+    let forward_sites = proposal_site_count(state, plan.move_type);
+    if forward_sites == 0 {
+        return f64::NEG_INFINITY;
+    }
+
+    let reverse_sites =
+        proposal_site_count(&plan.proposed_state, reverse_move_type(plan.move_type));
+    if reverse_sites == 0 {
+        return f64::NEG_INFINITY;
+    }
+
+    site_count_to_f64(forward_sites).ln() - site_count_to_f64(reverse_sites).ln()
+}
+
+const fn reverse_move_type(move_type: MoveType) -> MoveType {
+    match move_type {
+        MoveType::Move22 => MoveType::Move22,
+        MoveType::Move13Add => MoveType::Move31Remove,
+        MoveType::Move31Remove => MoveType::Move13Add,
+        MoveType::EdgeFlip => MoveType::EdgeFlip,
+    }
+}
+
+/// Converts local-site counts to finite values for proposal-ratio accounting.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "site counts are converted only for logarithmic Metropolis-Hastings ratios"
+)]
+const fn site_count_to_f64(count: usize) -> f64 {
+    count as f64
+}
+
 /// Applies the Metropolis acceptance rule to a proposed action change.
 ///
 /// Factoring this out keeps the probability rule isolated from move selection
 /// and makes deterministic unit tests possible with a seeded RNG.
+#[cfg(test)]
 fn metropolis_accept<R: Rng + ?Sized>(delta_action: f64, temperature: f64, rng: &mut R) -> bool {
-    delta_action <= 0.0 || rng.random::<f64>() < (-delta_action / temperature).exp()
+    metropolis_accept_log_alpha(-delta_action / temperature, rng)
+}
+
+fn metropolis_accept_log_alpha<R: Rng + ?Sized>(log_alpha: f64, rng: &mut R) -> bool {
+    log_alpha >= 0.0 || rng.random::<f64>() < log_alpha.exp()
 }
 
 /// Compares action values with a scale-aware tolerance for checkpoint validation.
@@ -1837,17 +1993,17 @@ fn apply_accepted_move(
 /// The move kernels keep causal, geometric, and backend failures orthogonal; this
 /// wrapper adds the Metropolis step, move type, and retry context callers need to
 /// debug a failed accepted application.
-const fn accepted_move_error(
+fn accepted_move_error(
     step: u32,
     move_type: MoveType,
     attempts: usize,
-    last_failure: String,
+    source: CdtError,
 ) -> CdtError {
     CdtError::MetropolisMoveApplicationFailed {
         step,
         move_type,
         attempts,
-        last_failure,
+        source: MetropolisMoveApplicationFailure::from(source),
     }
 }
 
@@ -2393,6 +2549,38 @@ mod tests {
     }
 
     #[test]
+    fn chain_counters_rejects_counter_sum_overflow() {
+        let stats = MoveStatistics {
+            moves_22_attempted: u64::MAX,
+            moves_13_attempted: 1,
+            ..MoveStatistics::new()
+        };
+        let Err(CdtError::CheckpointResumeFailed { reason, detail }) = chain_counters(&stats)
+        else {
+            panic!("expected overflowing move statistics to fail");
+        };
+
+        assert_eq!(reason, CheckpointResumeReason::MoveStatisticsInvariant);
+        assert!(detail.contains("attempted move count exceeds u64::MAX"));
+    }
+
+    #[test]
+    fn chain_counters_rejects_hard_failures_above_attempted() {
+        let stats = MoveStatistics {
+            moves_22_attempted: 1,
+            moves_22_hard_failed: 2,
+            ..MoveStatistics::new()
+        };
+        let Err(CdtError::CheckpointResumeFailed { reason, detail }) = chain_counters(&stats)
+        else {
+            panic!("expected impossible hard-failure statistics to fail");
+        };
+
+        assert_eq!(reason, CheckpointResumeReason::MoveStatisticsInvariant);
+        assert!(detail.contains("accepted plus hard-failure count exceeds attempted move count"));
+    }
+
+    #[test]
     fn explicit_cdt_volume_profiles_count_time_slabs() {
         let strip = CdtTriangulation::from_cdt_strip(4, 3).expect("create Delaunay strip");
         assert_eq!(strip.volume_profile(), vec![6, 6, 0]);
@@ -2781,6 +2969,46 @@ mod tests {
         } else {
             assert!(proposed_log_prob.is_infinite() && proposed_log_prob.is_sign_negative());
         }
+    }
+
+    #[test]
+    fn cdt_proposal_log_q_ratio_uses_forward_and_reverse_site_counts() {
+        let action_config = ActionConfig::default();
+        let triangulation =
+            CdtTriangulation::from_toroidal_cdt(4, 3).expect("toroidal CDT should build");
+        let mut moves = ErgodicsSystem::with_seed(19);
+        let action_before = action_for(&action_config, &triangulation);
+        let plan = propose_concrete_plan(
+            &triangulation,
+            &mut moves,
+            &action_config,
+            MoveType::Move13Add,
+            action_before,
+        )
+        .expect("planning should not hard-fail")
+        .expect("toroidal triangulation should have a volume-add proposal");
+
+        let forward_sites = proposal_site_count(&triangulation, MoveType::Move13Add);
+        let reverse_sites = proposal_site_count(&plan.proposed_state, MoveType::Move31Remove);
+        assert!(forward_sites > 0);
+        assert!(reverse_sites > 0);
+
+        let expected =
+            site_count_to_f64(forward_sites).ln() - site_count_to_f64(reverse_sites).ln();
+        assert_relative_eq!(
+            concrete_log_q_ratio(&triangulation, &plan),
+            expected,
+            epsilon = 1e-12
+        );
+
+        let proposal = CdtProposal::new(action_config).expect("valid proposal configuration");
+        assert_relative_eq!(
+            proposal
+                .log_q_ratio(&triangulation, &plan)
+                .expect("proposal-ratio scoring should not fail"),
+            expected,
+            epsilon = 1e-12
+        );
     }
 
     #[test]

--- a/src/cdt/triangulation/builders.rs
+++ b/src/cdt/triangulation/builders.rs
@@ -678,7 +678,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
 mod tests {
     use super::*;
     use crate::cdt::foliation::{EdgeType, FoliationError, SimplexType};
-    use crate::errors::CdtValidationCheck;
+    use crate::errors::{CdtValidationCheck, CdtValidationFailure};
     use crate::geometry::generators::{build_delaunay2_from_simplices, build_delaunay2_with_data};
 
     /// Builds a minimal labeled Delaunay backend for constructor tests.
@@ -1035,9 +1035,8 @@ mod tests {
             result,
             Err(CdtError::ValidationFailed {
                 ref check,
-                ref detail,
+                failure: CdtValidationFailure::InvalidCdtTriangle { .. },
             }) if *check == CdtValidationCheck::Causality
-                && detail.contains("invalid CDT triangle")
         ));
     }
 

--- a/src/cdt/triangulation/foliation.rs
+++ b/src/cdt/triangulation/foliation.rs
@@ -5,7 +5,9 @@
 use super::CdtTriangulation;
 use crate::cdt::foliation::{EdgeType, Foliation, FoliationError, SimplexType, classify_simplex};
 use crate::config::CdtTopology;
-use crate::errors::{BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck};
+use crate::errors::{
+    BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
+};
 use crate::geometry::DelaunayBackend2D;
 use crate::geometry::backends::delaunay::{
     DelaunayEdgeHandle, DelaunayFaceHandle, DelaunayVertexHandle,
@@ -311,20 +313,20 @@ impl CdtTriangulation<DelaunayBackend2D> {
                 let coords = self.geometry.vertex_coordinates(&vh).map_err(|e| {
                     CdtError::ValidationFailed {
                         check: CdtValidationCheck::FoliationAssignment,
-                        detail: format!(
-                            "failed to read coordinates for vertex {:?}: {e}",
-                            vh.vertex_key()
-                        ),
+                        failure: CdtValidationFailure::VertexCoordinateReadFailed {
+                            vertex: format!("{:?}", vh.vertex_key()),
+                            detail: e.to_string(),
+                        },
                     }
                 })?;
                 if coords.len() < 2 {
                     return Err(CdtError::ValidationFailed {
                         check: CdtValidationCheck::FoliationAssignment,
-                        detail: format!(
-                            "vertex {:?} has {} coordinates, expected ≥ 2",
-                            vh.vertex_key(),
-                            coords.len()
-                        ),
+                        failure: CdtValidationFailure::VertexCoordinateDimension {
+                            vertex: format!("{:?}", vh.vertex_key()),
+                            actual: coords.len(),
+                            expected_minimum: 2,
+                        },
                     });
                 }
                 Ok((vh, coords[1]))
@@ -865,10 +867,9 @@ impl CdtTriangulation<DelaunayBackend2D> {
             if self.simplex_type(&face).is_none() {
                 return Err(CdtError::ValidationFailed {
                     check: CdtValidationCheck::SimplexClassification,
-                    detail: format!(
-                        "face {:?} is not a strict CDT simplex (expected Up or Down)",
-                        face.simplex_key()
-                    ),
+                    failure: CdtValidationFailure::NonStrictSimplex {
+                        face: format!("{:?}", face.simplex_key()),
+                    },
                 });
             }
         }
@@ -912,10 +913,9 @@ impl CdtTriangulation<DelaunayBackend2D> {
             let Some(ct) = self.simplex_type(face) else {
                 return Err(CdtError::ValidationFailed {
                     check: CdtValidationCheck::SimplexClassification,
-                    detail: format!(
-                        "face {:?} is not a strict CDT simplex (expected Up or Down)",
-                        face.simplex_key()
-                    ),
+                    failure: CdtValidationFailure::NonStrictSimplex {
+                        face: format!("{:?}", face.simplex_key()),
+                    },
                 });
             };
             classifications.push((face.simplex_key(), ct));
@@ -1393,11 +1393,15 @@ mod tests {
 
         assert!(matches!(
             CdtTriangulation::from_labeled_delaunay(backend, 1, 2),
-            Err(CdtError::ValidationFailed { ref check, ref detail })
+            Err(CdtError::ValidationFailed {
+                ref check,
+                failure: CdtValidationFailure::InvalidCdtTriangle {
+                    spacelike_edges: 3,
+                    timelike_edges: 0,
+                    ..
+                },
+            })
                 if *check == CdtValidationCheck::Causality
-                    && detail.contains("invalid CDT triangle")
-                    && detail.contains("spacelike=3")
-                    && detail.contains("timelike=0")
         ));
     }
 

--- a/src/cdt/triangulation/validation.rs
+++ b/src/cdt/triangulation/validation.rs
@@ -3,7 +3,9 @@
 //! Whole-triangulation validation and causality checks.
 
 use super::CdtTriangulation;
-use crate::errors::{CdtError, CdtResult, CdtValidationCheck, DelaunayValidationLevel};
+use crate::errors::{
+    CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure, DelaunayValidationLevel,
+};
 use crate::geometry::DelaunayBackend2D;
 use crate::geometry::backends::delaunay::DelaunayError;
 use crate::geometry::traits::TriangulationQuery;
@@ -203,18 +205,21 @@ impl CdtTriangulation<DelaunayBackend2D> {
                 );
                 CdtError::ValidationFailed {
                     check: CdtValidationCheck::Causality,
-                    detail: "failed to resolve face vertices".to_string(),
+                    failure: CdtValidationFailure::FaceVerticesUnavailable {
+                        face: format!("{:?}", face.simplex_key()),
+                        detail: err.to_string(),
+                    },
                 }
             })?;
 
             if verts.len() != 3 {
                 return Err(CdtError::ValidationFailed {
                     check: CdtValidationCheck::Causality,
-                    detail: format!(
-                        "face {:?} has {} vertices, expected 3",
-                        face.simplex_key(),
-                        verts.len(),
-                    ),
+                    failure: CdtValidationFailure::FaceVertexCount {
+                        face: format!("{:?}", face.simplex_key()),
+                        actual: verts.len(),
+                        expected: 3,
+                    },
                 });
             }
 
@@ -229,10 +234,9 @@ impl CdtTriangulation<DelaunayBackend2D> {
                     );
                     CdtError::ValidationFailed {
                         check: CdtValidationCheck::Causality,
-                        detail: format!(
-                            "vertex {:?} has no time label in a foliated triangulation",
-                            verts[0].vertex_key(),
-                        ),
+                        failure: CdtValidationFailure::MissingVertexTimeLabel {
+                            vertex: format!("{:?}", verts[0].vertex_key()),
+                        },
                     }
                 })?;
             let t1 = self
@@ -246,10 +250,9 @@ impl CdtTriangulation<DelaunayBackend2D> {
                     );
                     CdtError::ValidationFailed {
                         check: CdtValidationCheck::Causality,
-                        detail: format!(
-                            "vertex {:?} has no time label in a foliated triangulation",
-                            verts[1].vertex_key(),
-                        ),
+                        failure: CdtValidationFailure::MissingVertexTimeLabel {
+                            vertex: format!("{:?}", verts[1].vertex_key()),
+                        },
                     }
                 })?;
             let t2 = self
@@ -263,10 +266,9 @@ impl CdtTriangulation<DelaunayBackend2D> {
                     );
                     CdtError::ValidationFailed {
                         check: CdtValidationCheck::Causality,
-                        detail: format!(
-                            "vertex {:?} has no time label in a foliated triangulation",
-                            verts[2].vertex_key(),
-                        ),
+                        failure: CdtValidationFailure::MissingVertexTimeLabel {
+                            vertex: format!("{:?}", verts[2].vertex_key()),
+                        },
                     }
                 })?;
 
@@ -291,12 +293,11 @@ impl CdtTriangulation<DelaunayBackend2D> {
             if !(spacelike == 1 && timelike == 2) {
                 return Err(CdtError::ValidationFailed {
                     check: CdtValidationCheck::Causality,
-                    detail: format!(
-                        "invalid CDT triangle at face {:?}: spacelike={}, timelike={}",
-                        face.simplex_key(),
-                        spacelike,
-                        timelike
-                    ),
+                    failure: CdtValidationFailure::InvalidCdtTriangle {
+                        face: format!("{:?}", face.simplex_key()),
+                        spacelike_edges: spacelike,
+                        timelike_edges: timelike,
+                    },
                 });
             }
         }
@@ -482,11 +483,15 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(CdtError::ValidationFailed { ref check, ref detail })
+            Err(CdtError::ValidationFailed {
+                ref check,
+                failure: CdtValidationFailure::InvalidCdtTriangle {
+                    spacelike_edges: 3,
+                    timelike_edges: 0,
+                    ..
+                },
+            })
                 if *check == CdtValidationCheck::Causality
-                    && detail.contains("invalid CDT triangle")
-                    && detail.contains("spacelike=3")
-                    && detail.contains("timelike=0")
         ));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,9 +12,11 @@
 use crate::cdt::action::ActionConfig;
 use crate::cdt::metropolis::MetropolisConfig;
 use crate::errors::{CdtError, CdtResult};
-use clap::{Parser, ValueEnum};
+use clap::error::ErrorKind;
+use clap::{ArgGroup, Error as ClapError, Parser, ValueEnum};
 use dirs::home_dir;
 use serde::{Deserialize, Serialize};
+use std::ffi::OsString;
 use std::fmt::{self, Display};
 use std::path::{Component, Path, PathBuf};
 
@@ -55,62 +57,58 @@ impl fmt::Display for CdtTopology {
 
 /// Main configuration structure for CDT simulations.
 ///
-/// This combines all configuration options for the CDT simulation,
-/// including triangulation generation, action calculation, and
-/// Metropolis algorithm parameters.
-#[derive(Parser, Debug, Clone, Serialize, Deserialize)]
-#[command(author, version, about, long_about = None)]
+/// This combines the canonical runtime options for CDT construction,
+/// action calculation, and Metropolis sampling. Command-line parsing may derive
+/// some of these values from more ergonomic inputs; for example,
+/// `--vertices-per-slice` is converted into the total [`Self::vertices`] count.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CdtConfig {
-    /// Dimensionality of the triangulation
-    #[arg(short, long, value_parser = clap::value_parser!(u8).range(2..3))]
+    /// Dimensionality of the triangulation.
     pub dimension: Option<u8>,
 
-    /// Number of vertices in the initial triangulation
-    #[arg(short, long, value_parser = clap::value_parser!(u32).range(3..))]
+    /// Total number of vertices in the initial triangulation.
+    ///
+    /// This is the canonical runtime count. For regular initial CDT data it
+    /// must divide evenly by [`Self::timeslices`]; the binary's
+    /// `--vertices-per-slice` option computes this total before constructing
+    /// `CdtConfig`.
     pub vertices: u32,
 
-    /// Number of timeslices in the triangulation
-    #[arg(short, long, value_parser = clap::value_parser!(u32).range(1..))]
+    /// Number of time slices in the initial triangulation.
     pub timeslices: u32,
 
-    /// Temperature for Metropolis algorithm
-    #[arg(long, default_value = "1.0")]
+    /// Temperature for the Metropolis acceptance rule.
     pub temperature: f64,
 
-    /// Number of Monte Carlo steps to execute
-    #[arg(long, default_value = "1000")]
+    /// Number of Monte Carlo proposals to evaluate when simulation is enabled.
     pub steps: u32,
 
-    /// Number of thermalization steps (before measurements begin)
-    #[arg(long, default_value = "100")]
+    /// Number of initial simulation steps to exclude from measurements.
     pub thermalization_steps: u32,
 
-    /// Measurement frequency (take measurement every N steps)
-    #[arg(long, default_value = "10", value_parser = clap::value_parser!(u32).range(1..))]
+    /// Measurement frequency, in simulation steps.
     pub measurement_frequency: u32,
 
-    /// Coupling constant κ₀ for vertices in the action
-    #[arg(long, default_value = "1.0")]
+    /// Coupling constant κ₀ for vertices in the action.
     pub coupling_0: f64,
 
-    /// Coupling constant κ₂ for triangles in the action
-    #[arg(long, default_value = "1.0")]
+    /// Coupling constant κ₂ for triangles in the action.
     pub coupling_2: f64,
 
-    /// Cosmological constant λ in the action
-    #[arg(long, default_value = "0.1")]
+    /// Cosmological constant λ in the action.
+    ///
+    /// Current simulations do not apply volume fixing. In the unfixed-volume
+    /// ensemble this coupling controls volume growth or shrinkage through the
+    /// ordinary action difference.
     pub cosmological_constant: f64,
 
     /// Run the full CDT Metropolis simulation after constructing the initial triangulation.
-    #[arg(long, default_value_t = false)]
     pub simulate: bool,
 
-    /// Optional RNG seed for reproducible simulations
-    #[arg(long)]
+    /// Optional RNG seed for reproducible simulations.
     pub seed: Option<u64>,
 
-    /// Topology and boundary conditions for triangulation generation
-    #[arg(long, value_enum, default_value_t = CdtTopology::default())]
+    /// Topology and boundary conditions for triangulation generation.
     pub topology: CdtTopology,
 
     /// Write per-measurement simulation data to a CSV file.
@@ -119,7 +117,6 @@ pub struct CdtConfig {
     /// [`CdtConfig::resolve_path`]. Parent directories are created when output
     /// is written. [`crate::run_simulation`] rejects configurations where CSV
     /// and JSON output paths resolve to the same file.
-    #[arg(long, value_name = "PATH")]
     pub output_csv: Option<PathBuf>,
 
     /// Write simulation metadata and aggregate summary data to a JSON file.
@@ -128,8 +125,173 @@ pub struct CdtConfig {
     /// [`CdtConfig::resolve_path`]. Parent directories are created when output
     /// is written. [`crate::run_simulation`] rejects configurations where CSV
     /// and JSON output paths resolve to the same file.
-    #[arg(long, value_name = "PATH")]
     pub output_json: Option<PathBuf>,
+}
+
+/// Command-line arguments accepted by the `cdt` binary.
+#[derive(Parser)]
+#[command(
+    author,
+    version,
+    about = "Run 1+1-dimensional Causal Dynamical Triangulations simulations",
+    long_about = "Run 1+1-dimensional Causal Dynamical Triangulations simulations.\n\nConstruct a foliated CDT triangulation, optionally run the Metropolis move loop, and write measurement summaries. Prefer --vertices-per-slice for regular initial data; --vertices remains available when the total initial vertex count is already known.",
+    group = ArgGroup::new("vertex_count")
+        .required(true)
+        .args(["vertices", "vertices_per_slice"])
+)]
+struct CdtCliArgs {
+    #[arg(
+        short,
+        long,
+        help = "Triangulation dimension; currently only 2 is implemented",
+        value_parser = clap::value_parser!(u8).range(2..3)
+    )]
+    dimension: Option<u8>,
+
+    #[arg(
+        short,
+        long,
+        help = "Total initial vertex count; must divide evenly by --timeslices",
+        value_parser = clap::value_parser!(u32).range(3..)
+    )]
+    vertices: Option<u32>,
+
+    #[arg(
+        long,
+        help = "Vertices per spatial slice; total vertices are computed as this value times --timeslices",
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    vertices_per_slice: Option<u32>,
+
+    #[arg(
+        short,
+        long,
+        help = "Number of time slices; open-boundary requires at least 2, toroidal at least 3",
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    timeslices: u32,
+
+    #[arg(long, default_value = "1.0", help = "Positive Metropolis temperature")]
+    temperature: f64,
+
+    #[arg(
+        long,
+        default_value = "1000",
+        help = "Number of Metropolis proposals to evaluate when --simulate is set"
+    )]
+    steps: u32,
+
+    #[arg(
+        long,
+        default_value = "100",
+        help = "Number of initial simulation steps to exclude from measurements"
+    )]
+    thermalization_steps: u32,
+
+    #[arg(
+        long,
+        default_value = "10",
+        help = "Record one measurement every N simulation steps",
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    measurement_frequency: u32,
+
+    #[arg(
+        long,
+        default_value = "1.0",
+        help = "Regge action vertex coupling kappa_0"
+    )]
+    coupling_0: f64,
+
+    #[arg(
+        long,
+        default_value = "1.0",
+        help = "Regge action triangle coupling kappa_2"
+    )]
+    coupling_2: f64,
+
+    #[arg(
+        long,
+        default_value = "0.1",
+        help = "Regge action cosmological constant lambda"
+    )]
+    cosmological_constant: f64,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Run the Metropolis move loop after constructing the initial triangulation"
+    )]
+    simulate: bool,
+
+    #[arg(long, help = "RNG seed for reproducible move selection and acceptance")]
+    seed: Option<u64>,
+
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = CdtTopology::default(),
+        help = "Topology and boundary conditions for the initial triangulation"
+    )]
+    topology: CdtTopology,
+
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Write per-measurement simulation data to a CSV file",
+        long_help = "Write per-measurement simulation data to a CSV file. Relative paths are resolved from the current working directory, and parent directories are created when output is written."
+    )]
+    output_csv: Option<PathBuf>,
+
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Write run metadata, aggregate summaries, and final triangulation data to JSON",
+        long_help = "Write run metadata, aggregate summaries, and final triangulation data to JSON. Relative paths are resolved from the current working directory, and parent directories are created when output is written."
+    )]
+    output_json: Option<PathBuf>,
+}
+
+impl CdtCliArgs {
+    /// Converts parsed CLI arguments into the canonical runtime configuration.
+    fn into_config(self) -> Result<CdtConfig, ClapError> {
+        let vertices = if let Some(vertices) = self.vertices {
+            vertices
+        } else {
+            let vertices_per_slice = self
+                .vertices_per_slice
+                .expect("required clap group should set one vertex count");
+            vertices_per_slice
+                .checked_mul(self.timeslices)
+                .ok_or_else(|| {
+                    ClapError::raw(
+                        ErrorKind::ValueValidation,
+                        format!(
+                            "--vertices-per-slice ({vertices_per_slice}) × --timeslices ({}) exceeds u32::MAX",
+                            self.timeslices
+                        ),
+                    )
+                })?
+        };
+
+        Ok(CdtConfig {
+            dimension: self.dimension,
+            vertices,
+            timeslices: self.timeslices,
+            temperature: self.temperature,
+            steps: self.steps,
+            thermalization_steps: self.thermalization_steps,
+            measurement_frequency: self.measurement_frequency,
+            coupling_0: self.coupling_0,
+            coupling_2: self.coupling_2,
+            cosmological_constant: self.cosmological_constant,
+            simulate: self.simulate,
+            seed: self.seed,
+            topology: self.topology,
+            output_csv: self.output_csv,
+            output_json: self.output_json,
+        })
+    }
 }
 
 /// Controls how dimension overrides are applied when merging configuration.
@@ -478,7 +640,11 @@ pub(crate) fn validate_schedule(
 }
 
 impl CdtConfig {
-    /// Builds a new instance of `CdtConfig` from command line arguments.
+    /// Builds a new instance of `CdtConfig` from command-line arguments.
+    ///
+    /// This uses the binary-facing CLI parser and exits the process with
+    /// Clap's diagnostic when parsing fails. Prefer [`Self::try_from_args`] in
+    /// tests or embedding contexts that need structured errors.
     ///
     /// # Examples
     ///
@@ -489,7 +655,9 @@ impl CdtConfig {
     /// ```
     #[must_use]
     pub fn from_args() -> Self {
-        Self::parse()
+        CdtCliArgs::parse()
+            .into_config()
+            .unwrap_or_else(|err| err.exit())
     }
 
     /// Parses a `CdtConfig` from an explicit argument iterator without exiting
@@ -501,8 +669,9 @@ impl CdtConfig {
     ///
     /// # Errors
     ///
-    /// Returns [`clap::Error`] when required arguments are missing or any value
-    /// fails Clap validation.
+    /// Returns [`clap::Error`] when required arguments are missing, when any
+    /// value fails Clap validation, or when `--vertices-per-slice ×
+    /// --timeslices` overflows `u32`.
     ///
     /// # Examples
     ///
@@ -511,8 +680,8 @@ impl CdtConfig {
     ///
     /// let config = CdtConfig::try_from_args([
     ///     "cdt",
-    ///     "--vertices",
-    ///     "16",
+    ///     "--vertices-per-slice",
+    ///     "4",
     ///     "--timeslices",
     ///     "4",
     /// ])
@@ -521,15 +690,19 @@ impl CdtConfig {
     /// assert_eq!(config.vertices, 16);
     /// assert_eq!(config.timeslices, 4);
     /// ```
-    pub fn try_from_args<I, T>(args: I) -> Result<Self, clap::Error>
+    pub fn try_from_args<I, T>(args: I) -> Result<Self, ClapError>
     where
         I: IntoIterator<Item = T>,
-        T: Into<std::ffi::OsString> + Clone,
+        T: Into<OsString> + Clone,
     {
-        Self::try_parse_from(args)
+        CdtCliArgs::try_parse_from(args)?.into_config()
     }
 
-    /// Creates a new `CdtConfig` with specified basic parameters and default action parameters.
+    /// Creates a new configuration from total vertices and time slices.
+    ///
+    /// The `vertices` argument is the total initial vertex count, not a
+    /// per-slice count. Call [`Self::validate`] before running a simulation to
+    /// check topology-specific divisibility and per-slice minimums.
     ///
     /// # Examples
     ///
@@ -861,6 +1034,45 @@ mod tests {
         assert_eq!(config.timeslices, 3);
         assert!(config.simulate);
         assert_eq!(config.seed, Some(42));
+    }
+
+    #[test]
+    fn try_from_args_computes_total_vertices_from_vertices_per_slice() {
+        let config = CdtConfig::try_from_args([
+            "cdt",
+            "--vertices-per-slice",
+            "8",
+            "--timeslices",
+            "6",
+            "--topology",
+            "toroidal",
+        ])
+        .expect("per-slice CLI arguments should parse");
+
+        assert_eq!(config.vertices, 48);
+        assert_eq!(config.timeslices, 6);
+        assert_eq!(config.topology, CdtTopology::Toroidal);
+    }
+
+    #[test]
+    fn try_from_args_rejects_vertices_per_slice_overflow() {
+        let vertices_per_slice = u32::MAX.to_string();
+        let error = CdtConfig::try_from_args([
+            "cdt",
+            "--vertices-per-slice",
+            &vertices_per_slice,
+            "--timeslices",
+            "2",
+        ])
+        .expect_err("overflowed per-slice total should be a parse error");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        assert!(
+            error
+                .to_string()
+                .contains("--vertices-per-slice (4294967295) × --timeslices (2) exceeds u32::MAX"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -131,6 +131,146 @@ impl fmt::Display for CdtValidationCheck {
     }
 }
 
+/// Structured detail for crate-owned CDT validation failures.
+///
+/// This refines [`CdtError::ValidationFailed`] beyond a coarse
+/// [`CdtValidationCheck`] so callers can inspect common CDT invariant failures
+/// without parsing display text. Variants still keep string diagnostics where
+/// the source is an upstream backend message or an opaque backend handle.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::errors::CdtValidationFailure;
+///
+/// let failure = CdtValidationFailure::InvalidCdtTriangle {
+///     face: "FaceKey(3v1)".to_string(),
+///     spacelike_edges: 3,
+///     timelike_edges: 0,
+/// };
+///
+/// assert!(format!("{failure}").contains("spacelike=3"));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CdtValidationFailure {
+    /// Generic backend geometry validation failed with an upstream diagnostic.
+    BackendGeometry {
+        /// Upstream geometry validation diagnostic.
+        detail: String,
+    },
+    /// Face vertices could not be resolved through the geometry backend.
+    FaceVerticesUnavailable {
+        /// Face being validated.
+        face: String,
+        /// Lower-level face-vertex lookup diagnostic.
+        detail: String,
+    },
+    /// A face had the wrong number of vertices for a CDT triangle.
+    FaceVertexCount {
+        /// Face being validated.
+        face: String,
+        /// Number of vertices observed.
+        actual: usize,
+        /// Number of vertices expected.
+        expected: usize,
+    },
+    /// A vertex in a foliated triangulation was missing its time label.
+    MissingVertexTimeLabel {
+        /// Vertex missing its time label.
+        vertex: String,
+    },
+    /// A triangle had the wrong spacelike/timelike edge pattern.
+    InvalidCdtTriangle {
+        /// Face being validated.
+        face: String,
+        /// Number of spacelike edges observed.
+        spacelike_edges: u8,
+        /// Number of timelike edges observed.
+        timelike_edges: u8,
+    },
+    /// Coordinate lookup failed while assigning foliation labels.
+    VertexCoordinateReadFailed {
+        /// Vertex whose coordinates could not be read.
+        vertex: String,
+        /// Lower-level coordinate lookup diagnostic.
+        detail: String,
+    },
+    /// A vertex coordinate did not have enough dimensions for foliation assignment.
+    VertexCoordinateDimension {
+        /// Vertex whose coordinate dimensionality was invalid.
+        vertex: String,
+        /// Number of coordinates observed.
+        actual: usize,
+        /// Minimum number of coordinates expected.
+        expected_minimum: usize,
+    },
+    /// A foliated face was not classifiable as a strict Up or Down CDT simplex.
+    NonStrictSimplex {
+        /// Face being classified.
+        face: String,
+    },
+    /// Local ergodic-move candidate geometry failed a post-mutation invariant.
+    ErgodicMoveCandidateGeometry {
+        /// Diagnostic for the failed local candidate.
+        detail: String,
+    },
+}
+
+impl fmt::Display for CdtValidationFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BackendGeometry { detail } | Self::ErgodicMoveCandidateGeometry { detail } => {
+                formatter.write_str(detail)
+            }
+            Self::FaceVerticesUnavailable { face, detail } => {
+                write!(
+                    formatter,
+                    "failed to resolve vertices for face {face}: {detail}"
+                )
+            }
+            Self::FaceVertexCount {
+                face,
+                actual,
+                expected,
+            } => write!(
+                formatter,
+                "face {face} has {actual} vertices, expected {expected}"
+            ),
+            Self::MissingVertexTimeLabel { vertex } => write!(
+                formatter,
+                "vertex {vertex} has no time label in a foliated triangulation"
+            ),
+            Self::InvalidCdtTriangle {
+                face,
+                spacelike_edges,
+                timelike_edges,
+            } => write!(
+                formatter,
+                "invalid CDT triangle at face {face}: spacelike={spacelike_edges}, timelike={timelike_edges}"
+            ),
+            Self::VertexCoordinateReadFailed { vertex, detail } => {
+                write!(
+                    formatter,
+                    "failed to read coordinates for vertex {vertex}: {detail}"
+                )
+            }
+            Self::VertexCoordinateDimension {
+                vertex,
+                actual,
+                expected_minimum,
+            } => write!(
+                formatter,
+                "vertex {vertex} has {actual} coordinates, expected ≥ {expected_minimum}"
+            ),
+            Self::NonStrictSimplex { face } => write!(
+                formatter,
+                "face {face} is not a strict CDT simplex (expected Up or Down)"
+            ),
+        }
+    }
+}
+
 /// Category explaining why a checkpoint could not be resumed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -215,6 +355,170 @@ impl fmt::Display for CheckpointResumeReason {
     }
 }
 
+/// Lower-level source for a Metropolis-accepted move that could not be applied.
+///
+/// [`CdtError::MetropolisMoveApplicationFailed`] uses this enum to preserve the
+/// category and structured context of a hard failure after Metropolis has
+/// accepted a move type. It is intentionally smaller than recursively storing a
+/// full [`CdtError`] while still giving callers typed branches for backend,
+/// validation, topology, foliation, and causality failures.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::errors::{
+///     BackendMutationOperation, MetropolisMoveApplicationFailure,
+/// };
+///
+/// let failure = MetropolisMoveApplicationFailure::BackendMutation {
+///     operation: BackendMutationOperation::RemoveVertex,
+///     target: "vertex VertexKey(7v1)".to_string(),
+///     detail: "backend reported invalid vertex key".to_string(),
+/// };
+///
+/// assert!(format!("{failure}").contains("remove_vertex"));
+/// ```
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum MetropolisMoveApplicationFailure {
+    /// A backend payload or topology edit failed while applying the accepted move.
+    #[error("backend mutation failed [{operation}] on {target}: {detail}")]
+    BackendMutation {
+        /// Mutation operation being attempted.
+        operation: BackendMutationOperation,
+        /// Human-readable target handle.
+        target: String,
+        /// Additional failure detail.
+        detail: String,
+    },
+    /// A backend mutation failed, then rollback of staged payloads also failed.
+    #[error(
+        "backend mutation failed [{operation}] on {target}: {detail}; rollback failed: {rollback_errors}"
+    )]
+    BackendRollback {
+        /// Mutation operation being attempted when the first failure occurred.
+        operation: BackendMutationOperation,
+        /// Human-readable target handle for the first failure.
+        target: String,
+        /// Primary mutation failure detail.
+        detail: String,
+        /// Rollback failure details for one or more payloads.
+        rollback_errors: String,
+    },
+    /// Upstream Delaunay validation rejected the evolved geometry.
+    #[error("Delaunay validation failed [{level}]: {detail}")]
+    DelaunayValidation {
+        /// Cumulative upstream validation level being enforced.
+        level: DelaunayValidationLevel,
+        /// Upstream validation diagnostic.
+        detail: String,
+    },
+    /// CDT validation rejected the evolved triangulation.
+    #[error("validation failed [{check}]: {failure}")]
+    Validation {
+        /// Validation check that failed.
+        check: CdtValidationCheck,
+        /// Structured validation failure detail.
+        failure: CdtValidationFailure,
+    },
+    /// Topology metadata did not match the evolved backend Euler characteristic.
+    #[error(
+        "topology mismatch for {topology}: Euler characteristic χ={euler_characteristic}, expected one of {expected_euler_characteristics:?} (V={vertices}, E={edges}, F={faces})"
+    )]
+    TopologyMismatch {
+        /// Topology requested by CDT metadata.
+        topology: CdtTopology,
+        /// Observed Euler characteristic from the backend.
+        euler_characteristic: i128,
+        /// Accepted Euler characteristics for the requested topology.
+        expected_euler_characteristics: Vec<i128>,
+        /// Backend vertex count at validation time.
+        vertices: usize,
+        /// Backend edge count at validation time.
+        edges: usize,
+        /// Backend face count at validation time.
+        faces: usize,
+    },
+    /// Foliation bookkeeping or validation failed.
+    #[error("foliation validation failed: {0}")]
+    Foliation(FoliationError),
+    /// A post-mutation edge violated CDT causality.
+    #[error("{}", format_causality_violation(*time_0, *time_1, *step_distance))]
+    CausalityViolation {
+        /// Time label of the first endpoint.
+        time_0: u32,
+        /// Time label of the second endpoint.
+        time_1: u32,
+        /// Topology-aware temporal step distance between the two labels.
+        step_distance: u32,
+    },
+    /// A hard failure reached the Metropolis boundary through an unexpected error category.
+    #[error("unexpected accepted-move failure: {detail}")]
+    Unexpected {
+        /// Lower-level error text retained for diagnostics.
+        detail: String,
+    },
+}
+
+impl From<CdtError> for MetropolisMoveApplicationFailure {
+    fn from(error: CdtError) -> Self {
+        match error {
+            CdtError::BackendMutationFailed {
+                operation,
+                target,
+                detail,
+            } => Self::BackendMutation {
+                operation,
+                target,
+                detail,
+            },
+            CdtError::BackendRollbackFailed {
+                operation,
+                target,
+                detail,
+                rollback_errors,
+            } => Self::BackendRollback {
+                operation,
+                target,
+                detail,
+                rollback_errors,
+            },
+            CdtError::DelaunayValidationFailed { level, detail } => {
+                Self::DelaunayValidation { level, detail }
+            }
+            CdtError::ValidationFailed { check, failure } => Self::Validation { check, failure },
+            CdtError::TopologyMismatch {
+                topology,
+                euler_characteristic,
+                expected_euler_characteristics,
+                vertices,
+                edges,
+                faces,
+            } => Self::TopologyMismatch {
+                topology,
+                euler_characteristic,
+                expected_euler_characteristics,
+                vertices,
+                edges,
+                faces,
+            },
+            CdtError::Foliation(error) => Self::Foliation(error),
+            CdtError::CausalityViolation {
+                time_0,
+                time_1,
+                step_distance,
+            } => Self::CausalityViolation {
+                time_0,
+                time_1,
+                step_distance,
+            },
+            error => Self::Unexpected {
+                detail: error.to_string(),
+            },
+        }
+    }
+}
+
 /// Main error type for CDT operations.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 #[non_exhaustive]
@@ -281,8 +585,13 @@ pub enum CdtError {
         expected: String,
     },
     /// Metropolis accepted a move, but a hard backend or invariant failure stopped application.
+    ///
+    /// The [`Self::MetropolisMoveApplicationFailed::source`] field keeps the
+    /// lower-level failure category as [`MetropolisMoveApplicationFailure`] so
+    /// callers can distinguish backend mutation, validation, topology,
+    /// foliation, and causality failures without parsing the rendered message.
     #[error(
-        "Metropolis accepted {move_type:?} at step {step}, but applying it failed after {attempts} attempts; last failure: {last_failure}"
+        "Metropolis accepted {move_type:?} at step {step}, but applying it failed after {attempts} attempts; source: {source}"
     )]
     MetropolisMoveApplicationFailed {
         /// Monte Carlo step whose accepted move could not be applied.
@@ -292,7 +601,7 @@ pub enum CdtError {
         /// Number of application attempts made before failing.
         attempts: usize,
         /// Most specific lower-level rejection or failure observed.
-        last_failure: String,
+        source: MetropolisMoveApplicationFailure,
     },
     /// Constructed triangulation metadata is internally inconsistent.
     #[error(
@@ -308,13 +617,17 @@ pub enum CdtError {
         /// Expected constraint for the metadata field.
         expected: String,
     },
-    /// Validation of a constructed triangulation failed
-    #[error("Validation failed [{check}]: {detail}")]
+    /// Validation of a constructed triangulation failed.
+    ///
+    /// The [`Self::ValidationFailed::check`] field identifies the broad
+    /// validation phase, while [`Self::ValidationFailed::failure`] carries the
+    /// typed invariant failure within that phase.
+    #[error("Validation failed [{check}]: {failure}")]
     ValidationFailed {
         /// Validation check that failed.
         check: CdtValidationCheck,
-        /// Human-readable description of the failure
-        detail: String,
+        /// Structured validation failure detail.
+        failure: CdtValidationFailure,
     },
     /// Topology metadata does not match the backend Euler characteristic.
     #[error(
@@ -720,13 +1033,87 @@ mod tests {
     fn test_validation_failed_error() {
         let error = CdtError::ValidationFailed {
             check: CdtValidationCheck::Geometry,
-            detail: "backend reported invalid triangulation structure".to_string(),
+            failure: CdtValidationFailure::BackendGeometry {
+                detail: "backend reported invalid triangulation structure".to_string(),
+            },
         };
         let display = format!("{error}");
         assert_eq!(
             display,
             "Validation failed [geometry]: backend reported invalid triangulation structure"
         );
+    }
+
+    #[test]
+    fn cdt_validation_failure_display_covers_structured_variants() {
+        let cases = [
+            (
+                CdtValidationFailure::BackendGeometry {
+                    detail: "backend rejected structure".to_string(),
+                },
+                "backend rejected structure",
+            ),
+            (
+                CdtValidationFailure::FaceVerticesUnavailable {
+                    face: "FaceKey(3v1)".to_string(),
+                    detail: "backend reported invalid simplex key".to_string(),
+                },
+                "failed to resolve vertices for face FaceKey(3v1): backend reported invalid simplex key",
+            ),
+            (
+                CdtValidationFailure::FaceVertexCount {
+                    face: "FaceKey(3v1)".to_string(),
+                    actual: 4,
+                    expected: 3,
+                },
+                "face FaceKey(3v1) has 4 vertices, expected 3",
+            ),
+            (
+                CdtValidationFailure::MissingVertexTimeLabel {
+                    vertex: "VertexKey(7v1)".to_string(),
+                },
+                "vertex VertexKey(7v1) has no time label in a foliated triangulation",
+            ),
+            (
+                CdtValidationFailure::InvalidCdtTriangle {
+                    face: "FaceKey(3v1)".to_string(),
+                    spacelike_edges: 3,
+                    timelike_edges: 0,
+                },
+                "invalid CDT triangle at face FaceKey(3v1): spacelike=3, timelike=0",
+            ),
+            (
+                CdtValidationFailure::VertexCoordinateReadFailed {
+                    vertex: "VertexKey(7v1)".to_string(),
+                    detail: "missing vertex".to_string(),
+                },
+                "failed to read coordinates for vertex VertexKey(7v1): missing vertex",
+            ),
+            (
+                CdtValidationFailure::VertexCoordinateDimension {
+                    vertex: "VertexKey(7v1)".to_string(),
+                    actual: 1,
+                    expected_minimum: 2,
+                },
+                "vertex VertexKey(7v1) has 1 coordinates, expected ≥ 2",
+            ),
+            (
+                CdtValidationFailure::NonStrictSimplex {
+                    face: "FaceKey(3v1)".to_string(),
+                },
+                "face FaceKey(3v1) is not a strict CDT simplex (expected Up or Down)",
+            ),
+            (
+                CdtValidationFailure::ErgodicMoveCandidateGeometry {
+                    detail: "candidate edge has no adjacent faces".to_string(),
+                },
+                "candidate edge has no adjacent faces",
+            ),
+        ];
+
+        for (failure, expected) in cases {
+            assert_eq!(failure.to_string(), expected);
+        }
     }
 
     #[test]
@@ -801,16 +1188,81 @@ mod tests {
 
     #[test]
     fn test_metropolis_move_application_failed_error() {
+        let source = MetropolisMoveApplicationFailure::BackendMutation {
+            operation: BackendMutationOperation::SetVertexData,
+            target: "vertex VertexKey(123v1)".to_string(),
+            detail: "backend reported invalid vertex key".to_string(),
+        };
         let error = CdtError::MetropolisMoveApplicationFailed {
             step: 17,
             move_type: MoveType::Move31Remove,
             attempts: 8,
-            last_failure: "no geometrically valid candidate site found".to_string(),
+            source: source.clone(),
         };
         let display = format!("{error}");
         assert_eq!(
             display,
-            "Metropolis accepted Move31Remove at step 17, but applying it failed after 8 attempts; last failure: no geometrically valid candidate site found"
+            "Metropolis accepted Move31Remove at step 17, but applying it failed after 8 attempts; source: backend mutation failed [set_vertex_data] on vertex VertexKey(123v1): backend reported invalid vertex key"
+        );
+        assert_eq!(
+            Error::source(&error).map(ToString::to_string),
+            Some(source.to_string())
+        );
+    }
+
+    #[test]
+    fn metropolis_move_application_failure_preserves_backend_mutation_fields() {
+        let failure = MetropolisMoveApplicationFailure::from(CdtError::BackendMutationFailed {
+            operation: BackendMutationOperation::RemoveVertex,
+            target: "vertex VertexKey(7v1)".to_string(),
+            detail: "backend reported invalid vertex key".to_string(),
+        });
+
+        let MetropolisMoveApplicationFailure::BackendMutation {
+            operation,
+            target,
+            detail,
+        } = failure
+        else {
+            panic!("expected backend mutation failure source");
+        };
+
+        assert_eq!(operation, BackendMutationOperation::RemoveVertex);
+        assert_eq!(target, "vertex VertexKey(7v1)");
+        assert_eq!(detail, "backend reported invalid vertex key");
+    }
+
+    #[test]
+    fn metropolis_move_application_failure_preserves_validation_fields() {
+        let validation_failure = CdtValidationFailure::InvalidCdtTriangle {
+            face: "FaceKey(3v1)".to_string(),
+            spacelike_edges: 3,
+            timelike_edges: 0,
+        };
+        let failure = MetropolisMoveApplicationFailure::from(CdtError::ValidationFailed {
+            check: CdtValidationCheck::Causality,
+            failure: validation_failure.clone(),
+        });
+
+        let MetropolisMoveApplicationFailure::Validation { check, failure } = failure else {
+            panic!("expected validation failure source");
+        };
+
+        assert_eq!(check, CdtValidationCheck::Causality);
+        assert_eq!(failure, validation_failure);
+    }
+
+    #[test]
+    fn metropolis_move_application_failure_unexpected_retains_diagnostic() {
+        let failure = MetropolisMoveApplicationFailure::from(CdtError::UnsupportedDimension(3));
+
+        let MetropolisMoveApplicationFailure::Unexpected { detail } = failure else {
+            panic!("expected unexpected failure source");
+        };
+
+        assert_eq!(
+            detail,
+            "Unsupported dimension: 3. Only 2D is currently supported"
         );
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -512,6 +512,7 @@ impl From<CdtError> for MetropolisMoveApplicationFailure {
                 time_1,
                 step_distance,
             },
+            CdtError::MetropolisMoveApplicationFailed { source, .. } => source,
             error => Self::Unexpected {
                 detail: error.to_string(),
             },
@@ -1250,6 +1251,94 @@ mod tests {
 
         assert_eq!(check, CdtValidationCheck::Causality);
         assert_eq!(failure, validation_failure);
+    }
+
+    #[test]
+    fn metropolis_move_application_failure_preserves_structured_sources() {
+        let cases = [
+            (
+                CdtError::BackendRollbackFailed {
+                    operation: BackendMutationOperation::FlipEdge,
+                    target: "edge EdgeKey(5v1)".to_string(),
+                    detail: "flip failed".to_string(),
+                    rollback_errors: "rollback failed".to_string(),
+                },
+                MetropolisMoveApplicationFailure::BackendRollback {
+                    operation: BackendMutationOperation::FlipEdge,
+                    target: "edge EdgeKey(5v1)".to_string(),
+                    detail: "flip failed".to_string(),
+                    rollback_errors: "rollback failed".to_string(),
+                },
+            ),
+            (
+                CdtError::DelaunayValidationFailed {
+                    level: DelaunayValidationLevel::Three,
+                    detail: "invalid triangulation".to_string(),
+                },
+                MetropolisMoveApplicationFailure::DelaunayValidation {
+                    level: DelaunayValidationLevel::Three,
+                    detail: "invalid triangulation".to_string(),
+                },
+            ),
+            (
+                CdtError::TopologyMismatch {
+                    topology: CdtTopology::Toroidal,
+                    euler_characteristic: 1,
+                    expected_euler_characteristics: vec![0],
+                    vertices: 3,
+                    edges: 3,
+                    faces: 1,
+                },
+                MetropolisMoveApplicationFailure::TopologyMismatch {
+                    topology: CdtTopology::Toroidal,
+                    euler_characteristic: 1,
+                    expected_euler_characteristics: vec![0],
+                    vertices: 3,
+                    edges: 3,
+                    faces: 1,
+                },
+            ),
+            (
+                CdtError::Foliation(FoliationError::EmptySlice { slice: 3 }),
+                MetropolisMoveApplicationFailure::Foliation(FoliationError::EmptySlice {
+                    slice: 3,
+                }),
+            ),
+            (
+                CdtError::CausalityViolation {
+                    time_0: 0,
+                    time_1: 2,
+                    step_distance: 2,
+                },
+                MetropolisMoveApplicationFailure::CausalityViolation {
+                    time_0: 0,
+                    time_1: 2,
+                    step_distance: 2,
+                },
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(MetropolisMoveApplicationFailure::from(error), expected);
+        }
+    }
+
+    #[test]
+    fn metropolis_move_application_failure_from_wrapper_preserves_source() {
+        let source = MetropolisMoveApplicationFailure::BackendMutation {
+            operation: BackendMutationOperation::RemoveVertex,
+            target: "vertex VertexKey(7v1)".to_string(),
+            detail: "backend reported invalid vertex key".to_string(),
+        };
+        let failure =
+            MetropolisMoveApplicationFailure::from(CdtError::MetropolisMoveApplicationFailed {
+                step: 17,
+                move_type: MoveType::Move31Remove,
+                attempts: 8,
+                source: source.clone(),
+            });
+
+        assert_eq!(failure, source);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,8 +141,9 @@ pub use cdt::observables::{estimate_hausdorff_dimension, estimate_spectral_dimen
 pub use cdt::results::{Measurement, SimulationResultsBackend};
 pub use config::{CdtConfig, CdtConfigOverrides, CdtTopology, DimensionOverride, TestConfig};
 pub use errors::{
-    BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CheckpointOperation,
-    CheckpointResumeReason, DelaunayValidationLevel, OutputFormat,
+    BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
+    CheckpointOperation, CheckpointResumeReason, DelaunayValidationLevel,
+    MetropolisMoveApplicationFailure, OutputFormat,
 };
 
 use crate::util::saturating_usize_to_u32;
@@ -196,21 +197,28 @@ pub mod prelude {
     /// Focused exports for crate error handling.
     ///
     /// ```
-    /// use causal_triangulations::prelude::errors::CdtError;
+    /// use causal_triangulations::prelude::errors::{
+    ///     BackendMutationOperation, CdtError, MetropolisMoveApplicationFailure,
+    /// };
     /// use causal_triangulations::prelude::moves::MoveType;
     ///
     /// let err = CdtError::MetropolisMoveApplicationFailed {
     ///     step: 3,
     ///     move_type: MoveType::Move31Remove,
     ///     attempts: 8,
-    ///     last_failure: "no geometrically valid candidate site found".to_string(),
+    ///     source: MetropolisMoveApplicationFailure::BackendMutation {
+    ///         operation: BackendMutationOperation::RemoveVertex,
+    ///         target: "vertex VertexKey(7v1)".to_string(),
+    ///         detail: "backend reported invalid vertex key".to_string(),
+    ///     },
     /// };
     /// assert!(format!("{err}").contains("Metropolis accepted Move31Remove"));
     /// ```
     pub mod errors {
         pub use crate::errors::{
-            BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CheckpointOperation,
-            CheckpointResumeReason, DelaunayValidationLevel, OutputFormat,
+            BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck,
+            CdtValidationFailure, CheckpointOperation, CheckpointResumeReason,
+            DelaunayValidationLevel, MetropolisMoveApplicationFailure, OutputFormat,
         };
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -23,6 +23,10 @@ fn temp_output_dir(name: &str) -> PathBuf {
     ))
 }
 
+fn cdt_command() -> Command {
+    Command::new(assert_cmd::cargo::cargo_bin!("cdt"))
+}
+
 /// Returns the current test thread name with path separators and
 /// reserved characters removed.
 fn safe_thread_name() -> String {
@@ -40,7 +44,7 @@ fn safe_thread_name() -> String {
 
 #[test]
 fn exit_success() {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
     cmd.arg("-v");
     cmd.arg("36");
     cmd.arg("-t");
@@ -50,7 +54,7 @@ fn exit_success() {
 
 #[test]
 fn cdt_cli_args() {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
 
     cmd.arg("-v");
     cmd.arg("36");
@@ -65,7 +69,7 @@ fn cdt_cli_args() {
 
 #[test]
 fn cdt_cli_no_args() {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
 
     cmd.assert().failure().stderr(predicate::str::contains(
         "error: the following required arguments were not provided:",
@@ -73,8 +77,43 @@ fn cdt_cli_no_args() {
 }
 
 #[test]
+fn cdt_cli_help_documents_readme_usage() {
+    let mut cmd = cdt_command();
+
+    cmd.arg("--help");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Run 1+1-dimensional Causal Dynamical Triangulations simulations",
+        ))
+        .stdout(predicate::str::contains(
+            "Vertices per spatial slice; total vertices are computed",
+        ))
+        .stdout(predicate::str::contains("--vertices-per-slice"))
+        .stdout(predicate::str::contains("--topology <TOPOLOGY>"))
+        .stdout(predicate::str::contains("toroidal"))
+        .stdout(predicate::str::contains("--output-json <PATH>"));
+}
+
+#[test]
+fn cdt_cli_rejects_ambiguous_vertex_count_inputs() {
+    let mut cmd = cdt_command();
+
+    cmd.arg("--vertices").arg("12");
+    cmd.arg("--vertices-per-slice").arg("4");
+    cmd.arg("--timeslices").arg("3");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "the argument '--vertices <VERTICES>' cannot be used with '--vertices-per-slice <VERTICES_PER_SLICE>'",
+        ));
+}
+
+#[test]
 fn cdt_cli_invalid_args() {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
 
     cmd.arg("-v");
     cmd.arg("36");
@@ -90,7 +129,7 @@ fn cdt_cli_invalid_args() {
 
 #[test]
 fn cdt_cli_rejects_unimplemented_dimension_at_parse_time() {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
 
     cmd.arg("-v");
     cmd.arg("36");
@@ -108,9 +147,9 @@ fn cdt_cli_rejects_unimplemented_dimension_at_parse_time() {
 fn cdt_cli_invalid_measurement_frequency_zero() {
     // Note: This would be caught by clap's range validation now,
     // but we test the error message for completeness
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
 
-    cmd.arg("--vertices").arg("12");
+    cmd.arg("--vertices-per-slice").arg("4");
     cmd.arg("--timeslices").arg("3");
     cmd.arg("--measurement-frequency").arg("0");
 
@@ -121,9 +160,9 @@ fn cdt_cli_invalid_measurement_frequency_zero() {
 
 #[test]
 fn cdt_cli_invalid_measurement_frequency_too_large() {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
 
-    cmd.arg("--vertices").arg("12");
+    cmd.arg("--vertices-per-slice").arg("4");
     cmd.arg("--timeslices").arg("3");
     cmd.arg("--steps").arg("100");
     cmd.arg("--measurement-frequency").arg("200");
@@ -136,9 +175,9 @@ fn cdt_cli_invalid_measurement_frequency_too_large() {
 
 #[test]
 fn cdt_cli_runs_simulation_with_real_moves() {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
 
-    cmd.arg("--vertices").arg("12");
+    cmd.arg("--vertices-per-slice").arg("4");
     cmd.arg("--timeslices").arg("3");
     cmd.arg("--steps").arg("20");
     cmd.arg("--thermalization-steps").arg("15");
@@ -155,9 +194,9 @@ fn cdt_cli_writes_configured_outputs() {
     let output_dir = temp_output_dir("outputs");
     let csv_path = output_dir.join("measurements.csv");
     let json_path = output_dir.join("summary.json");
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
 
-    cmd.arg("--vertices").arg("12");
+    cmd.arg("--vertices-per-slice").arg("4");
     cmd.arg("--timeslices").arg("3");
     cmd.arg("--steps").arg("4");
     cmd.arg("--thermalization-steps").arg("0");
@@ -181,8 +220,54 @@ fn cdt_cli_writes_configured_outputs() {
 }
 
 #[test]
+fn cdt_cli_readme_toroidal_simulation_command_writes_json() {
+    let output_dir = temp_output_dir("readme-toroidal");
+    let json_path = output_dir.join("toroidal-summary.json");
+    let mut cmd = cdt_command();
+
+    cmd.arg("--vertices-per-slice").arg("4");
+    cmd.arg("--timeslices").arg("3");
+    cmd.arg("--topology").arg("toroidal");
+    cmd.arg("--steps").arg("20");
+    cmd.arg("--thermalization-steps").arg("0");
+    cmd.arg("--measurement-frequency").arg("5");
+    cmd.arg("--temperature").arg("1.5");
+    cmd.arg("--seed").arg("105");
+    cmd.arg("--simulate");
+    cmd.arg("--output-json").arg(&json_path);
+    cmd.env("RUST_LOG", "error");
+
+    cmd.assert().success();
+
+    let json = fs::read_to_string(&json_path).expect("JSON output should be readable");
+    let parsed: Value = from_str(&json).expect("summary should parse");
+    fs::remove_dir_all(&output_dir).expect("temporary output directory should be removable");
+
+    assert_eq!(parsed["config"]["vertices"], 12);
+    assert_eq!(parsed["config"]["timeslices"], 3);
+    assert_eq!(parsed["config"]["topology"], "toroidal");
+    assert_eq!(parsed["config"]["simulate"], true);
+    assert_eq!(parsed["final_triangulation"]["topology"], "toroidal");
+    assert_eq!(parsed["final_triangulation"]["time_slices"], 3);
+    assert_eq!(
+        parsed["steps"]
+            .as_array()
+            .expect("steps should be an array")
+            .len(),
+        20
+    );
+    assert_eq!(
+        parsed["measurements"]
+            .as_array()
+            .expect("measurements should be an array")
+            .len(),
+        5
+    );
+}
+
+#[test]
 fn cdt_cli_rejects_missing_post_thermalization_measurement() {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
 
     cmd.arg("--vertices").arg("12");
     cmd.arg("--timeslices").arg("3");
@@ -199,7 +284,7 @@ fn cdt_cli_rejects_missing_post_thermalization_measurement() {
 #[test]
 fn cdt_cli_invalid_vertices_too_few() {
     // This should be caught by clap's range validation
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
 
     cmd.arg("--vertices").arg("2");
     cmd.arg("--timeslices").arg("3");
@@ -212,7 +297,7 @@ fn cdt_cli_invalid_vertices_too_few() {
 #[test]
 fn cdt_cli_invalid_timeslices_zero() {
     // This should be caught by clap's range validation
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
 
     cmd.arg("--vertices").arg("10");
     cmd.arg("--timeslices").arg("0");
@@ -225,7 +310,7 @@ fn cdt_cli_invalid_timeslices_zero() {
 #[test]
 fn cdt_cli_config_validation_comprehensive() {
     // Test a complex scenario with valid parameters to ensure our validation doesn't break normal usage
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cdt"));
+    let mut cmd = cdt_command();
 
     cmd.arg("--vertices").arg("12");
     cmd.arg("--timeslices").arg("3");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7,6 +7,7 @@
 
 use approx::{abs_diff_eq, assert_relative_eq};
 use causal_triangulations::prelude::action::ActionConfig;
+use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveResult};
 use causal_triangulations::prelude::simulation::{MetropolisAlgorithm, MetropolisConfig};
 use causal_triangulations::prelude::triangulation::{
     CdtTopology, CdtTriangulation, TriangulationQuery,
@@ -120,6 +121,23 @@ mod integration_tests {
             .triangulation()
             .validate_simplex_classification()
             .expect("final toroidal simplex classification remains valid");
+
+        let mut local_moves = ErgodicsSystem::with_seed(0);
+        let mut inverse_fixture =
+            CdtTriangulation::from_toroidal_cdt(8, 8).expect("build toroidal inverse fixture");
+        assert_eq!(
+            local_moves.attempt_13_move(&mut inverse_fixture),
+            MoveResult::Success,
+            "periodic toroidal local dynamics should accept a volume-increasing move"
+        );
+        assert_eq!(
+            local_moves.attempt_31_move(&mut inverse_fixture),
+            MoveResult::Success,
+            "periodic toroidal local dynamics should accept the inverse volume move after growth"
+        );
+        inverse_fixture
+            .validate()
+            .expect("direct grow-then-inverse toroidal dynamics preserve invariants");
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -70,6 +70,7 @@ mod integration_tests {
         let triangulation = CdtTriangulation::from_toroidal_cdt(8, 6).expect("build toroidal CDT");
         assert_eq!(triangulation.metadata().topology, CdtTopology::Toroidal);
         assert_eq!(triangulation.geometry().euler_characteristic(), 0);
+        let initial_profile = triangulation.volume_profile();
         triangulation
             .validate_topology()
             .expect("initial toroidal topology is valid");
@@ -88,6 +89,19 @@ mod integration_tests {
         assert!(
             results.move_stats().total_accepted() > 0,
             "periodic toroidal simulation should accept at least one move"
+        );
+        assert!(
+            results.move_stats().moves_13_accepted > 0,
+            "periodic toroidal simulation should accept at least one volume-increasing move"
+        );
+        assert!(
+            results.move_stats().moves_31_accepted > 0,
+            "periodic toroidal simulation should accept at least one inverse volume move after growth"
+        );
+        assert_ne!(
+            results.triangulation().volume_profile(),
+            initial_profile,
+            "periodic toroidal volume moves should change the final volume profile"
         );
         assert_eq!(
             results.triangulation().metadata().topology,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -65,9 +65,9 @@ mod integration_tests {
 
     #[test]
     fn test_toroidal_metropolis_accepts_periodic_moves_and_preserves_topology() {
-        const STEPS: u32 = 200;
+        const STEPS: u32 = 80;
 
-        let triangulation = CdtTriangulation::from_toroidal_cdt(8, 6).expect("build toroidal CDT");
+        let triangulation = CdtTriangulation::from_toroidal_cdt(4, 3).expect("build toroidal CDT");
         assert_eq!(triangulation.metadata().topology, CdtTopology::Toroidal);
         assert_eq!(triangulation.geometry().euler_characteristic(), 0);
         let initial_profile = triangulation.volume_profile();
@@ -93,10 +93,6 @@ mod integration_tests {
         assert!(
             results.move_stats().moves_13_accepted > 0,
             "periodic toroidal simulation should accept at least one volume-increasing move"
-        );
-        assert!(
-            results.move_stats().moves_31_accepted > 0,
-            "periodic toroidal simulation should accept at least one inverse volume move after growth"
         );
         assert_ne!(
             results.triangulation().volume_profile(),

--- a/tests/large_scale_debug.rs
+++ b/tests/large_scale_debug.rs
@@ -1,0 +1,268 @@
+#![cfg_attr(not(feature = "slow-tests"), allow(dead_code))]
+#![forbid(unsafe_code)]
+
+//! Large-scale CDT debug harnesses.
+//!
+//! These tests are intended for manual performance and invariant debugging at
+//! sizes larger than the default integration-test budget. They are gated behind
+//! the `slow-tests` feature and should usually be run through the matching
+//! `just debug-large-scale-*` and `just perf-large-scale-debug` recipes.
+
+#[cfg(feature = "slow-tests")]
+use causal_triangulations::prelude::moves::ErgodicsSystem;
+use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
+use causal_triangulations::prelude::triangulation::{
+    CdtTopology, CdtTriangulation2D, TriangulationQuery,
+};
+use std::{env, time::Duration};
+#[cfg(feature = "slow-tests")]
+use std::{hint::black_box, time::Instant};
+
+const DEFAULT_TOTAL_VERTICES: u32 = 512;
+const DEFAULT_TIMESLICES: u32 = 16;
+const DEFAULT_SWEEPS: u32 = 10;
+const DEFAULT_SEED: u64 = 0xCD71_0139;
+
+#[derive(Clone, Copy, Default)]
+struct MoveAcceptanceCounts {
+    total: u64,
+    hard_failures: u64,
+    move_22: u64,
+    move_13: u64,
+    move_31: u64,
+    edge_flip: u64,
+}
+
+impl MoveAcceptanceCounts {
+    /// Captures the accepted and hard-failure counters from cumulative move statistics.
+    const fn from_stats(stats: &MoveStatistics) -> Self {
+        Self {
+            total: stats.total_accepted(),
+            hard_failures: stats.total_hard_failures(),
+            move_22: accepted_count(stats, MoveType::Move22),
+            move_13: accepted_count(stats, MoveType::Move13Add),
+            move_31: accepted_count(stats, MoveType::Move31Remove),
+            edge_flip: accepted_count(stats, MoveType::EdgeFlip),
+        }
+    }
+
+    /// Returns per-sweep counter deltas relative to the previous cumulative snapshot.
+    const fn delta_since(self, previous: Self) -> Self {
+        Self {
+            total: self.total - previous.total,
+            hard_failures: self.hard_failures - previous.hard_failures,
+            move_22: self.move_22 - previous.move_22,
+            move_13: self.move_13 - previous.move_13,
+            move_31: self.move_31 - previous.move_31,
+            edge_flip: self.edge_flip - previous.edge_flip,
+        }
+    }
+}
+
+/// Reads an unsigned 32-bit environment variable or returns the supplied default.
+fn env_u32(name: &str, default: u32) -> u32 {
+    env::var(name).ok().map_or(default, |value| {
+        value
+            .parse::<u32>()
+            .unwrap_or_else(|_| panic!("{name} must be an unsigned 32-bit integer"))
+    })
+}
+
+/// Reads a case-specific unsigned 32-bit variable before falling back to a generic one.
+fn env_u32_prefer(specific_name: &str, generic_name: &str, default: u32) -> u32 {
+    env::var(specific_name).ok().map_or_else(
+        || env_u32(generic_name, default),
+        |value| {
+            value
+                .parse::<u32>()
+                .unwrap_or_else(|_| panic!("{specific_name} must be an unsigned 32-bit integer"))
+        },
+    )
+}
+
+/// Reads an unsigned 64-bit environment variable, accepting decimal or hexadecimal input.
+fn env_u64(name: &str, default: u64) -> u64 {
+    env::var(name)
+        .ok()
+        .map_or(default, |value| parse_u64(name, &value))
+}
+
+/// Reads a case-specific unsigned 64-bit variable before falling back to a generic one.
+fn env_u64_prefer(specific_name: &str, generic_name: &str, default: u64) -> u64 {
+    env::var(specific_name).ok().map_or_else(
+        || env_u64(generic_name, default),
+        |value| parse_u64(specific_name, &value),
+    )
+}
+
+/// Parses decimal or `0x`-prefixed hexadecimal unsigned 64-bit values for debug seeds.
+fn parse_u64(name: &str, value: &str) -> u64 {
+    let trimmed = value.trim();
+    trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+        .map_or_else(
+            || {
+                trimmed
+                    .parse::<u64>()
+                    .unwrap_or_else(|_| panic!("{name} must be an unsigned 64-bit integer"))
+            },
+            |hex| {
+                u64::from_str_radix(hex, 16)
+                    .unwrap_or_else(|_| panic!("{name} must be an unsigned 64-bit integer"))
+            },
+        )
+}
+
+/// Returns the optional wall-clock cap used to stop unexpectedly slow debug runs.
+fn optional_runtime_cap() -> Option<Duration> {
+    let seconds = env_u64("CDT_LARGE_DEBUG_MAX_RUNTIME_SECS", 0);
+    (seconds > 0).then(|| Duration::from_secs(seconds))
+}
+
+/// Converts total vertices into a regular per-slice count for the current constructor.
+fn vertices_per_slice(total_vertices: u32, timeslices: u32) -> u32 {
+    assert!(
+        timeslices > 0,
+        "CDT_LARGE_DEBUG_TIMESLICES must be positive"
+    );
+    assert!(
+        total_vertices >= timeslices,
+        "CDT_LARGE_DEBUG_VERTICES must be at least CDT_LARGE_DEBUG_TIMESLICES"
+    );
+    assert_eq!(
+        total_vertices % timeslices,
+        0,
+        "CDT_LARGE_DEBUG_VERTICES must divide evenly by CDT_LARGE_DEBUG_TIMESLICES"
+    );
+
+    total_vertices / timeslices
+}
+
+/// Checks the toroidal invariants that every large-scale random sweep must preserve.
+fn assert_toroidal_invariants(triangulation: &CdtTriangulation2D) {
+    triangulation
+        .validate()
+        .expect("large-scale toroidal CDT should validate after random sweeps");
+    assert_eq!(triangulation.metadata().topology, CdtTopology::Toroidal);
+    assert_eq!(triangulation.geometry().euler_characteristic(), 0);
+}
+
+/// Reads the accepted counter for one move type.
+const fn accepted_count(stats: &MoveStatistics, move_type: MoveType) -> u64 {
+    match move_type {
+        MoveType::Move22 => stats.moves_22_accepted,
+        MoveType::Move13Add => stats.moves_13_accepted,
+        MoveType::Move31Remove => stats.moves_31_accepted,
+        MoveType::EdgeFlip => stats.edge_flips_accepted,
+    }
+}
+
+#[cfg(feature = "slow-tests")]
+#[test]
+fn debug_large_scale_1p1() {
+    let total_vertices = env_u32_prefer(
+        "CDT_LARGE_DEBUG_VERTICES_1P1",
+        "CDT_LARGE_DEBUG_VERTICES",
+        DEFAULT_TOTAL_VERTICES,
+    );
+    let timeslices = env_u32_prefer(
+        "CDT_LARGE_DEBUG_TIMESLICES_1P1",
+        "CDT_LARGE_DEBUG_TIMESLICES",
+        DEFAULT_TIMESLICES,
+    );
+    let sweeps = env_u32_prefer(
+        "CDT_LARGE_DEBUG_SWEEPS_1P1",
+        "CDT_LARGE_DEBUG_SWEEPS",
+        DEFAULT_SWEEPS,
+    );
+    let seed = env_u64_prefer(
+        "CDT_LARGE_DEBUG_SEED_1P1",
+        "CDT_LARGE_DEBUG_SEED",
+        DEFAULT_SEED,
+    );
+    let vertices_per_slice = vertices_per_slice(total_vertices, timeslices);
+    let runtime_cap = optional_runtime_cap();
+
+    let started_at = Instant::now();
+    let mut triangulation = CdtTriangulation2D::from_toroidal_cdt(vertices_per_slice, timeslices)
+        .expect("large-scale toroidal CDT fixture should build");
+    let mut ergodics = ErgodicsSystem::with_seed(seed);
+    let initial_profile = triangulation.volume_profile();
+    let mut expected_attempts = 0_u64;
+    let mut previous_acceptance = MoveAcceptanceCounts::default();
+    let mut previous_elapsed = Duration::ZERO;
+    let expected_vertices =
+        usize::try_from(total_vertices).expect("vertex count should fit in usize");
+
+    assert_eq!(triangulation.vertex_count(), expected_vertices);
+    assert_toroidal_invariants(&triangulation);
+
+    println!(
+        "1+1 toroidal CDT large-scale debug: vertices={total_vertices}, timeslices={timeslices}, \
+         vertices_per_slice={vertices_per_slice}, initial_simplices={}, sweeps={sweeps}, seed=0x{seed:X}",
+        triangulation.face_count()
+    );
+
+    for sweep in 1..=sweeps {
+        let attempts = triangulation.face_count();
+        expected_attempts += u64::try_from(attempts).expect("attempt count should fit in u64");
+
+        for _ in 0..attempts {
+            let result = ergodics.attempt_random_move(&mut triangulation);
+            black_box(result);
+        }
+
+        assert_toroidal_invariants(&triangulation);
+        let acceptance = MoveAcceptanceCounts::from_stats(&ergodics.stats);
+        let sweep_acceptance = acceptance.delta_since(previous_acceptance);
+        let elapsed = started_at.elapsed();
+        let sweep_elapsed = elapsed.saturating_sub(previous_elapsed);
+        println!(
+            "sweep {sweep}/{sweeps}: sweep_attempts={attempts}, final_vertices={}, final_simplices={}, \
+             sweep_accepted={} (Move22={}, Move13Add={}, Move31Remove={}, EdgeFlip={}), \
+             sweep_hard_failures={}, total_accepted={}, total_attempted={}, total_hard_failures={}, \
+             sweep_elapsed={sweep_elapsed:?}, total_elapsed={elapsed:?}",
+            triangulation.vertex_count(),
+            triangulation.face_count(),
+            sweep_acceptance.total,
+            sweep_acceptance.move_22,
+            sweep_acceptance.move_13,
+            sweep_acceptance.move_31,
+            sweep_acceptance.edge_flip,
+            sweep_acceptance.hard_failures,
+            acceptance.total,
+            expected_attempts,
+            acceptance.hard_failures,
+        );
+        previous_acceptance = acceptance;
+        previous_elapsed = elapsed;
+
+        if let Some(cap) = runtime_cap {
+            assert!(
+                elapsed <= cap,
+                "large-scale CDT debug run exceeded CDT_LARGE_DEBUG_MAX_RUNTIME_SECS={}",
+                cap.as_secs()
+            );
+        }
+    }
+
+    assert_eq!(ergodics.stats.total_attempted(), expected_attempts);
+    assert!(
+        ergodics.stats.total_accepted() > 0,
+        "large-scale random sweeps should accept at least one move"
+    );
+    assert!(
+        ergodics.stats.moves_13_accepted > 0,
+        "large-scale random sweeps should exercise toroidal Move13Add"
+    );
+    assert!(
+        ergodics.stats.moves_31_accepted > 0,
+        "large-scale random sweeps should exercise toroidal Move31Remove"
+    );
+    assert_ne!(
+        triangulation.volume_profile(),
+        initial_profile,
+        "large-scale random sweeps should change the toroidal volume profile"
+    );
+}

--- a/tests/physics_integration.rs
+++ b/tests/physics_integration.rs
@@ -58,7 +58,11 @@ fn assert_physics_pipeline(config: &CdtConfig) {
     );
 
     let stats = results.move_stats();
-    assert!(stats.moves_22_attempted > 0);
+    assert_eq!(
+        stats.total_attempted(),
+        u64::from(config.steps),
+        "one move proposal should be recorded for each configured simulation step"
+    );
     assert!(stats.total_acceptance_rate() > 0.0);
 }
 

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -13,14 +13,14 @@ fn toroidal_observables_run_accepts_periodic_moves_after_offset_support() {
     // handling, and the observables workflow should report accepted moves while
     // preserving the toroidal CDT invariants.
     let triangulation =
-        CdtTriangulation::from_toroidal_cdt(8, 8).expect("observables fixture should build");
+        CdtTriangulation::from_toroidal_cdt(4, 3).expect("observables fixture should build");
 
-    let metropolis_config = MetropolisConfig::new(1.0, 80, 20, 10).with_seed(7);
+    let metropolis_config = MetropolisConfig::new(1.0, 20, 0, 5).with_seed(7);
     let results =
         MetropolisAlgorithm::new(metropolis_config, ActionConfig::default()).run(triangulation);
     let results = results.expect("toroidal observables regression run should complete");
 
-    assert_eq!(results.move_stats().total_attempted(), 80);
+    assert_eq!(results.move_stats().total_attempted(), 20);
     assert!(
         results.move_stats().total_accepted() > 0,
         "periodic toroidal runs should accept moves after delaunay offset-aware flips"

--- a/tests/semgrep/docs/cli_vertices.sh
+++ b/tests/semgrep/docs/cli_vertices.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2215
+
+# ok: causal-triangulations.cli.prefer-vertices-per-slice-in-user-facing-runs
+./target/release/cdt --vertices-per-slice 4 --timeslices 8
+
+# ok: causal-triangulations.cli.prefer-vertices-per-slice-in-user-facing-runs
+cargo run --bin cdt -- --vertices-per-slice 4 --timeslices 8
+
+# ruleid: causal-triangulations.cli.prefer-vertices-per-slice-in-user-facing-runs
+./target/release/cdt --vertices 32 --timeslices 8
+
+# ruleid: causal-triangulations.cli.prefer-vertices-per-slice-in-user-facing-runs
+cargo run --bin cdt -- --vertices 32 --timeslices 8
+
+# ruleid: causal-triangulations.cli.prefer-vertices-per-slice-in-user-facing-runs
+--vertices 32 \
+	--timeslices 8


### PR DESCRIPTION
- Support toroidal volume-changing CDT moves that preserve χ = 0, foliation, and closed spatial slices.
- Plan concrete Metropolis-Hastings proposals before acceptance and weight forward/reverse local-site counts for detailed balance.
- Add hard-failure move telemetry and typed validation/application failure details for sampler diagnostics.
- Document binary usage, unfixed-volume ensemble behavior, large-scale debug workflows, and release-roadmap scope.

BREAKING CHANGE: CdtError::ValidationFailed now carries CdtValidationFailure instead of a detail string, CdtError::MetropolisMoveApplicationFailed now carries MetropolisMoveApplicationFailure instead of last_failure, and CdtConfig command-line parsing now derives through the binary-facing parser rather than Parser on CdtConfig itself.

Closes #139