### PR TITLE
feat(cdt)!: add proposal-site accounting and profiled CDT starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ cargo build --release
 # Build an open-boundary triangulation and record the initial measurement
 ./target/release/cdt --vertices-per-slice 4 --timeslices 5 --output-json open-boundary-summary.json
 
+# Build nonuniform open-boundary initial data from an explicit spatial volume profile
+./target/release/cdt --volume-profile 4,6,5 --output-json open-profile-summary.json
+
 # Run a periodic toroidal simulation and write both output formats
 ./target/release/cdt \
   --vertices-per-slice 8 \
@@ -85,9 +88,11 @@ cargo build --release
   --output-json toroidal-summary.json
 ```
 
-Prefer `--vertices-per-slice` for regular initial data; the binary computes the total initial vertex count as `vertices_per_slice × timeslices`. `--vertices`
-is still accepted when you already know the total, but it must divide evenly by `--timeslices`. Open-boundary runs require at least 4 vertices per slice and
-toroidal runs require at least 3 vertices per slice. Without `--simulate`, the binary only builds the initial triangulation and writes the step-0 measurement.
+Prefer `--vertices-per-slice` for regular equal-slice initial data; the binary computes the total initial vertex count as `vertices_per_slice × timeslices`. Use
+`--volume-profile N0,N1,...` for explicit nonuniform spatial slice volumes; when supplied without `--timeslices`, the number of profile entries defines the
+time-slice count. `--vertices` is still accepted when you already know the total for regular data, but it must divide evenly by `--timeslices`. Open-boundary
+runs require at least 4 vertices per slice and toroidal runs require at least 3 vertices per slice. Without `--simulate`, the binary only builds the initial
+triangulation and writes the step-0 measurement.
 
 ### Ensemble And Volume Behavior
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -104,6 +104,9 @@ These references provide the algorithmic foundations for Monte Carlo simulations
 - Israel, N. S., and Lindner, J. F. "Quantum gravity on a laptop: 1+1 Dimensional Causal Dynamical Triangulation simulation." _Results in Physics_ 2 (2012):
   164-169. DOI: [10.1016/j.rinp.2012.10.001](https://doi.org/10.1016/j.rinp.2012.10.001)
 
+- Getchell, Adam. "CDT-plusplus: Causal Dynamical Triangulations in C++." Repository: <https://github.com/acgetchell/CDT-plusplus>. A Zenodo DOI will be added
+  after a formal release.
+
 ### Ergodic Moves and Alexander Moves
 
 - Alexander, J. W. "The combinatorial theory of complexes." _Annals of Mathematics_ 31, no. 2 (1930): 292-320. DOI:

--- a/benches/README.md
+++ b/benches/README.md
@@ -28,6 +28,8 @@ CDT workflows that should stay comparable across releases:
 - generating open-boundary and toroidal CDT triangulations;
 - validating generated triangulations;
 - attempting individual ergodic move types;
+- iterating proposal-site candidates through public move-attempt and single-step
+  Metropolis proposal paths;
 - executing ten random-move sweeps, where each sweep attempts one move per
   current simplex;
 - running short Metropolis simulations sized as ten initial sweeps.
@@ -126,6 +128,13 @@ cargo bench -- --save-baseline my_baseline
   - `random_move_selection`: Random move type selection
   - `random_move_attempt`: Complete random move attempt
 - **Use Case**: Optimizing Monte Carlo move proposal
+
+The CI suite also includes `cdt_proposal_site_move_attempts_2d` and
+`cdt_single_metropolis_proposal_2d`. These benchmarks exercise the public paths
+that iterate explicit proposal sites, apply a selected site on a cloned proposed
+state, and, for Metropolis proposals, compute reverse-site counts for the
+Hastings ratio. They are the first place to check before adding a
+crate-internal benchmark hook for isolated proposal-site enumeration.
 
 ### 6. Metropolis Simulation (`metropolis_simulation`)
 

--- a/benches/cdt_benchmarks.rs
+++ b/benches/cdt_benchmarks.rs
@@ -12,7 +12,8 @@
 use causal_triangulations::prelude::action::ActionConfig;
 use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveStatistics, MoveType};
 use causal_triangulations::prelude::simulation::{
-    Measurement, MetropolisAlgorithm, MetropolisConfig, MonteCarloStep, SimulationResultsBackend,
+    Measurement, MetropolisAlgorithm, MetropolisConfig, MonteCarloStep, ProposalStatistics,
+    SimulationResultsBackend,
 };
 use causal_triangulations::prelude::triangulation::{CdtTriangulation2D, TriangulationQuery};
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
@@ -290,6 +291,7 @@ fn bench_simulation_analysis(c: &mut Criterion) {
         config,
         action_config,
         MoveStatistics::new(),
+        ProposalStatistics::new(),
         vec![
             MonteCarloStep {
                 step: 1,

--- a/benches/ci_performance_suite.rs
+++ b/benches/ci_performance_suite.rs
@@ -12,6 +12,8 @@
 //! 4. Ten-sweep random-move workloads, where each sweep attempts one move per
 //!    current simplex.
 //! 5. Short Metropolis runs sized as ten initial sweeps.
+//! 6. Public proposal-site iteration paths used by move attempts and one-step
+//!    Metropolis proposal planning.
 
 use causal_triangulations::prelude::action::ActionConfig;
 use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveStatistics, MoveType};
@@ -99,6 +101,27 @@ const SWEEP_FIXTURES: &[CdtFixture] = &[
     },
 ];
 
+const PROPOSAL_FIXTURES: &[CdtFixture] = &[
+    CdtFixture {
+        name: "open_strip_medium",
+        topology: TopologyFixture::OpenStrip,
+        vertices_per_slice: 20,
+        time_slices: 10,
+    },
+    CdtFixture {
+        name: "toroidal_medium",
+        topology: TopologyFixture::Toroidal,
+        vertices_per_slice: 12,
+        time_slices: 10,
+    },
+    CdtFixture {
+        name: "toroidal_probe",
+        topology: TopologyFixture::Toroidal,
+        vertices_per_slice: 32,
+        time_slices: 16,
+    },
+];
+
 impl CdtFixture {
     /// Builds the requested CDT topology for a benchmark fixture.
     fn build(self) -> CdtTriangulation2D {
@@ -114,6 +137,21 @@ impl CdtFixture {
     }
 }
 
+/// Attempts one selected move type through the public move API.
+fn attempt_selected_move(
+    ergodics: &mut ErgodicsSystem,
+    move_type: MoveType,
+    triangulation: &mut CdtTriangulation2D,
+) {
+    let result = match move_type {
+        MoveType::Move22 => ergodics.attempt_22_move(triangulation),
+        MoveType::Move13Add => ergodics.attempt_13_move(triangulation),
+        MoveType::Move31Remove => ergodics.attempt_31_move(triangulation),
+        MoveType::EdgeFlip => ergodics.attempt_edge_flip(triangulation),
+    };
+    black_box(result);
+}
+
 /// Materializes a fixture once so benchmarks can use stable size metadata.
 fn prepare_fixture(fixture: CdtFixture) -> PreparedFixture {
     let triangulation = fixture.build();
@@ -125,6 +163,15 @@ fn prepare_fixture(fixture: CdtFixture) -> PreparedFixture {
         vertices,
         simplices,
     }
+}
+
+/// Runs one Metropolis proposal step through the public simulation driver.
+fn run_single_metropolis_proposal(triangulation: CdtTriangulation2D) {
+    let config = MetropolisConfig::new(1.0, 1, 0, 1).with_seed(BENCH_SEED);
+    let results = MetropolisAlgorithm::new(config, ActionConfig::default())
+        .run(triangulation)
+        .expect("single-step Metropolis proposal workload should run");
+    black_box(results.proposal_stats());
 }
 
 /// Converts Criterion throughput element counts without silently truncating.
@@ -249,14 +296,71 @@ fn bench_cdt_move_attempts(c: &mut Criterion) {
                         )
                     },
                     |(mut ergodics, mut triangulation)| {
-                        let result = match move_type {
-                            MoveType::Move22 => ergodics.attempt_22_move(&mut triangulation),
-                            MoveType::Move13Add => ergodics.attempt_13_move(&mut triangulation),
-                            MoveType::Move31Remove => ergodics.attempt_31_move(&mut triangulation),
-                            MoveType::EdgeFlip => ergodics.attempt_edge_flip(&mut triangulation),
-                        };
-                        black_box(result)
+                        attempt_selected_move(&mut ergodics, move_type, &mut triangulation);
                     },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmarks proposal-site iteration through public move-attempt APIs.
+fn bench_cdt_proposal_site_move_attempts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cdt_proposal_site_move_attempts_2d");
+
+    for &fixture in PROPOSAL_FIXTURES {
+        let prepared = prepare_fixture(fixture);
+        group.throughput(Throughput::Elements(usize_to_u64(prepared.simplices)));
+        for move_type in [
+            MoveType::Move22,
+            MoveType::Move13Add,
+            MoveType::Move31Remove,
+            MoveType::EdgeFlip,
+        ] {
+            group.bench_with_input(
+                BenchmarkId::new(
+                    format!("{}_{move_type:?}", prepared.fixture.name),
+                    prepared.simplices,
+                ),
+                &move_type,
+                |b, &move_type| {
+                    b.iter_batched(
+                        || {
+                            (
+                                ErgodicsSystem::with_seed(BENCH_SEED),
+                                prepared.triangulation.clone(),
+                            )
+                        },
+                        |(mut ergodics, mut triangulation)| {
+                            attempt_selected_move(&mut ergodics, move_type, &mut triangulation);
+                        },
+                        BatchSize::LargeInput,
+                    );
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+/// Benchmarks one public Metropolis proposal step, including cloned planning and reverse counts.
+fn bench_cdt_single_metropolis_proposal(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cdt_single_metropolis_proposal_2d");
+
+    for &fixture in PROPOSAL_FIXTURES {
+        let prepared = prepare_fixture(fixture);
+        group.throughput(Throughput::Elements(usize_to_u64(prepared.simplices)));
+        group.bench_with_input(
+            BenchmarkId::new(prepared.fixture.name, prepared.simplices),
+            &prepared,
+            |b, prepared| {
+                b.iter_batched(
+                    || prepared.triangulation.clone(),
+                    run_single_metropolis_proposal,
                     BatchSize::LargeInput,
                 );
             },
@@ -332,6 +436,8 @@ criterion_group!(
         bench_cdt_generation,
         bench_cdt_validation,
         bench_cdt_move_attempts,
+        bench_cdt_proposal_site_move_attempts,
+        bench_cdt_single_metropolis_proposal,
         bench_cdt_random_move_sweeps,
         bench_cdt_metropolis_ten_sweeps
 );

--- a/docs/CLI_EXAMPLES.md
+++ b/docs/CLI_EXAMPLES.md
@@ -26,7 +26,9 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 - `--vertices-per-slice <N>`: Vertices on each initial spatial slice. Prefer this for regular CDT initial data; the binary computes
   `total vertices = vertices-per-slice × timeslices`.
 - `--vertices <N>`: Total initial vertex count. Use this only when the total is already known; it must divide evenly by `--timeslices`.
-- `--timeslices <N>`: Number of time slices in the CDT foliation (minimum 1)
+- `--volume-profile <N0,N1,...>`: Explicit vertices per initial spatial slice for nonuniform CDT initial data. The profile length defines `--timeslices` when
+  `--timeslices` is omitted.
+- `--timeslices <N>`: Number of time slices in the CDT foliation (required unless `--volume-profile` is supplied)
 
 ### Optional Simulation Parameters
 
@@ -76,7 +78,20 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 **Use Case:** Study phase transitions or scaling behavior
 
-### 3. High-Temperature Simulation
+### 3. Nonuniform Initial Volume Profile
+
+```bash
+./target/release/cdt \
+  --volume-profile 4,6,5 \
+  --steps 100 \
+  --thermalization-steps 10 \
+  --measurement-frequency 10 \
+  --simulate
+```
+
+**Use Case:** Start from explicit nonuniform spatial volumes `N(t)` instead of the regular equal-slice fixture.
+
+### 4. High-Temperature Simulation
 
 ```bash
 # High temperature configuration
@@ -90,7 +105,7 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 **Use Case:** Explore classical geometry limit
 
-### 4. Low-Temperature Simulation
+### 5. Low-Temperature Simulation
 
 ```bash
 # Low temperature configuration
@@ -105,7 +120,7 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 **Use Case:** Study quantum fluctuations and crumpled phase
 
-### 5. Custom Physics Parameters
+### 6. Custom Physics Parameters
 
 ```bash
 # Modified coupling constants
@@ -120,7 +135,7 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 **Use Case:** Explore modified gravity or different action formulations
 
-### 6. Triangulation-Only Mode
+### 7. Triangulation-Only Mode
 
 ```bash
 # Generate triangulation without running Monte Carlo simulation

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -194,8 +194,12 @@ through to upstream `delaunay::` APIs directly.
   wrapper methods
 - `from_cdt_strip(vertices_per_slice, num_slices)` — Delaunay-built open-boundary 1+1 CDT strip with strict Up/Down simplex classification and upstream Level
   1–4 Delaunay validation before wrapping
+- `from_cdt_strip_profile(volume_profile)` — open-boundary 1+1 CDT strip from explicit nonuniform per-slice vertex counts; builds labeled point data and
+  delegates triangulation to the Delaunay constructor before strict initial validation
 - `from_toroidal_cdt(vertices_per_slice, num_slices)` — periodic Delaunay S¹×S¹ toroidal CDT (χ = 0) with upstream Level 1–4 validation before wrapping;
   requires `vertices_per_slice ≥ 3` and `num_slices ≥ 3`
+- `from_toroidal_cdt_profile(volume_profile)` — periodic S¹×S¹ toroidal CDT from explicit per-slice vertex counts, preserving closed spatial slices and
+  periodic time
 - `assign_foliation_by_y(num_slices)` — bin existing vertices into time slices
 - Query methods: `time_label`, `edge_type`, `vertices_at_time`, `slice_sizes`, `has_foliation`
 - Validation: constructors require upstream Delaunay Level 1–4 validation for initial meshes; `validate()` is the post-move/final-state contract and requires
@@ -215,16 +219,16 @@ The implementation is split into child modules under `src/cdt/triangulation/`:
 - `OpenBoundary` (default) — finite strip with boundary, χ ∈ {1, 2}
 - `Toroidal` — periodic in space and time, S¹×S¹, χ = 0
 - Wired through `CdtConfig.topology`, `CdtConfigOverrides.topology`, the CLI `--topology` flag, and `CdtMetadata.topology`
-- `run_simulation()` dispatches on topology: `Toroidal` → `from_toroidal_cdt`, `OpenBoundary` → `from_cdt_strip`; `vertices` is the total vertex count and must
-  divide evenly across `timeslices`
+- `run_simulation()` dispatches on topology and profile mode: regular `Toroidal` → `from_toroidal_cdt`, regular `OpenBoundary` → `from_cdt_strip`, and explicit
+  `CdtConfig.volume_profile` → the matching profile constructor; `vertices` is always the total vertex count
 
 ### `cdt/metropolis.rs` — Metropolis move ordering
 
-`MetropolisAlgorithm::run()` proposes a move type, plans a concrete local transition on a cloned triangulation, computes `ΔS` and the forward/reverse
-Metropolis-Hastings site-count ratio, accepts or rejects the concrete proposal, and only replaces the live triangulation after acceptance. Planning failures are
-rolled back inside the move kernels; retry exhaustion is recorded as a rejection, while hard backend failures remain structured errors. Toroidal move
-finalization rejects and rolls back candidate sites that would violate χ = 0 or the closed-S¹ per-slice foliation invariant. See `docs/metropolis.md` for the
-detailed ordering.
+`MetropolisAlgorithm::run()` proposes a move type, samples an explicit local proposal site from the same universe used for proposal counts, plans that site on a
+cloned triangulation, computes `ΔS` and the forward/reverse Metropolis-Hastings site-count ratio, accepts or rejects the concrete proposal, and only replaces
+the live triangulation after acceptance. Ordinary causal, geometric, and backend edit failures are self-loop proposal outcomes recorded in
+`ProposalStatistics`; hard backend failures remain structured errors. Toroidal move finalization rejects and rolls back candidate sites that would violate χ =
+0 or the closed-S¹ per-slice foliation invariant. See `docs/metropolis.md` for the detailed ordering and detailed-balance contract.
 
 ### `cdt/results.rs` — Simulation outputs
 

--- a/docs/foliation.md
+++ b/docs/foliation.md
@@ -15,8 +15,9 @@ For the periodic 1+1 CDT cases:
 - **Causality constraint**: no edge may span more than one time slice (|Δt| ≤ 1)
 
 This implementation also supports open-boundary strip variants. `from_toroidal_cdt()` builds the periodic S¹ × S¹ toroidal case, while `from_cdt_strip()` builds
-open spatial-interval strip geometries over discrete time. Both constructor families use the same edge classification and causality constraint, but their
-topology metadata and boundary expectations differ.
+regular open spatial-interval strip geometries over discrete time. Profile constructors, `from_cdt_strip_profile()` and `from_toroidal_cdt_profile()`, accept
+explicit per-slice spatial volumes `N(t)` for nonuniform initial data. All constructor families use the same edge classification and causality constraint, but
+their topology metadata and boundary expectations differ.
 
 ## Architecture
 
@@ -43,13 +44,14 @@ access; CDT mutation paths are narrow so cache and foliation synchronization sta
 ## Time Label Assignment
 
 For `from_cdt_strip()` and `from_toroidal_cdt()`, time labels are assigned directly while building vertices. Vertex `(i, t)` receives label `t`, so each slice
-starts with exactly `vertices_per_slice` vertices. The constructors require their Delaunay-built simplices to span adjacent slices before returning.
+starts with exactly `vertices_per_slice` vertices. The profile constructors instead derive slice counts from the supplied `N(t)` vector, still storing each
+vertex's label as `t`. Uniform slices are therefore a regular initial condition, not a CDT requirement.
 
 `assign_foliation_by_y()` uses band-based bucketing and writes labels through the same CDT-owned label-write path.
 
 ## Delaunay Construction
 
-The open-boundary strip constructor places vertices in a lightly perturbed layered grid with:
+The regular open-boundary strip constructor places vertices in a lightly perturbed layered grid with:
 
 - **Spatial extent**: 1.0, with `vertices_per_slice` evenly spaced vertices per slice
 - **Temporal gap**: 1.0, with integer y-coordinates `0, 1, 2, ...`
@@ -57,15 +59,23 @@ The open-boundary strip constructor places vertices in a lightly perturbed layer
 
 Parameters: `vertices_per_slice ≥ 4`, `num_slices ≥ 2`.
 
+`from_cdt_strip_profile()` places each open spatial slice according to the corresponding profile entry and delegates triangulation to the Delaunay point-data
+constructor. The returned mesh must pass the same initial-constructor contract as the regular open strip: upstream Delaunay Level 1-4 validation plus CDT
+topology, foliation, causality, and strict Up/Down simplex classification.
+
 The toroidal constructor places vertices on a unit lattice in an `N × T` periodic domain and uses the upstream periodic image-point Delaunay constructor. It
 then checks the requested `V = N·T`, `E = 3·N·T`, `F = 2·N·T` toroidal counts and strict CDT classification.
+
+`from_toroidal_cdt_profile()` places each closed S¹ slice according to the corresponding profile entry and uses the periodic image-point constructor directly.
+It preserves closed spatial slices, periodic time, χ = 0, and strict CDT simplex classification for the returned initial torus.
 
 ## Initialization vs Evolution Validation
 
 Initial CDT constructors are stricter than post-move validation:
 
-- **Initialization**: `from_cdt_strip()` and `from_toroidal_cdt()` must pass upstream Delaunay Level 1-4 validation before returning. This certifies the
-  starting mesh as a valid, well-behaved PL-manifold and Delaunay triangulation.
+- **Initialization**: regular `from_cdt_strip()`, profiled `from_cdt_strip_profile()`, regular `from_toroidal_cdt()`, and
+  `from_toroidal_cdt_profile()` must pass upstream Delaunay Level 1-4 validation before returning. This certifies those starting meshes as valid,
+  well-behaved PL-manifold Delaunay triangulations.
 - **After ergodic moves / simulation completion**: `CdtTriangulation::validate()` requires upstream structural validity plus CDT topology, foliation, causality,
   and simplex-classification invariants. It intentionally does not require Level 4 Delaunay-ness, because the CDT move kernels are not expected to preserve the
   Delaunay empty-circumsphere predicate.

--- a/docs/metropolis.md
+++ b/docs/metropolis.md
@@ -1,30 +1,32 @@
-# Metropolis Move Ordering
+# Metropolis Move Ordering And Detailed Balance
 
 `MetropolisAlgorithm::run()` uses a proposal-before-mutation ordering for CDT Monte Carlo steps.
 
 For each step:
 
 1. Select a move type with `ErgodicsSystem::select_random_move()`.
-2. Build a concrete delayed proposal for that move type by selecting and applying a realizable local site on a cloned triangulation. If no concrete site exists,
-   record the step as a rejected proposal and continue without changing the live triangulation.
+2. Enumerate the sampleable local sites for that move type and select one site uniformly from that same site universe. If no site exists, record the step as a
+   self-loop proposal and continue without changing the live triangulation.
 3. Compute the proposed action change from the concrete proposal's simplex-count delta:
    - `(2,2)` / edge flip: `ΔN0 = 0`, `ΔN1 = 0`, `ΔN2 = 0`
    - `(1,3)`: `ΔN0 = +1`, `ΔN1 = +3`, `ΔN2 = +2`
    - `(3,1)`: `ΔN0 = -1`, `ΔN1 = -3`, `ΔN2 = -2`
-4. Count the forward sites for the selected move type and the reverse sites for the inverse move type on the proposed state.
-5. Accept with the Metropolis-Hastings probability
+4. Apply the selected site once on a cloned proposed state. Ordinary causal, geometric, or backend edit failures are self-loop proposal outcomes; the live
+   triangulation is unchanged.
+5. Count the forward sites for the selected move type and the reverse sites for the inverse move type on the proposed state.
+6. Accept successful transitions with the Metropolis-Hastings probability
    `min(1, exp(-ΔS / T + log(q(current | proposed) / q(proposed | current))))`. For equal move-family weights this adds
    `log(forward_site_count / reverse_site_count)` to the ordinary action term, so `(1,3)` and `(3,1)` proposals account for their different site
    multiplicities.
-6. Only after acceptance, replace the live triangulation with the planned proposed state.
-7. If proposal planning hits a hard backend or invariant failure, return `CdtError::MetropolisMoveApplicationFailed` with the step, move type, retry count, and
+7. Only after acceptance, replace the live triangulation with the planned proposed state.
+8. If proposal planning hits a hard backend or invariant failure, return `CdtError::MetropolisMoveApplicationFailed` with the step, move type, retry count, and
    lower-level failure.
 
 This ordering avoids mutating the live triangulation for Metropolis-rejected moves while still binding each proposal to a concrete local transition before the
 acceptance draw. Rollback remains inside the move kernels while planning on the cloned state because a backend edit can fail after a site has been selected or
-after partial invariant refresh work. Exhausted local-site retries are ordinary proposal rejections because the selected move type did not bind to a realizable
-local site within the bounded search. The recorded `SimulationResultsBackend::move_stats` counts Metropolis-level attempted and applied moves, while
-`ErgodicsSystem::stats` remains local to the lower-level move kernel.
+after partial invariant refresh work. The recorded `SimulationResultsBackend::move_stats` counts Metropolis-level attempted and applied moves, while
+`SimulationResultsBackend::proposal_stats` records proposal-kernel telemetry such as no-site outcomes, sampled-site failures, Metropolis rejections, and
+accepted transitions.
 
 ## Proposal-Ratio Correction
 
@@ -54,9 +56,85 @@ log_q_ratio = log(N_forward) - log(N_reverse)
 inverse move type in the proposed triangulation. For example, a `(1,3)` proposal counts valid `(1,3)` sites before the move and valid reverse `(3,1)` sites
 after the move. This corrects proposal asymmetry for detailed balance without adding volume fixing or changing the target action.
 
+The proposal-site universe must be the same for sampling and counting. If the sampler can choose a site, that site belongs in the denominator used for the
+proposal probability, even if applying it later returns an ordinary geometric, causal, or backend rejection.
+
 This is the ordinary Metropolis-Hastings proposal-ratio correction: it uses the actual proposal kernel, not empirical acceptance counts from the run. Hastings'
 original Markov-chain sampling paper gives the general acceptance rule, and Brunekreef, Görlich, and Loll describe CDT Monte Carlo moves together with their
 detailed-balance equations. See [REFERENCES.md](../REFERENCES.md) for the full citations.
 
 The integration test `test_toroidal_metropolis_accepts_periodic_moves_and_preserves_topology` covers this contract by running a seeded S¹×S¹ simulation,
 requiring at least one accepted periodic move, and checking final topology, foliation, causality, simplex classification, and Euler characteristic.
+
+## Proposal Sites
+
+A CDT proposal is represented by an explicit local site selected from the current triangulation:
+
+1. Choose a move family `m` from the configured move-family distribution.
+2. Enumerate the sampleable local sites `S_m(x)` for the current triangulation `x`.
+3. Select one site uniformly and apply that exact site to the cloned proposed state.
+4. Treat ordinary local or backend rejections as self-loop proposals, not hard failures.
+5. Score successful transitions with the Metropolis-Hastings proposal ratio for the actual proposal kernel.
+
+For state `x`, move family `m`, and a sampleable site set `S_m(x)`, a uniformly sampled site contributes:
+
+```text
+p(m | x) / |S_m(x)|
+```
+
+to the proposal probability. The full transition probability from `x` to a distinct proposed state `y` is the sum over every sampled site that produces that
+same `y`:
+
+```text
+q(x -> y) = sum over (m, s) where apply(x, m, s) = y of p(m | x) / |S_m(x)|
+```
+
+For equal move-family weights and one proposal site per resulting state, this reduces to the familiar site-count correction:
+
+```text
+log_q_ratio = log(|S_forward(x)|) - log(|S_reverse(y)|)
+```
+
+If multiple proposal sites can produce the same final triangulation, that multiplicity must be included:
+
+```text
+log_q_ratio =
+    log(p(reverse | y)) - log(p(forward | x))
+  + log(multiplicity(y -> x)) - log(multiplicity(x -> y))
+  + log(|S_forward(x)|) - log(|S_reverse(y)|)
+```
+
+The implementation should prefer canonical proposal-site definitions that make the multiplicity term equal to one. When that is not possible, the concrete
+proposal plan must carry enough identity to compute the forward and reverse transition multiplicities explicitly.
+
+## Ordinary Rejections
+
+Ordinary proposal failures are self-loop probability mass. They do not alter the acceptance formula for successful transitions and must not be fed back into
+the proposal ratio from empirical counters.
+
+Ordinary rejections include:
+
+- selected sites that fail CDT-local geometric or causal checks
+- selected backend edits that fail atomically before committing a new CDT state
+- Metropolis rejections of otherwise valid proposed transitions
+
+Hard failures are different. A hard failure means a mutation partially committed or a required rollback/finalization invariant failed. Hard failures are
+diagnostic errors, not normal MCMC rejection outcomes.
+
+## Proposal Statistics
+
+`ProposalStatistics` is telemetry, not part of the Markov kernel. It records:
+
+- selected move-family proposals
+- sampleable forward-site denominators observed during planning
+- no-site outcomes
+- ordinary geometric, causal, and backend proposal rejections
+- Metropolis rejections
+- successful committed transitions
+- hard failures
+
+These counters explain chain stickiness and backend behavior, but detailed balance is maintained by the proposal probability used at the current step, not by
+empirical frequencies accumulated earlier in the run.
+
+The explicit-site model avoids dry-run cloning every candidate during site counting. The only required full triangulation clone is the planned proposed state
+used by delayed Metropolis acceptance, plus a narrow rollback snapshot around composite mutations whose intermediate backend steps can partially commit.

--- a/docs/moves.md
+++ b/docs/moves.md
@@ -84,10 +84,10 @@ not clone the triangulation. If a selected mutation or required post-mutation sy
 non-success `MoveResult`. Toroidal post-move topology or closed-ring foliation failures are treated as rollbackable local-site rejections, because the candidate
 site was geometrically editable but would break the periodic CDT contract.
 
-The Metropolis loop first clones the current triangulation and plans a concrete move on that cloned triangulation; see `src/cdt/metropolis.rs`. It then performs
-the accept/reject decision from the proposed move metadata; see `docs/metropolis.md`. Only accepted proposals swap the cloned, mutated state into the live
-simulation. Failed applications on the cloned state are retried from the restored clone state, exhausted retries are recorded as rejected proposals, and hard
-backend mutation or invariant-refresh failures still return `CdtError::MetropolisMoveApplicationFailed`.
+The Metropolis loop first selects an explicit local proposal site, clones the current triangulation, and applies that exact site on the cloned proposed state;
+see `src/cdt/metropolis.rs`. It then performs the accept/reject decision from the proposed move metadata; see `docs/metropolis.md`. Only accepted proposals
+swap the cloned, mutated state into the live simulation. Ordinary causal, geometric, or backend edit failures on the cloned state are self-loop proposal
+outcomes recorded in `ProposalStatistics`; hard backend mutation or invariant-refresh failures still return `CdtError::MetropolisMoveApplicationFailed`.
 
 ## Ensemble And Volume Fixing
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,6 +22,8 @@ The v0.1.0 foundation work focuses on making the crate a usable, validated 1+1 C
   ([#141](https://github.com/acgetchell/causal-triangulations/issues/141))
 - [ ] Track release-readiness gates for the first public release
   ([#140](https://github.com/acgetchell/causal-triangulations/issues/140))
+- [ ] Audit public doctests for fallible error handling
+  ([#151](https://github.com/acgetchell/causal-triangulations/issues/151))
 
 ## 1+1 Maturity
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,6 +43,12 @@ The post-v0.1.0 1+1 track should keep the default ensemble scientifically explic
 - Add λ scan utilities for unfixed-volume 1+1 CDT runs
   ([#143](https://github.com/acgetchell/causal-triangulations/issues/143)). These should help users tune the cosmological constant, which is conjugate to the
   lattice volume term and controls volume growth or shrinkage in unfixed-volume runs.
+- Adopt the upstream lift-aware simplex barycenter helper once `delaunay#420` ships
+  ([#147](https://github.com/acgetchell/causal-triangulations/issues/147)). This should replace the local `(1,3)` insertion-point policy while preserving the
+  existing k=1 flip delegation, and is dependency-gated cleanup for move-kernel geometry ownership rather than a new CDT ensemble.
+- Redesign public error shapes for ergonomic typed diagnostics
+  ([#149](https://github.com/acgetchell/causal-triangulations/issues/149)). This should build on the current typed category enums by evaluating richer observed
+  values, constraints, and matching patterns without blocking the v0.1.0 correctness work.
 
 ## Higher-Dimensional CDT Tracks
 

--- a/src/cdt/action.rs
+++ b/src/cdt/action.rs
@@ -5,7 +5,7 @@
 //! This module implements the discrete Einstein-Hilbert action used in CDT,
 //! which is based on the Regge calculus formulation of general relativity.
 
-use crate::errors::{CdtError, CdtResult};
+use crate::errors::{CdtError, CdtResult, ConfigurationSetting};
 use serde::{Deserialize, Serialize};
 
 /// Calculates the 2D Regge Action for a given triangulation.
@@ -116,9 +116,12 @@ impl ActionConfig {
     /// assert!(ActionConfig::new(f64::NAN, 1.0, 0.1).validate().is_err());
     /// ```
     pub fn validate(&self) -> CdtResult<()> {
-        validate_coupling("coupling_0", self.coupling_0)?;
-        validate_coupling("coupling_2", self.coupling_2)?;
-        validate_coupling("cosmological_constant", self.cosmological_constant)
+        validate_coupling(ConfigurationSetting::Coupling0, self.coupling_0)?;
+        validate_coupling(ConfigurationSetting::Coupling2, self.coupling_2)?;
+        validate_coupling(
+            ConfigurationSetting::CosmologicalConstant,
+            self.cosmological_constant,
+        )
     }
 
     /// Calculates the action for given simplex counts.
@@ -147,12 +150,12 @@ impl ActionConfig {
 }
 
 /// Rejects non-finite action couplings before they can poison action/log-probability math.
-fn validate_coupling(setting: &str, value: f64) -> CdtResult<()> {
+fn validate_coupling(setting: ConfigurationSetting, value: f64) -> CdtResult<()> {
     if value.is_finite() {
         Ok(())
     } else {
         Err(CdtError::InvalidConfiguration {
-            setting: setting.to_string(),
+            setting,
             provided_value: value.to_string(),
             expected: "finite".to_string(),
         })

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -57,7 +57,8 @@ pub enum MoveResult {
 /// moves that committed and validated successfully. Hard-failure counts record
 /// proposals that mutated the backend but failed post-mutation CDT invariants;
 /// those failures remain in the attempt denominator but are not counted as
-/// accepted moves.
+/// accepted moves. Individual counters and aggregate totals saturate at
+/// `u64::MAX` so long-running or restored simulations cannot wrap telemetry.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MoveStatistics {
     /// Number of (2,2) moves attempted
@@ -106,7 +107,7 @@ impl MoveStatistics {
         Self::default()
     }
 
-    /// Records an attempted move.
+    /// Records an attempted move, saturating the matching counter at `u64::MAX`.
     ///
     /// # Examples
     ///
@@ -119,14 +120,24 @@ impl MoveStatistics {
     /// ```
     pub const fn record_attempt(&mut self, move_type: MoveType) {
         match move_type {
-            MoveType::Move22 => self.moves_22_attempted += 1,
-            MoveType::Move13Add => self.moves_13_attempted += 1,
-            MoveType::Move31Remove => self.moves_31_attempted += 1,
-            MoveType::EdgeFlip => self.edge_flips_attempted += 1,
+            MoveType::Move22 => {
+                self.moves_22_attempted = self.moves_22_attempted.saturating_add(1);
+            }
+            MoveType::Move13Add => {
+                self.moves_13_attempted = self.moves_13_attempted.saturating_add(1);
+            }
+            MoveType::Move31Remove => {
+                self.moves_31_attempted = self.moves_31_attempted.saturating_add(1);
+            }
+            MoveType::EdgeFlip => {
+                self.edge_flips_attempted = self.edge_flips_attempted.saturating_add(1);
+            }
         }
     }
 
     /// Records a successful move that committed and validated.
+    ///
+    /// The matching accepted counter saturates at `u64::MAX`.
     ///
     /// # Examples
     ///
@@ -139,10 +150,18 @@ impl MoveStatistics {
     /// ```
     pub const fn record_success(&mut self, move_type: MoveType) {
         match move_type {
-            MoveType::Move22 => self.moves_22_accepted += 1,
-            MoveType::Move13Add => self.moves_13_accepted += 1,
-            MoveType::Move31Remove => self.moves_31_accepted += 1,
-            MoveType::EdgeFlip => self.edge_flips_accepted += 1,
+            MoveType::Move22 => {
+                self.moves_22_accepted = self.moves_22_accepted.saturating_add(1);
+            }
+            MoveType::Move13Add => {
+                self.moves_13_accepted = self.moves_13_accepted.saturating_add(1);
+            }
+            MoveType::Move31Remove => {
+                self.moves_31_accepted = self.moves_31_accepted.saturating_add(1);
+            }
+            MoveType::EdgeFlip => {
+                self.edge_flips_accepted = self.edge_flips_accepted.saturating_add(1);
+            }
         }
     }
 
@@ -151,7 +170,8 @@ impl MoveStatistics {
     /// Hard failures are distinct from ordinary proposal rejections and are not
     /// counted as accepted moves. Call this after the corresponding
     /// [`Self::record_attempt`] so acceptance-rate denominators continue to
-    /// reflect all selected proposals.
+    /// reflect all selected proposals. The matching hard-failure counter
+    /// saturates at `u64::MAX`.
     ///
     /// # Examples
     ///
@@ -166,10 +186,18 @@ impl MoveStatistics {
     /// ```
     pub const fn record_hard_failure(&mut self, move_type: MoveType) {
         match move_type {
-            MoveType::Move22 => self.moves_22_hard_failed += 1,
-            MoveType::Move13Add => self.moves_13_hard_failed += 1,
-            MoveType::Move31Remove => self.moves_31_hard_failed += 1,
-            MoveType::EdgeFlip => self.edge_flips_hard_failed += 1,
+            MoveType::Move22 => {
+                self.moves_22_hard_failed = self.moves_22_hard_failed.saturating_add(1);
+            }
+            MoveType::Move13Add => {
+                self.moves_13_hard_failed = self.moves_13_hard_failed.saturating_add(1);
+            }
+            MoveType::Move31Remove => {
+                self.moves_31_hard_failed = self.moves_31_hard_failed.saturating_add(1);
+            }
+            MoveType::EdgeFlip => {
+                self.edge_flips_hard_failed = self.edge_flips_hard_failed.saturating_add(1);
+            }
         }
     }
 
@@ -229,14 +257,8 @@ impl MoveStatistics {
     /// ```
     #[must_use]
     pub fn total_acceptance_rate(&self) -> f64 {
-        let total_attempted = self.moves_22_attempted
-            + self.moves_13_attempted
-            + self.moves_31_attempted
-            + self.edge_flips_attempted;
-        let total_accepted = self.moves_22_accepted
-            + self.moves_13_accepted
-            + self.moves_31_accepted
-            + self.edge_flips_accepted;
+        let total_attempted = self.total_attempted();
+        let total_accepted = self.total_accepted();
 
         if total_attempted == 0 {
             0.0
@@ -250,7 +272,7 @@ impl MoveStatistics {
     /// Returns the total number of attempted moves across all move types.
     ///
     /// This includes proposals that were later accepted, rejected, or recorded
-    /// as hard failures.
+    /// as hard failures. The returned total saturates at `u64::MAX`.
     ///
     /// # Examples
     ///
@@ -265,15 +287,16 @@ impl MoveStatistics {
     #[must_use]
     pub const fn total_attempted(&self) -> u64 {
         self.moves_22_attempted
-            + self.moves_13_attempted
-            + self.moves_31_attempted
-            + self.edge_flips_attempted
+            .saturating_add(self.moves_13_attempted)
+            .saturating_add(self.moves_31_attempted)
+            .saturating_add(self.edge_flips_attempted)
     }
 
     /// Returns the total number of accepted moves across all move types.
     ///
     /// This counts only moves that committed and validated successfully. It does
-    /// not include ordinary rejections or hard failures.
+    /// not include ordinary rejections or hard failures. The returned total
+    /// saturates at `u64::MAX`.
     ///
     /// # Examples
     ///
@@ -288,16 +311,17 @@ impl MoveStatistics {
     #[must_use]
     pub const fn total_accepted(&self) -> u64 {
         self.moves_22_accepted
-            + self.moves_13_accepted
-            + self.moves_31_accepted
-            + self.edge_flips_accepted
+            .saturating_add(self.moves_13_accepted)
+            .saturating_add(self.moves_31_accepted)
+            .saturating_add(self.edge_flips_accepted)
     }
 
     /// Returns the total number of hard failures across all move types.
     ///
     /// A hard failure means a proposal mutated backend state before a required
     /// post-mutation CDT invariant check failed. Public move attempts roll back
-    /// the triangulation before returning [`MoveResult::HardFailure`].
+    /// the triangulation before returning [`MoveResult::HardFailure`]. The
+    /// returned total saturates at `u64::MAX`.
     ///
     /// # Examples
     ///
@@ -312,9 +336,9 @@ impl MoveStatistics {
     #[must_use]
     pub const fn total_hard_failures(&self) -> u64 {
         self.moves_22_hard_failed
-            + self.moves_13_hard_failed
-            + self.moves_31_hard_failed
-            + self.edge_flips_hard_failed
+            .saturating_add(self.moves_13_hard_failed)
+            .saturating_add(self.moves_31_hard_failed)
+            .saturating_add(self.edge_flips_hard_failed)
     }
 }
 
@@ -336,22 +360,62 @@ pub struct ErgodicsSystem {
     rng: Xoshiro256PlusPlus,
 }
 
+/// Labeling instruction for a vertex inserted by a `(1,3)` proposal.
+///
+/// Unfoliated triangulations do not carry vertex time labels, while foliated
+/// proposals must write the selected causal slice label before validation.
 #[derive(Debug, Clone, Copy)]
-enum InsertionLabel {
+pub(crate) enum InsertionLabel {
     Unfoliated,
     Label(u32),
 }
 
-struct ToroidalInsertionCandidate {
+/// Concrete toroidal `(1,3)` proposal realized as a spacelike-link split.
+///
+/// The candidate keeps both backend operations together: subdivide the chosen
+/// face at `point`, label the new vertex, then flip the original spacelike edge.
+pub(crate) struct ToroidalInsertionCandidate {
     edge: DelaunayEdgeHandle,
     face: DelaunayFaceHandle,
     point: [f64; 2],
     label: u32,
 }
 
-struct ToroidalRemovalCandidate {
+/// Concrete toroidal `(3,1)` proposal realized as flip-then-collapse.
+///
+/// The vertex cannot be collapsed directly in periodic CDT; the stored edge is
+/// flipped first to expose the inverse local volume move.
+pub(crate) struct ToroidalRemovalCandidate {
     vertex: DelaunayVertexHandle,
     flip_edge: DelaunayEdgeHandle,
+}
+
+/// Concrete local site selected from a move-family proposal.
+///
+/// Metropolis planning samples one of these after counting the same site
+/// universe used in the Hastings correction, so selection and denominator
+/// semantics remain aligned.
+pub(crate) enum ProposalSite {
+    EdgeFlip(DelaunayEdgeHandle),
+    FaceSubdivision {
+        face: DelaunayFaceHandle,
+        point: [f64; 2],
+        label: InsertionLabel,
+    },
+    ToroidalInsertion(ToroidalInsertionCandidate),
+    VertexRemoval(DelaunayVertexHandle),
+    ToroidalRemoval(ToroidalRemovalCandidate),
+}
+
+/// Result of sampling a move family over its concrete local site universe.
+///
+/// `site_count` is the forward proposal denominator, `site` is the sampled site
+/// when one exists, and `geometric_candidate_seen` distinguishes empty geometry
+/// from causally rejected geometry for public move-result reporting.
+pub(crate) struct ProposalSiteSelection {
+    pub(crate) site_count: usize,
+    pub(crate) site: Option<ProposalSite>,
+    geometric_candidate_seen: bool,
 }
 
 impl ErgodicsSystem {
@@ -413,6 +477,81 @@ impl ErgodicsSystem {
             1 => MoveType::Move13Add,
             2 => MoveType::Move31Remove,
             _ => MoveType::EdgeFlip,
+        }
+    }
+
+    /// Samples one concrete proposal site from the same universe used for proposal counts.
+    ///
+    /// Reservoir sampling avoids allocating candidate lists while preserving a
+    /// uniform draw over the deterministic visitor order used by
+    /// [`proposal_site_count`].
+    pub(crate) fn select_proposal_site(
+        &mut self,
+        triangulation: &CdtTriangulation2D,
+        move_type: MoveType,
+    ) -> ProposalSiteSelection {
+        let mut site_count = 0;
+        let mut selected_site = None;
+        let geometric_candidate_seen = visit_proposal_sites(triangulation, move_type, |site| {
+            site_count += 1;
+            if self.rng.random_range(0..site_count) == 0 {
+                selected_site = Some(site);
+            }
+        });
+
+        ProposalSiteSelection {
+            site_count,
+            site: selected_site,
+            geometric_candidate_seen,
+        }
+    }
+
+    /// Applies one previously selected proposal site.
+    ///
+    /// Matching the site variant against the move family keeps accidental
+    /// cross-family application as a normal geometric rejection without touching
+    /// backend state.
+    pub(crate) fn apply_proposal_site(
+        &mut self,
+        triangulation: &mut CdtTriangulation2D,
+        move_type: MoveType,
+        site: ProposalSite,
+    ) -> MoveResult {
+        match (move_type, site) {
+            (MoveType::Move22 | MoveType::EdgeFlip, ProposalSite::EdgeFlip(edge)) => {
+                self.apply_edge_flip_site(triangulation, move_type, edge)
+            }
+            (MoveType::Move13Add, ProposalSite::FaceSubdivision { face, point, label }) => {
+                self.apply_face_subdivision_site(triangulation, face, point, label)
+            }
+            (MoveType::Move13Add, ProposalSite::ToroidalInsertion(candidate)) => {
+                self.apply_toroidal_insertion_site(triangulation, candidate)
+            }
+            (MoveType::Move31Remove, ProposalSite::VertexRemoval(vertex)) => {
+                self.apply_vertex_removal_site(triangulation, vertex)
+            }
+            (MoveType::Move31Remove, ProposalSite::ToroidalRemoval(candidate)) => {
+                self.apply_toroidal_removal_site(triangulation, candidate)
+            }
+            (
+                MoveType::Move22 | MoveType::EdgeFlip,
+                ProposalSite::FaceSubdivision { .. }
+                | ProposalSite::ToroidalInsertion(_)
+                | ProposalSite::VertexRemoval(_)
+                | ProposalSite::ToroidalRemoval(_),
+            )
+            | (
+                MoveType::Move13Add,
+                ProposalSite::EdgeFlip(_)
+                | ProposalSite::VertexRemoval(_)
+                | ProposalSite::ToroidalRemoval(_),
+            )
+            | (
+                MoveType::Move31Remove,
+                ProposalSite::EdgeFlip(_)
+                | ProposalSite::FaceSubdivision { .. }
+                | ProposalSite::ToroidalInsertion(_),
+            ) => MoveResult::GeometricViolation,
         }
     }
 
@@ -500,152 +639,12 @@ impl ErgodicsSystem {
     /// every early return must pass a `MoveResult` through `rollback_if_failed`
     /// or restore state itself.
     fn attempt_13_move_mutating(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
-        if matches!(triangulation.metadata().topology, CdtTopology::Toroidal)
-            && triangulation.has_foliation()
-        {
-            return self.attempt_toroidal_13_move_mutating(triangulation);
-        }
-
-        let mut geometric_candidate_seen = false;
-        let mut causal_candidate_count = 0;
-        let mut selected_candidate = None;
-
-        for face in triangulation.geometry().faces() {
-            let Some(point) = centroid(triangulation, &face) else {
-                continue;
-            };
-            geometric_candidate_seen = true;
-
-            let Some(label) = insertion_label(triangulation, &face) else {
-                continue;
-            };
-            if !insertion_candidate_is_committable(triangulation, &face, &point, label) {
-                continue;
-            }
-
-            causal_candidate_count += 1;
-            if self.rng.random_range(0..causal_candidate_count) == 0 {
-                selected_candidate = Some((face, point, label));
-            }
-        }
-
-        let Some((face, point, label)) = selected_candidate else {
-            if !geometric_candidate_seen {
-                return MoveResult::GeometricViolation;
-            }
-            return if triangulation.has_foliation() {
-                MoveResult::CausalityViolation
-            } else {
-                MoveResult::GeometricViolation
-            };
+        let selection = self.select_proposal_site(triangulation, MoveType::Move13Add);
+        let Some(site) = selection.site else {
+            return rejected_empty_selection(triangulation, &selection);
         };
 
-        let subdivision_target = format!("face {:?}", face.simplex_key());
-        let snapshot = triangulation.clone();
-        let subdivision = triangulation.subdivide_face(face, &point);
-
-        let subdivision = match subdivision {
-            Ok(subdivision) => subdivision,
-            Err(err) => {
-                let result = reject_backend(
-                    BackendMutationOperation::SubdivideFace,
-                    subdivision_target,
-                    &err,
-                );
-                return rollback_if_failed(triangulation, snapshot, result);
-            }
-        };
-
-        if let InsertionLabel::Label(label) = label {
-            let set_label = triangulation.set_vertex_data(&subdivision.new_vertex, Some(label));
-            if let Err(err) = set_label {
-                let result = MoveResult::HardFailure(CdtError::BackendMutationFailed {
-                    operation: BackendMutationOperation::SetVertexData,
-                    target: format!("vertex {:?}", subdivision.new_vertex.vertex_key()),
-                    detail: err.to_string(),
-                });
-                return rollback_if_failed(triangulation, snapshot, result);
-            }
-        }
-
-        let result = self.finish_mutated_move(triangulation, MoveType::Move13Add);
-        rollback_if_failed(triangulation, snapshot, result)
-    }
-
-    /// Applies the toroidal volume-add move as a spacelike-link split.
-    ///
-    /// The backend only exposes primitive bistellar edits, so this composes a
-    /// face subdivision with an immediate flip of the original spacelike link.
-    /// The intermediate same-slice triangle is never finalized as CDT state.
-    fn attempt_toroidal_13_move_mutating(
-        &mut self,
-        triangulation: &mut CdtTriangulation2D,
-    ) -> MoveResult {
-        let mut geometric_candidate_seen = false;
-        let mut causal_candidate_count = 0;
-        let mut selected_candidate = None;
-
-        let geometry = triangulation.geometry();
-        for edge in geometry.edges() {
-            let Ok(Some(adjacent)) = geometry.edge_adjacent_faces(&edge) else {
-                continue;
-            };
-            geometric_candidate_seen = true;
-
-            let Some(candidate) = toroidal_insertion_candidate(triangulation, edge, &adjacent)
-            else {
-                continue;
-            };
-            if !toroidal_insertion_candidate_is_committable(triangulation, &candidate) {
-                continue;
-            }
-
-            causal_candidate_count += 1;
-            if self.rng.random_range(0..causal_candidate_count) == 0 {
-                selected_candidate = Some(candidate);
-            }
-        }
-
-        let Some(candidate) = selected_candidate else {
-            if !geometric_candidate_seen {
-                return MoveResult::GeometricViolation;
-            }
-            return MoveResult::CausalityViolation;
-        };
-
-        let snapshot = triangulation.clone();
-        let subdivision_target = format!("face {:?}", candidate.face.simplex_key());
-        let subdivision = triangulation.subdivide_face(candidate.face, &candidate.point);
-        let subdivision = match subdivision {
-            Ok(subdivision) => subdivision,
-            Err(err) => {
-                let result = reject_backend(
-                    BackendMutationOperation::SubdivideFace,
-                    subdivision_target,
-                    &err,
-                );
-                return rollback_if_failed(triangulation, snapshot, result);
-            }
-        };
-
-        if let Err(err) =
-            triangulation.set_vertex_data(&subdivision.new_vertex, Some(candidate.label))
-        {
-            let result = MoveResult::HardFailure(CdtError::BackendMutationFailed {
-                operation: BackendMutationOperation::SetVertexData,
-                target: format!("vertex {:?}", subdivision.new_vertex.vertex_key()),
-                detail: err.to_string(),
-            });
-            return rollback_if_failed(triangulation, snapshot, result);
-        }
-
-        let flip_target = format!("{:?}", candidate.edge);
-        let flip_result = triangulation.flip_edge(candidate.edge);
-        let result = match flip_result {
-            Ok(_) => self.finish_mutated_move(triangulation, MoveType::Move13Add),
-            Err(err) => reject_backend(BackendMutationOperation::FlipEdge, flip_target, &err),
-        };
-        rollback_if_failed(triangulation, snapshot, result)
+        self.apply_proposal_site(triangulation, MoveType::Move13Add, site)
     }
 
     /// Attempts a (3,1) move on the triangulation.
@@ -698,102 +697,12 @@ impl ErgodicsSystem {
     /// bookkeeping. Once the snapshot exists, every early return must pass a
     /// `MoveResult` through `rollback_if_failed` or restore state itself.
     fn attempt_31_move_mutating(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
-        if matches!(triangulation.metadata().topology, CdtTopology::Toroidal)
-            && triangulation.has_foliation()
-        {
-            return self.attempt_toroidal_31_move_mutating(triangulation);
-        }
-
-        let mut geometric_candidate_seen = false;
-        let mut causal_candidate_count = 0;
-        let mut selected_vertex = None;
-
-        for vertex in triangulation.geometry().vertices() {
-            let Some(neighbors) = neighbors3(triangulation, &vertex) else {
-                continue;
-            };
-            geometric_candidate_seen = true;
-
-            if !removal_candidate_is_causal(triangulation, &vertex, &neighbors) {
-                continue;
-            }
-            if !removal_candidate_is_committable(triangulation, &vertex, &neighbors) {
-                continue;
-            }
-
-            causal_candidate_count += 1;
-            if self.rng.random_range(0..causal_candidate_count) == 0 {
-                selected_vertex = Some(vertex);
-            }
-        }
-
-        let Some(vertex) = selected_vertex else {
-            if !geometric_candidate_seen {
-                return MoveResult::GeometricViolation;
-            }
-            return if triangulation.has_foliation() {
-                MoveResult::CausalityViolation
-            } else {
-                MoveResult::GeometricViolation
-            };
+        let selection = self.select_proposal_site(triangulation, MoveType::Move31Remove);
+        let Some(site) = selection.site else {
+            return rejected_empty_selection(triangulation, &selection);
         };
 
-        let removal_target = format!("vertex {:?}", vertex.vertex_key());
-        let snapshot = triangulation.clone();
-        let removal = triangulation.remove_vertex(vertex);
-
-        let result = match removal {
-            Ok(_) => self.finish_mutated_move(triangulation, MoveType::Move31Remove),
-            Err(err) => {
-                reject_backend(BackendMutationOperation::RemoveVertex, removal_target, &err)
-            }
-        };
-        rollback_if_failed(triangulation, snapshot, result)
-    }
-
-    /// Applies the toroidal inverse volume move as flip-then-collapse.
-    fn attempt_toroidal_31_move_mutating(
-        &mut self,
-        triangulation: &mut CdtTriangulation2D,
-    ) -> MoveResult {
-        let mut candidate_count = 0_usize;
-        let mut selected_candidate = None;
-
-        for vertex in triangulation.geometry().vertices() {
-            let Some(candidate) = toroidal_removal_candidate(triangulation, vertex) else {
-                continue;
-            };
-            if !toroidal_removal_candidate_is_committable(triangulation, &candidate) {
-                continue;
-            }
-
-            candidate_count += 1;
-            if self.rng.random_range(0..candidate_count) == 0 {
-                selected_candidate = Some(candidate);
-            }
-        }
-
-        let Some(candidate) = selected_candidate else {
-            return MoveResult::GeometricViolation;
-        };
-
-        let snapshot = triangulation.clone();
-        let flip_target = format!("{:?}", candidate.flip_edge);
-        let flip_result = triangulation.flip_edge(candidate.flip_edge);
-        if let Err(err) = flip_result {
-            let result = reject_backend(BackendMutationOperation::FlipEdge, flip_target, &err);
-            return rollback_if_failed(triangulation, snapshot, result);
-        }
-
-        let removal_target = format!("vertex {:?}", candidate.vertex.vertex_key());
-        let removal = triangulation.remove_vertex(candidate.vertex);
-        let result = match removal {
-            Ok(_) => self.finish_mutated_move(triangulation, MoveType::Move31Remove),
-            Err(err) => {
-                reject_backend(BackendMutationOperation::RemoveVertex, removal_target, &err)
-            }
-        };
-        rollback_if_failed(triangulation, snapshot, result)
+        self.apply_proposal_site(triangulation, MoveType::Move31Remove, site)
     }
 
     /// Attempts an edge flip move on the triangulation.
@@ -874,33 +783,24 @@ impl ErgodicsSystem {
         triangulation: &mut CdtTriangulation2D,
         move_type: MoveType,
     ) -> MoveResult {
-        let mut geometric_candidate_seen = false;
-        let mut causal_candidate_count = 0;
-        let mut selected_edge = None;
-
-        let geometry = triangulation.geometry();
-        for edge in geometry.edges() {
-            let Ok(Some(adjacent)) = geometry.edge_adjacent_faces(&edge) else {
-                continue;
-            };
-            geometric_candidate_seen = true;
-            if !edge_flip_candidate_is_committable(triangulation, &edge, &adjacent) {
-                continue;
-            }
-
-            causal_candidate_count += 1;
-            if self.rng.random_range(0..causal_candidate_count) == 0 {
-                selected_edge = Some(edge);
-            }
-        }
-
-        let Some(edge) = selected_edge else {
-            if geometric_candidate_seen && triangulation.has_foliation() {
-                return MoveResult::CausalityViolation;
-            }
-            return MoveResult::GeometricViolation;
+        let selection = self.select_proposal_site(triangulation, move_type);
+        let Some(site) = selection.site else {
+            return rejected_empty_selection(triangulation, &selection);
         };
 
+        self.apply_proposal_site(triangulation, move_type, site)
+    }
+
+    /// Applies a selected edge-flip site and rolls back any failed mutation.
+    ///
+    /// This is shared by `Move22` and `EdgeFlip`, which are public names for the
+    /// same 2D k=2 bistellar flip kernel.
+    fn apply_edge_flip_site(
+        &mut self,
+        triangulation: &mut CdtTriangulation2D,
+        move_type: MoveType,
+        edge: DelaunayEdgeHandle,
+    ) -> MoveResult {
         let flip_target = format!("{edge:?}");
         let snapshot = triangulation.clone();
         let flip_result = triangulation.flip_edge(edge);
@@ -908,6 +808,142 @@ impl ErgodicsSystem {
         let result = match flip_result {
             Ok(_) => self.finish_mutated_move(triangulation, move_type),
             Err(err) => reject_backend(BackendMutationOperation::FlipEdge, flip_target, &err),
+        };
+        rollback_if_failed(triangulation, snapshot, result)
+    }
+
+    /// Applies a selected open-boundary face subdivision site.
+    ///
+    /// The mutation is finalized only after optional vertex labeling,
+    /// foliation synchronization, and evolved-CDT validation all succeed.
+    fn apply_face_subdivision_site(
+        &mut self,
+        triangulation: &mut CdtTriangulation2D,
+        face: DelaunayFaceHandle,
+        point: [f64; 2],
+        label: InsertionLabel,
+    ) -> MoveResult {
+        let subdivision_target = format!("face {:?}", face.simplex_key());
+        let snapshot = triangulation.clone();
+        let subdivision = triangulation.subdivide_face(face, &point);
+
+        let subdivision = match subdivision {
+            Ok(subdivision) => subdivision,
+            Err(err) => {
+                let result = reject_backend(
+                    BackendMutationOperation::SubdivideFace,
+                    subdivision_target,
+                    &err,
+                );
+                return rollback_if_failed(triangulation, snapshot, result);
+            }
+        };
+
+        if let InsertionLabel::Label(label) = label {
+            let set_label = triangulation.set_vertex_data(&subdivision.new_vertex, Some(label));
+            if let Err(err) = set_label {
+                let result = reject_backend(
+                    BackendMutationOperation::SetVertexData,
+                    format!("vertex {:?}", subdivision.new_vertex.vertex_key()),
+                    &err,
+                );
+                return rollback_if_failed(triangulation, snapshot, result);
+            }
+        }
+
+        let result = self.finish_mutated_move(triangulation, MoveType::Move13Add);
+        rollback_if_failed(triangulation, snapshot, result)
+    }
+
+    /// Applies the toroidal volume-add move as a spacelike-link split.
+    ///
+    /// The backend only exposes primitive bistellar edits, so this composes a
+    /// face subdivision with an immediate flip of the original spacelike link.
+    /// The intermediate same-slice triangle is never finalized as CDT state.
+    fn apply_toroidal_insertion_site(
+        &mut self,
+        triangulation: &mut CdtTriangulation2D,
+        candidate: ToroidalInsertionCandidate,
+    ) -> MoveResult {
+        let snapshot = triangulation.clone();
+        let subdivision_target = format!("face {:?}", candidate.face.simplex_key());
+        let subdivision = triangulation.subdivide_face(candidate.face, &candidate.point);
+        let subdivision = match subdivision {
+            Ok(subdivision) => subdivision,
+            Err(err) => {
+                let result = reject_backend(
+                    BackendMutationOperation::SubdivideFace,
+                    subdivision_target,
+                    &err,
+                );
+                return rollback_if_failed(triangulation, snapshot, result);
+            }
+        };
+
+        if let Err(err) =
+            triangulation.set_vertex_data(&subdivision.new_vertex, Some(candidate.label))
+        {
+            let result = reject_backend(
+                BackendMutationOperation::SetVertexData,
+                format!("vertex {:?}", subdivision.new_vertex.vertex_key()),
+                &err,
+            );
+            return rollback_if_failed(triangulation, snapshot, result);
+        }
+
+        let flip_target = format!("{:?}", candidate.edge);
+        let flip_result = triangulation.flip_edge(candidate.edge);
+        let result = match flip_result {
+            Ok(_) => self.finish_mutated_move(triangulation, MoveType::Move13Add),
+            Err(err) => reject_backend(BackendMutationOperation::FlipEdge, flip_target, &err),
+        };
+        rollback_if_failed(triangulation, snapshot, result)
+    }
+
+    /// Applies a selected open-boundary vertex-removal site.
+    ///
+    /// The candidate was already screened for causal and replacement-face
+    /// preconditions; this function owns the backend edit, validation, and
+    /// rollback boundary.
+    fn apply_vertex_removal_site(
+        &mut self,
+        triangulation: &mut CdtTriangulation2D,
+        vertex: DelaunayVertexHandle,
+    ) -> MoveResult {
+        let removal_target = format!("vertex {:?}", vertex.vertex_key());
+        let snapshot = triangulation.clone();
+        let removal = triangulation.remove_vertex(vertex);
+
+        let result = match removal {
+            Ok(_) => self.finish_mutated_move(triangulation, MoveType::Move31Remove),
+            Err(err) => {
+                reject_backend(BackendMutationOperation::RemoveVertex, removal_target, &err)
+            }
+        };
+        rollback_if_failed(triangulation, snapshot, result)
+    }
+
+    /// Applies the toroidal inverse volume move as flip-then-collapse.
+    fn apply_toroidal_removal_site(
+        &mut self,
+        triangulation: &mut CdtTriangulation2D,
+        candidate: ToroidalRemovalCandidate,
+    ) -> MoveResult {
+        let snapshot = triangulation.clone();
+        let flip_target = format!("{:?}", candidate.flip_edge);
+        let flip_result = triangulation.flip_edge(candidate.flip_edge);
+        if let Err(err) = flip_result {
+            let result = reject_backend(BackendMutationOperation::FlipEdge, flip_target, &err);
+            return rollback_if_failed(triangulation, snapshot, result);
+        }
+
+        let removal_target = format!("vertex {:?}", candidate.vertex.vertex_key());
+        let removal = triangulation.remove_vertex(candidate.vertex);
+        let result = match removal {
+            Ok(_) => self.finish_mutated_move(triangulation, MoveType::Move31Remove),
+            Err(err) => {
+                reject_backend(BackendMutationOperation::RemoveVertex, removal_target, &err)
+            }
         };
         rollback_if_failed(triangulation, snapshot, result)
     }
@@ -960,6 +996,22 @@ fn rollback_if_failed(
 
     *triangulation = snapshot;
     result
+}
+
+/// Converts an empty sampled site set into the public move-result category.
+///
+/// Seeing geometric candidates but no sampleable foliated sites means causality
+/// filtered every candidate; no geometric candidates means the move is
+/// unavailable for topological/backend shape reasons.
+fn rejected_empty_selection(
+    triangulation: &CdtTriangulation2D,
+    selection: &ProposalSiteSelection,
+) -> MoveResult {
+    if selection.geometric_candidate_seen && triangulation.has_foliation() {
+        MoveResult::CausalityViolation
+    } else {
+        MoveResult::GeometricViolation
+    }
 }
 
 /// Converts an unexpected backend edit error into the move-level rejection shape.
@@ -1077,7 +1129,7 @@ fn flip_is_causal(
 }
 
 /// Checks whether a k=2 edge flip passes the cheap deterministic edit guards.
-fn edge_flip_candidate_is_committable(
+fn edge_flip_candidate_is_sampleable(
     triangulation: &CdtTriangulation2D,
     edge: &DelaunayEdgeHandle,
     adjacent: &EdgeAdjacentFaces<DelaunayVertexHandle, DelaunayFaceHandle>,
@@ -1086,9 +1138,6 @@ fn edge_flip_candidate_is_committable(
     triangulation.geometry().can_flip_edge(edge)
         && flip_is_causal(triangulation, adjacent)
         && !edge_exists_between(triangulation, opposite_0, opposite_1)
-        && candidate_mutation_succeeds(triangulation, |candidate| {
-            candidate.flip_edge(edge.clone()).is_ok()
-        })
 }
 
 /// Finds the inserted vertex label that makes a `(1,3)` subdivision causal.
@@ -1110,24 +1159,8 @@ fn insertion_label(
 }
 
 /// Checks coordinate-level backend preconditions for face subdivision.
-fn insertion_candidate_is_committable(
-    triangulation: &CdtTriangulation2D,
-    face: &DelaunayFaceHandle,
-    point: &[f64; 2],
-    label: InsertionLabel,
-) -> bool {
+fn insertion_candidate_is_sampleable(point: &[f64; 2]) -> bool {
     point.iter().all(|coordinate| coordinate.is_finite())
-        && candidate_mutation_succeeds(triangulation, |candidate| {
-            let Ok(subdivision) = candidate.subdivide_face(face.clone(), point) else {
-                return false;
-            };
-            if let InsertionLabel::Label(label) = label {
-                return candidate
-                    .set_vertex_data(&subdivision.new_vertex, Some(label))
-                    .is_ok();
-            }
-            true
-        })
 }
 
 /// Returns the previous and next labels around the toroidal time circle.
@@ -1206,24 +1239,11 @@ fn toroidal_insertion_candidate(
 }
 
 /// Checks backend-local preconditions for the toroidal spacelike-link split.
-fn toroidal_insertion_candidate_is_committable(
-    triangulation: &CdtTriangulation2D,
-    candidate: &ToroidalInsertionCandidate,
-) -> bool {
+fn toroidal_insertion_candidate_is_sampleable(candidate: &ToroidalInsertionCandidate) -> bool {
     candidate
         .point
         .iter()
         .all(|coordinate| coordinate.is_finite())
-        && candidate_mutation_succeeds(triangulation, |dry_run| {
-            let Ok(subdivision) = dry_run.subdivide_face(candidate.face.clone(), &candidate.point)
-            else {
-                return false;
-            };
-            dry_run
-                .set_vertex_data(&subdivision.new_vertex, Some(candidate.label))
-                .is_ok()
-                && dry_run.flip_edge(candidate.edge.clone()).is_ok()
-        })
 }
 
 /// Finds a CDT-valid inserted vertex label without topology-specific guards.
@@ -1272,6 +1292,10 @@ fn vertex_point_2d(
 ///
 /// Returning `None` keeps malformed or non-triangular faces out of the mutation
 /// path instead of relying on the backend to reject them later.
+///
+/// TODO(acgetchell/delaunay#420): replace this local point-selection policy
+/// with a backend-owned simplex subdivision API once upstream Delaunay exposes
+/// one.
 fn centroid(triangulation: &CdtTriangulation2D, face: &DelaunayFaceHandle) -> Option<[f64; 2]> {
     let vertices = triangulation.geometry().face_vertices(face).ok()?;
     let [v0, v1, v2] = vertices.as_slice() else {
@@ -1467,27 +1491,19 @@ fn toroidal_removal_candidate(
 }
 
 /// Checks whether collapsing a degree-3 vertex would duplicate an existing face.
-fn removal_candidate_is_committable(
+fn removal_candidate_is_sampleable(
     triangulation: &CdtTriangulation2D,
-    vertex: &DelaunayVertexHandle,
     neighbors: &[DelaunayVertexHandle; 3],
 ) -> bool {
     !face_exists_with_vertices(triangulation, neighbors)
-        && candidate_mutation_succeeds(triangulation, |candidate| {
-            candidate.remove_vertex(vertex.clone()).is_ok()
-        })
 }
 
 /// Checks backend-local preconditions for the toroidal flip-then-collapse move.
-fn toroidal_removal_candidate_is_committable(
+fn toroidal_removal_candidate_is_sampleable(
     triangulation: &CdtTriangulation2D,
     candidate: &ToroidalRemovalCandidate,
 ) -> bool {
     triangulation.geometry().can_flip_edge(&candidate.flip_edge)
-        && candidate_mutation_succeeds(triangulation, |dry_run| {
-            dry_run.flip_edge(candidate.flip_edge.clone()).is_ok()
-                && dry_run.remove_vertex(candidate.vertex.clone()).is_ok()
-        })
 }
 
 /// Collects the three distinct neighboring vertices around a removable vertex.
@@ -1571,105 +1587,136 @@ pub(crate) fn proposal_site_count(
     triangulation: &CdtTriangulation2D,
     move_type: MoveType,
 ) -> usize {
-    match move_type {
-        MoveType::Move22 | MoveType::EdgeFlip => edge_flip_site_count(triangulation),
-        MoveType::Move13Add => insertion_site_count(triangulation),
-        MoveType::Move31Remove => removal_site_count(triangulation),
-    }
+    let mut site_count = 0;
+    visit_proposal_sites(triangulation, move_type, |_| site_count += 1);
+    site_count
 }
 
-fn edge_flip_site_count(triangulation: &CdtTriangulation2D) -> usize {
-    let geometry = triangulation.geometry();
-    geometry
-        .edges()
-        .filter(|edge| {
-            let Ok(Some(adjacent)) = geometry.edge_adjacent_faces(edge) else {
-                return false;
-            };
-            edge_flip_candidate_is_committable(triangulation, edge, &adjacent)
-        })
-        .count()
-}
-
-fn insertion_site_count(triangulation: &CdtTriangulation2D) -> usize {
-    if is_toroidal_foliated(triangulation) {
-        return toroidal_insertion_site_count(triangulation);
-    }
-
-    triangulation
-        .geometry()
-        .faces()
-        .filter(|face| {
-            let Some(point) = centroid(triangulation, face) else {
-                return false;
-            };
-            let Some(label) = insertion_label(triangulation, face) else {
-                return false;
-            };
-
-            insertion_candidate_is_committable(triangulation, face, &point, label)
-        })
-        .count()
-}
-
-fn toroidal_insertion_site_count(triangulation: &CdtTriangulation2D) -> usize {
-    let geometry = triangulation.geometry();
-    geometry
-        .edges()
-        .filter(|edge| {
-            let Ok(Some(adjacent)) = geometry.edge_adjacent_faces(edge) else {
-                return false;
-            };
-            let Some(insert) = toroidal_insertion_candidate(triangulation, edge.clone(), &adjacent)
-            else {
-                return false;
-            };
-            toroidal_insertion_candidate_is_committable(triangulation, &insert)
-        })
-        .count()
-}
-
-fn removal_site_count(triangulation: &CdtTriangulation2D) -> usize {
-    if is_toroidal_foliated(triangulation) {
-        return triangulation
-            .geometry()
-            .vertices()
-            .filter(|vertex| {
-                let Some(remove) = toroidal_removal_candidate(triangulation, vertex.clone()) else {
-                    return false;
-                };
-                toroidal_removal_candidate_is_committable(triangulation, &remove)
-            })
-            .count();
-    }
-
-    triangulation
-        .geometry()
-        .vertices()
-        .filter(|vertex| {
-            let Some(neighbors) = neighbors3(triangulation, vertex) else {
-                return false;
-            };
-            removal_candidate_is_causal(triangulation, vertex, &neighbors)
-                && removal_candidate_is_committable(triangulation, vertex, &neighbors)
-        })
-        .count()
-}
-
-/// Tests a candidate mutation on a cloned triangulation before counting or sampling it.
+/// Visits every sampleable proposal site for one move family.
 ///
-/// Metropolis-Hastings site counts must include only sites that can actually
-/// commit through the same backend mutation path as the executor. Cheap local
-/// guards run first where possible, and this dry-run catches remaining backend
-/// constraints without mutating the live state.
-fn candidate_mutation_succeeds(
+/// The return value records whether any coarse geometric candidate existed,
+/// even if no candidate survived causal or backend-local screening.
+fn visit_proposal_sites(
     triangulation: &CdtTriangulation2D,
-    operation: impl FnOnce(&mut CdtTriangulation2D) -> bool,
+    move_type: MoveType,
+    mut visit: impl FnMut(ProposalSite),
 ) -> bool {
-    let mut candidate = triangulation.clone();
-    operation(&mut candidate)
+    match move_type {
+        MoveType::Move22 | MoveType::EdgeFlip => edge_flip_sites(triangulation, &mut visit),
+        MoveType::Move13Add => insertion_sites(triangulation, &mut visit),
+        MoveType::Move31Remove => removal_sites(triangulation, &mut visit),
+    }
 }
 
+/// Visits sampleable k=2 edge-flip sites.
+///
+/// Each visited edge has two adjacent faces, passes the causal flip guard, and
+/// avoids creating a duplicate edge between opposite vertices.
+fn edge_flip_sites(
+    triangulation: &CdtTriangulation2D,
+    visit: &mut impl FnMut(ProposalSite),
+) -> bool {
+    let geometry = triangulation.geometry();
+    let mut geometric_candidate_seen = false;
+    for edge in geometry.edges() {
+        let Ok(Some(adjacent)) = geometry.edge_adjacent_faces(&edge) else {
+            continue;
+        };
+        geometric_candidate_seen = true;
+        if edge_flip_candidate_is_sampleable(triangulation, &edge, &adjacent) {
+            visit(ProposalSite::EdgeFlip(edge));
+        }
+    }
+    geometric_candidate_seen
+}
+
+/// Visits sampleable `(1,3)` insertion sites for the triangulation topology.
+///
+/// Toroidal foliated triangulations use the spacelike-link split visitor;
+/// ordinary face subdivision is used for open-boundary and unfoliated states.
+fn insertion_sites(
+    triangulation: &CdtTriangulation2D,
+    visit: &mut impl FnMut(ProposalSite),
+) -> bool {
+    if is_toroidal_foliated(triangulation) {
+        return toroidal_insertion_sites(triangulation, visit);
+    }
+
+    let mut geometric_candidate_seen = false;
+    for face in triangulation.geometry().faces() {
+        let Some(point) = centroid(triangulation, &face) else {
+            continue;
+        };
+        geometric_candidate_seen = true;
+        let Some(label) = insertion_label(triangulation, &face) else {
+            continue;
+        };
+
+        if insertion_candidate_is_sampleable(&point) {
+            visit(ProposalSite::FaceSubdivision { face, point, label });
+        }
+    }
+    geometric_candidate_seen
+}
+
+/// Visits sampleable toroidal `(1,3)` spacelike-link split sites.
+///
+/// The visitor only receives candidates whose adjacent faces identify a
+/// same-slice edge with neighboring time labels and a finite insertion point.
+fn toroidal_insertion_sites(
+    triangulation: &CdtTriangulation2D,
+    visit: &mut impl FnMut(ProposalSite),
+) -> bool {
+    let geometry = triangulation.geometry();
+    let mut geometric_candidate_seen = false;
+    for edge in geometry.edges() {
+        let Ok(Some(adjacent)) = geometry.edge_adjacent_faces(&edge) else {
+            continue;
+        };
+        geometric_candidate_seen = true;
+        let Some(insert) = toroidal_insertion_candidate(triangulation, edge, &adjacent) else {
+            continue;
+        };
+        if toroidal_insertion_candidate_is_sampleable(&insert) {
+            visit(ProposalSite::ToroidalInsertion(insert));
+        }
+    }
+    geometric_candidate_seen
+}
+
+/// Visits sampleable `(3,1)` removal sites for the triangulation topology.
+///
+/// Toroidal foliated states use flip-then-collapse candidates; open-boundary
+/// and unfoliated states use direct degree-3 vertex collapses.
+fn removal_sites(triangulation: &CdtTriangulation2D, visit: &mut impl FnMut(ProposalSite)) -> bool {
+    if is_toroidal_foliated(triangulation) {
+        for vertex in triangulation.geometry().vertices() {
+            let Some(remove) = toroidal_removal_candidate(triangulation, vertex) else {
+                continue;
+            };
+            if toroidal_removal_candidate_is_sampleable(triangulation, &remove) {
+                visit(ProposalSite::ToroidalRemoval(remove));
+            }
+        }
+        return true;
+    }
+
+    let mut geometric_candidate_seen = false;
+    for vertex in triangulation.geometry().vertices() {
+        let Some(neighbors) = neighbors3(triangulation, &vertex) else {
+            continue;
+        };
+        geometric_candidate_seen = true;
+        if removal_candidate_is_causal(triangulation, &vertex, &neighbors)
+            && removal_candidate_is_sampleable(triangulation, &neighbors)
+        {
+            visit(ProposalSite::VertexRemoval(vertex));
+        }
+    }
+    geometric_candidate_seen
+}
+
+/// Checks whether toroidal move kernels must preserve periodic foliation structure.
 fn is_toroidal_foliated(triangulation: &CdtTriangulation2D) -> bool {
     matches!(triangulation.metadata().topology, CdtTopology::Toroidal)
         && triangulation.has_foliation()
@@ -1756,6 +1803,100 @@ mod tests {
         assert_eq!(stats.edge_flips_hard_failed, 1);
         assert_eq!(stats.total_hard_failures(), 4);
         assert_relative_eq!(stats.total_acceptance_rate(), 0.5);
+    }
+
+    #[test]
+    fn move_statistics_saturate_extreme_counters() {
+        let mut stats = MoveStatistics {
+            moves_22_attempted: u64::MAX,
+            moves_13_attempted: 1,
+            moves_31_attempted: 1,
+            edge_flips_attempted: 1,
+            moves_22_accepted: u64::MAX,
+            moves_13_accepted: 1,
+            moves_31_accepted: 1,
+            edge_flips_accepted: 1,
+            moves_22_hard_failed: u64::MAX,
+            moves_13_hard_failed: 1,
+            moves_31_hard_failed: 1,
+            edge_flips_hard_failed: 1,
+        };
+
+        stats.record_attempt(MoveType::Move22);
+        stats.record_success(MoveType::Move22);
+        stats.record_hard_failure(MoveType::Move22);
+
+        assert_eq!(stats.moves_22_attempted, u64::MAX);
+        assert_eq!(stats.moves_22_accepted, u64::MAX);
+        assert_eq!(stats.moves_22_hard_failed, u64::MAX);
+        assert_eq!(stats.total_attempted(), u64::MAX);
+        assert_eq!(stats.total_accepted(), u64::MAX);
+        assert_eq!(stats.total_hard_failures(), u64::MAX);
+    }
+
+    #[test]
+    fn move_statistics_saturate_each_move_type_counter() {
+        for move_type in [
+            MoveType::Move22,
+            MoveType::Move13Add,
+            MoveType::Move31Remove,
+            MoveType::EdgeFlip,
+        ] {
+            let mut stats = MoveStatistics::new();
+            match move_type {
+                MoveType::Move22 => {
+                    stats.moves_22_attempted = u64::MAX;
+                    stats.moves_22_accepted = u64::MAX;
+                    stats.moves_22_hard_failed = u64::MAX;
+                }
+                MoveType::Move13Add => {
+                    stats.moves_13_attempted = u64::MAX;
+                    stats.moves_13_accepted = u64::MAX;
+                    stats.moves_13_hard_failed = u64::MAX;
+                }
+                MoveType::Move31Remove => {
+                    stats.moves_31_attempted = u64::MAX;
+                    stats.moves_31_accepted = u64::MAX;
+                    stats.moves_31_hard_failed = u64::MAX;
+                }
+                MoveType::EdgeFlip => {
+                    stats.edge_flips_attempted = u64::MAX;
+                    stats.edge_flips_accepted = u64::MAX;
+                    stats.edge_flips_hard_failed = u64::MAX;
+                }
+            }
+
+            stats.record_attempt(move_type);
+            stats.record_success(move_type);
+            stats.record_hard_failure(move_type);
+
+            let (attempted, accepted, hard_failed) = match move_type {
+                MoveType::Move22 => (
+                    stats.moves_22_attempted,
+                    stats.moves_22_accepted,
+                    stats.moves_22_hard_failed,
+                ),
+                MoveType::Move13Add => (
+                    stats.moves_13_attempted,
+                    stats.moves_13_accepted,
+                    stats.moves_13_hard_failed,
+                ),
+                MoveType::Move31Remove => (
+                    stats.moves_31_attempted,
+                    stats.moves_31_accepted,
+                    stats.moves_31_hard_failed,
+                ),
+                MoveType::EdgeFlip => (
+                    stats.edge_flips_attempted,
+                    stats.edge_flips_accepted,
+                    stats.edge_flips_hard_failed,
+                ),
+            };
+            assert_eq!(attempted, u64::MAX);
+            assert_eq!(accepted, u64::MAX);
+            assert_eq!(hard_failed, u64::MAX);
+            assert_relative_eq!(stats.acceptance_rate(move_type), 1.0);
+        }
     }
 
     #[test]
@@ -1993,7 +2134,96 @@ mod tests {
     }
 
     #[test]
-    fn removal_committable_guard_rejects_existing_replacement_face() {
+    fn selected_proposal_site_reports_count_and_empty_state() {
+        let mut system = ErgodicsSystem::with_seed(11);
+        let mut triangulation = single_triangle();
+
+        let empty_selection = system.select_proposal_site(&triangulation, MoveType::Move31Remove);
+        assert_eq!(empty_selection.site_count, 0);
+        assert!(empty_selection.site.is_none());
+
+        let insertion_selection = system.select_proposal_site(&triangulation, MoveType::Move13Add);
+        assert_eq!(
+            insertion_selection.site_count,
+            proposal_site_count(&triangulation, MoveType::Move13Add)
+        );
+        let Some(insertion_site) = insertion_selection.site else {
+            panic!("nonempty insertion selection should include a concrete site");
+        };
+
+        let result =
+            system.apply_proposal_site(&mut triangulation, MoveType::Move13Add, insertion_site);
+        assert_eq!(result, MoveResult::Success);
+
+        let removal_selection = system.select_proposal_site(&triangulation, MoveType::Move31Remove);
+        assert_eq!(
+            removal_selection.site_count,
+            proposal_site_count(&triangulation, MoveType::Move31Remove)
+        );
+        assert!(removal_selection.site.is_some());
+    }
+
+    #[test]
+    fn mismatched_proposal_site_rejects_without_mutating() {
+        let mut system = ErgodicsSystem::with_seed(11);
+        let mut triangulation = single_triangle();
+        let counts_before = (
+            triangulation.vertex_count(),
+            triangulation.edge_count(),
+            triangulation.face_count(),
+            triangulation.metadata().modification_count,
+        );
+
+        let insertion_selection = system.select_proposal_site(&triangulation, MoveType::Move13Add);
+        let Some(insertion_site) = insertion_selection.site else {
+            panic!("single triangle should expose one insertion site");
+        };
+
+        let result =
+            system.apply_proposal_site(&mut triangulation, MoveType::Move22, insertion_site);
+
+        assert_eq!(result, MoveResult::GeometricViolation);
+        assert_eq!(
+            (
+                triangulation.vertex_count(),
+                triangulation.edge_count(),
+                triangulation.face_count(),
+                triangulation.metadata().modification_count,
+            ),
+            counts_before
+        );
+        triangulation
+            .validate()
+            .expect("rejecting a mismatched proposal site should leave CDT invariants intact");
+    }
+
+    #[test]
+    fn proposal_site_count_handles_nonuniform_toroidal_profiles() {
+        let mut system = ErgodicsSystem::with_seed(7);
+        let mut triangulation = CdtTriangulation2D::from_toroidal_cdt_profile(&[3, 4, 5, 4])
+            .expect("nonuniform toroidal CDT should build");
+
+        let initial_insertions = proposal_site_count(&triangulation, MoveType::Move13Add);
+        let initial_removals = proposal_site_count(&triangulation, MoveType::Move31Remove);
+        assert!(
+            initial_insertions > 0,
+            "nonuniform toroidal profiles should expose counted insertion sites"
+        );
+        assert!(
+            initial_removals > 0,
+            "nonuniform toroidal profiles should expose counted inverse-volume sites"
+        );
+
+        let result = system.attempt_13_move(&mut triangulation);
+        assert_eq!(result, MoveResult::Success);
+        triangulation
+            .validate()
+            .expect("counted nonuniform-profile insertion should preserve CDT invariants");
+        assert!(proposal_site_count(&triangulation, MoveType::Move13Add) > 0);
+    }
+
+    #[test]
+    fn removal_sampleable_guard_rejects_existing_replacement_face() {
         let triangulation = single_triangle();
         let face = triangulation
             .geometry()
@@ -2013,9 +2243,8 @@ mod tests {
             &triangulation,
             &replacement_vertices
         ));
-        assert!(!removal_candidate_is_committable(
+        assert!(!removal_candidate_is_sampleable(
             &triangulation,
-            v0,
             &replacement_vertices
         ));
     }
@@ -2119,12 +2348,21 @@ mod tests {
             triangulation.face_count(),
         );
 
-        let result = system.attempt_31_move(&mut triangulation);
+        let mut removed = false;
+        for _ in 0..64 {
+            match system.attempt_31_move(&mut triangulation) {
+                MoveResult::Success => {
+                    removed = true;
+                    break;
+                }
+                MoveResult::Rejected(_) | MoveResult::GeometricViolation => {}
+                other => panic!("unexpected toroidal removal result: {other:?}"),
+            }
+        }
 
-        assert_eq!(
-            result,
-            MoveResult::Success,
-            "periodic toroidal Move31Remove should apply with upstream offset-aware flips"
+        assert!(
+            removed,
+            "sampleable periodic toroidal Move31Remove sites should include upstream offset-aware successes"
         );
         assert_eq!(system.stats.moves_31_accepted, 1);
         assert_eq!(
@@ -2160,20 +2398,46 @@ mod tests {
 
         assert!(
             proposal_site_count(&triangulation, MoveType::Move31Remove) > 0,
-            "initial toroidal CDT should expose committable inverse-volume sites"
+            "initial toroidal CDT should expose sampleable inverse-volume sites"
         );
         assert!(proposal_site_count(&triangulation, MoveType::Move13Add) > 0);
 
-        let insert = system.attempt_13_move(&mut triangulation);
-        assert_eq!(insert, MoveResult::Success);
+        let mut inserted = false;
+        for _ in 0..64 {
+            match system.attempt_13_move(&mut triangulation) {
+                MoveResult::Success => {
+                    inserted = true;
+                    break;
+                }
+                MoveResult::Rejected(_) | MoveResult::CausalityViolation => {}
+                other => panic!("unexpected toroidal insertion result: {other:?}"),
+            }
+        }
+        assert!(
+            inserted,
+            "sampleable toroidal insertion sites should include successes"
+        );
 
         assert!(
             proposal_site_count(&triangulation, MoveType::Move31Remove) > 0,
-            "a toroidal spacelike-link split should expose at least one committable inverse site"
+            "a toroidal spacelike-link split should expose at least one sampleable inverse site"
         );
 
-        let removal = system.attempt_31_move(&mut triangulation);
-        assert_eq!(removal, MoveResult::Success);
+        let mut removed = false;
+        for _ in 0..64 {
+            match system.attempt_31_move(&mut triangulation) {
+                MoveResult::Success => {
+                    removed = true;
+                    break;
+                }
+                MoveResult::Rejected(_) | MoveResult::GeometricViolation => {}
+                other => panic!("unexpected toroidal removal result: {other:?}"),
+            }
+        }
+        assert!(
+            removed,
+            "sampleable toroidal inverse sites should include successes"
+        );
         triangulation
             .validate()
             .expect("proposal-counted toroidal inverse move should preserve CDT invariants");
@@ -2193,10 +2457,9 @@ mod tests {
 
         let result = system.attempt_31_move(&mut triangulation);
 
-        assert_eq!(
-            result,
-            MoveResult::GeometricViolation,
-            "minimal periodic toroidal slices should not expose removable volume candidates"
+        assert!(
+            matches!(result, MoveResult::CausalityViolation),
+            "minimal periodic toroidal slices should reject volume removal causally, got {result:?}"
         );
         assert_eq!(system.stats.moves_31_attempted, 1);
         assert_eq!(system.stats.moves_31_accepted, 0);

--- a/src/cdt/metropolis.rs
+++ b/src/cdt/metropolis.rs
@@ -5,20 +5,21 @@
 //! This module implements the Monte Carlo sampling algorithm used to sample
 //! triangulation configurations according to the CDT path integral measure.
 //!
-//! The simulation accepts or rejects a proposed move type before mutating the
-//! triangulation. Accepted moves are then applied through the CDT ergodic move
-//! kernels; failed accepted applications are rolled back and retried at another
-//! randomly selected local site.
+//! The simulation selects an explicit local proposal site, applies it once on a
+//! cloned proposed state, and only swaps that state into the live chain after
+//! Metropolis-Hastings acceptance. Ordinary site failures are self-loop
+//! proposal outcomes tracked in [`crate::cdt::metropolis::ProposalStatistics`].
 
 use crate::cdt::action::ActionConfig;
 use crate::cdt::ergodic_moves::{
     ErgodicsSystem, MoveResult, MoveStatistics, MoveType, proposal_site_count,
 };
-use crate::cdt::results::{Measurement, SimulationResultsBackend};
+use crate::cdt::results::{Measurement, SimulationResultsBackend, SimulationResultsParts};
 use crate::cdt::triangulation::SimulationEvent;
 use crate::config::validate_schedule;
 use crate::errors::{
-    CdtError, CdtResult, CheckpointResumeReason, MetropolisMoveApplicationFailure,
+    CdtError, CdtResult, CheckpointResumeReason, ConfigurationSetting,
+    MetropolisMoveApplicationFailure,
 };
 use crate::geometry::CdtTriangulation2D;
 use crate::util::saturating_usize_to_u32;
@@ -29,8 +30,6 @@ use std::error::Error;
 use std::fmt;
 use std::hint::cold_path;
 use std::time::{Duration, Instant};
-
-const ACCEPTED_MOVE_RETRIES: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct SimplexCounts {
@@ -158,9 +157,13 @@ impl MetropolisConfig {
 }
 
 /// Adapts shared schedule validation errors to the Metropolis-specific error variant.
-fn invalid_sim_config(setting: &str, provided_value: String, expected: String) -> CdtError {
+const fn invalid_sim_config(
+    setting: ConfigurationSetting,
+    provided_value: String,
+    expected: String,
+) -> CdtError {
     CdtError::InvalidSimulationConfiguration {
-        setting: setting.to_string(),
+        setting,
         provided_value,
         expected,
     }
@@ -172,7 +175,7 @@ fn validate_temperature(temperature: f64) -> CdtResult<()> {
         Ok(())
     } else {
         Err(invalid_sim_config(
-            "temperature",
+            ConfigurationSetting::Temperature,
             temperature.to_string(),
             "finite and positive".to_string(),
         ))
@@ -383,7 +386,6 @@ pub struct CdtProposalInfo {
 /// count-action level, but the bounded random local-site search did not find a
 /// concrete site where the move could be applied.
 #[derive(Debug, Clone, PartialEq)]
-#[non_exhaustive]
 enum CdtProposalSiteRejection {
     /// The selected local site would violate CDT causality.
     CausalityViolation,
@@ -448,13 +450,135 @@ impl Error for CdtProposalSiteRejection {
 pub enum CdtProposalError {
     /// Constructing or applying a concrete proposal hit a hard backend or invariant failure.
     ApplicationFailed {
-        /// Accepted move type.
+        /// Move type whose concrete application failed.
         move_type: MoveType,
         /// Local-site attempt that hit the hard failure.
         attempt: usize,
         /// Typed lower-level failure observed while committing the accepted move.
         source: CdtError,
     },
+}
+
+/// Telemetry for concrete Metropolis proposal outcomes.
+///
+/// These counters describe the proposal kernel observed during a run. They are
+/// diagnostic only: detailed balance is enforced by the per-step proposal
+/// probability used in the Hastings ratio, not by accumulated empirical counts.
+///
+/// The struct is non-exhaustive so future releases can add proposal telemetry
+/// without breaking downstream code. Construct empty accumulators with
+/// [`Self::new`] or [`Default::default`], and inspect fields through shared
+/// references returned by [`CdtMcmcCheckpoint::proposal_stats`] or
+/// [`SimulationResultsBackend::proposal_stats`]. Counters saturate at
+/// `u64::MAX` instead of wrapping.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::simulation::ProposalStatistics;
+///
+/// let stats = ProposalStatistics::new();
+/// assert_eq!(stats.move_family_proposals, 0);
+/// assert_eq!(stats.accepted_transitions, 0);
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ProposalStatistics {
+    /// Number of selected move-family proposals, saturating at `u64::MAX`.
+    pub move_family_proposals: u64,
+    /// Sum of sampleable forward-site denominators observed during planning,
+    /// saturating at `u64::MAX`.
+    pub observed_forward_sites: u64,
+    /// Number of proposals with no sampleable local site, saturating at `u64::MAX`.
+    pub no_site_proposals: u64,
+    /// Number of sampled sites rejected by causal checks, saturating at `u64::MAX`.
+    pub site_causality_rejections: u64,
+    /// Number of sampled sites rejected by geometric checks, saturating at `u64::MAX`.
+    pub site_geometric_rejections: u64,
+    /// Number of sampled sites rejected by backend mutation errors, saturating at `u64::MAX`.
+    pub site_backend_rejections: u64,
+    /// Number of valid proposed transitions rejected by the Metropolis draw,
+    /// saturating at `u64::MAX`.
+    pub metropolis_rejections: u64,
+    /// Number of proposed transitions committed to the chain, saturating at `u64::MAX`.
+    pub accepted_transitions: u64,
+    /// Number of proposal attempts that hit a hard failure, saturating at `u64::MAX`.
+    pub hard_failures: u64,
+}
+
+impl ProposalStatistics {
+    /// Creates an empty proposal telemetry accumulator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
+    ///
+    /// let stats = ProposalStatistics::new();
+    /// assert_eq!(stats, ProposalStatistics::default());
+    /// ```
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            move_family_proposals: 0,
+            observed_forward_sites: 0,
+            no_site_proposals: 0,
+            site_causality_rejections: 0,
+            site_geometric_rejections: 0,
+            site_backend_rejections: 0,
+            metropolis_rejections: 0,
+            accepted_transitions: 0,
+            hard_failures: 0,
+        }
+    }
+
+    /// Records one selected move family and the forward-site denominator observed for it.
+    ///
+    /// This is proposal-kernel telemetry only; the per-step Hastings ratio uses
+    /// the instantaneous site count directly rather than accumulated statistics.
+    fn record_move_family(&mut self, forward_sites: usize) {
+        self.move_family_proposals = self.move_family_proposals.saturating_add(1);
+        self.observed_forward_sites = self
+            .observed_forward_sites
+            .saturating_add(u64::try_from(forward_sites).unwrap_or(u64::MAX));
+    }
+
+    /// Records a move-family proposal with no concrete local site.
+    const fn record_no_site(&mut self) {
+        self.no_site_proposals = self.no_site_proposals.saturating_add(1);
+    }
+
+    /// Classifies a sampled-site rejection without changing chain state.
+    ///
+    /// These are ordinary self-loop proposal outcomes, not hard failures.
+    const fn record_site_rejection(&mut self, rejection: &CdtProposalSiteRejection) {
+        match rejection {
+            CdtProposalSiteRejection::CausalityViolation => {
+                self.site_causality_rejections = self.site_causality_rejections.saturating_add(1);
+            }
+            CdtProposalSiteRejection::GeometricViolation => {
+                self.site_geometric_rejections = self.site_geometric_rejections.saturating_add(1);
+            }
+            CdtProposalSiteRejection::Kernel(_) => {
+                self.site_backend_rejections = self.site_backend_rejections.saturating_add(1);
+            }
+        }
+    }
+
+    /// Records Metropolis rejection after a valid proposed transition was scored.
+    const fn record_metropolis_rejection(&mut self) {
+        self.metropolis_rejections = self.metropolis_rejections.saturating_add(1);
+    }
+
+    /// Records a proposed transition that was committed to the live chain.
+    const fn record_accepted_transition(&mut self) {
+        self.accepted_transitions = self.accepted_transitions.saturating_add(1);
+    }
+
+    /// Records an unexpected hard failure during proposal application.
+    const fn record_hard_failure(&mut self) {
+        self.hard_failures = self.hard_failures.saturating_add(1);
+    }
 }
 
 impl fmt::Display for CdtProposalError {
@@ -585,9 +709,11 @@ impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
     ) -> Result<Option<Self::Plan>, Self::Error> {
         let move_type = self.moves.select_random_move();
         let action_before = action_for(&self.action_config, state);
+        let mut proposal_stats = ProposalStatistics::new();
         let plan = match propose_concrete_plan(
             state,
             &mut self.moves,
+            &mut proposal_stats,
             &self.action_config,
             move_type,
             action_before,
@@ -700,6 +826,8 @@ pub struct CdtMcmcCheckpoint {
     current_step: u32,
     current_action: f64,
     move_stats: MoveStatistics,
+    #[serde(default)]
+    proposal_stats: ProposalStatistics,
     steps: Vec<MonteCarloStep>,
     measurements: Vec<Measurement>,
     elapsed_time: Duration,
@@ -856,6 +984,31 @@ impl CdtMcmcCheckpoint {
         &self.move_stats
     }
 
+    /// Returns accumulated proposal-kernel telemetry through the checkpoint step.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let checkpoint = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///         ActionConfig::default(),
+    ///     )
+    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///
+    ///     assert_eq!(checkpoint.proposal_stats().move_family_proposals, 1);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn proposal_stats(&self) -> &ProposalStatistics {
+        &self.proposal_stats
+    }
+
     /// Returns accumulated step telemetry through the checkpoint step.
     ///
     /// # Examples
@@ -931,15 +1084,16 @@ impl CdtMcmcCheckpoint {
     #[must_use]
     pub fn into_results(self) -> SimulationResultsBackend {
         let (triangulation, _, _) = self.chain.into_parts();
-        SimulationResultsBackend::from_parts(
-            self.config,
-            self.action_config,
-            self.move_stats,
-            self.steps,
-            self.measurements,
-            self.elapsed_time,
+        SimulationResultsBackend::from_parts(SimulationResultsParts {
+            config: self.config,
+            action_config: self.action_config,
+            move_stats: self.move_stats,
+            proposal_stats: self.proposal_stats,
+            steps: self.steps,
+            measurements: self.measurements,
+            elapsed_time: self.elapsed_time,
             triangulation,
-        )
+        })
     }
 }
 
@@ -950,6 +1104,7 @@ struct MetropolisRunState {
     acceptance_rng: Xoshiro256PlusPlus,
     ergodics: ErgodicsSystem,
     move_stats: MoveStatistics,
+    proposal_stats: ProposalStatistics,
     steps: Vec<MonteCarloStep>,
     measurements: Vec<Measurement>,
     elapsed_time: Duration,
@@ -1206,6 +1361,7 @@ impl MetropolisAlgorithm {
                 ErgodicsSystem::with_seed(seed.wrapping_add(0x9E37_79B9_7F4A_7C15))
             }),
             move_stats: MoveStatistics::new(),
+            proposal_stats: ProposalStatistics::new(),
             steps: Vec::new(),
             measurements,
             elapsed_time: Duration::ZERO,
@@ -1275,6 +1431,7 @@ impl MetropolisRunState {
             acceptance_rng: checkpoint.acceptance_rng,
             ergodics: checkpoint.ergodics,
             move_stats: checkpoint.move_stats,
+            proposal_stats: checkpoint.proposal_stats,
             steps: checkpoint.steps,
             measurements: checkpoint.measurements,
             elapsed_time: checkpoint.elapsed_time,
@@ -1300,6 +1457,7 @@ impl MetropolisRunState {
             current_step: self.current_step,
             current_action: self.current_action,
             move_stats: self.move_stats,
+            proposal_stats: self.proposal_stats,
             steps: self.steps,
             measurements: self.measurements,
             elapsed_time: self.elapsed_time,
@@ -1323,7 +1481,7 @@ fn run_one_step(
     state
         .triangulation
         .record_event(SimulationEvent::MoveAttempted {
-            move_type: format!("{move_type:?}"),
+            move_type,
             step: step.into(),
         });
 
@@ -1337,27 +1495,25 @@ fn run_one_step(
     let mut accepted = false;
     let mut action_after = None;
 
-    let plan = if delta_action.is_some() {
-        match propose_concrete_plan(
-            &state.triangulation,
-            &mut state.ergodics,
-            &algorithm.action_config,
-            move_type,
-            action_before,
-        ) {
-            Ok(plan) => plan,
-            Err(err) => {
-                state.move_stats.record_hard_failure(move_type);
-                return Err(accepted_move_error(
-                    step,
-                    move_type,
-                    err.attempt,
-                    err.source,
-                ));
-            }
+    let plan = match propose_concrete_plan(
+        &state.triangulation,
+        &mut state.ergodics,
+        &mut state.proposal_stats,
+        &algorithm.action_config,
+        move_type,
+        action_before,
+    ) {
+        Ok(plan) => plan,
+        Err(err) => {
+            state.move_stats.record_hard_failure(move_type);
+            state.proposal_stats.record_hard_failure();
+            return Err(accepted_move_error(
+                step,
+                move_type,
+                err.attempt,
+                err.source,
+            ));
         }
-    } else {
-        None
     };
 
     if let Some(plan) = plan {
@@ -1373,14 +1529,17 @@ fn run_one_step(
             action_after = Some(applied_action);
             state.current_action = applied_action;
             state.move_stats.record_success(move_type);
+            state.proposal_stats.record_accepted_transition();
             state
                 .triangulation
                 .record_event(SimulationEvent::MoveAccepted {
-                    move_type: format!("{move_type:?}"),
+                    move_type,
                     step: step.into(),
                     action_change: applied_action - action_before,
                 });
             validate_evolved_cdt_if_due(state)?;
+        } else {
+            state.proposal_stats.record_metropolis_rejection();
         }
     }
 
@@ -1841,28 +2000,46 @@ fn proposed_delta_action(
 fn propose_concrete_plan(
     state: &CdtTriangulation2D,
     moves: &mut ErgodicsSystem,
+    proposal_stats: &mut ProposalStatistics,
     action_config: &ActionConfig,
     move_type: MoveType,
     action_before: f64,
 ) -> Result<Option<CdtProposalPlan>, MoveApplicationError> {
     if proposed_delta_action(action_config, simplex_counts(state), move_type).is_none() {
+        proposal_stats.record_move_family(0);
+        proposal_stats.record_no_site();
         return Ok(None);
     }
-    let forward_site_count = proposal_site_count(state, move_type);
-    if forward_site_count == 0 {
+    let selection = moves.select_proposal_site(state, move_type);
+    let forward_site_count = selection.site_count;
+    proposal_stats.record_move_family(forward_site_count);
+    let Some(site) = selection.site else {
+        proposal_stats.record_no_site();
         return Ok(None);
-    }
+    };
 
     let mut proposed_state = state.clone();
-    let action_after = match apply_accepted_move(
-        &mut proposed_state,
-        moves,
-        action_config,
-        move_type,
-        action_before,
-    )? {
-        AcceptedMoveResult::Applied { action_after } => action_after,
-        AcceptedMoveResult::NoApplicableSite { .. } => return Ok(None),
+    let result = moves.apply_proposal_site(&mut proposed_state, move_type, site);
+    let action_after = match result {
+        MoveResult::Success => action_for(action_config, &proposed_state),
+        MoveResult::HardFailure(err) => {
+            return Err(MoveApplicationError {
+                attempt: 1,
+                source: err,
+            });
+        }
+        MoveResult::CausalityViolation => {
+            proposal_stats.record_site_rejection(&CdtProposalSiteRejection::CausalityViolation);
+            return Ok(None);
+        }
+        MoveResult::GeometricViolation => {
+            proposal_stats.record_site_rejection(&CdtProposalSiteRejection::GeometricViolation);
+            return Ok(None);
+        }
+        MoveResult::Rejected(err) => {
+            proposal_stats.record_site_rejection(&CdtProposalSiteRejection::Kernel(err));
+            return Ok(None);
+        }
     };
     let delta_action = action_after - action_before;
 
@@ -1931,66 +2108,10 @@ fn actions_match(left: f64, right: f64) -> bool {
     (left - right).abs() <= f64::EPSILON * scale * 8.0
 }
 
-/// Applies an already-accepted move, rolling back and retrying failed sites.
-///
-/// Retry exhaustion means the move type did not bind to a realizable local site
-/// in the bounded random search, so callers record a normal rejection. Hard
-/// backend failures still return a structured error.
-#[derive(Debug, Clone, PartialEq)]
-enum AcceptedMoveResult {
-    Applied {
-        action_after: f64,
-    },
-    NoApplicableSite {
-        last_rejection: Option<CdtProposalSiteRejection>,
-    },
-}
-
 #[derive(Debug, Clone, PartialEq)]
 struct MoveApplicationError {
     attempt: usize,
     source: CdtError,
-}
-
-fn apply_accepted_move(
-    triangulation: &mut CdtTriangulation2D,
-    moves: &mut ErgodicsSystem,
-    action_config: &ActionConfig,
-    move_type: MoveType,
-    action_before: f64,
-) -> Result<AcceptedMoveResult, MoveApplicationError> {
-    let mut last_rejection = None;
-    for attempt in 1..=ACCEPTED_MOVE_RETRIES {
-        let counts_before = simplex_counts(triangulation);
-        let result = attempt_move(moves, move_type, triangulation);
-        let rejection = match result {
-            MoveResult::Success => {
-                let action_after = action_for(action_config, triangulation);
-                return Ok(AcceptedMoveResult::Applied { action_after });
-            }
-            MoveResult::HardFailure(err) => {
-                return Err(MoveApplicationError {
-                    attempt,
-                    source: err,
-                });
-            }
-            MoveResult::CausalityViolation => CdtProposalSiteRejection::CausalityViolation,
-            MoveResult::GeometricViolation => CdtProposalSiteRejection::GeometricViolation,
-            MoveResult::Rejected(err) => CdtProposalSiteRejection::Kernel(err),
-        };
-        debug_assert_eq!(
-            simplex_counts(triangulation),
-            counts_before,
-            "failed move kernels must roll back simplex counts before returning"
-        );
-        last_rejection = Some(rejection);
-    }
-
-    debug_assert!(
-        actions_match(action_for(action_config, triangulation), action_before),
-        "failed accepted move retries must leave the triangulation rolled back"
-    );
-    Ok(AcceptedMoveResult::NoApplicableSite { last_rejection })
 }
 
 /// Builds the simulation-level error for an accepted move that could not be applied.
@@ -2009,23 +2130,6 @@ fn accepted_move_error(
         move_type,
         attempts,
         source: MetropolisMoveApplicationFailure::from(source),
-    }
-}
-
-/// Dispatches one selected move type to the ergodic move system.
-///
-/// Keeping dispatch behind this helper lets the Metropolis loop work with move
-/// proposals uniformly while the move module retains ownership of each kernel.
-fn attempt_move(
-    moves: &mut ErgodicsSystem,
-    move_type: MoveType,
-    triangulation: &mut CdtTriangulation2D,
-) -> MoveResult {
-    match move_type {
-        MoveType::Move22 => moves.attempt_22_move(triangulation),
-        MoveType::Move13Add => moves.attempt_13_move(triangulation),
-        MoveType::Move31Remove => moves.attempt_31_move(triangulation),
-        MoveType::EdgeFlip => moves.attempt_edge_flip(triangulation),
     }
 }
 
@@ -2072,10 +2176,7 @@ mod tests {
         state.move_stats.record_attempt(move_type);
         state
             .triangulation
-            .record_event(SimulationEvent::MoveAttempted {
-                move_type: format!("{move_type:?}"),
-                step: 1,
-            });
+            .record_event(SimulationEvent::MoveAttempted { move_type, step: 1 });
         state.steps.push(MonteCarloStep {
             step: 1,
             move_type,
@@ -2114,6 +2215,7 @@ mod tests {
             acceptance_rng: simulation_rng(Some(1)),
             ergodics: ErgodicsSystem::with_seed(2),
             move_stats: MoveStatistics::new(),
+            proposal_stats: ProposalStatistics::new(),
             steps: Vec::new(),
             measurements: Vec::new(),
             elapsed_time: Duration::ZERO,
@@ -2388,6 +2490,24 @@ mod tests {
             first_resumed.triangulation().slice_sizes(),
             second_resumed.triangulation().slice_sizes()
         );
+    }
+
+    #[test]
+    fn serialized_checkpoint_missing_proposal_stats_defaults_on_restore() {
+        let checkpoint = serializable_rejected_checkpoint(ActionConfig::default());
+        let mut payload = to_value(&checkpoint).expect("checkpoint should serialize");
+        payload
+            .as_object_mut()
+            .expect("checkpoint payload should be an object")
+            .remove("proposal_stats");
+
+        let restored: CdtMcmcCheckpoint =
+            from_str(&payload.to_string()).expect("legacy checkpoint should deserialize");
+
+        assert_eq!(restored.proposal_stats(), &ProposalStatistics::new());
+        MetropolisAlgorithm::new(MetropolisConfig::new(1.0, 2, 0, 1), ActionConfig::default())
+            .resume_from_checkpoint(restored)
+            .expect("legacy checkpoint with default proposal stats should resume");
     }
 
     #[test]
@@ -2711,34 +2831,104 @@ mod tests {
     }
 
     #[test]
-    fn accepted_move_retry_exhaustion_is_rejection_result_and_rolls_back() {
-        let mut triangulation =
+    fn concrete_plan_site_rejection_is_self_loop_telemetry() {
+        let triangulation =
             CdtTriangulation::from_seeded_points(3, 1, 2, 53).expect("Failed to create");
         let action_config = ActionConfig::default();
         let counts_before = simplex_counts(&triangulation);
         let action_before = action_for(&action_config, &triangulation);
         let mut moves = ErgodicsSystem::with_seed(7);
+        let mut proposal_stats = ProposalStatistics::new();
 
-        let result = apply_accepted_move(
-            &mut triangulation,
+        let result = propose_concrete_plan(
+            &triangulation,
             &mut moves,
+            &mut proposal_stats,
             &action_config,
             MoveType::Move31Remove,
             action_before,
         )
-        .expect("site retry exhaustion is an ordinary rejection result");
+        .expect("site rejection is an ordinary proposal outcome");
 
-        let AcceptedMoveResult::NoApplicableSite { last_rejection } = result else {
-            panic!("Expected NoApplicableSite");
-        };
-        assert!(matches!(
-            last_rejection,
-            Some(
-                CdtProposalSiteRejection::GeometricViolation | CdtProposalSiteRejection::Kernel(_)
-            )
-        ));
+        assert!(result.is_none());
+        assert_eq!(proposal_stats.move_family_proposals, 1);
+        assert_eq!(proposal_stats.no_site_proposals, 1);
         assert_eq!(simplex_counts(&triangulation), counts_before);
         assert_relative_eq!(action_for(&action_config, &triangulation), action_before);
+    }
+
+    #[test]
+    fn proposal_statistics_saturate_extreme_counters() {
+        let mut stats = ProposalStatistics {
+            move_family_proposals: u64::MAX,
+            observed_forward_sites: u64::MAX - 1,
+            no_site_proposals: u64::MAX,
+            site_causality_rejections: u64::MAX,
+            site_geometric_rejections: u64::MAX,
+            site_backend_rejections: u64::MAX,
+            metropolis_rejections: u64::MAX,
+            accepted_transitions: u64::MAX,
+            hard_failures: u64::MAX,
+        };
+
+        stats.record_move_family(2);
+        stats.record_no_site();
+        stats.record_site_rejection(&CdtProposalSiteRejection::CausalityViolation);
+        stats.record_site_rejection(&CdtProposalSiteRejection::GeometricViolation);
+        stats.record_site_rejection(&CdtProposalSiteRejection::Kernel(
+            CdtError::InvalidSimulationConfiguration {
+                setting: ConfigurationSetting::Steps,
+                provided_value: "0".to_string(),
+                expected: "≥ 1".to_string(),
+            },
+        ));
+        stats.record_metropolis_rejection();
+        stats.record_accepted_transition();
+        stats.record_hard_failure();
+
+        assert_eq!(stats.move_family_proposals, u64::MAX);
+        assert_eq!(stats.observed_forward_sites, u64::MAX);
+        assert_eq!(stats.no_site_proposals, u64::MAX);
+        assert_eq!(stats.site_causality_rejections, u64::MAX);
+        assert_eq!(stats.site_geometric_rejections, u64::MAX);
+        assert_eq!(stats.site_backend_rejections, u64::MAX);
+        assert_eq!(stats.metropolis_rejections, u64::MAX);
+        assert_eq!(stats.accepted_transitions, u64::MAX);
+        assert_eq!(stats.hard_failures, u64::MAX);
+    }
+
+    #[test]
+    fn run_records_proposal_statistics_for_each_selected_move_family() {
+        let config = MetropolisConfig::new(1.0, 12, 0, 1).with_seed(2);
+        let algorithm = MetropolisAlgorithm::new(config.clone(), ActionConfig::default());
+        let triangulation =
+            CdtTriangulation::from_seeded_points(3, 1, 2, 53).expect("Failed to create");
+
+        let results = algorithm
+            .run(triangulation)
+            .expect("short run should finish");
+        let proposal_stats = results.proposal_stats();
+        let classified_proposals = proposal_stats.no_site_proposals
+            + proposal_stats.site_causality_rejections
+            + proposal_stats.site_geometric_rejections
+            + proposal_stats.site_backend_rejections
+            + proposal_stats.metropolis_rejections
+            + proposal_stats.accepted_transitions
+            + proposal_stats.hard_failures;
+
+        assert_eq!(
+            proposal_stats.move_family_proposals,
+            u64::from(config.steps)
+        );
+        assert_eq!(
+            proposal_stats.move_family_proposals,
+            results.move_stats().total_attempted()
+        );
+        assert_eq!(
+            proposal_stats.accepted_transitions,
+            results.move_stats().total_accepted()
+        );
+        assert_eq!(classified_proposals, proposal_stats.move_family_proposals);
     }
 
     #[test]
@@ -2754,7 +2944,7 @@ mod tests {
                 provided_value,
                 expected,
             } => {
-                assert_eq!(setting, "measurement_frequency");
+                assert_eq!(setting, ConfigurationSetting::MeasurementFrequency);
                 assert_eq!(provided_value, "0");
                 assert_eq!(expected, "≥ 1");
             }
@@ -2774,7 +2964,7 @@ mod tests {
                 CdtError::InvalidSimulationConfiguration {
                     setting, expected, ..
                 } => {
-                    assert_eq!(setting, "temperature", "T={bad_temp}");
+                    assert_eq!(setting, ConfigurationSetting::Temperature, "T={bad_temp}");
                     assert_eq!(expected, "finite and positive", "T={bad_temp}");
                 }
                 other => panic!(
@@ -2798,7 +2988,7 @@ mod tests {
                 provided_value,
                 expected,
             } => {
-                assert_eq!(setting, "measurement schedule");
+                assert_eq!(setting, ConfigurationSetting::MeasurementSchedule);
                 assert!(
                     provided_value.contains("steps=19")
                         && provided_value.contains("thermalization_steps=15")
@@ -2825,7 +3015,7 @@ mod tests {
                 provided_value,
                 expected,
             } => {
-                assert_eq!(setting, "measurement schedule");
+                assert_eq!(setting, ConfigurationSetting::MeasurementSchedule);
                 assert!(
                     provided_value.contains("steps=4294967295")
                         && provided_value.contains("thermalization_steps=4294967295")
@@ -2870,7 +3060,7 @@ mod tests {
                 provided_value,
                 expected,
             } => {
-                assert_eq!(setting, "coupling_0");
+                assert_eq!(setting, ConfigurationSetting::Coupling0);
                 assert_eq!(provided_value, "inf");
                 assert_eq!(expected, "finite");
             }
@@ -2891,7 +3081,7 @@ mod tests {
                     provided_value: _,
                     expected,
                 } => {
-                    assert_eq!(setting, "temperature");
+                    assert_eq!(setting, ConfigurationSetting::Temperature);
                     assert_eq!(expected, "finite and positive");
                 }
                 other => panic!("Expected InvalidSimulationConfiguration, got {other:?}"),
@@ -2911,7 +3101,7 @@ mod tests {
                 provided_value: _,
                 expected,
             } => {
-                assert_eq!(setting, "coupling_0");
+                assert_eq!(setting, ConfigurationSetting::Coupling0);
                 assert_eq!(expected, "finite");
             }
             other => panic!("Expected InvalidConfiguration, got {other:?}"),
@@ -2931,7 +3121,7 @@ mod tests {
                 provided_value: _,
                 expected,
             } => {
-                assert_eq!(setting, "coupling_2");
+                assert_eq!(setting, ConfigurationSetting::Coupling2);
                 assert_eq!(expected, "finite");
             }
             other => panic!("Expected InvalidConfiguration, got {other:?}"),
@@ -2984,10 +3174,12 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_toroidal_cdt(4, 3).expect("toroidal CDT should build");
         let mut moves = ErgodicsSystem::with_seed(19);
+        let mut proposal_stats = ProposalStatistics::new();
         let action_before = action_for(&action_config, &triangulation);
         let plan = propose_concrete_plan(
             &triangulation,
             &mut moves,
+            &mut proposal_stats,
             &action_config,
             MoveType::Move13Add,
             action_before,

--- a/src/cdt/metropolis.rs
+++ b/src/cdt/metropolis.rs
@@ -1486,11 +1486,9 @@ fn run_one_step(
         });
 
     let action_before = state.current_action;
-    let mut delta_action = proposed_delta_action(
-        &algorithm.action_config,
-        simplex_counts(&state.triangulation),
-        move_type,
-    );
+    // A selected move family is not yet a concrete proposal; self-loop outcomes
+    // such as no usable site or a rejected sampled site must not report a ΔS.
+    let mut delta_action = None;
 
     let mut accepted = false;
     let mut action_after = None;

--- a/src/cdt/results.rs
+++ b/src/cdt/results.rs
@@ -230,6 +230,10 @@ impl SimulationResultsBackend {
     /// use the same data shape but avoid revalidating immediately after the run has
     /// already checked its final CDT invariants.
     ///
+    /// The supplied [`MoveStatistics`] and [`ProposalStatistics`] are preserved
+    /// verbatim so serialized or externally reconstructed telemetry keeps the
+    /// same wire shape as results produced by the Metropolis runner.
+    ///
     /// # Errors
     ///
     /// Returns [`CdtError::InvalidSimulationConfiguration`] if `config` is not a
@@ -248,7 +252,8 @@ impl SimulationResultsBackend {
     /// ```
     /// use causal_triangulations::prelude::moves::MoveStatistics;
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, ProposalStatistics,
+    ///     SimulationResultsBackend,
     /// };
     /// use std::time::Duration;
     ///
@@ -258,6 +263,7 @@ impl SimulationResultsBackend {
     ///         MetropolisConfig::new(1.0, 1, 0, 1),
     ///         ActionConfig::default(),
     ///         MoveStatistics::new(),
+    ///         ProposalStatistics::new(),
     ///         vec![],
     ///         vec![],
     ///         Duration::from_millis(0),
@@ -267,10 +273,15 @@ impl SimulationResultsBackend {
     ///     Ok(())
     /// }
     /// ```
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "public constructor mirrors the serialized simulation result components"
+    )]
     pub fn new(
         config: MetropolisConfig,
         action_config: ActionConfig,
         move_stats: MoveStatistics,
+        proposal_stats: ProposalStatistics,
         steps: Vec<MonteCarloStep>,
         measurements: Vec<Measurement>,
         elapsed_time: Duration,
@@ -283,7 +294,7 @@ impl SimulationResultsBackend {
             config,
             action_config,
             move_stats,
-            proposal_stats: ProposalStatistics::new(),
+            proposal_stats,
             steps,
             measurements,
             elapsed_time,
@@ -322,6 +333,7 @@ impl SimulationResultsBackend {
     ///         config.clone(),
     ///         ActionConfig::default(),
     ///         MoveStatistics::new(),
+    ///         Default::default(),
     ///         vec![],
     ///         vec![],
     ///         Duration::ZERO,
@@ -353,6 +365,7 @@ impl SimulationResultsBackend {
     ///         MetropolisConfig::new(1.0, 1, 0, 1),
     ///         action_config.clone(),
     ///         MoveStatistics::new(),
+    ///         Default::default(),
     ///         vec![],
     ///         vec![],
     ///         Duration::ZERO,
@@ -384,6 +397,7 @@ impl SimulationResultsBackend {
     ///         MetropolisConfig::new(1.0, 1, 0, 1),
     ///         ActionConfig::default(),
     ///         move_stats,
+    ///         Default::default(),
     ///         vec![],
     ///         vec![],
     ///         Duration::ZERO,
@@ -439,6 +453,7 @@ impl SimulationResultsBackend {
     ///         MetropolisConfig::new(1.0, 1, 0, 1),
     ///         ActionConfig::default(),
     ///         MoveStatistics::new(),
+    ///         Default::default(),
     ///         vec![],
     ///         vec![],
     ///         Duration::ZERO,
@@ -469,6 +484,7 @@ impl SimulationResultsBackend {
     ///         MetropolisConfig::new(1.0, 1, 0, 1),
     ///         ActionConfig::default(),
     ///         MoveStatistics::new(),
+    ///         Default::default(),
     ///         vec![],
     ///         vec![],
     ///         Duration::ZERO,
@@ -500,6 +516,7 @@ impl SimulationResultsBackend {
     ///         MetropolisConfig::new(1.0, 1, 0, 1),
     ///         ActionConfig::default(),
     ///         MoveStatistics::new(),
+    ///         Default::default(),
     ///         vec![],
     ///         vec![],
     ///         elapsed,
@@ -530,6 +547,7 @@ impl SimulationResultsBackend {
     ///         MetropolisConfig::new(1.0, 1, 0, 1),
     ///         ActionConfig::default(),
     ///         MoveStatistics::new(),
+    ///         Default::default(),
     ///         vec![],
     ///         vec![],
     ///         Duration::ZERO,
@@ -561,6 +579,7 @@ impl SimulationResultsBackend {
     ///     let results = SimulationResultsBackend::new(
     ///         config,
     ///         ActionConfig::default(),
+    ///         Default::default(),
     ///         Default::default(),
     ///         vec![],
     ///         vec![],
@@ -607,6 +626,7 @@ impl SimulationResultsBackend {
     ///     let results = SimulationResultsBackend::new(
     ///         config,
     ///         ActionConfig::default(),
+    ///         Default::default(),
     ///         Default::default(),
     ///         vec![],
     ///         vec![],
@@ -655,6 +675,7 @@ impl SimulationResultsBackend {
     ///     let results = SimulationResultsBackend::new(
     ///         config,
     ///         ActionConfig::default(),
+    ///         Default::default(),
     ///         Default::default(),
     ///         vec![],
     ///         vec![
@@ -720,6 +741,7 @@ impl SimulationResultsBackend {
     ///     let results = SimulationResultsBackend::new(
     ///         config,
     ///         ActionConfig::default(),
+    ///         Default::default(),
     ///         Default::default(),
     ///         vec![],
     ///         vec![
@@ -789,6 +811,7 @@ impl SimulationResultsBackend {
     ///         MetropolisConfig::new(1.0, 1, 0, 1),
     ///         ActionConfig::default(),
     ///         Default::default(),
+    ///         Default::default(),
     ///         vec![],
     ///         vec![],
     ///         Duration::from_millis(0),
@@ -829,6 +852,7 @@ impl SimulationResultsBackend {
     ///         MetropolisConfig::new(1.0, 1, 0, 1),
     ///         ActionConfig::default(),
     ///         Default::default(),
+    ///         Default::default(),
     ///         vec![],
     ///         vec![],
     ///         Duration::from_millis(0),
@@ -867,6 +891,7 @@ impl SimulationResultsBackend {
     ///     let results = SimulationResultsBackend::new(
     ///         config,
     ///         ActionConfig::default(),
+    ///         Default::default(),
     ///         Default::default(),
     ///         vec![],
     ///         vec![],
@@ -1150,6 +1175,17 @@ mod tests {
         let mut move_stats = MoveStatistics::new();
         move_stats.record_attempt(MoveType::Move22);
         move_stats.record_success(MoveType::Move22);
+        let proposal_stats = ProposalStatistics {
+            move_family_proposals: 2,
+            observed_forward_sites: 7,
+            no_site_proposals: 1,
+            site_causality_rejections: 0,
+            site_geometric_rejections: 0,
+            site_backend_rejections: 0,
+            metropolis_rejections: 0,
+            accepted_transitions: 1,
+            hard_failures: 0,
+        };
         let step = MonteCarloStep {
             step: 2,
             move_type: MoveType::Move22,
@@ -1167,6 +1203,7 @@ mod tests {
             config.clone(),
             action_config.clone(),
             move_stats,
+            proposal_stats.clone(),
             vec![step],
             vec![measurement],
             elapsed,
@@ -1178,6 +1215,7 @@ mod tests {
         assert_eq!(results.action_config(), &action_config);
         assert_eq!(results.move_stats().total_attempted(), 1);
         assert_eq!(results.move_stats().total_accepted(), 1);
+        assert_eq!(results.proposal_stats(), &proposal_stats);
         assert_eq!(results.steps()[0].step, 2);
         assert_eq!(results.measurements()[0].volume_profile, vec![4, 4, 4]);
         assert_eq!(results.elapsed_time(), elapsed);
@@ -1193,6 +1231,7 @@ mod tests {
             MetropolisConfig::new(0.0, 1, 0, 1),
             ActionConfig::default(),
             MoveStatistics::new(),
+            ProposalStatistics::new(),
             vec![],
             vec![],
             Duration::ZERO,
@@ -1221,6 +1260,7 @@ mod tests {
             MetropolisConfig::new(1.0, 1, 0, 1),
             ActionConfig::new(f64::NAN, 0.0, 0.0),
             MoveStatistics::new(),
+            ProposalStatistics::new(),
             vec![],
             vec![],
             Duration::ZERO,
@@ -1259,6 +1299,7 @@ mod tests {
             MetropolisConfig::new(1.0, 1, 0, 1),
             ActionConfig::default(),
             MoveStatistics::new(),
+            ProposalStatistics::new(),
             vec![],
             vec![],
             Duration::ZERO,
@@ -1280,6 +1321,7 @@ mod tests {
             MetropolisConfig::new(1.0, 1, 0, 1),
             ActionConfig::default(),
             MoveStatistics::new(),
+            ProposalStatistics::new(),
             vec![],
             vec![],
             Duration::ZERO,
@@ -1311,6 +1353,7 @@ mod tests {
             MetropolisConfig::new(1.0, 1, 0, 1),
             ActionConfig::default(),
             MoveStatistics::new(),
+            ProposalStatistics::new(),
             vec![],
             vec![],
             Duration::ZERO,

--- a/src/cdt/results.rs
+++ b/src/cdt/results.rs
@@ -8,7 +8,7 @@
 
 use crate::cdt::action::ActionConfig;
 use crate::cdt::ergodic_moves::MoveStatistics;
-use crate::cdt::metropolis::{MetropolisConfig, MonteCarloStep};
+use crate::cdt::metropolis::{MetropolisConfig, MonteCarloStep, ProposalStatistics};
 use crate::cdt::observables::{estimate_hausdorff_dimension, estimate_spectral_dimension};
 use crate::config::{CdtConfig, CdtTopology};
 use crate::errors::{CdtError, CdtResult, OutputFormat};
@@ -120,6 +120,9 @@ pub struct SimulationResultsBackend {
     action_config: ActionConfig,
     /// Metropolis-level ergodic move statistics
     move_stats: MoveStatistics,
+    /// Concrete proposal-kernel telemetry
+    #[serde(default)]
+    proposal_stats: ProposalStatistics,
     /// All Monte Carlo steps performed
     steps: Vec<MonteCarloStep>,
     /// Measurements taken during simulation
@@ -135,25 +138,43 @@ struct SimulationResultsBackendWire {
     config: MetropolisConfig,
     action_config: ActionConfig,
     move_stats: MoveStatistics,
+    #[serde(default)]
+    proposal_stats: ProposalStatistics,
     steps: Vec<MonteCarloStep>,
     measurements: Vec<Measurement>,
     elapsed_time: Duration,
     triangulation: CdtTriangulation2D,
 }
 
+/// Validated components for constructing a simulation result snapshot.
+pub(crate) struct SimulationResultsParts {
+    pub(crate) config: MetropolisConfig,
+    pub(crate) action_config: ActionConfig,
+    pub(crate) move_stats: MoveStatistics,
+    pub(crate) proposal_stats: ProposalStatistics,
+    pub(crate) steps: Vec<MonteCarloStep>,
+    pub(crate) measurements: Vec<Measurement>,
+    pub(crate) elapsed_time: Duration,
+    pub(crate) triangulation: CdtTriangulation2D,
+}
+
 impl TryFrom<SimulationResultsBackendWire> for SimulationResultsBackend {
     type Error = CdtError;
 
     fn try_from(wire: SimulationResultsBackendWire) -> Result<Self, Self::Error> {
-        Self::new(
-            wire.config,
-            wire.action_config,
-            wire.move_stats,
-            wire.steps,
-            wire.measurements,
-            wire.elapsed_time,
-            wire.triangulation,
-        )
+        wire.config.validate()?;
+        wire.action_config.validate()?;
+        wire.triangulation.validate_evolved_cdt()?;
+        Ok(Self::from_parts(SimulationResultsParts {
+            config: wire.config,
+            action_config: wire.action_config,
+            move_stats: wire.move_stats,
+            proposal_stats: wire.proposal_stats,
+            steps: wire.steps,
+            measurements: wire.measurements,
+            elapsed_time: wire.elapsed_time,
+            triangulation: wire.triangulation,
+        }))
     }
 }
 
@@ -174,6 +195,7 @@ struct SimulationSummary<'a> {
     metropolis_config: &'a MetropolisConfig,
     action_config: &'a ActionConfig,
     move_stats: &'a MoveStatistics,
+    proposal_stats: &'a ProposalStatistics,
     aggregate: AggregateSummary,
     final_triangulation: TriangulationSummary,
     steps: &'a [MonteCarloStep],
@@ -257,35 +279,29 @@ impl SimulationResultsBackend {
         config.validate()?;
         action_config.validate()?;
         triangulation.validate_evolved_cdt()?;
-        Ok(Self::from_parts(
+        Ok(Self::from_parts(SimulationResultsParts {
             config,
             action_config,
             move_stats,
+            proposal_stats: ProposalStatistics::new(),
             steps,
             measurements,
             elapsed_time,
             triangulation,
-        ))
+        }))
     }
 
     /// Creates a result snapshot from components that were already validated by this crate.
-    pub(crate) const fn from_parts(
-        config: MetropolisConfig,
-        action_config: ActionConfig,
-        move_stats: MoveStatistics,
-        steps: Vec<MonteCarloStep>,
-        measurements: Vec<Measurement>,
-        elapsed_time: Duration,
-        triangulation: CdtTriangulation2D,
-    ) -> Self {
+    pub(crate) fn from_parts(parts: SimulationResultsParts) -> Self {
         Self {
-            config,
-            action_config,
-            move_stats,
-            steps,
-            measurements,
-            elapsed_time,
-            triangulation,
+            config: parts.config,
+            action_config: parts.action_config,
+            move_stats: parts.move_stats,
+            proposal_stats: parts.proposal_stats,
+            steps: parts.steps,
+            measurements: parts.measurements,
+            elapsed_time: parts.elapsed_time,
+            triangulation: parts.triangulation,
         }
     }
 
@@ -380,6 +396,31 @@ impl SimulationResultsBackend {
     #[must_use]
     pub const fn move_stats(&self) -> &MoveStatistics {
         &self.move_stats
+    }
+
+    /// Returns concrete proposal-kernel telemetry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let results = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///         ActionConfig::default(),
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///
+    ///     assert_eq!(results.proposal_stats().move_family_proposals, 1);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn proposal_stats(&self) -> &ProposalStatistics {
+        &self.proposal_stats
     }
 
     /// Returns recorded Monte Carlo step telemetry.
@@ -955,6 +996,7 @@ impl SimulationResultsBackend {
             metropolis_config: &self.config,
             action_config: &self.action_config,
             move_stats: &self.move_stats,
+            proposal_stats: &self.proposal_stats,
             aggregate: AggregateSummary {
                 acceptance_rate: self.acceptance_rate(),
                 average_action: mean_measurement_action(self.equilibrium_measurements_iter()),
@@ -1028,9 +1070,10 @@ mod tests {
     use crate::cdt::ergodic_moves::MoveType;
     use crate::cdt::foliation::FoliationError;
     use crate::cdt::triangulation::CdtTriangulation;
+    use crate::errors::ConfigurationSetting;
     use crate::geometry::traits::TriangulationQuery;
     use approx::assert_relative_eq;
-    use serde_json::{Value, from_str};
+    use serde_json::{Value, from_str, to_value};
     use std::env;
     use std::fs;
     use std::path::PathBuf;
@@ -1048,6 +1091,7 @@ mod tests {
             config,
             action_config: ActionConfig::default(),
             move_stats: MoveStatistics::new(),
+            proposal_stats: ProposalStatistics::new(),
             steps,
             measurements,
             elapsed_time: Duration::from_millis(100),
@@ -1162,7 +1206,7 @@ mod tests {
                 ref setting,
                 ref provided_value,
                 ref expected,
-            } if setting == "temperature"
+            } if *setting == ConfigurationSetting::Temperature
                 && provided_value == "0"
                 && expected == "finite and positive"
         ));
@@ -1190,7 +1234,7 @@ mod tests {
                 ref setting,
                 ref provided_value,
                 ref expected,
-            } if setting == "coupling_0" && provided_value == "NaN" && expected == "finite"
+            } if *setting == ConfigurationSetting::Coupling0 && provided_value == "NaN" && expected == "finite"
         ));
     }
 
@@ -1260,6 +1304,36 @@ mod tests {
     }
 
     #[test]
+    fn deserialization_defaults_missing_proposal_stats() {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let results = SimulationResultsBackend::new(
+            MetropolisConfig::new(1.0, 1, 0, 1),
+            ActionConfig::default(),
+            MoveStatistics::new(),
+            vec![],
+            vec![],
+            Duration::ZERO,
+            triangulation,
+        )
+        .expect("valid result components should construct");
+        let mut payload = to_value(&results).expect("results should serialize");
+        payload
+            .as_object_mut()
+            .expect("results payload should be an object")
+            .remove("proposal_stats");
+
+        let restored: SimulationResultsBackend =
+            from_str(&payload.to_string()).expect("legacy results should deserialize");
+
+        assert_eq!(restored.proposal_stats(), &ProposalStatistics::new());
+        restored
+            .triangulation()
+            .validate()
+            .expect("legacy results should still validate triangulation");
+    }
+
+    #[test]
     fn result_wire_validation_rejects_invalid_metropolis_config() {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
@@ -1267,6 +1341,7 @@ mod tests {
             config: MetropolisConfig::new(0.0, 1, 0, 1),
             action_config: ActionConfig::default(),
             move_stats: MoveStatistics::new(),
+            proposal_stats: ProposalStatistics::new(),
             steps: vec![],
             measurements: vec![],
             elapsed_time: Duration::ZERO,
@@ -1280,7 +1355,7 @@ mod tests {
                 ref setting,
                 ref provided_value,
                 ref expected,
-            } if setting == "temperature" && provided_value == "0" && expected == "finite and positive"
+            } if *setting == ConfigurationSetting::Temperature && provided_value == "0" && expected == "finite and positive"
         ));
     }
 
@@ -1292,6 +1367,7 @@ mod tests {
             config: MetropolisConfig::new(1.0, 1, 0, 1),
             action_config: ActionConfig::new(f64::NAN, 0.0, 0.0),
             move_stats: MoveStatistics::new(),
+            proposal_stats: ProposalStatistics::new(),
             steps: vec![],
             measurements: vec![],
             elapsed_time: Duration::ZERO,
@@ -1305,7 +1381,7 @@ mod tests {
                 ref setting,
                 ref provided_value,
                 ref expected,
-            } if setting == "coupling_0" && provided_value == "NaN" && expected == "finite"
+            } if *setting == ConfigurationSetting::Coupling0 && provided_value == "NaN" && expected == "finite"
         ));
     }
 

--- a/src/cdt/triangulation.rs
+++ b/src/cdt/triangulation.rs
@@ -5,9 +5,10 @@
 //! This module provides CDT-specific triangulation data structures that work
 //! with any geometry backend implementing the trait interfaces.
 
+use crate::cdt::ergodic_moves::MoveType;
 use crate::cdt::foliation::{Foliation, FoliationError};
 use crate::config::CdtTopology;
-use crate::errors::{CdtError, CdtResult};
+use crate::errors::{CdtError, CdtResult, TriangulationMetadataField};
 use crate::geometry::DelaunayBackend2D;
 use crate::geometry::traits::TriangulationQuery;
 use serde::de::Error as DeError;
@@ -32,7 +33,7 @@ pub struct CdtTriangulation<B> {
     foliation_synced_at_modification: Option<u64>,
 }
 
-/// CDT-specific metadata
+/// Metadata describing the CDT foliation, topology, and simulation history.
 #[derive(Debug, Clone)]
 pub struct CdtMetadata {
     /// Number of time slices in the CDT foliation
@@ -47,7 +48,9 @@ pub struct CdtMetadata {
     pub last_modified: Instant,
     /// Count of modifications made to the triangulation
     pub modification_count: u64,
-    /// History of simulation events
+    /// Ordered simulation event history recorded for this triangulation.
+    ///
+    /// Move events identify proposals and acceptances with [`MoveType`].
     pub simulation_history: Vec<SimulationEvent>,
 }
 
@@ -64,37 +67,61 @@ struct CachedValue<T> {
     modification_count: u64,
 }
 
-/// Events in simulation history
+/// Event recorded in a CDT simulation history.
+///
+/// The history is stored on [`CdtMetadata::simulation_history`]. Move events
+/// use [`MoveType`] to keep history, checkpoint serialization, and move
+/// statistics aligned with the crate's supported ergodic move set.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::moves::MoveType;
+/// use causal_triangulations::prelude::triangulation::SimulationEvent;
+///
+/// let event = SimulationEvent::MoveAttempted {
+///     move_type: MoveType::Move13Add,
+///     step: 7,
+/// };
+///
+/// assert!(matches!(
+///     event,
+///     SimulationEvent::MoveAttempted {
+///         move_type: MoveType::Move13Add,
+///         step: 7,
+///     }
+/// ));
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SimulationEvent {
-    /// Triangulation was created
+    /// Triangulation creation event.
     Created {
-        /// Initial number of vertices
+        /// Initial number of vertices.
         vertex_count: usize,
-        /// Number of time slices
+        /// Number of time slices.
         time_slices: u32,
     },
-    /// An ergodic move was attempted
+    /// Ergodic move proposal event.
     MoveAttempted {
-        /// Type of move attempted
-        move_type: String,
-        /// Simulation step number
+        /// Type of move attempted.
+        move_type: MoveType,
+        /// Simulation step number.
         step: u64,
     },
-    /// An ergodic move was accepted
+    /// Accepted ergodic move event.
     MoveAccepted {
-        /// Type of move accepted
-        move_type: String,
-        /// Simulation step number
+        /// Type of move accepted.
+        move_type: MoveType,
+        /// Simulation step number.
         step: u64,
-        /// Change in action from this move
+        /// Change in action from this move.
         action_change: f64,
     },
-    /// A measurement was taken
+    /// Observable measurement event.
     MeasurementTaken {
-        /// Simulation step number
+        /// Simulation step number.
         step: u64,
-        /// Action value measured
+        /// Action value measured.
         action: f64,
     },
 }
@@ -263,7 +290,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// ```
     ///
     /// ```rust
-    /// use causal_triangulations::prelude::errors::CdtError;
+    /// use causal_triangulations::prelude::errors::{CdtError, TriangulationMetadataField};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
@@ -285,7 +312,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///         topology,
     ///         provided_value,
     ///         expected,
-    ///     } if field == "timeslices"
+    ///     } if field == TriangulationMetadataField::Timeslices
     ///         && topology == CdtTopology::Toroidal
     ///         && provided_value == "2"
     ///         && expected == "≥ 3"
@@ -293,7 +320,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// ```
     ///
     /// ```rust
-    /// use causal_triangulations::prelude::errors::CdtError;
+    /// use causal_triangulations::prelude::errors::{CdtError, TriangulationMetadataField};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
@@ -366,7 +393,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     fn check_time_slices(topology: CdtTopology, time_slices: u32) -> CdtResult<()> {
         if time_slices == 0 {
             return Err(CdtError::InvalidTriangulationMetadata {
-                field: "timeslices".to_string(),
+                field: TriangulationMetadataField::Timeslices,
                 topology,
                 provided_value: "0".to_string(),
                 expected: "≥ 1".to_string(),
@@ -375,7 +402,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
 
         if matches!(topology, CdtTopology::Toroidal) && time_slices < 3 {
             return Err(CdtError::InvalidTriangulationMetadata {
-                field: "timeslices".to_string(),
+                field: TriangulationMetadataField::Timeslices,
                 topology,
                 provided_value: time_slices.to_string(),
                 expected: "≥ 3".to_string(),
@@ -392,7 +419,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
         let backend_dimension = self.geometry.dimension();
         if usize::from(self.metadata.dimension) != backend_dimension {
             return Err(CdtError::InvalidTriangulationMetadata {
-                field: "dimension".to_string(),
+                field: TriangulationMetadataField::Dimension,
                 topology: self.metadata.topology,
                 provided_value: self.metadata.dimension.to_string(),
                 expected: format!("backend dimension ({backend_dimension})"),
@@ -669,7 +696,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::prelude::errors::CdtError;
+    /// use causal_triangulations::prelude::errors::{CdtError, TriangulationMetadataField};
     /// use causal_triangulations::prelude::triangulation::{CdtTopology, CdtTriangulation};
     ///
     /// let mut tri = CdtTriangulation::from_toroidal_cdt(4, 3)
@@ -683,7 +710,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///         topology,
     ///         provided_value,
     ///         expected,
-    ///     } if field == "timeslices"
+    ///     } if field == TriangulationMetadataField::Timeslices
     ///         && topology == CdtTopology::Toroidal
     ///         && provided_value == "2"
     ///         && expected == "≥ 3"
@@ -726,7 +753,7 @@ mod tests {
     use super::*;
     use crate::geometry::generators::build_delaunay2_with_data;
     use serde_json::error::Category;
-    use serde_json::{from_str, to_string};
+    use serde_json::{from_str, from_value, json, to_string, to_value};
     use std::num::NonZeroUsize;
     use std::thread;
     use std::time::{Duration, Instant};
@@ -782,7 +809,7 @@ mod tests {
                 topology,
                 ref provided_value,
                 ref expected,
-            }) if field == "timeslices"
+            }) if *field == TriangulationMetadataField::Timeslices
                 && topology == CdtTopology::OpenBoundary
                 && provided_value == "0"
                 && expected == "≥ 1"
@@ -801,7 +828,7 @@ mod tests {
                 topology,
                 ref provided_value,
                 ref expected,
-            }) if field == "dimension"
+            }) if *field == TriangulationMetadataField::Dimension
                 && topology == CdtTopology::OpenBoundary
                 && provided_value == "3"
                 && expected == "backend dimension (2)"
@@ -821,7 +848,7 @@ mod tests {
                 ref provided_value,
                 ref expected,
                 ..
-            }) if field == "dimension"
+            }) if *field == TriangulationMetadataField::Dimension
                 && provided_value == "3"
                 && expected == "backend dimension (2)"
         ));
@@ -1007,12 +1034,12 @@ mod tests {
         thread::sleep(Duration::from_millis(5));
 
         triangulation.record_event(SimulationEvent::MoveAttempted {
-            move_type: "test_move".to_string(),
+            move_type: MoveType::Move22,
             step: 1,
         });
 
         triangulation.record_event(SimulationEvent::MoveAccepted {
-            move_type: "test_move".to_string(),
+            move_type: MoveType::Move22,
             step: 1,
             action_change: -0.5,
         });
@@ -1033,7 +1060,7 @@ mod tests {
         let history = &triangulation.metadata().simulation_history;
         match &history[initial_history_len] {
             SimulationEvent::MoveAttempted { move_type, step } => {
-                assert_eq!(move_type, "test_move");
+                assert_eq!(*move_type, MoveType::Move22);
                 assert_eq!(*step, 1);
             }
             _ => panic!("Expected MoveAttempted event"),
@@ -1045,7 +1072,7 @@ mod tests {
                 step,
                 action_change,
             } => {
-                assert_eq!(move_type, "test_move");
+                assert_eq!(*move_type, MoveType::Move22);
                 assert_eq!(*step, 1);
                 approx::assert_relative_eq!(*action_change, -0.5);
             }
@@ -1090,7 +1117,7 @@ mod tests {
         let initial_slice_sizes = tri.slice_sizes().to_vec();
 
         tri.record_event(SimulationEvent::MoveAttempted {
-            move_type: "history_only".to_string(),
+            move_type: MoveType::EdgeFlip,
             step: 7,
         });
 
@@ -1167,7 +1194,7 @@ mod tests {
                 ref provided_value,
                 ref expected,
                 ..
-            }) if field == "timeslices" && provided_value == "0" && expected == "≥ 1"
+            }) if *field == TriangulationMetadataField::Timeslices && provided_value == "0" && expected == "≥ 1"
         ));
     }
 
@@ -1271,11 +1298,11 @@ mod tests {
                 time_slices: 2,
             },
             SimulationEvent::MoveAttempted {
-                move_type: "flip".to_string(),
+                move_type: MoveType::EdgeFlip,
                 step: 1,
             },
             SimulationEvent::MoveAccepted {
-                move_type: "flip".to_string(),
+                move_type: MoveType::EdgeFlip,
                 step: 1,
                 action_change: 0.5,
             },
@@ -1290,6 +1317,53 @@ mod tests {
             // Should not panic and should contain meaningful content
             assert!(!debug_str.is_empty());
         }
+    }
+
+    #[test]
+    fn simulation_event_move_type_serializes_as_enum_variant() {
+        let event = SimulationEvent::MoveAccepted {
+            move_type: MoveType::Move31Remove,
+            step: 9,
+            action_change: -1.25,
+        };
+
+        let value = to_value(&event).expect("event should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "MoveAccepted": {
+                    "move_type": "Move31Remove",
+                    "step": 9,
+                    "action_change": -1.25
+                }
+            })
+        );
+
+        let restored: SimulationEvent =
+            from_value(value).expect("typed move event should deserialize");
+        match restored {
+            SimulationEvent::MoveAccepted {
+                move_type,
+                step,
+                action_change,
+            } => {
+                assert_eq!(move_type, MoveType::Move31Remove);
+                assert_eq!(step, 9);
+                approx::assert_relative_eq!(action_change, -1.25);
+            }
+            other => panic!("expected MoveAccepted event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn simulation_event_rejects_free_form_move_type_strings() {
+        let invalid_json = r#"{"MoveAttempted":{"move_type":"test_move","step":1}}"#;
+
+        let error = from_str::<SimulationEvent>(invalid_json)
+            .expect_err("move history should reject unsupported move strings");
+
+        assert_checkpoint_data_error(&error, &["unknown variant `test_move`", "Move22"]);
     }
 
     #[test]
@@ -1389,7 +1463,7 @@ mod tests {
                 topology,
                 ref provided_value,
                 ref expected,
-            }) if field == "timeslices"
+            }) if *field == TriangulationMetadataField::Timeslices
                 && topology == CdtTopology::Toroidal
                 && provided_value == "2"
                 && expected == "≥ 3"
@@ -1413,7 +1487,7 @@ mod tests {
                 topology,
                 ref provided_value,
                 ref expected,
-            }) if field == "timeslices"
+            }) if *field == TriangulationMetadataField::Timeslices
                 && topology == CdtTopology::Toroidal
                 && provided_value == "2"
                 && expected == "≥ 3"
@@ -1495,7 +1569,7 @@ mod tests {
         let mut triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay CDT strip should build");
         triangulation.record_event(SimulationEvent::MoveAttempted {
-            move_type: "Move22".to_string(),
+            move_type: MoveType::Move22,
             step: 1,
         });
         triangulation.record_event(SimulationEvent::MeasurementTaken {
@@ -1768,7 +1842,7 @@ mod prop_tests {
             prop_assert!(initial_history_len >= 1, "Should have at least creation event");
 
             triangulation.record_event(SimulationEvent::MoveAttempted {
-                move_type: "test".to_string(),
+                move_type: MoveType::Move22,
                 step: 1,
             });
             triangulation.record_event(SimulationEvent::MeasurementTaken {

--- a/src/cdt/triangulation/builders.rs
+++ b/src/cdt/triangulation/builders.rs
@@ -120,6 +120,78 @@ pub(super) fn validate_strip_counts(
     Ok(())
 }
 
+/// Computes the open-strip triangle count used to validate profiled builder output.
+///
+/// The count is checked before foliation construction so a backend mesh with
+/// mismatched topology cannot be paired with the caller's requested profile.
+fn open_profile_face_count(profile: &[u32]) -> CdtResult<u32> {
+    let (&first_slice, rest) =
+        profile
+            .split_first()
+            .ok_or_else(|| CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::EmptyVolumeProfile,
+                provided_value: "[]".to_string(),
+                expected_range: "at least one time slice".to_string(),
+            })?;
+    let last_slice = rest.last().copied().unwrap_or(first_slice);
+    let total_vertices = profile.iter().try_fold(0_u32, |total, &vertices| {
+        total
+            .checked_add(vertices)
+            .ok_or_else(|| CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::VertexCountOverflow,
+                provided_value: format!("{profile:?}"),
+                expected_range: "sum ≤ u32::MAX".to_string(),
+            })
+    })?;
+    let slice_count =
+        u32::try_from(profile.len()).map_err(|err| CdtError::InvalidGenerationParameters {
+            issue: GenerationParameterIssue::VolumeProfileLengthOverflow,
+            provided_value: profile.len().to_string(),
+            expected_range: format!("length must fit in u32: {err}"),
+        })?;
+
+    total_vertices
+        .checked_mul(2)
+        .and_then(|faces| faces.checked_sub(first_slice))
+        .and_then(|faces| faces.checked_sub(last_slice))
+        .and_then(|faces| faces.checked_sub(slice_count.checked_mul(2)?))
+        .and_then(|faces| faces.checked_add(2))
+        .ok_or_else(|| CdtError::InvalidGenerationParameters {
+            issue: GenerationParameterIssue::SimplexCountOverflow,
+            provided_value: format!("{profile:?}"),
+            expected_range: "open-strip face count must fit in u32".to_string(),
+        })
+}
+
+/// Verifies that a profiled open-boundary builder returned the requested mesh size.
+///
+/// This protects [`CdtTriangulation::from_cdt_strip_profile`] from constructing
+/// foliation metadata for a backend whose vertex or face topology does not
+/// match the requested spatial volume profile.
+fn validate_profile_strip_counts(
+    backend: &DelaunayBackend2D,
+    total_vertices: u32,
+    expected_vertices: usize,
+    expected_faces: usize,
+    coordinate_max: f64,
+) -> CdtResult<()> {
+    if backend.vertex_count() != expected_vertices || backend.face_count() != expected_faces {
+        return Err(strip_generation_error(
+            total_vertices,
+            coordinate_max,
+            format!(
+                "build_delaunay2_with_data()/from_cdt_strip_profile() produced {} vertices and {} faces, expected {} vertices and {} faces",
+                backend.vertex_count(),
+                backend.face_count(),
+                expected_vertices,
+                expected_faces,
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
 /// Builds a CDT-level generation error for periodic toroidal construction failures.
 const fn toroidal_generation_error(
     total_vertices: u32,
@@ -706,7 +778,9 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// than two slices, any slice has fewer than four vertices, or derived counts
     /// overflow.
     /// Returns [`CdtError::DelaunayGenerationFailed`] if coordinate storage cannot
-    /// be reserved or if the Delaunay constructor rejects the profiled point data.
+    /// be reserved, if the Delaunay constructor rejects the profiled point data,
+    /// or if the generated backend vertex or face count does not match the
+    /// requested profile.
     /// Returns [`CdtError::DelaunayValidationFailed`] if the constructed backend
     /// fails the Level 1-4 Delaunay validator. Returns [`CdtError::TopologyMismatch`],
     /// [`CdtError::Foliation`], [`CdtError::CausalityViolation`], or
@@ -728,13 +802,27 @@ impl CdtTriangulation<DelaunayBackend2D> {
     pub fn from_cdt_strip_profile(volume_profile: &[u32]) -> CdtResult<Self> {
         let (total_vertices, num_slices) =
             validate_spatial_profile(volume_profile, 2, 4, "open-boundary topology")?;
-        let vertex_specs = open_profile_vertices(volume_profile, total_vertices)?;
-        let dt = build_delaunay2_with_data(&vertex_specs).map_err(|error| {
-            remap_strip_generation_error(error, total_vertices, f64::from(num_slices))
+        let coordinate_max = f64::from(num_slices);
+        let expected_vertices = usize::try_from(total_vertices).map_err(|err| {
+            strip_generation_error(total_vertices, coordinate_max, err.to_string())
         })?;
+        let expected_faces =
+            usize::try_from(open_profile_face_count(volume_profile)?).map_err(|err| {
+                strip_generation_error(total_vertices, coordinate_max, err.to_string())
+            })?;
+        let vertex_specs = open_profile_vertices(volume_profile, total_vertices)?;
+        let dt = build_delaunay2_with_data(&vertex_specs)
+            .map_err(|error| remap_strip_generation_error(error, total_vertices, coordinate_max))?;
         let backend = validated_backend(dt)?;
+        validate_profile_strip_counts(
+            &backend,
+            total_vertices,
+            expected_vertices,
+            expected_faces,
+            coordinate_max,
+        )?;
         let slice_sizes = profile_slice_sizes(volume_profile, |err| {
-            strip_generation_error(total_vertices, f64::from(num_slices), err)
+            strip_generation_error(total_vertices, coordinate_max, err)
         })?;
 
         let foliation =
@@ -1451,13 +1539,65 @@ mod tests {
             .expect("nonuniform Delaunay strip should build");
 
         assert_eq!(tri.vertex_count(), 15);
-        assert!(tri.face_count() > 0);
+        assert_eq!(tri.face_count(), 17);
         assert_eq!(tri.slice_sizes(), &[4, 6, 5]);
         assert_eq!(tri.volume_profile().len(), 3);
         assert!(tri.validate_topology().is_ok());
         assert!(tri.validate_foliation().is_ok());
         assert!(tri.validate_causality_delaunay().is_ok());
         assert!(tri.validate_simplex_classification().is_ok());
+    }
+
+    #[test]
+    fn test_open_profile_face_count_matches_open_strip_topology() {
+        assert_eq!(
+            open_profile_face_count(&[4, 4]).expect("regular two-slice strip should count"),
+            6
+        );
+        assert_eq!(
+            open_profile_face_count(&[4, 4, 4]).expect("regular three-slice strip should count"),
+            12
+        );
+        assert_eq!(
+            open_profile_face_count(&[4, 6, 5]).expect("nonuniform strip should count"),
+            17
+        );
+    }
+
+    #[test]
+    fn test_open_profile_face_count_rejects_empty_profile() {
+        let result = open_profile_face_count(&[]);
+
+        assert!(matches!(
+            result,
+            Err(CdtError::InvalidGenerationParameters {
+                ref issue,
+                ref provided_value,
+                ref expected_range,
+            }) if *issue == GenerationParameterIssue::EmptyVolumeProfile
+                && provided_value == "[]"
+                && expected_range == "at least one time slice"
+        ));
+    }
+
+    #[test]
+    fn test_profile_strip_count_validation_rejects_backend_count_mismatch() {
+        let tri = CdtTriangulation::from_cdt_strip_profile(&[4, 6, 5])
+            .expect("nonuniform Delaunay strip should build");
+        let result = validate_profile_strip_counts(tri.geometry(), 15, 16, 18, 3.0);
+
+        assert!(matches!(
+            result,
+            Err(CdtError::DelaunayGenerationFailed {
+                vertex_count: 15,
+                coordinate_range: (0.0, 3.0),
+                attempt: 1,
+                ref underlying_error,
+            }) if underlying_error
+                .contains("build_delaunay2_with_data()/from_cdt_strip_profile()")
+                && underlying_error.contains("produced 15 vertices and 17 faces")
+                && underlying_error.contains("expected 16 vertices and 18 faces")
+        ));
     }
 
     #[test]

--- a/src/cdt/triangulation/builders.rs
+++ b/src/cdt/triangulation/builders.rs
@@ -5,7 +5,7 @@
 use super::CdtTriangulation;
 use crate::cdt::foliation::{Foliation, FoliationError};
 use crate::config::CdtTopology;
-use crate::errors::{CdtError, CdtResult, DelaunayValidationLevel};
+use crate::errors::{CdtError, CdtResult, DelaunayValidationLevel, GenerationParameterIssue};
 use crate::geometry::DelaunayBackend2D;
 use crate::geometry::generators::{
     DelaunayTriangulation2D, build_delaunay2_with_data, build_periodic_toroidal_delaunay2,
@@ -159,6 +159,177 @@ pub(super) fn validate_toroidal_counts(
     Ok(())
 }
 
+/// Validates an explicit per-slice spatial volume profile.
+fn validate_spatial_profile(
+    profile: &[u32],
+    minimum_slices: u32,
+    minimum_vertices_per_slice: u32,
+    topology_label: &str,
+) -> CdtResult<(u32, u32)> {
+    if profile.is_empty() {
+        return Err(CdtError::InvalidGenerationParameters {
+            issue: GenerationParameterIssue::EmptyVolumeProfile,
+            provided_value: "[]".to_string(),
+            expected_range: "at least one time slice".to_string(),
+        });
+    }
+
+    let num_slices =
+        u32::try_from(profile.len()).map_err(|err| CdtError::InvalidGenerationParameters {
+            issue: GenerationParameterIssue::VolumeProfileLengthOverflow,
+            provided_value: profile.len().to_string(),
+            expected_range: format!("length must fit in u32: {err}"),
+        })?;
+    if num_slices < minimum_slices {
+        return Err(CdtError::InvalidGenerationParameters {
+            issue: GenerationParameterIssue::InsufficientNumberOfTimeSlices,
+            provided_value: num_slices.to_string(),
+            expected_range: format!("≥ {minimum_slices} for {topology_label}"),
+        });
+    }
+
+    let mut total_vertices = 0_u32;
+    for (slice, &vertices) in profile.iter().enumerate() {
+        if vertices < minimum_vertices_per_slice {
+            return Err(CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::InsufficientVerticesInVolumeProfileSlice,
+                provided_value: format!("slice {slice} has {vertices}"),
+                expected_range: format!(
+                    "each slice ≥ {minimum_vertices_per_slice} for {topology_label}"
+                ),
+            });
+        }
+        total_vertices = total_vertices.checked_add(vertices).ok_or_else(|| {
+            CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::VertexCountOverflow,
+                provided_value: format!("{profile:?}"),
+                expected_range: "sum ≤ u32::MAX".to_string(),
+            }
+        })?;
+    }
+
+    Ok((total_vertices, num_slices))
+}
+
+/// Converts a spatial volume profile to `usize` slice sizes.
+fn profile_slice_sizes(
+    profile: &[u32],
+    mut generation_failed: impl FnMut(String) -> CdtError,
+) -> CdtResult<Vec<usize>> {
+    profile
+        .iter()
+        .map(|&volume| usize::try_from(volume).map_err(|err| generation_failed(err.to_string())))
+        .collect()
+}
+
+/// Builds labeled periodic coordinates for a toroidal CDT profile.
+fn toroidal_profile_vertices(
+    profile: &[u32],
+    total_vertices: u32,
+) -> CdtResult<Vec<([f64; 2], u32)>> {
+    let expected_vertices = usize::try_from(total_vertices)
+        .map_err(|err| toroidal_generation_error(total_vertices, (0.0, 0.0), err.to_string()))?;
+    let max_slice_volume = profile.iter().copied().max().unwrap_or(1);
+    let domain_x = f64::from(max_slice_volume);
+    let mut vertex_specs = Vec::new();
+    vertex_specs.try_reserve_exact(expected_vertices).map_err(|err| {
+        toroidal_generation_error(
+            total_vertices,
+            (0.0, domain_x),
+            format!(
+                "from_toroidal_cdt_profile() failed to reserve {expected_vertices} vertex specs: {err}"
+            ),
+        )
+    })?;
+
+    for (slice, &vertices) in profile.iter().enumerate() {
+        let label = u32::try_from(slice).map_err(|err| {
+            toroidal_generation_error(total_vertices, (0.0, domain_x), err.to_string())
+        })?;
+        let spacing = domain_x / f64::from(vertices);
+        for index in 0..vertices {
+            let x = f64::from(index) * spacing;
+            let y = f64::from(label);
+            vertex_specs.push(([x, y], label));
+        }
+    }
+
+    Ok(vertex_specs)
+}
+
+/// Builds labeled open-boundary coordinates for a CDT strip profile.
+fn open_profile_vertices(profile: &[u32], total_vertices: u32) -> CdtResult<Vec<([f64; 2], u32)>> {
+    let expected_vertices = usize::try_from(total_vertices).map_err(|err| {
+        strip_generation_error(total_vertices, f64::from(total_vertices), err.to_string())
+    })?;
+    let profile_len = u32::try_from(profile.len()).map_err(|err| {
+        strip_generation_error(total_vertices, f64::from(total_vertices), err.to_string())
+    })?;
+    let max_slice_volume = profile.iter().copied().max().unwrap_or(2);
+    let min_spacing = 1.0_f64 / f64::from(max_slice_volume - 1);
+    let side_jitter = min_spacing / 4.0;
+    let interior_jitter = min_spacing / (16.0 * f64::from(profile_len));
+    let vertical_jitter = 1.0_f64 / (64.0 * f64::from(profile_len));
+    let coordinate_max = f64::from(profile_len).max(2.0);
+    let mut vertex_specs = Vec::new();
+    vertex_specs.try_reserve_exact(expected_vertices).map_err(|err| {
+        strip_generation_error(
+            total_vertices,
+            coordinate_max,
+            format!(
+                "from_cdt_strip_profile() failed to reserve {expected_vertices} vertex specs: {err}"
+            ),
+        )
+    })?;
+
+    for (slice, &vertices) in profile.iter().enumerate() {
+        let label = u32::try_from(slice).map_err(|err| {
+            strip_generation_error(total_vertices, coordinate_max, err.to_string())
+        })?;
+        let spacing = 1.0_f64 / f64::from(vertices - 1);
+        let temporal_index = f64::from(label);
+        let temporal_span = f64::from(profile_len - 1);
+        let side_arc =
+            side_jitter * temporal_index * (temporal_span - temporal_index) / temporal_span.powi(2);
+        for index in 0..vertices {
+            let x = if index == 0 || index == vertices - 1 {
+                let boundary = f64::from(index).mul_add(spacing, side_jitter);
+                if index == 0 {
+                    boundary - side_arc
+                } else {
+                    boundary + side_arc
+                }
+            } else {
+                let sign = if (index + label).is_multiple_of(2) {
+                    1.0
+                } else {
+                    -1.0
+                };
+                f64::from(index).mul_add(spacing, side_jitter) + sign * interior_jitter
+            };
+            let spatial_index = f64::from(index);
+            let arc = vertical_jitter * spatial_index * f64::from(vertices - 1 - index)
+                / f64::from((vertices - 1).pow(2));
+            let base_y = f64::from(label) + vertical_jitter;
+            let y = if slice == 0 {
+                base_y - arc
+            } else if slice + 1 == profile.len() {
+                base_y + arc
+            } else {
+                let sign = if (index + label).is_multiple_of(2) {
+                    1.0
+                } else {
+                    -1.0
+                };
+                (sign * arc).mul_add(0.5, base_y)
+            };
+            vertex_specs.push(([x, y], label));
+        }
+    }
+
+    Ok(vertex_specs)
+}
+
 impl CdtTriangulation<DelaunayBackend2D> {
     /// Re-reads current backend labels during validation so stale stored bookkeeping is detected.
     pub(super) fn live_slice_sizes_from_vertex_labels(
@@ -229,7 +400,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
 
         if vertices < 3 {
             return Err(CdtError::InvalidGenerationParameters {
-                issue: "Insufficient vertex count".to_string(),
+                issue: GenerationParameterIssue::InsufficientVertexCount,
                 provided_value: vertices.to_string(),
                 expected_range: "≥ 3".to_string(),
             });
@@ -282,7 +453,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
 
         if vertices < 3 {
             return Err(CdtError::InvalidGenerationParameters {
-                issue: "Insufficient vertex count".to_string(),
+                issue: GenerationParameterIssue::InsufficientVertexCount,
                 provided_value: vertices.to_string(),
                 expected_range: "≥ 3".to_string(),
             });
@@ -395,14 +566,14 @@ impl CdtTriangulation<DelaunayBackend2D> {
     pub fn from_cdt_strip(vertices_per_slice: u32, num_slices: u32) -> CdtResult<Self> {
         if vertices_per_slice < 4 {
             return Err(CdtError::InvalidGenerationParameters {
-                issue: "Insufficient vertices per slice".to_string(),
+                issue: GenerationParameterIssue::InsufficientVerticesPerSlice,
                 provided_value: vertices_per_slice.to_string(),
                 expected_range: "≥ 4".to_string(),
             });
         }
         if num_slices < 2 {
             return Err(CdtError::InvalidGenerationParameters {
-                issue: "Insufficient number of time slices".to_string(),
+                issue: GenerationParameterIssue::InsufficientNumberOfTimeSlices,
                 provided_value: num_slices.to_string(),
                 expected_range: "≥ 2".to_string(),
             });
@@ -410,7 +581,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
 
         let total_vertices = vertices_per_slice.checked_mul(num_slices).ok_or_else(|| {
             CdtError::InvalidGenerationParameters {
-                issue: "Vertex count overflow".to_string(),
+                issue: GenerationParameterIssue::VertexCountOverflow,
                 provided_value: format!("{vertices_per_slice} × {num_slices}"),
                 expected_range: "product ≤ u32::MAX".to_string(),
             }
@@ -420,7 +591,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
         let temporal_quads = num_slices - 1;
         let total_quads = spatial_quads.checked_mul(temporal_quads).ok_or_else(|| {
             CdtError::InvalidGenerationParameters {
-                issue: "Simplex count overflow".to_string(),
+                issue: GenerationParameterIssue::SimplexCountOverflow,
                 provided_value: format!("{spatial_quads} × {temporal_quads}"),
                 expected_range: "product ≤ u32::MAX".to_string(),
             }
@@ -429,7 +600,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
             total_quads
                 .checked_mul(2)
                 .ok_or_else(|| CdtError::InvalidGenerationParameters {
-                    issue: "Simplex count overflow".to_string(),
+                    issue: GenerationParameterIssue::SimplexCountOverflow,
                     provided_value: format!("2 × {total_quads}"),
                     expected_range: "product ≤ u32::MAX".to_string(),
                 })?;
@@ -520,6 +691,62 @@ impl CdtTriangulation<DelaunayBackend2D> {
         Ok(tri)
     }
 
+    /// Construct a Delaunay-backed open-boundary 1+1 CDT strip from a spatial volume profile.
+    ///
+    /// Each entry in `volume_profile` is the number of vertices on that time
+    /// slice. Unlike [`Self::from_cdt_strip`], adjacent slices may have different
+    /// spatial volumes; this represents a general nonuniform CDT initial
+    /// geometry rather than a regular fixture.
+    /// The triangulation itself is delegated to
+    /// [`crate::geometry::generators::build_delaunay2_with_data`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidGenerationParameters`] if the profile has fewer
+    /// than two slices, any slice has fewer than four vertices, or derived counts
+    /// overflow.
+    /// Returns [`CdtError::DelaunayGenerationFailed`] if coordinate storage cannot
+    /// be reserved or if the Delaunay constructor rejects the profiled point data.
+    /// Returns [`CdtError::DelaunayValidationFailed`] if the constructed backend
+    /// fails the Level 1-4 Delaunay validator. Returns [`CdtError::TopologyMismatch`],
+    /// [`CdtError::Foliation`], [`CdtError::CausalityViolation`], or
+    /// [`CdtError::ValidationFailed`] if the constructed mesh violates CDT
+    /// invariants.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::*;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::from_cdt_strip_profile(&[4, 6, 5])?;
+    ///     assert_eq!(tri.slice_sizes(), &[4, 6, 5]);
+    ///     assert!(tri.validate_simplex_classification().is_ok());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn from_cdt_strip_profile(volume_profile: &[u32]) -> CdtResult<Self> {
+        let (total_vertices, num_slices) =
+            validate_spatial_profile(volume_profile, 2, 4, "open-boundary topology")?;
+        let vertex_specs = open_profile_vertices(volume_profile, total_vertices)?;
+        let dt = build_delaunay2_with_data(&vertex_specs).map_err(|error| {
+            remap_strip_generation_error(error, total_vertices, f64::from(num_slices))
+        })?;
+        let backend = validated_backend(dt)?;
+        let slice_sizes = profile_slice_sizes(volume_profile, |err| {
+            strip_generation_error(total_vertices, f64::from(num_slices), err)
+        })?;
+
+        let foliation =
+            Foliation::from_slice_sizes(slice_sizes, num_slices).map_err(CdtError::from)?;
+        let mut tri = Self::try_new(backend, num_slices, 2)?;
+        tri.foliation = Some(foliation);
+        tri.mark_foliation_synchronized();
+        tri.validate_initial_delaunay_cdt()?;
+
+        Ok(tri)
+    }
+
     /// Construct a foliated 1+1 CDT on a torus (S¹×S¹).
     ///
     /// Places `vertices_per_slice` vertices per time slice on a unit lattice
@@ -577,7 +804,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     pub fn from_toroidal_cdt(vertices_per_slice: u32, num_slices: u32) -> CdtResult<Self> {
         if vertices_per_slice < 3 {
             return Err(CdtError::InvalidGenerationParameters {
-                issue: "Insufficient vertices per slice".to_string(),
+                issue: GenerationParameterIssue::InsufficientVerticesPerSlice,
                 provided_value: vertices_per_slice.to_string(),
                 expected_range: "≥ 3".to_string(),
             });
@@ -587,7 +814,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
             // identify (t-1, t) with (t, t+1), so each spatial edge would be
             // shared by 4 triangles instead of 2 — a non-manifold mesh.
             return Err(CdtError::InvalidGenerationParameters {
-                issue: "Insufficient number of time slices".to_string(),
+                issue: GenerationParameterIssue::InsufficientNumberOfTimeSlices,
                 provided_value: num_slices.to_string(),
                 expected_range: "≥ 3".to_string(),
             });
@@ -595,7 +822,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
 
         let total_vertices = vertices_per_slice.checked_mul(num_slices).ok_or_else(|| {
             CdtError::InvalidGenerationParameters {
-                issue: "Vertex count overflow".to_string(),
+                issue: GenerationParameterIssue::VertexCountOverflow,
                 provided_value: format!("{vertices_per_slice} × {num_slices}"),
                 expected_range: "product ≤ u32::MAX".to_string(),
             }
@@ -604,7 +831,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
             total_vertices
                 .checked_mul(2)
                 .ok_or_else(|| CdtError::InvalidGenerationParameters {
-                    issue: "Simplex count overflow".to_string(),
+                    issue: GenerationParameterIssue::SimplexCountOverflow,
                     provided_value: format!("2 × {total_vertices}"),
                     expected_range: "product ≤ u32::MAX".to_string(),
                 })?;
@@ -672,13 +899,96 @@ impl CdtTriangulation<DelaunayBackend2D> {
 
         Ok(tri)
     }
+
+    /// Construct a periodic 1+1 CDT torus from a spatial volume profile.
+    ///
+    /// Each profile entry gives the number of vertices on one closed S¹ spatial
+    /// slice. Time wraps periodically, so the final slice is adjacent to slice
+    /// zero. Unlike [`Self::from_toroidal_cdt`], adjacent slices may have
+    /// different spatial volumes.
+    /// The triangulation itself is delegated to
+    /// [`crate::geometry::generators::build_periodic_toroidal_delaunay2`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidGenerationParameters`] if the profile has fewer
+    /// than three slices, any slice has fewer than three vertices, or derived
+    /// counts overflow.
+    /// Returns [`CdtError::DelaunayGenerationFailed`] if coordinate storage cannot
+    /// be reserved, if the periodic Delaunay constructor rejects the profiled point
+    /// data, or if the resulting vertex or face counts do not match the requested
+    /// profile. Returns [`CdtError::DelaunayValidationFailed`] if the constructed
+    /// backend fails the Level 1-4 Delaunay validator. Returns
+    /// [`CdtError::TopologyMismatch`], [`CdtError::Foliation`],
+    /// [`CdtError::CausalityViolation`], or [`CdtError::ValidationFailed`] if the
+    /// constructed mesh violates CDT invariants.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::*;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::from_toroidal_cdt_profile(&[3, 4, 5, 4])?;
+    ///     assert_eq!(tri.slice_sizes(), &[3, 4, 5, 4]);
+    ///     assert_eq!(tri.time_slices(), 4);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn from_toroidal_cdt_profile(volume_profile: &[u32]) -> CdtResult<Self> {
+        let (total_vertices, num_slices) =
+            validate_spatial_profile(volume_profile, 3, 3, "toroidal topology")?;
+        let total_simplices =
+            total_vertices
+                .checked_mul(2)
+                .ok_or_else(|| CdtError::InvalidGenerationParameters {
+                    issue: GenerationParameterIssue::SimplexCountOverflow,
+                    provided_value: format!("2 × {total_vertices}"),
+                    expected_range: "product ≤ u32::MAX".to_string(),
+                })?;
+        let expected_vertices = usize::try_from(total_vertices).map_err(|err| {
+            toroidal_generation_error(total_vertices, (0.0, 0.0), err.to_string())
+        })?;
+        let expected_faces = usize::try_from(total_simplices).map_err(|err| {
+            toroidal_generation_error(total_vertices, (0.0, 0.0), err.to_string())
+        })?;
+        let max_slice_volume = volume_profile.iter().copied().max().unwrap_or(1);
+        let domain = [f64::from(max_slice_volume), f64::from(num_slices)];
+        let coordinate_range = (0.0, domain[0].max(domain[1]) - 1.0);
+        let generation_failed = |underlying_error: String| {
+            toroidal_generation_error(total_vertices, coordinate_range, underlying_error)
+        };
+
+        let vertex_specs = toroidal_profile_vertices(volume_profile, total_vertices)?;
+        let dt = build_periodic_toroidal_delaunay2(&vertex_specs, domain)
+            .map_err(|e| remap_toroidal_generation_error(e, total_vertices))?;
+        let backend = validated_backend(dt)?;
+        validate_toroidal_counts(
+            &backend,
+            total_vertices,
+            expected_vertices,
+            expected_faces,
+            coordinate_range,
+        )?;
+
+        let slice_sizes = profile_slice_sizes(volume_profile, generation_failed)?;
+        let foliation =
+            Foliation::from_slice_sizes(slice_sizes, num_slices).map_err(CdtError::from)?;
+
+        let mut tri = Self::with_topology(backend, num_slices, 2, CdtTopology::Toroidal)?;
+        tri.foliation = Some(foliation);
+        tri.mark_foliation_synchronized();
+        tri.validate_initial_delaunay_cdt()?;
+
+        Ok(tri)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::cdt::foliation::{EdgeType, FoliationError, SimplexType};
-    use crate::errors::{CdtValidationCheck, CdtValidationFailure};
+    use crate::errors::{CdtValidationCheck, CdtValidationFailure, TriangulationMetadataField};
     use crate::geometry::generators::{build_delaunay2_from_simplices, build_delaunay2_with_data};
 
     /// Builds a minimal labeled Delaunay backend for constructor tests.
@@ -755,7 +1065,7 @@ mod tests {
     #[test]
     fn test_remap_toroidal_generation_error_preserves_other_errors() {
         let original = CdtError::InvalidGenerationParameters {
-            issue: "bad".to_string(),
+            issue: GenerationParameterIssue::InvalidCoordinateRange,
             provided_value: "x".to_string(),
             expected_range: "y".to_string(),
         };
@@ -894,7 +1204,7 @@ mod tests {
                 ref provided_value,
                 ref expected,
                 ..
-            }) if field == "timeslices" && provided_value == "0" && expected == "≥ 1"
+            }) if *field == TriangulationMetadataField::Timeslices && provided_value == "0" && expected == "≥ 1"
         ));
     }
 
@@ -911,7 +1221,7 @@ mod tests {
                     provided_value,
                     ..
                 }) => {
-                    assert_eq!(issue, "Insufficient vertex count");
+                    assert_eq!(issue, GenerationParameterIssue::InsufficientVertexCount);
                     assert_eq!(provided_value, count.to_string());
                 }
                 other => panic!(
@@ -932,7 +1242,7 @@ mod tests {
                 provided_value,
                 ..
             }) => {
-                assert_eq!(issue, "Insufficient vertex count");
+                assert_eq!(issue, GenerationParameterIssue::InsufficientVertexCount);
                 assert_eq!(provided_value, "2");
             }
             other => panic!("Expected InvalidGenerationParameters, got {other:?}"),
@@ -978,7 +1288,7 @@ mod tests {
                 ref provided_value,
                 ref expected,
                 ..
-            }) if field == "timeslices" && provided_value == "0" && expected == "≥ 1"
+            }) if *field == TriangulationMetadataField::Timeslices && provided_value == "0" && expected == "≥ 1"
         ));
     }
 
@@ -1090,7 +1400,7 @@ mod tests {
                 ref issue,
                 ref provided_value,
                 ref expected_range,
-            }) if issue == "Insufficient vertices per slice"
+            }) if *issue == GenerationParameterIssue::InsufficientVerticesPerSlice
                 && provided_value == "3"
                 && expected_range == "≥ 4"
         ));
@@ -1102,7 +1412,7 @@ mod tests {
                 ref issue,
                 ref provided_value,
                 ref expected_range,
-            }) if issue == "Insufficient number of time slices"
+            }) if *issue == GenerationParameterIssue::InsufficientNumberOfTimeSlices
                 && provided_value == "1"
                 && expected_range == "≥ 2"
         ));
@@ -1118,7 +1428,7 @@ mod tests {
                 ref issue,
                 ref provided_value,
                 ref expected_range,
-            }) if issue == "Simplex count overflow"
+            }) if *issue == GenerationParameterIssue::SimplexCountOverflow
                 && provided_value == "2 × 4294836224"
                 && expected_range == "product ≤ u32::MAX"
         ));
@@ -1129,11 +1439,57 @@ mod tests {
         let tri = CdtTriangulation::from_cdt_strip(4, 2).expect("Delaunay strip should build");
         assert_eq!(tri.vertex_count(), 8);
         assert_eq!(tri.face_count(), 6);
-        assert!(tri.geometry().validate_delaunay().is_ok());
         assert!(tri.validate_topology().is_ok());
         assert!(tri.validate_foliation().is_ok());
         assert!(tri.validate_causality_delaunay().is_ok());
         assert!(tri.validate_simplex_classification().is_ok());
+    }
+
+    #[test]
+    fn test_from_cdt_strip_profile_builds_nonuniform_valid_mesh() {
+        let tri = CdtTriangulation::from_cdt_strip_profile(&[4, 6, 5])
+            .expect("nonuniform Delaunay strip should build");
+
+        assert_eq!(tri.vertex_count(), 15);
+        assert!(tri.face_count() > 0);
+        assert_eq!(tri.slice_sizes(), &[4, 6, 5]);
+        assert_eq!(tri.volume_profile().len(), 3);
+        assert!(tri.validate_topology().is_ok());
+        assert!(tri.validate_foliation().is_ok());
+        assert!(tri.validate_causality_delaunay().is_ok());
+        assert!(tri.validate_simplex_classification().is_ok());
+    }
+
+    #[test]
+    fn test_from_cdt_strip_profile_rejects_invalid_profile() {
+        let result = CdtTriangulation::from_cdt_strip_profile(&[4, 3, 5]);
+
+        assert!(matches!(
+            result,
+            Err(CdtError::InvalidGenerationParameters {
+                ref issue,
+                ref provided_value,
+                ref expected_range,
+            }) if *issue == GenerationParameterIssue::InsufficientVerticesInVolumeProfileSlice
+                && provided_value == "slice 1 has 3"
+                && expected_range == "each slice ≥ 4 for open-boundary topology"
+        ));
+    }
+
+    #[test]
+    fn test_from_cdt_strip_profile_rejects_too_few_slices() {
+        let result = CdtTriangulation::from_cdt_strip_profile(&[4]);
+
+        assert!(matches!(
+            result,
+            Err(CdtError::InvalidGenerationParameters {
+                ref issue,
+                ref provided_value,
+                ref expected_range,
+            }) if *issue == GenerationParameterIssue::InsufficientNumberOfTimeSlices
+                && provided_value == "1"
+                && expected_range == "≥ 2 for open-boundary topology"
+        ));
     }
 
     #[test]
@@ -1209,6 +1565,51 @@ mod tests {
     }
 
     #[test]
+    fn test_from_toroidal_cdt_profile_builds_nonuniform_valid_mesh() {
+        let tri = CdtTriangulation::from_toroidal_cdt_profile(&[3, 4, 5, 4])
+            .expect("nonuniform toroidal CDT should build");
+
+        assert_eq!(tri.vertex_count(), 16);
+        assert_eq!(tri.face_count(), 32);
+        assert_eq!(tri.edge_count(), 48);
+        assert_eq!(tri.slice_sizes(), &[3, 4, 5, 4]);
+        assert_eq!(tri.geometry().euler_characteristic(), 0);
+        assert!(matches!(tri.metadata().topology, CdtTopology::Toroidal));
+        assert!(tri.geometry().validate_delaunay().is_ok());
+        assert!(tri.validate_topology().is_ok());
+        assert!(tri.validate_foliation().is_ok());
+        assert!(tri.validate_causality().is_ok());
+        assert!(tri.validate_simplex_classification().is_ok());
+    }
+
+    #[test]
+    fn test_from_toroidal_cdt_profile_rejects_invalid_profile() {
+        let few_slices = CdtTriangulation::from_toroidal_cdt_profile(&[3, 4]);
+        assert!(matches!(
+            few_slices,
+            Err(CdtError::InvalidGenerationParameters {
+                ref issue,
+                ref provided_value,
+                ref expected_range,
+            }) if *issue == GenerationParameterIssue::InsufficientNumberOfTimeSlices
+                && provided_value == "2"
+                && expected_range == "≥ 3 for toroidal topology"
+        ));
+
+        let small_slice = CdtTriangulation::from_toroidal_cdt_profile(&[3, 2, 3]);
+        assert!(matches!(
+            small_slice,
+            Err(CdtError::InvalidGenerationParameters {
+                ref issue,
+                ref provided_value,
+                ref expected_range,
+            }) if *issue == GenerationParameterIssue::InsufficientVerticesInVolumeProfileSlice
+                && provided_value == "slice 1 has 2"
+                && expected_range == "each slice ≥ 3 for toroidal topology"
+        ));
+    }
+
+    #[test]
     fn test_from_toroidal_cdt_initializes_delaunay_pl_manifold() {
         let tri = CdtTriangulation::from_toroidal_cdt(4, 3).expect("build toroidal CDT");
         assert_eq!(tri.vertex_count(), 12);
@@ -1243,7 +1644,7 @@ mod tests {
                 ref issue,
                 ref provided_value,
                 ref expected_range,
-            }) if issue == "Insufficient vertices per slice"
+            }) if *issue == GenerationParameterIssue::InsufficientVerticesPerSlice
                 && provided_value == "2"
                 && expected_range == "≥ 3"
         ));
@@ -1256,7 +1657,7 @@ mod tests {
                     ref issue,
                     ref provided_value,
                     ref expected_range,
-                }) if issue == "Insufficient number of time slices"
+                }) if *issue == GenerationParameterIssue::InsufficientNumberOfTimeSlices
                     && provided_value == &slices.to_string()
                     && expected_range == "≥ 3"
             ));
@@ -1273,7 +1674,7 @@ mod tests {
                 ref issue,
                 ref provided_value,
                 ref expected_range,
-            }) if issue == "Vertex count overflow"
+            }) if *issue == GenerationParameterIssue::VertexCountOverflow
                 && provided_value == "4294967295 × 3"
                 && expected_range == "product ≤ u32::MAX"
         ));

--- a/src/cdt/triangulation/foliation.rs
+++ b/src/cdt/triangulation/foliation.rs
@@ -7,6 +7,7 @@ use crate::cdt::foliation::{EdgeType, Foliation, FoliationError, SimplexType, cl
 use crate::config::CdtTopology;
 use crate::errors::{
     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
+    GenerationParameterIssue,
 };
 use crate::geometry::DelaunayBackend2D;
 use crate::geometry::backends::delaunay::{
@@ -300,7 +301,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     pub fn assign_foliation_by_y(&mut self, num_slices: u32) -> CdtResult<()> {
         if num_slices == 0 {
             return Err(CdtError::InvalidGenerationParameters {
-                issue: "Number of slices must be positive".to_string(),
+                issue: GenerationParameterIssue::NonPositiveSliceCount,
                 provided_value: "0".to_string(),
                 expected_range: "≥ 1".to_string(),
             });
@@ -1024,6 +1025,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::errors::TriangulationMetadataField;
     use crate::geometry::generators::build_delaunay2_with_data;
     use std::thread;
     use std::time::Duration;
@@ -1238,7 +1240,7 @@ mod tests {
                 topology,
                 ref provided_value,
                 ref expected,
-            }) if field == "timeslices"
+            }) if *field == TriangulationMetadataField::Timeslices
                 && topology == CdtTopology::Toroidal
                 && provided_value == "2"
                 && expected == "≥ 3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@
 
 use crate::cdt::action::ActionConfig;
 use crate::cdt::metropolis::MetropolisConfig;
-use crate::errors::{CdtError, CdtResult};
+use crate::errors::{CdtError, CdtResult, ConfigurationSetting};
 use clap::error::ErrorKind;
 use clap::{ArgGroup, Error as ClapError, Parser, ValueEnum};
 use dirs::home_dir;
@@ -60,7 +60,8 @@ impl fmt::Display for CdtTopology {
 /// This combines the canonical runtime options for CDT construction,
 /// action calculation, and Metropolis sampling. Command-line parsing may derive
 /// some of these values from more ergonomic inputs; for example,
-/// `--vertices-per-slice` is converted into the total [`Self::vertices`] count.
+/// `--vertices-per-slice` is converted into the total [`Self::vertices`] count
+/// and `--volume-profile` records explicit per-slice initial spatial volumes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CdtConfig {
     /// Dimensionality of the triangulation.
@@ -76,6 +77,13 @@ pub struct CdtConfig {
 
     /// Number of time slices in the initial triangulation.
     pub timeslices: u32,
+
+    /// Optional explicit initial spatial volume profile, in vertices per time slice.
+    ///
+    /// When present, this vector has exactly [`Self::timeslices`] entries and its
+    /// sum equals [`Self::vertices`]. It represents general nonuniform CDT
+    /// initial data. When absent, initialization uses regular equal-size slices.
+    pub volume_profile: Option<Vec<u32>>,
 
     /// Temperature for the Metropolis acceptance rule.
     pub temperature: f64,
@@ -134,10 +142,10 @@ pub struct CdtConfig {
     author,
     version,
     about = "Run 1+1-dimensional Causal Dynamical Triangulations simulations",
-    long_about = "Run 1+1-dimensional Causal Dynamical Triangulations simulations.\n\nConstruct a foliated CDT triangulation, optionally run the Metropolis move loop, and write measurement summaries. Prefer --vertices-per-slice for regular initial data; --vertices remains available when the total initial vertex count is already known.",
+    long_about = "Run 1+1-dimensional Causal Dynamical Triangulations simulations.\n\nConstruct a foliated CDT triangulation, optionally run the Metropolis move loop, and write measurement summaries. Prefer --vertices-per-slice for regular initial data or --volume-profile for explicit nonuniform initial slice volumes; --vertices remains available when the total initial vertex count is already known.",
     group = ArgGroup::new("vertex_count")
         .required(true)
-        .args(["vertices", "vertices_per_slice"])
+        .args(["vertices", "vertices_per_slice", "volume_profile"])
 )]
 struct CdtCliArgs {
     #[arg(
@@ -167,9 +175,18 @@ struct CdtCliArgs {
         short,
         long,
         help = "Number of time slices; open-boundary requires at least 2, toroidal at least 3",
+        required_unless_present = "volume_profile",
         value_parser = clap::value_parser!(u32).range(1..)
     )]
-    timeslices: u32,
+    timeslices: Option<u32>,
+
+    #[arg(
+        long,
+        value_name = "N0,N1,...",
+        help = "Explicit vertices per time slice for nonuniform initial spatial volume",
+        long_help = "Explicit vertices per time slice for nonuniform initial spatial volume, for example 8,10,7,9. If --timeslices is also supplied it must match the number of profile entries."
+    )]
+    volume_profile: Option<String>,
 
     #[arg(long, default_value = "1.0", help = "Positive Metropolis temperature")]
     temperature: f64,
@@ -255,29 +272,65 @@ struct CdtCliArgs {
 impl CdtCliArgs {
     /// Converts parsed CLI arguments into the canonical runtime configuration.
     fn into_config(self) -> Result<CdtConfig, ClapError> {
-        let vertices = if let Some(vertices) = self.vertices {
-            vertices
+        let (vertices, timeslices, volume_profile) = if let Some(raw_profile) = self.volume_profile
+        {
+            let profile = parse_volume_profile(&raw_profile).map_err(|err| {
+                ClapError::raw(
+                    ErrorKind::ValueValidation,
+                    format!("invalid --volume-profile: {err}"),
+                )
+            })?;
+            let profile_slices = u32::try_from(profile.len()).map_err(|err| {
+                ClapError::raw(
+                    ErrorKind::ValueValidation,
+                    format!("--volume-profile has too many entries for u32 timeslices: {err}"),
+                )
+            })?;
+            let timeslices = self.timeslices.unwrap_or(profile_slices);
+            if timeslices != profile_slices {
+                return Err(ClapError::raw(
+                    ErrorKind::ValueValidation,
+                    format!(
+                        "--timeslices ({timeslices}) must match --volume-profile entry count ({profile_slices})"
+                    ),
+                ));
+            }
+            let vertices = profile.iter().try_fold(0_u32, |total, &volume| {
+                total.checked_add(volume).ok_or_else(|| {
+                    ClapError::raw(
+                        ErrorKind::ValueValidation,
+                        "--volume-profile total vertices exceed u32::MAX",
+                    )
+                })
+            })?;
+            (vertices, timeslices, Some(profile))
         } else {
-            let vertices_per_slice = self
-                .vertices_per_slice
-                .expect("required clap group should set one vertex count");
-            vertices_per_slice
-                .checked_mul(self.timeslices)
-                .ok_or_else(|| {
+            let timeslices = self
+                .timeslices
+                .expect("required clap arguments should set timeslices without a volume profile");
+            let vertices = if let Some(vertices) = self.vertices {
+                vertices
+            } else {
+                let vertices_per_slice = self
+                    .vertices_per_slice
+                    .expect("required clap group should set one vertex count");
+                vertices_per_slice.checked_mul(timeslices).ok_or_else(|| {
                     ClapError::raw(
                         ErrorKind::ValueValidation,
                         format!(
-                            "--vertices-per-slice ({vertices_per_slice}) × --timeslices ({}) exceeds u32::MAX",
-                            self.timeslices
+                            "--vertices-per-slice ({vertices_per_slice}) × --timeslices ({timeslices}) exceeds u32::MAX"
                         ),
                     )
                 })?
+            };
+            (vertices, timeslices, None)
         };
 
         Ok(CdtConfig {
             dimension: self.dimension,
             vertices,
-            timeslices: self.timeslices,
+            timeslices,
+            volume_profile,
             temperature: self.temperature,
             steps: self.steps,
             thermalization_steps: self.thermalization_steps,
@@ -315,6 +368,16 @@ pub struct CdtConfigOverrides {
     pub vertices: Option<u32>,
     /// Optional override for the timeslice count.
     pub timeslices: Option<u32>,
+    /// Optional override for the explicit initial spatial volume profile.
+    ///
+    /// `None` leaves the base profile unchanged, `Some(None)` clears it so
+    /// regular equal-size slices are used, and `Some(Some(profile))` replaces it
+    /// with explicit per-slice volumes.
+    #[expect(
+        clippy::option_option,
+        reason = "None=no override, Some(None)=clear profile, Some(Some(v))=set profile"
+    )]
+    pub volume_profile: Option<Option<Vec<u32>>>,
     /// Optional override for the temperature.
     pub temperature: Option<f64>,
     /// Optional override for the total number of steps.
@@ -400,6 +463,10 @@ impl CdtConfig {
 
         if let Some(timeslices) = overrides.timeslices {
             merged.timeslices = timeslices;
+        }
+
+        if let Some(volume_profile) = &overrides.volume_profile {
+            merged.volume_profile.clone_from(volume_profile);
         }
 
         if let Some(temperature) = overrides.temperature {
@@ -549,7 +616,7 @@ fn normalize_components(path: &Path) -> PathBuf {
 
 /// Builds a typed configuration error from displayable values without duplicating field names.
 fn invalid_config(
-    setting: &str,
+    setting: ConfigurationSetting,
     provided_value: &impl Display,
     expected: &impl Display,
 ) -> CdtError {
@@ -557,20 +624,55 @@ fn invalid_config(
 }
 
 /// Preserves already-formatted validation values when shared validators produce owned strings.
-fn invalid_config_parts(setting: &str, provided_value: String, expected: String) -> CdtError {
+const fn invalid_config_parts(
+    setting: ConfigurationSetting,
+    provided_value: String,
+    expected: String,
+) -> CdtError {
     CdtError::InvalidConfiguration {
-        setting: setting.to_string(),
+        setting,
         provided_value,
         expected,
     }
 }
 
 /// Rejects non-finite action couplings before they can poison action/log-probability math.
-fn validate_coupling(setting: &str, value: f64) -> CdtResult<()> {
+fn validate_coupling(setting: ConfigurationSetting, value: f64) -> CdtResult<()> {
     if value.is_finite() {
         Ok(())
     } else {
         Err(invalid_config(setting, &value, &"finite"))
+    }
+}
+
+/// Parses a comma-separated spatial volume profile from the CLI.
+fn parse_volume_profile(raw: &str) -> Result<Vec<u32>, String> {
+    let mut profile = Vec::new();
+
+    for (index, entry) in raw.split(',').enumerate() {
+        let trimmed = entry.trim();
+        if trimmed.is_empty() {
+            return Err(format!("volume profile entry {} is empty", index + 1));
+        }
+        let volume = trimmed.parse::<u32>().map_err(|err| {
+            format!(
+                "volume profile entry {} ({trimmed}) is not a positive integer: {err}",
+                index + 1
+            )
+        })?;
+        if volume == 0 {
+            return Err(format!(
+                "volume profile entry {} must be at least 1",
+                index + 1
+            ));
+        }
+        profile.push(volume);
+    }
+
+    if profile.is_empty() {
+        Err("volume profile must contain at least one entry".to_string())
+    } else {
+        Ok(profile)
     }
 }
 
@@ -580,27 +682,31 @@ pub(crate) fn validate_schedule(
     steps: u32,
     thermalization_steps: u32,
     measurement_frequency: u32,
-    mut error_for: impl FnMut(&str, String, String) -> CdtError,
+    mut error_for: impl FnMut(ConfigurationSetting, String, String) -> CdtError,
 ) -> CdtResult<()> {
-    let mut invalid = |setting: &str, provided_value: String, expected: String| {
+    let mut invalid = |setting: ConfigurationSetting, provided_value: String, expected: String| {
         Err(error_for(setting, provided_value, expected))
     };
 
     if !temperature.is_finite() || temperature <= 0.0 {
         return invalid(
-            "temperature",
+            ConfigurationSetting::Temperature,
             temperature.to_string(),
             "finite and positive".to_string(),
         );
     }
 
     if steps == 0 {
-        return invalid("steps", steps.to_string(), "≥ 1".to_string());
+        return invalid(
+            ConfigurationSetting::Steps,
+            steps.to_string(),
+            "≥ 1".to_string(),
+        );
     }
 
     if measurement_frequency == 0 {
         return invalid(
-            "measurement_frequency",
+            ConfigurationSetting::MeasurementFrequency,
             measurement_frequency.to_string(),
             "≥ 1".to_string(),
         );
@@ -608,7 +714,7 @@ pub(crate) fn validate_schedule(
 
     if measurement_frequency > steps {
         return invalid(
-            "measurement_frequency",
+            ConfigurationSetting::MeasurementFrequency,
             measurement_frequency.to_string(),
             format!("≤ steps ({steps})"),
         );
@@ -616,7 +722,7 @@ pub(crate) fn validate_schedule(
 
     if thermalization_steps > steps {
         return invalid(
-            "thermalization_steps",
+            ConfigurationSetting::ThermalizationSteps,
             thermalization_steps.to_string(),
             format!("≤ steps ({steps})"),
         );
@@ -628,7 +734,7 @@ pub(crate) fn validate_schedule(
 
     if first_post_thermalization_measurement > u64::from(steps) {
         return invalid(
-            "measurement schedule",
+            ConfigurationSetting::MeasurementSchedule,
             format!(
                 "steps={steps}, thermalization_steps={thermalization_steps}, measurement_frequency={measurement_frequency}"
             ),
@@ -670,8 +776,9 @@ impl CdtConfig {
     /// # Errors
     ///
     /// Returns [`clap::Error`] when required arguments are missing, when any
-    /// value fails Clap validation, or when `--vertices-per-slice ×
-    /// --timeslices` overflows `u32`.
+    /// value fails Clap validation, when `--vertices-per-slice × --timeslices`
+    /// overflows `u32`, or when `--volume-profile` cannot be parsed or does not
+    /// match an explicitly supplied `--timeslices` count.
     ///
     /// # Examples
     ///
@@ -720,6 +827,7 @@ impl CdtConfig {
             dimension: Some(2),
             vertices,
             timeslices,
+            volume_profile: None,
             temperature: 1.0,
             steps: 1000,
             thermalization_steps: 100,
@@ -809,12 +917,9 @@ impl CdtConfig {
     /// action couplings or temperature are non-finite, if the measurement
     /// schedule cannot produce a post-thermalization measurement, or if topology
     /// constraints on time slices, total vertices, or per-slice vertices are not
-    /// satisfied.
-    /// Open-boundary topology additionally requires `timeslices ≥ 2`,
-    /// `vertices ≥ 4 · timeslices`, and `vertices` evenly divisible by
-    /// `timeslices` so each spatial slice carries the same `N ≥ 4` vertices.
-    /// Toroidal topology requires the analogous `timeslices ≥ 3` and `N ≥ 3`
-    /// constraints.
+    /// satisfied. Regular equal-slice initialization requires `vertices` to be
+    /// divisible by `timeslices`; explicit [`Self::volume_profile`] initialization
+    /// instead requires the profile length and sum to match the configured counts.
     ///
     /// # Examples
     ///
@@ -826,66 +931,35 @@ impl CdtConfig {
     /// ```
     pub fn validate(&self) -> CdtResult<()> {
         if self.vertices < 3 {
-            return Err(invalid_config("vertices", &self.vertices, &"≥ 3"));
+            return Err(invalid_config(
+                ConfigurationSetting::Vertices,
+                &self.vertices,
+                &"≥ 3",
+            ));
         }
 
         if self.timeslices == 0 {
-            return Err(invalid_config("timeslices", &self.timeslices, &"≥ 1"));
+            return Err(invalid_config(
+                ConfigurationSetting::Timeslices,
+                &self.timeslices,
+                &"≥ 1",
+            ));
         }
 
         if let Some(dim) = self.dimension
             && dim != 2
         {
-            return Err(invalid_config("dimension", &dim, &"2"));
+            return Err(invalid_config(ConfigurationSetting::Dimension, &dim, &"2"));
         }
 
-        validate_coupling("coupling_0", self.coupling_0)?;
-        validate_coupling("coupling_2", self.coupling_2)?;
-        validate_coupling("cosmological_constant", self.cosmological_constant)?;
+        validate_coupling(ConfigurationSetting::Coupling0, self.coupling_0)?;
+        validate_coupling(ConfigurationSetting::Coupling2, self.coupling_2)?;
+        validate_coupling(
+            ConfigurationSetting::CosmologicalConstant,
+            self.cosmological_constant,
+        )?;
 
-        let (minimum_slices, minimum_vertices_per_slice, topology_label) = match self.topology {
-            CdtTopology::OpenBoundary => (2, 4, "open-boundary topology"),
-            CdtTopology::Toroidal => (3, 3, "toroidal topology"),
-        };
-
-        if self.timeslices < minimum_slices {
-            return Err(invalid_config_parts(
-                "timeslices",
-                self.timeslices.to_string(),
-                format!("≥ {minimum_slices} for {topology_label}"),
-            ));
-        }
-        if !self.vertices.is_multiple_of(self.timeslices) {
-            return Err(invalid_config_parts(
-                "vertices",
-                self.vertices.to_string(),
-                format!(
-                    "divisible by timeslices ({}) for {topology_label}",
-                    self.timeslices
-                ),
-            ));
-        }
-        let min_total = self
-            .timeslices
-            .checked_mul(minimum_vertices_per_slice)
-            .ok_or_else(|| {
-                invalid_config_parts(
-                    "timeslices",
-                    self.timeslices.to_string(),
-                    format!(
-                        "{minimum_vertices_per_slice} · timeslices must fit in u32 for {topology_label}"
-                    ),
-                )
-            })?;
-        if self.vertices < min_total {
-            return Err(invalid_config_parts(
-                "vertices",
-                self.vertices.to_string(),
-                format!(
-                    "≥ {minimum_vertices_per_slice} · timeslices ({min_total}) for {topology_label}"
-                ),
-            ));
-        }
+        self.validate_volume_constraints()?;
 
         validate_schedule(
             self.temperature,
@@ -896,6 +970,123 @@ impl CdtConfig {
                 invalid_config_parts(setting, provided_value, expected)
             },
         )
+    }
+
+    /// Validates topology-specific initial volume constraints.
+    ///
+    /// Regular configurations require equal slice divisibility and minimum
+    /// per-slice volume; explicit profiles are delegated to the profile-aware
+    /// validator so count and shape errors remain distinguishable.
+    fn validate_volume_constraints(&self) -> CdtResult<()> {
+        let (minimum_slices, minimum_vertices_per_slice, topology_label) = match self.topology {
+            CdtTopology::OpenBoundary => (2, 4, "open-boundary topology"),
+            CdtTopology::Toroidal => (3, 3, "toroidal topology"),
+        };
+
+        if self.timeslices < minimum_slices {
+            return Err(invalid_config_parts(
+                ConfigurationSetting::Timeslices,
+                self.timeslices.to_string(),
+                format!("≥ {minimum_slices} for {topology_label}"),
+            ));
+        }
+
+        if let Some(profile) = &self.volume_profile {
+            return self.validate_explicit_volume_profile(
+                profile,
+                minimum_vertices_per_slice,
+                topology_label,
+            );
+        }
+
+        if !self.vertices.is_multiple_of(self.timeslices) {
+            return Err(invalid_config_parts(
+                ConfigurationSetting::Vertices,
+                self.vertices.to_string(),
+                format!(
+                    "divisible by timeslices ({}) for {topology_label}",
+                    self.timeslices
+                ),
+            ));
+        }
+
+        let min_total = self
+            .timeslices
+            .checked_mul(minimum_vertices_per_slice)
+            .ok_or_else(|| {
+                invalid_config_parts(
+                    ConfigurationSetting::Timeslices,
+                    self.timeslices.to_string(),
+                    format!(
+                        "{minimum_vertices_per_slice} · timeslices must fit in u32 for {topology_label}"
+                    ),
+                )
+            })?;
+        if self.vertices < min_total {
+            return Err(invalid_config_parts(
+                ConfigurationSetting::Vertices,
+                self.vertices.to_string(),
+                format!(
+                    "≥ {minimum_vertices_per_slice} · timeslices ({min_total}) for {topology_label}"
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Validates that an explicit volume profile matches configured counts.
+    ///
+    /// This checks profile length, per-slice minima, sum overflow, and agreement
+    /// with the top-level total vertex count before construction begins.
+    fn validate_explicit_volume_profile(
+        &self,
+        profile: &[u32],
+        minimum_vertices_per_slice: u32,
+        topology_label: &str,
+    ) -> CdtResult<()> {
+        let expected_len = usize::try_from(self.timeslices).map_err(|err| {
+            invalid_config_parts(
+                ConfigurationSetting::Timeslices,
+                self.timeslices.to_string(),
+                format!("must fit usize for volume profile validation: {err}"),
+            )
+        })?;
+        if profile.len() != expected_len {
+            return Err(invalid_config_parts(
+                ConfigurationSetting::VolumeProfile,
+                format!("{} entries", profile.len()),
+                format!("{} entries for configured timeslices", self.timeslices),
+            ));
+        }
+
+        let mut total = 0_u32;
+        for (slice, &volume) in profile.iter().enumerate() {
+            if volume < minimum_vertices_per_slice {
+                return Err(invalid_config_parts(
+                    ConfigurationSetting::VolumeProfile,
+                    format!("slice {slice} has {volume}"),
+                    format!("each slice ≥ {minimum_vertices_per_slice} for {topology_label}"),
+                ));
+            }
+            total = total.checked_add(volume).ok_or_else(|| {
+                invalid_config_parts(
+                    ConfigurationSetting::VolumeProfile,
+                    format!("{profile:?}"),
+                    "sum must fit in u32".to_string(),
+                )
+            })?;
+        }
+
+        if total != self.vertices {
+            return Err(invalid_config_parts(
+                ConfigurationSetting::Vertices,
+                self.vertices.to_string(),
+                format!("sum of volume_profile ({total})"),
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -920,6 +1111,7 @@ impl TestConfig {
             dimension: Some(2),
             vertices: 16,
             timeslices: 2,
+            volume_profile: None,
             temperature: 1.0,
             steps: 10,
             thermalization_steps: 2,
@@ -951,6 +1143,7 @@ impl TestConfig {
             dimension: Some(2),
             vertices: 64,
             timeslices: 4,
+            volume_profile: None,
             temperature: 1.0,
             steps: 100,
             thermalization_steps: 20,
@@ -982,6 +1175,7 @@ impl TestConfig {
             dimension: Some(2),
             vertices: 256,
             timeslices: 8,
+            volume_profile: None,
             temperature: 1.0,
             steps: 1000,
             thermalization_steps: 100,
@@ -1138,7 +1332,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "vertices" && provided_value == "2" && expected == "≥ 3"
+            }) if setting == ConfigurationSetting::Vertices && provided_value == "2" && expected == "≥ 3"
         ));
 
         let invalid_timeslices = CdtConfig {
@@ -1151,7 +1345,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "timeslices" && provided_value == "0" && expected == "≥ 1"
+            }) if setting == ConfigurationSetting::Timeslices && provided_value == "0" && expected == "≥ 1"
         ));
 
         let invalid_temperature = CdtConfig {
@@ -1164,7 +1358,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "temperature"
+            }) if setting == ConfigurationSetting::Temperature
                 && provided_value == "-1"
                 && expected == "finite and positive"
         ));
@@ -1179,7 +1373,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "measurement_frequency"
+            }) if setting == ConfigurationSetting::MeasurementFrequency
                 && provided_value == "0"
                 && expected == "≥ 1"
         ));
@@ -1194,7 +1388,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "steps" && provided_value == "0" && expected == "≥ 1"
+            }) if setting == ConfigurationSetting::Steps && provided_value == "0" && expected == "≥ 1"
         ));
 
         let invalid_dimension = CdtConfig {
@@ -1207,19 +1401,24 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "dimension" && provided_value == "4" && expected == "2"
+            }) if setting == ConfigurationSetting::Dimension && provided_value == "4" && expected == "2"
         ));
 
         for (setting, value) in [
-            ("coupling_0", f64::NAN),
-            ("coupling_2", f64::INFINITY),
-            ("cosmological_constant", f64::NEG_INFINITY),
+            (ConfigurationSetting::Coupling0, f64::NAN),
+            (ConfigurationSetting::Coupling2, f64::INFINITY),
+            (
+                ConfigurationSetting::CosmologicalConstant,
+                f64::NEG_INFINITY,
+            ),
         ] {
             let mut invalid_action_coupling = CdtConfig::new(36, 3);
             match setting {
-                "coupling_0" => invalid_action_coupling.coupling_0 = value,
-                "coupling_2" => invalid_action_coupling.coupling_2 = value,
-                "cosmological_constant" => invalid_action_coupling.cosmological_constant = value,
+                ConfigurationSetting::Coupling0 => invalid_action_coupling.coupling_0 = value,
+                ConfigurationSetting::Coupling2 => invalid_action_coupling.coupling_2 = value,
+                ConfigurationSetting::CosmologicalConstant => {
+                    invalid_action_coupling.cosmological_constant = value;
+                }
                 _ => unreachable!("test case should name a known action coupling"),
             }
             assert!(matches!(
@@ -1253,7 +1452,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "measurement_frequency"
+            }) if setting == ConfigurationSetting::MeasurementFrequency
                 && provided_value == "2000"
                 && expected == "≤ steps (1000)"
         ));
@@ -1303,7 +1502,7 @@ mod tests {
                 provided_value,
                 expected,
             }) => {
-                assert_eq!(setting, "measurement schedule");
+                assert_eq!(setting, ConfigurationSetting::MeasurementSchedule);
                 assert!(
                     provided_value.contains("steps=19")
                         && provided_value.contains("thermalization_steps=15")
@@ -1327,7 +1526,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "thermalization_steps"
+            }) if setting == ConfigurationSetting::ThermalizationSteps
                 && provided_value == "11"
                 && expected == "≤ steps (10)"
         ));
@@ -1344,7 +1543,7 @@ mod tests {
                 provided_value,
                 expected,
             }) => {
-                assert_eq!(setting, "measurement schedule");
+                assert_eq!(setting, ConfigurationSetting::MeasurementSchedule);
                 assert!(
                     provided_value.contains("steps=4294967295")
                         && provided_value.contains("thermalization_steps=4294967295")
@@ -1384,7 +1583,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "timeslices"
+            }) if setting == ConfigurationSetting::Timeslices
                 && provided_value == "2"
                 && expected == "≥ 3 for toroidal topology"
         ));
@@ -1402,7 +1601,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "vertices"
+            }) if setting == ConfigurationSetting::Vertices
                 && provided_value == "11"
                 && expected == "divisible by timeslices (3) for toroidal topology"
         ));
@@ -1420,7 +1619,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "vertices"
+            }) if setting == ConfigurationSetting::Vertices
                 && provided_value == "6"
                 && expected == "≥ 3 · timeslices (9) for toroidal topology"
         ));
@@ -1437,7 +1636,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "timeslices"
+            }) if setting == ConfigurationSetting::Timeslices
                 && provided_value == u32::MAX.to_string()
                 && expected == "3 · timeslices must fit in u32 for toroidal topology"
         ));
@@ -1468,7 +1667,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "timeslices"
+            }) if setting == ConfigurationSetting::Timeslices
                 && provided_value == "1"
                 && expected == "≥ 2 for open-boundary topology"
         ));
@@ -1485,7 +1684,7 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "vertices"
+            }) if setting == ConfigurationSetting::Vertices
                 && provided_value == "11"
                 && expected == "divisible by timeslices (3) for open-boundary topology"
         ));
@@ -1502,10 +1701,111 @@ mod tests {
                 setting,
                 provided_value,
                 expected,
-            }) if setting == "vertices"
+            }) if setting == ConfigurationSetting::Vertices
                 && provided_value == "9"
                 && expected == "≥ 4 · timeslices (12) for open-boundary topology"
         ));
+    }
+
+    #[test]
+    fn test_config_validation_open_boundary_volume_profile() {
+        let valid_profile = CdtConfig {
+            vertices: 15,
+            timeslices: 3,
+            volume_profile: Some(vec![4, 6, 5]),
+            ..CdtConfig::new(12, 3)
+        };
+        assert!(
+            valid_profile.validate().is_ok(),
+            "nonuniform open-boundary profiles should not require divisible vertex counts"
+        );
+
+        let mismatched_sum = CdtConfig {
+            vertices: 14,
+            timeslices: 3,
+            volume_profile: Some(vec![4, 6, 5]),
+            ..CdtConfig::new(12, 3)
+        };
+        assert!(matches!(
+            mismatched_sum.validate(),
+            Err(CdtError::InvalidConfiguration {
+                setting,
+                provided_value,
+                expected,
+            }) if setting == ConfigurationSetting::Vertices
+                && provided_value == "14"
+                && expected == "sum of volume_profile (15)"
+        ));
+
+        let mismatched_len = CdtConfig {
+            vertices: 15,
+            timeslices: 4,
+            volume_profile: Some(vec![4, 6, 5]),
+            ..CdtConfig::new(16, 4)
+        };
+        assert!(matches!(
+            mismatched_len.validate(),
+            Err(CdtError::InvalidConfiguration {
+                setting,
+                provided_value,
+                expected,
+            }) if setting == ConfigurationSetting::VolumeProfile
+                && provided_value == "3 entries"
+                && expected == "4 entries for configured timeslices"
+        ));
+    }
+
+    #[test]
+    fn test_config_validation_toroidal_volume_profile_minimum_slice_size() {
+        let valid_profile = CdtConfig {
+            vertices: 16,
+            timeslices: 4,
+            topology: CdtTopology::Toroidal,
+            volume_profile: Some(vec![3, 4, 5, 4]),
+            ..CdtConfig::new(16, 4)
+        };
+        assert!(valid_profile.validate().is_ok());
+
+        let too_small = CdtConfig {
+            vertices: 11,
+            timeslices: 4,
+            topology: CdtTopology::Toroidal,
+            volume_profile: Some(vec![3, 2, 3, 3]),
+            ..CdtConfig::new(12, 4)
+        };
+        assert!(matches!(
+            too_small.validate(),
+            Err(CdtError::InvalidConfiguration {
+                setting,
+                provided_value,
+                expected,
+            }) if setting == ConfigurationSetting::VolumeProfile
+                && provided_value == "slice 1 has 2"
+                && expected == "each slice ≥ 3 for toroidal topology"
+        ));
+    }
+
+    #[test]
+    fn test_try_from_args_derives_counts_from_volume_profile() {
+        let config = CdtConfig::try_from_args(["cdt", "--volume-profile", "4, 6,5"])
+            .expect("volume profile CLI should derive counts");
+
+        assert_eq!(config.vertices, 15);
+        assert_eq!(config.timeslices, 3);
+        assert_eq!(config.volume_profile, Some(vec![4, 6, 5]));
+    }
+
+    #[test]
+    fn test_try_from_args_rejects_malformed_volume_profile() {
+        let error = CdtConfig::try_from_args(["cdt", "--volume-profile", "4,,5"])
+            .expect_err("empty profile entries should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("invalid --volume-profile: volume profile entry 2 is empty"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -1564,6 +1864,7 @@ mod tests {
         let base = CdtConfig::new(10, 2);
         let overrides = CdtConfigOverrides {
             timeslices: Some(5),
+            volume_profile: Some(Some(vec![4, 6, 5])),
             steps: Some(250),
             thermalization_steps: Some(25),
             measurement_frequency: Some(5),
@@ -1580,6 +1881,7 @@ mod tests {
         let merged = base.merge_with_override(&overrides);
 
         assert_eq!(merged.timeslices, 5);
+        assert_eq!(merged.volume_profile, Some(vec![4, 6, 5]));
         assert_eq!(merged.steps, 250);
         assert_eq!(merged.thermalization_steps, 25);
         assert_eq!(merged.measurement_frequency, 5);
@@ -1606,6 +1908,26 @@ mod tests {
         let merged = base.merge_with_override(&overrides);
 
         assert_eq!(merged.seed, None);
+    }
+
+    #[test]
+    fn test_merge_with_override_can_clear_volume_profile() {
+        let base = CdtConfig {
+            vertices: 15,
+            timeslices: 3,
+            volume_profile: Some(vec![4, 6, 5]),
+            ..CdtConfig::new(12, 3)
+        };
+        let overrides = CdtConfigOverrides {
+            volume_profile: Some(None),
+            ..CdtConfigOverrides::default()
+        };
+
+        let merged = base.merge_with_override(&overrides);
+
+        assert_eq!(merged.volume_profile, None);
+        assert_eq!(merged.vertices, 15);
+        assert_eq!(merged.timeslices, 3);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -431,10 +431,12 @@ impl CdtConfig {
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::prelude::errors::CdtResult;
     /// use causal_triangulations::prelude::config::{
     ///     CdtConfig, CdtConfigOverrides, DimensionOverride,
     /// };
     ///
+    /// fn main() -> CdtResult<()> {
     /// let base = CdtConfig::new(10, 2);
     /// let overrides = CdtConfigOverrides {
     ///     dimension: Some(DimensionOverride::Clear),
@@ -442,13 +444,19 @@ impl CdtConfig {
     ///     ..CdtConfigOverrides::default()
     /// };
     ///
-    /// let merged = base.merge_with_override(&overrides);
+    /// let merged = base.merge_with_override(&overrides)?;
     /// assert_eq!(merged.dimension, None);
     /// assert_eq!(merged.vertices, 24);
     /// assert_eq!(merged.timeslices, 2);
+    /// # Ok(())
+    /// }
     /// ```
-    #[must_use]
-    pub fn merge_with_override(&self, overrides: &CdtConfigOverrides) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidConfiguration`] if an override volume profile cannot
+    /// be represented by the `u32` vertex or time-slice counts stored in [`CdtConfig`].
+    pub fn merge_with_override(&self, overrides: &CdtConfigOverrides) -> CdtResult<Self> {
         let mut merged = self.clone();
 
         if let Some(dimension_override) = overrides.dimension {
@@ -474,10 +482,25 @@ impl CdtConfig {
         // merged config can pair stale vertex/time-slice totals with new slices.
         match &overrides.volume_profile {
             Some(Some(profile)) => {
-                merged.vertices = profile
-                    .iter()
-                    .fold(0_u32, |total, &vertices| total.saturating_add(vertices));
-                merged.timeslices = u32::try_from(profile.len()).unwrap_or(u32::MAX);
+                let profile_vertices = profile.iter().try_fold(0_u32, |total, &vertices| {
+                    total.checked_add(vertices).ok_or_else(|| {
+                        invalid_config(
+                            ConfigurationSetting::Vertices,
+                            &format!("{profile:?}"),
+                            &"volume profile sum <= u32::MAX",
+                        )
+                    })
+                })?;
+                let profile_timeslices = u32::try_from(profile.len()).map_err(|err| {
+                    invalid_config(
+                        ConfigurationSetting::Timeslices,
+                        &profile.len(),
+                        &format!("volume profile length must fit in u32: {err}"),
+                    )
+                })?;
+
+                merged.vertices = profile_vertices;
+                merged.timeslices = profile_timeslices;
                 merged.volume_profile = Some(profile.clone());
             }
             Some(None) => merged.volume_profile = None,
@@ -532,7 +555,7 @@ impl CdtConfig {
             merged.output_json.clone_from(output_json);
         }
 
-        merged
+        Ok(merged)
     }
 
     /// Resolves a candidate path against a base directory, expanding user home references
@@ -1861,7 +1884,9 @@ mod tests {
             ..CdtConfigOverrides::default()
         };
 
-        let merged = base.merge_with_override(&overrides);
+        let merged = base
+            .merge_with_override(&overrides)
+            .expect("override merge should succeed");
 
         assert_eq!(merged.dimension, None);
         assert_eq!(merged.dimension(), 2);
@@ -1893,7 +1918,9 @@ mod tests {
             ..CdtConfigOverrides::default()
         };
 
-        let merged = base.merge_with_override(&overrides);
+        let merged = base
+            .merge_with_override(&overrides)
+            .expect("override merge should succeed");
 
         assert_eq!(merged.vertices, 15);
         assert_eq!(merged.timeslices, 3);
@@ -1921,7 +1948,9 @@ mod tests {
             ..CdtConfigOverrides::default()
         };
 
-        let merged = base.merge_with_override(&overrides);
+        let merged = base
+            .merge_with_override(&overrides)
+            .expect("override merge should succeed");
 
         assert_eq!(merged.seed, None);
     }
@@ -1939,7 +1968,9 @@ mod tests {
             ..CdtConfigOverrides::default()
         };
 
-        let merged = base.merge_with_override(&overrides);
+        let merged = base
+            .merge_with_override(&overrides)
+            .expect("override merge should succeed");
 
         assert_eq!(merged.volume_profile, None);
         assert_eq!(merged.vertices, 15);
@@ -1954,9 +1985,35 @@ mod tests {
             ..CdtConfigOverrides::default()
         };
 
-        let merged = base.merge_with_override(&overrides);
+        let merged = base
+            .merge_with_override(&overrides)
+            .expect("override merge should succeed");
         assert_eq!(merged.dimension, None);
         assert_eq!(merged.dimension(), 2); // dimension() defaults to 2 when None
+    }
+
+    #[test]
+    fn test_merge_with_override_rejects_volume_profile_vertex_overflow() {
+        let base = CdtConfig::new(10, 2);
+        let overrides = CdtConfigOverrides {
+            volume_profile: Some(Some(vec![u32::MAX, 1])),
+            ..CdtConfigOverrides::default()
+        };
+
+        let result = base.merge_with_override(&overrides);
+
+        assert!(
+            matches!(
+                result,
+                Err(CdtError::InvalidConfiguration {
+                    setting: ConfigurationSetting::Vertices,
+                    ref provided_value,
+                    ref expected,
+                }) if provided_value == "[4294967295, 1]"
+                    && expected == "volume profile sum <= u32::MAX"
+            ),
+            "{result:?}"
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -423,6 +423,11 @@ impl CdtConfig {
     /// unchanged. When an override value is provided, it replaces the corresponding field in
     /// the returned configuration.
     ///
+    /// A provided volume profile is an atomic override for its derived counts:
+    /// the returned configuration recomputes `vertices` from the profile sum and
+    /// `timeslices` from the profile length, even if those scalar fields were
+    /// also present in the override set.
+    ///
     /// # Examples
     ///
     /// ```
@@ -465,8 +470,18 @@ impl CdtConfig {
             merged.timeslices = timeslices;
         }
 
-        if let Some(volume_profile) = &overrides.volume_profile {
-            merged.volume_profile.clone_from(volume_profile);
+        // Profiles are atomic overrides for their derived counts; otherwise a
+        // merged config can pair stale vertex/time-slice totals with new slices.
+        match &overrides.volume_profile {
+            Some(Some(profile)) => {
+                merged.vertices = profile
+                    .iter()
+                    .fold(0_u32, |total, &vertices| total.saturating_add(vertices));
+                merged.timeslices = u32::try_from(profile.len()).unwrap_or(u32::MAX);
+                merged.volume_profile = Some(profile.clone());
+            }
+            Some(None) => merged.volume_profile = None,
+            None => {}
         }
 
         if let Some(temperature) = overrides.temperature {
@@ -1880,7 +1895,8 @@ mod tests {
 
         let merged = base.merge_with_override(&overrides);
 
-        assert_eq!(merged.timeslices, 5);
+        assert_eq!(merged.vertices, 15);
+        assert_eq!(merged.timeslices, 3);
         assert_eq!(merged.volume_profile, Some(vec![4, 6, 5]));
         assert_eq!(merged.steps, 250);
         assert_eq!(merged.thermalization_steps, 25);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,6 +32,202 @@ impl fmt::Display for DelaunayValidationLevel {
     }
 }
 
+/// Identifies the top-level or simulation configuration setting that failed validation.
+///
+/// Use this with [`CdtError::InvalidConfiguration`] and
+/// [`CdtError::InvalidSimulationConfiguration`] to inspect invalid settings
+/// without parsing rendered error messages.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::errors::{CdtError, ConfigurationSetting};
+/// use causal_triangulations::prelude::CdtConfig;
+///
+/// let config = CdtConfig {
+///     vertices: 2,
+///     ..CdtConfig::new(36, 3)
+/// };
+/// let err = config.validate().expect_err("vertices below the minimum are invalid");
+///
+/// assert!(matches!(
+///     err,
+///     CdtError::InvalidConfiguration {
+///         setting: ConfigurationSetting::Vertices,
+///         ..
+///     }
+/// ));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ConfigurationSetting {
+    /// CDT dimensionality setting.
+    Dimension,
+    /// Total vertex count setting.
+    Vertices,
+    /// Number of time slices setting.
+    Timeslices,
+    /// Metropolis temperature setting.
+    Temperature,
+    /// Number of Metropolis steps setting.
+    Steps,
+    /// Number of thermalization steps setting.
+    ThermalizationSteps,
+    /// Measurement cadence setting.
+    MeasurementFrequency,
+    /// Combined measurement schedule constraint.
+    MeasurementSchedule,
+    /// Bare inverse Newton coupling setting.
+    Coupling0,
+    /// Curvature coupling setting.
+    Coupling2,
+    /// Cosmological constant setting.
+    CosmologicalConstant,
+    /// Explicit per-slice volume profile setting.
+    VolumeProfile,
+}
+
+impl fmt::Display for ConfigurationSetting {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Dimension => formatter.write_str("dimension"),
+            Self::Vertices => formatter.write_str("vertices"),
+            Self::Timeslices => formatter.write_str("timeslices"),
+            Self::Temperature => formatter.write_str("temperature"),
+            Self::Steps => formatter.write_str("steps"),
+            Self::ThermalizationSteps => formatter.write_str("thermalization_steps"),
+            Self::MeasurementFrequency => formatter.write_str("measurement_frequency"),
+            Self::MeasurementSchedule => formatter.write_str("measurement schedule"),
+            Self::Coupling0 => formatter.write_str("coupling_0"),
+            Self::Coupling2 => formatter.write_str("coupling_2"),
+            Self::CosmologicalConstant => formatter.write_str("cosmological_constant"),
+            Self::VolumeProfile => formatter.write_str("volume_profile"),
+        }
+    }
+}
+
+/// Identifies the issue category for invalid triangulation generation parameters.
+///
+/// Use this with [`CdtError::InvalidGenerationParameters`] when a constructor
+/// rejects input before attempting triangulation.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::errors::{CdtError, GenerationParameterIssue};
+/// use causal_triangulations::prelude::triangulation::CdtTriangulation;
+///
+/// let err = CdtTriangulation::from_random_points(2, 2, 2)
+///     .expect_err("fewer than three vertices cannot form a triangulation");
+///
+/// assert!(matches!(
+///     err,
+///     CdtError::InvalidGenerationParameters {
+///         issue: GenerationParameterIssue::InsufficientVertexCount,
+///         ..
+///     }
+/// ));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum GenerationParameterIssue {
+    /// Coordinate range has invalid ordering or bounds.
+    InvalidCoordinateRange,
+    /// Toroidal domain extents are invalid.
+    InvalidToroidalDomain,
+    /// A supplied vertex coordinate is NaN or infinite.
+    NonFiniteVertexCoordinate,
+    /// Total vertex count is below the constructor minimum.
+    InsufficientVertexCount,
+    /// Per-slice vertex count is below the constructor minimum.
+    InsufficientVerticesPerSlice,
+    /// Number of time slices is below the topology minimum.
+    InsufficientNumberOfTimeSlices,
+    /// A slice count was zero where at least one slice is required.
+    NonPositiveSliceCount,
+    /// Explicit volume profile has no slices.
+    EmptyVolumeProfile,
+    /// Explicit volume profile length cannot fit in supported counters.
+    VolumeProfileLengthOverflow,
+    /// A volume-profile slice has too few vertices.
+    InsufficientVerticesInVolumeProfileSlice,
+    /// Total vertex count cannot fit in supported counters.
+    VertexCountOverflow,
+    /// Simplex count cannot fit in supported counters.
+    SimplexCountOverflow,
+}
+
+impl fmt::Display for GenerationParameterIssue {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidCoordinateRange => formatter.write_str("Invalid coordinate range"),
+            Self::InvalidToroidalDomain => formatter.write_str("Invalid toroidal domain"),
+            Self::NonFiniteVertexCoordinate => formatter.write_str("Non-finite vertex coordinate"),
+            Self::InsufficientVertexCount => formatter.write_str("Insufficient vertex count"),
+            Self::InsufficientVerticesPerSlice => {
+                formatter.write_str("Insufficient vertices per slice")
+            }
+            Self::InsufficientNumberOfTimeSlices => {
+                formatter.write_str("Insufficient number of time slices")
+            }
+            Self::NonPositiveSliceCount => formatter.write_str("Number of slices must be positive"),
+            Self::EmptyVolumeProfile => formatter.write_str("Empty volume profile"),
+            Self::VolumeProfileLengthOverflow => {
+                formatter.write_str("Volume profile length overflow")
+            }
+            Self::InsufficientVerticesInVolumeProfileSlice => {
+                formatter.write_str("Insufficient vertices in volume-profile slice")
+            }
+            Self::VertexCountOverflow => formatter.write_str("Vertex count overflow"),
+            Self::SimplexCountOverflow => formatter.write_str("Simplex count overflow"),
+        }
+    }
+}
+
+/// Identifies the CDT triangulation metadata field that failed validation.
+///
+/// Use this with [`CdtError::InvalidTriangulationMetadata`] to distinguish
+/// invalid metadata fields without relying on display text.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::errors::{CdtError, TriangulationMetadataField};
+/// use causal_triangulations::prelude::triangulation::CdtTopology;
+///
+/// let metadata_error = CdtError::InvalidTriangulationMetadata {
+///     field: TriangulationMetadataField::Timeslices,
+///     topology: CdtTopology::Toroidal,
+///     provided_value: "2".to_string(),
+///     expected: "at least three time slices".to_string(),
+/// };
+///
+/// assert!(matches!(
+///     metadata_error,
+///     CdtError::InvalidTriangulationMetadata {
+///         field: TriangulationMetadataField::Timeslices,
+///         ..
+///     }
+/// ));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum TriangulationMetadataField {
+    /// Number of time slices recorded in triangulation metadata.
+    Timeslices,
+    /// Dimensionality recorded in triangulation metadata.
+    Dimension,
+}
+
+impl fmt::Display for TriangulationMetadataField {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Timeslices => formatter.write_str("timeslices"),
+            Self::Dimension => formatter.write_str("dimension"),
+        }
+    }
+}
+
 /// Simulation output format for typed output read/write failures.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -556,8 +752,8 @@ pub enum CdtError {
         "Invalid triangulation parameters: {issue} (got: {provided_value}, expected: {expected_range})"
     )]
     InvalidGenerationParameters {
-        /// Description of the specific parameter issue
-        issue: String,
+        /// Structured category for the rejected generation parameter.
+        issue: GenerationParameterIssue,
         /// The actual value that was provided
         provided_value: String,
         /// The expected range or constraint for the parameter
@@ -566,8 +762,8 @@ pub enum CdtError {
     /// Top-level CDT configuration failed validation.
     #[error("Invalid configuration: {setting} (got: {provided_value}, expected: {expected})")]
     InvalidConfiguration {
-        /// Name of the invalid configuration setting.
-        setting: String,
+        /// Structured category for the invalid configuration setting.
+        setting: ConfigurationSetting,
         /// Value supplied for the setting.
         provided_value: String,
         /// Expected constraint for the setting.
@@ -578,8 +774,8 @@ pub enum CdtError {
         "Invalid simulation configuration: {setting} (got: {provided_value}, expected: {expected})"
     )]
     InvalidSimulationConfiguration {
-        /// Name of the invalid simulation setting.
-        setting: String,
+        /// Structured category for the invalid simulation setting.
+        setting: ConfigurationSetting,
         /// Value supplied for the setting.
         provided_value: String,
         /// Expected constraint for the setting.
@@ -609,8 +805,8 @@ pub enum CdtError {
         "Invalid triangulation metadata: {field} for {topology} (got: {provided_value}, expected: {expected})"
     )]
     InvalidTriangulationMetadata {
-        /// Name of the invalid metadata field.
-        field: String,
+        /// Structured category for the invalid metadata field.
+        field: TriangulationMetadataField,
         /// Topology whose invariant was violated.
         topology: CdtTopology,
         /// Value stored in the triangulation metadata.
@@ -795,7 +991,7 @@ mod tests {
     #[test]
     fn test_invalid_configuration_error() {
         let error = CdtError::InvalidConfiguration {
-            setting: "vertices".to_string(),
+            setting: ConfigurationSetting::Vertices,
             provided_value: "2".to_string(),
             expected: "≥ 3".to_string(),
         };
@@ -809,7 +1005,7 @@ mod tests {
     #[test]
     fn test_invalid_simulation_configuration_error() {
         let error = CdtError::InvalidSimulationConfiguration {
-            setting: "temperature".to_string(),
+            setting: ConfigurationSetting::Temperature,
             provided_value: "NaN".to_string(),
             expected: "finite and positive".to_string(),
         };
@@ -823,7 +1019,7 @@ mod tests {
     #[test]
     fn test_invalid_triangulation_metadata_error() {
         let error = CdtError::InvalidTriangulationMetadata {
-            field: "timeslices".to_string(),
+            field: TriangulationMetadataField::Timeslices,
             topology: CdtTopology::Toroidal,
             provided_value: "2".to_string(),
             expected: "≥ 3".to_string(),
@@ -886,6 +1082,110 @@ mod tests {
         assert_eq!(
             CdtValidationCheck::ErgodicMoveCandidateGeometry.to_string(),
             "ergodic_move_candidate_geometry"
+        );
+    }
+
+    #[test]
+    fn configuration_setting_display_covers_all_settings() {
+        let cases = [
+            (ConfigurationSetting::Dimension, "dimension"),
+            (ConfigurationSetting::Vertices, "vertices"),
+            (ConfigurationSetting::Timeslices, "timeslices"),
+            (ConfigurationSetting::Temperature, "temperature"),
+            (ConfigurationSetting::Steps, "steps"),
+            (
+                ConfigurationSetting::ThermalizationSteps,
+                "thermalization_steps",
+            ),
+            (
+                ConfigurationSetting::MeasurementFrequency,
+                "measurement_frequency",
+            ),
+            (
+                ConfigurationSetting::MeasurementSchedule,
+                "measurement schedule",
+            ),
+            (ConfigurationSetting::Coupling0, "coupling_0"),
+            (ConfigurationSetting::Coupling2, "coupling_2"),
+            (
+                ConfigurationSetting::CosmologicalConstant,
+                "cosmological_constant",
+            ),
+            (ConfigurationSetting::VolumeProfile, "volume_profile"),
+        ];
+
+        for (setting, expected) in cases {
+            assert_eq!(setting.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn generation_parameter_issue_display_covers_all_issues() {
+        let cases = [
+            (
+                GenerationParameterIssue::InvalidCoordinateRange,
+                "Invalid coordinate range",
+            ),
+            (
+                GenerationParameterIssue::InvalidToroidalDomain,
+                "Invalid toroidal domain",
+            ),
+            (
+                GenerationParameterIssue::NonFiniteVertexCoordinate,
+                "Non-finite vertex coordinate",
+            ),
+            (
+                GenerationParameterIssue::InsufficientVertexCount,
+                "Insufficient vertex count",
+            ),
+            (
+                GenerationParameterIssue::InsufficientVerticesPerSlice,
+                "Insufficient vertices per slice",
+            ),
+            (
+                GenerationParameterIssue::InsufficientNumberOfTimeSlices,
+                "Insufficient number of time slices",
+            ),
+            (
+                GenerationParameterIssue::NonPositiveSliceCount,
+                "Number of slices must be positive",
+            ),
+            (
+                GenerationParameterIssue::EmptyVolumeProfile,
+                "Empty volume profile",
+            ),
+            (
+                GenerationParameterIssue::VolumeProfileLengthOverflow,
+                "Volume profile length overflow",
+            ),
+            (
+                GenerationParameterIssue::InsufficientVerticesInVolumeProfileSlice,
+                "Insufficient vertices in volume-profile slice",
+            ),
+            (
+                GenerationParameterIssue::VertexCountOverflow,
+                "Vertex count overflow",
+            ),
+            (
+                GenerationParameterIssue::SimplexCountOverflow,
+                "Simplex count overflow",
+            ),
+        ];
+
+        for (issue, expected) in cases {
+            assert_eq!(issue.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn triangulation_metadata_field_display_covers_all_fields() {
+        assert_eq!(
+            TriangulationMetadataField::Timeslices.to_string(),
+            "timeslices"
+        );
+        assert_eq!(
+            TriangulationMetadataField::Dimension.to_string(),
+            "dimension"
         );
     }
 
@@ -1019,14 +1319,14 @@ mod tests {
     #[test]
     fn test_invalid_generation_parameters_error() {
         let error = CdtError::InvalidGenerationParameters {
-            issue: "Vertex count too small".to_string(),
+            issue: GenerationParameterIssue::InsufficientVertexCount,
             provided_value: "2".to_string(),
             expected_range: "at least 3".to_string(),
         };
         let display = format!("{error}");
         assert_eq!(
             display,
-            "Invalid triangulation parameters: Vertex count too small (got: 2, expected: at least 3)"
+            "Invalid triangulation parameters: Insufficient vertex count (got: 2, expected: at least 3)"
         );
     }
 
@@ -1542,17 +1842,17 @@ mod tests {
     #[test]
     fn test_error_equality() {
         let error1 = CdtError::InvalidConfiguration {
-            setting: "steps".to_string(),
+            setting: ConfigurationSetting::Steps,
             provided_value: "0".to_string(),
             expected: "≥ 1".to_string(),
         };
         let error2 = CdtError::InvalidConfiguration {
-            setting: "steps".to_string(),
+            setting: ConfigurationSetting::Steps,
             provided_value: "0".to_string(),
             expected: "≥ 1".to_string(),
         };
         let error3 = CdtError::InvalidConfiguration {
-            setting: "steps".to_string(),
+            setting: ConfigurationSetting::Steps,
             provided_value: "10".to_string(),
             expected: "≥ 1".to_string(),
         };
@@ -1571,20 +1871,20 @@ mod tests {
     #[test]
     fn test_error_debug() {
         let error = CdtError::InvalidConfiguration {
-            setting: "vertices".to_string(),
+            setting: ConfigurationSetting::Vertices,
             provided_value: "2".to_string(),
             expected: "≥ 3".to_string(),
         };
         let debug_str = format!("{error:?}");
         assert!(debug_str.contains("InvalidConfiguration"));
-        assert!(debug_str.contains("vertices"));
+        assert!(debug_str.contains("Vertices"));
     }
 
     #[test]
     fn test_cdt_result_type() {
         let success: CdtResult<i32> = Ok(42);
         let failure: CdtResult<i32> = Err(CdtError::InvalidConfiguration {
-            setting: "steps".to_string(),
+            setting: ConfigurationSetting::Steps,
             provided_value: "0".to_string(),
             expected: "≥ 1".to_string(),
         });
@@ -1603,7 +1903,7 @@ mod tests {
     #[test]
     fn test_std_error_trait() {
         let error = CdtError::InvalidConfiguration {
-            setting: "temperature".to_string(),
+            setting: ConfigurationSetting::Temperature,
             provided_value: "NaN".to_string(),
             expected: "finite and positive".to_string(),
         };

--- a/src/geometry/generators.rs
+++ b/src/geometry/generators.rs
@@ -7,7 +7,7 @@
 //! that directly imports from the `delaunay` crate (see
 //! `docs/dev/rust.md § Geometry Backend Isolation`).
 
-use crate::errors::{CdtError, CdtResult};
+use crate::errors::{CdtError, CdtResult, GenerationParameterIssue};
 pub use delaunay::TopologyGuarantee;
 use delaunay::geometry::kernel::AdaptiveKernel;
 use delaunay::geometry::point::Point;
@@ -36,12 +36,12 @@ fn generate_delaunay2_vertex_build_error(
 
 /// Builds a consistent typed validation error for generator argument checks.
 fn invalid_generation_parameters(
-    issue: &str,
+    issue: GenerationParameterIssue,
     provided_value: String,
     expected_range: &str,
 ) -> CdtError {
     CdtError::InvalidGenerationParameters {
-        issue: issue.to_string(),
+        issue,
         provided_value,
         expected_range: expected_range.to_string(),
     }
@@ -54,7 +54,7 @@ fn validate_coordinate_range(coordinate_range: (f64, f64)) -> CdtResult<()> {
         Ok(())
     } else {
         Err(invalid_generation_parameters(
-            "Invalid coordinate range",
+            GenerationParameterIssue::InvalidCoordinateRange,
             format!("[{min}, {max}]"),
             "finite min < max",
         ))
@@ -67,7 +67,7 @@ fn validate_explicit_coordinates(coords_with_data: &[([f64; 2], u32)]) -> CdtRes
         for (axis, value) in coord.iter().copied().enumerate() {
             if !value.is_finite() {
                 return Err(invalid_generation_parameters(
-                    "Non-finite vertex coordinate",
+                    GenerationParameterIssue::NonFiniteVertexCoordinate,
                     format!("vertex {vertex_index} axis {axis} = {value}"),
                     "finite coordinate values",
                 ));
@@ -82,7 +82,7 @@ fn validate_toroidal_domain(domain: [f64; 2]) -> CdtResult<()> {
     for (axis, period) in domain.into_iter().enumerate() {
         if !period.is_finite() || period <= 0.0 {
             return Err(invalid_generation_parameters(
-                "Invalid toroidal domain",
+                GenerationParameterIssue::InvalidToroidalDomain,
                 format!("axis {axis} period {period}"),
                 "finite and positive periods",
             ));
@@ -122,7 +122,7 @@ pub fn generate_delaunay2(
     // Validate parameters before attempting generation
     if number_of_vertices < 3 {
         return Err(invalid_generation_parameters(
-            "Insufficient vertex count",
+            GenerationParameterIssue::InsufficientVertexCount,
             number_of_vertices.to_string(),
             "≥ 3",
         ));
@@ -763,7 +763,7 @@ mod tests {
                         ref issue,
                         ref provided_value,
                         ref expected_range,
-                    }) if issue == "Invalid toroidal domain"
+                    }) if *issue == GenerationParameterIssue::InvalidToroidalDomain
                         && provided_value == expected_value
                         && expected_range == "finite and positive periods"
                 ),
@@ -788,7 +788,7 @@ mod tests {
                     ref issue,
                     ref provided_value,
                     ref expected_range,
-                }) if issue == "Non-finite vertex coordinate"
+                }) if *issue == GenerationParameterIssue::NonFiniteVertexCoordinate
                     && provided_value == "vertex 1 axis 1 = -inf"
                     && expected_range == "finite coordinate values"
             ),
@@ -853,7 +853,7 @@ mod tests {
                 provided_value,
                 expected_range,
             } => {
-                assert_eq!(issue, "Insufficient vertex count");
+                assert_eq!(issue, GenerationParameterIssue::InsufficientVertexCount);
                 assert_eq!(provided_value, "2");
                 assert_eq!(expected_range, "≥ 3");
             }
@@ -872,7 +872,7 @@ mod tests {
                 provided_value,
                 expected_range,
             } => {
-                assert_eq!(issue, "Invalid coordinate range");
+                assert_eq!(issue, GenerationParameterIssue::InvalidCoordinateRange);
                 assert_eq!(provided_value, "[10, 5]");
                 assert_eq!(expected_range, "finite min < max");
             }
@@ -887,7 +887,7 @@ mod tests {
 
         match result.unwrap_err() {
             CdtError::InvalidGenerationParameters { issue, .. } => {
-                assert_eq!(issue, "Invalid coordinate range");
+                assert_eq!(issue, GenerationParameterIssue::InvalidCoordinateRange);
             }
             _ => panic!("Expected InvalidGenerationParameters error"),
         }
@@ -904,7 +904,7 @@ mod tests {
                         ref issue,
                         ref expected_range,
                         ..
-                    }) if issue == "Invalid coordinate range"
+                    }) if *issue == GenerationParameterIssue::InvalidCoordinateRange
                         && expected_range == "finite min < max"
                 ),
                 "non-finite range {range:?} should be rejected, got {result:?}"
@@ -924,7 +924,7 @@ mod tests {
                     ref issue,
                     ref provided_value,
                     ref expected_range,
-                }) if issue == "Non-finite vertex coordinate"
+                }) if *issue == GenerationParameterIssue::NonFiniteVertexCoordinate
                     && provided_value == "vertex 1 axis 1 = NaN"
                     && expected_range == "finite coordinate values"
             ),
@@ -949,7 +949,7 @@ mod tests {
                     ref issue,
                     ref provided_value,
                     ref expected_range,
-                }) if issue == "Non-finite vertex coordinate"
+                }) if *issue == GenerationParameterIssue::NonFiniteVertexCoordinate
                     && provided_value == "vertex 2 axis 1 = -inf"
                     && expected_range == "finite coordinate values"
             ),
@@ -979,7 +979,7 @@ mod tests {
                     ref issue,
                     ref provided_value,
                     ref expected_range,
-                }) if issue == "Non-finite vertex coordinate"
+                }) if *issue == GenerationParameterIssue::NonFiniteVertexCoordinate
                     && provided_value == "vertex 1 axis 0 = inf"
                     && expected_range == "finite coordinate values"
             ),
@@ -1006,7 +1006,7 @@ mod tests {
                         ref issue,
                         ref provided_value,
                         ref expected_range,
-                    }) if issue == "Invalid toroidal domain"
+                    }) if *issue == GenerationParameterIssue::InvalidToroidalDomain
                         && provided_value == expected_value
                         && expected_range == "finite and positive periods"
                 ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,23 +135,25 @@ pub use cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveStatistics, MoveTyp
 pub use cdt::foliation::{EdgeType, Foliation, FoliationError, SimplexType};
 pub use cdt::metropolis::{
     CdtMcmcCheckpoint, CdtProposal, CdtProposalError, CdtProposalInfo, CdtProposalPlan, CdtTarget,
-    MetropolisAlgorithm, MetropolisConfig, MonteCarloStep,
+    MetropolisAlgorithm, MetropolisConfig, MonteCarloStep, ProposalStatistics,
 };
 pub use cdt::observables::{estimate_hausdorff_dimension, estimate_spectral_dimension};
 pub use cdt::results::{Measurement, SimulationResultsBackend};
 pub use config::{CdtConfig, CdtConfigOverrides, CdtTopology, DimensionOverride, TestConfig};
 pub use errors::{
     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
-    CheckpointOperation, CheckpointResumeReason, DelaunayValidationLevel,
-    MetropolisMoveApplicationFailure, OutputFormat,
+    CheckpointOperation, CheckpointResumeReason, ConfigurationSetting, DelaunayValidationLevel,
+    GenerationParameterIssue, MetropolisMoveApplicationFailure, OutputFormat,
+    TriangulationMetadataField,
 };
 
+use crate::cdt::results::SimulationResultsParts;
 use crate::util::saturating_usize_to_u32;
 use std::env;
 use std::time::Duration;
 
 // Trait-based triangulation (recommended)
-pub use cdt::triangulation::CdtTriangulation;
+pub use cdt::triangulation::{CdtTriangulation, SimulationEvent};
 pub use geometry::traits::TriangulationQuery;
 
 /// Prelude module for convenient imports.
@@ -218,7 +220,8 @@ pub mod prelude {
         pub use crate::errors::{
             BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck,
             CdtValidationFailure, CheckpointOperation, CheckpointResumeReason,
-            DelaunayValidationLevel, MetropolisMoveApplicationFailure, OutputFormat,
+            ConfigurationSetting, DelaunayValidationLevel, GenerationParameterIssue,
+            MetropolisMoveApplicationFailure, OutputFormat, TriangulationMetadataField,
         };
     }
 
@@ -236,7 +239,7 @@ pub mod prelude {
         pub use crate::cdt::action::{ActionConfig, compute_regge_action};
     }
 
-    /// Focused exports for CDT triangulation construction and queries.
+    /// Focused exports for CDT triangulation construction, queries, and history events.
     ///
     /// Lighter than `prelude::*` — just the types needed for building and
     /// inspecting triangulations (the most common doctest pattern).
@@ -251,12 +254,12 @@ pub mod prelude {
     /// }
     /// ```
     pub mod triangulation {
-        pub use crate::CdtTriangulation;
         pub use crate::cdt::foliation::{EdgeType, Foliation, FoliationError, SimplexType};
         pub use crate::config::CdtTopology;
         pub use crate::errors::{CdtError, CdtResult};
         pub use crate::geometry::CdtTriangulation2D;
         pub use crate::geometry::traits::TriangulationQuery;
+        pub use crate::{CdtTriangulation, SimulationEvent};
     }
 
     /// Focused exports for local CDT move kernels and move statistics.
@@ -287,9 +290,10 @@ pub mod prelude {
         pub use crate::cdt::ergodic_moves::MoveType;
         pub use crate::cdt::metropolis::{
             CdtMcmcCheckpoint, CdtProposal, CdtProposalError, CdtProposalInfo, CdtProposalPlan,
-            CdtTarget, MetropolisAlgorithm, MetropolisConfig, MonteCarloStep,
+            CdtTarget, MetropolisAlgorithm, MetropolisConfig, MonteCarloStep, ProposalStatistics,
         };
         pub use crate::cdt::results::{Measurement, SimulationResultsBackend};
+        pub use crate::cdt::triangulation::SimulationEvent;
         pub use crate::config::{CdtConfig, CdtTopology};
         pub use crate::errors::{CdtError, CdtResult};
         pub use crate::geometry::CdtTriangulation2D;
@@ -402,11 +406,11 @@ pub mod prelude {
 ///
 /// This function uses the trait-based geometry backend system, which provides
 /// better abstraction and testability compared to legacy approaches.
-/// Open-boundary runs construct a regular foliated strip with
-/// [`CdtTriangulation::from_cdt_strip`]; toroidal runs construct a periodic
-/// mesh with [`CdtTriangulation::from_toroidal_cdt`]. In both cases,
-/// [`CdtConfig::vertices`] is the total vertex count and must divide evenly
-/// across [`CdtConfig::timeslices`].
+/// Open-boundary runs construct a foliated strip; toroidal runs construct a
+/// periodic mesh. When [`CdtConfig::volume_profile`] is present, the initial
+/// geometry uses those explicit per-slice spatial volumes. Otherwise the run
+/// uses regular equal-size slices derived from the total [`CdtConfig::vertices`]
+/// count and [`CdtConfig::timeslices`].
 ///
 /// # Arguments
 ///
@@ -421,8 +425,8 @@ pub mod prelude {
 ///
 /// Returns [`CdtError::InvalidConfiguration`] if the configuration fails validation,
 /// including invalid measurement schedules, unsupported open-boundary or
-/// toroidal slice counts, or a total vertex count that cannot be divided into
-/// regular spatial slices.
+/// toroidal slice counts, invalid regular slice counts, or inconsistent
+/// explicit spatial volume profiles.
 /// Returns [`CdtError::UnsupportedDimension`] if a validated configuration requests
 /// a simulation dimension other than 2.
 /// Returns triangulation generation, topology, foliation, or Metropolis errors
@@ -469,24 +473,35 @@ pub fn run_simulation(config: &CdtConfig) -> CdtResult<SimulationResultsBackend>
     log::info!("Dimensionality: {}", config.dimension.unwrap_or(2));
     log::info!("Number of vertices: {vertices}");
     log::info!("Number of timeslices: {timeslices}");
+    if let Some(profile) = &config.volume_profile {
+        log::info!("Initial spatial volume profile: {profile:?}");
+    }
     log::info!("Topology: {:?}", config.topology);
     log::info!("Using trait-based backend system");
 
     // Create initial triangulation based on topology.
     //
-    // `config.vertices` is always the *total* vertex count. `validate()` has
-    // already checked the topology-specific divisibility and per-slice lower
-    // bounds, so we can safely divide to recover N = vertices/T per slice.
+    // `config.vertices` is always the *total* vertex count. With no explicit
+    // profile, `validate()` has checked topology-specific divisibility so we can
+    // divide to recover N = vertices/T per slice.
     let triangulation = match config.topology {
         CdtTopology::Toroidal => {
             log::info!("Constructing toroidal CDT (S¹×S¹)");
-            let vertices_per_slice = vertices / timeslices;
-            CdtTriangulation::from_toroidal_cdt(vertices_per_slice, timeslices)?
+            if let Some(profile) = &config.volume_profile {
+                CdtTriangulation::from_toroidal_cdt_profile(profile)?
+            } else {
+                let vertices_per_slice = vertices / timeslices;
+                CdtTriangulation::from_toroidal_cdt(vertices_per_slice, timeslices)?
+            }
         }
         CdtTopology::OpenBoundary => {
             log::info!("Constructing open-boundary CDT strip");
-            let vertices_per_slice = vertices / timeslices;
-            CdtTriangulation::from_cdt_strip(vertices_per_slice, timeslices)?
+            if let Some(profile) = &config.volume_profile {
+                CdtTriangulation::from_cdt_strip_profile(profile)?
+            } else {
+                let vertices_per_slice = vertices / timeslices;
+                CdtTriangulation::from_cdt_strip(vertices_per_slice, timeslices)?
+            }
         }
     };
 
@@ -522,12 +537,13 @@ pub fn run_simulation(config: &CdtConfig) -> CdtResult<SimulationResultsBackend>
             .to_action_config()
             .calculate_action(vertices, edges, triangles);
 
-        SimulationResultsBackend::from_parts(
-            config.to_metropolis_config(),
-            config.to_action_config(),
-            MoveStatistics::new(),
-            vec![],
-            vec![Measurement {
+        SimulationResultsBackend::from_parts(SimulationResultsParts {
+            config: config.to_metropolis_config(),
+            action_config: config.to_action_config(),
+            move_stats: MoveStatistics::new(),
+            proposal_stats: ProposalStatistics::new(),
+            steps: vec![],
+            measurements: vec![Measurement {
                 step: 0,
                 action: initial_action,
                 vertices,
@@ -535,9 +551,9 @@ pub fn run_simulation(config: &CdtConfig) -> CdtResult<SimulationResultsBackend>
                 triangles,
                 volume_profile: triangulation.volume_profile(),
             }],
-            Duration::from_millis(0),
+            elapsed_time: Duration::from_millis(0),
             triangulation,
-        )
+        })
     };
 
     write_configured_outputs(config, &results)?;
@@ -605,6 +621,7 @@ mod tests {
             dimension: Some(2),
             vertices: 36,
             timeslices: 3,
+            volume_profile: None,
             temperature: 1.0,
             steps: 10,
             thermalization_steps: 5,
@@ -735,7 +752,7 @@ mod tests {
             expected,
         }) = result
         {
-            assert_eq!(setting, "measurement_frequency");
+            assert_eq!(setting, ConfigurationSetting::MeasurementFrequency);
             assert_eq!(provided_value, "0");
             assert_eq!(expected, "≥ 1");
         } else {
@@ -761,7 +778,7 @@ mod tests {
             expected,
         }) = result
         {
-            assert_eq!(setting, "measurement_frequency");
+            assert_eq!(setting, ConfigurationSetting::MeasurementFrequency);
             assert_eq!(provided_value, "200");
             assert_eq!(expected, "≤ steps (100)");
         } else {
@@ -783,7 +800,7 @@ mod tests {
             expected,
         }) = result
         {
-            assert_eq!(setting, "vertices");
+            assert_eq!(setting, ConfigurationSetting::Vertices);
             assert_eq!(provided_value, "2");
             assert_eq!(expected, "≥ 3");
         } else {
@@ -805,7 +822,7 @@ mod tests {
             expected,
         }) = result
         {
-            assert_eq!(setting, "temperature");
+            assert_eq!(setting, ConfigurationSetting::Temperature);
             assert_eq!(provided_value, "-1");
             assert_eq!(expected, "finite and positive");
         } else {
@@ -863,6 +880,7 @@ mod tests {
             dimension: Some(2),
             vertices: 12,
             timeslices: 3,
+            volume_profile: None,
             temperature: 1.0,
             steps: 10,
             thermalization_steps: 5,
@@ -892,5 +910,56 @@ mod tests {
             results.triangulation().metadata().topology,
             CdtTopology::Toroidal
         ));
+    }
+
+    #[test]
+    fn test_run_simulation_uses_nonuniform_volume_profile() {
+        let config = CdtConfig {
+            vertices: 15,
+            timeslices: 3,
+            volume_profile: Some(vec![4, 6, 5]),
+            steps: 4,
+            thermalization_steps: 0,
+            measurement_frequency: 1,
+            ..create_test_config()
+        };
+
+        let results = run_simulation(&config).expect("profile-based simulation should run");
+
+        assert_eq!(results.triangulation().vertex_count(), 15);
+        assert_eq!(results.triangulation().slice_sizes(), &[4, 6, 5]);
+        assert_eq!(results.measurements()[0].volume_profile.len(), 3);
+        results
+            .triangulation()
+            .validate()
+            .expect("profile-based initial CDT should satisfy evolved invariants");
+    }
+
+    #[test]
+    fn test_run_simulation_uses_nonuniform_toroidal_volume_profile() {
+        let config = CdtConfig {
+            vertices: 16,
+            timeslices: 4,
+            topology: CdtTopology::Toroidal,
+            volume_profile: Some(vec![3, 4, 5, 4]),
+            steps: 4,
+            thermalization_steps: 0,
+            measurement_frequency: 1,
+            ..create_test_config()
+        };
+
+        let results =
+            run_simulation(&config).expect("toroidal profile-based simulation should run");
+
+        assert_eq!(results.triangulation().vertex_count(), 16);
+        assert_eq!(results.triangulation().slice_sizes(), &[3, 4, 5, 4]);
+        assert!(matches!(
+            results.triangulation().metadata().topology,
+            CdtTopology::Toroidal
+        ));
+        results
+            .triangulation()
+            .validate()
+            .expect("toroidal profile-based initial CDT should satisfy evolved invariants");
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7,7 +7,7 @@
 
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-use serde_json::{Value, from_str};
+use serde_json::{Value, from_str, json};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -91,6 +91,7 @@ fn cdt_cli_help_documents_readme_usage() {
             "Vertices per spatial slice; total vertices are computed",
         ))
         .stdout(predicate::str::contains("--vertices-per-slice"))
+        .stdout(predicate::str::contains("--volume-profile <N0,N1,...>"))
         .stdout(predicate::str::contains("--topology <TOPOLOGY>"))
         .stdout(predicate::str::contains("toroidal"))
         .stdout(predicate::str::contains("--output-json <PATH>"));
@@ -217,6 +218,44 @@ fn cdt_cli_writes_configured_outputs() {
     assert!(csv.starts_with("step,action,vertices,edges,triangles,accepted,delta_action\n"));
     assert_eq!(parsed["config"]["vertices"], 12);
     assert_eq!(parsed["final_triangulation"]["time_slices"], 3);
+}
+
+#[test]
+fn cdt_cli_accepts_nonuniform_volume_profile_without_timeslices() {
+    let output_dir = temp_output_dir("volume-profile");
+    let json_path = output_dir.join("summary.json");
+    let mut cmd = cdt_command();
+
+    cmd.arg("--volume-profile").arg("4,6,5");
+    cmd.arg("--steps").arg("4");
+    cmd.arg("--thermalization-steps").arg("0");
+    cmd.arg("--measurement-frequency").arg("1");
+    cmd.arg("--output-json").arg(&json_path);
+    cmd.env("RUST_LOG", "error");
+
+    cmd.assert().success();
+
+    let json = fs::read_to_string(&json_path).expect("JSON output should be readable");
+    let parsed: Value = from_str(&json).expect("summary should parse");
+    fs::remove_dir_all(&output_dir).expect("temporary output directory should be removable");
+
+    assert_eq!(parsed["config"]["vertices"], 15);
+    assert_eq!(parsed["config"]["timeslices"], 3);
+    assert_eq!(parsed["config"]["volume_profile"], json!([4, 6, 5]));
+    assert_eq!(parsed["final_triangulation"]["vertices"], 15);
+    assert_eq!(parsed["final_triangulation"]["time_slices"], 3);
+}
+
+#[test]
+fn cdt_cli_rejects_volume_profile_timeslice_mismatch() {
+    let mut cmd = cdt_command();
+
+    cmd.arg("--volume-profile").arg("4,6,5");
+    cmd.arg("--timeslices").arg("4");
+
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "--timeslices (4) must match --volume-profile entry count (3)",
+    ));
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -130,10 +130,20 @@ mod integration_tests {
             MoveResult::Success,
             "periodic toroidal local dynamics should accept a volume-increasing move"
         );
-        assert_eq!(
-            local_moves.attempt_31_move(&mut inverse_fixture),
-            MoveResult::Success,
-            "periodic toroidal local dynamics should accept the inverse volume move after growth"
+        let mut inverse_accepted = false;
+        for _ in 0..64 {
+            match local_moves.attempt_31_move(&mut inverse_fixture) {
+                MoveResult::Success => {
+                    inverse_accepted = true;
+                    break;
+                }
+                MoveResult::Rejected(_) | MoveResult::GeometricViolation => {}
+                other => panic!("unexpected toroidal inverse move result: {other:?}"),
+            }
+        }
+        assert!(
+            inverse_accepted,
+            "periodic toroidal local dynamics should include an accepted inverse volume move after growth"
         );
         inverse_fixture
             .validate()

--- a/tests/proptest_foliation.rs
+++ b/tests/proptest_foliation.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 //! Property-based tests for CDT foliation construction and validation.
 
+use causal_triangulations::prelude::errors::TriangulationMetadataField;
 use causal_triangulations::prelude::geometry::{DelaunayBackend2D, GeometryBackend};
 use causal_triangulations::prelude::triangulation::*;
 use proptest::prelude::*;
@@ -97,7 +98,7 @@ proptest! {
                 expected,
                 ..
             }) => {
-                prop_assert_eq!(field, "timeslices");
+                prop_assert_eq!(field, TriangulationMetadataField::Timeslices);
                 prop_assert_eq!(provided_value, "0");
                 prop_assert_eq!(expected, "≥ 1");
             }


### PR DESCRIPTION
- Add explicit spatial volume profiles for CLI/configuration, initial CDT construction, simulation output, and documentation.
- Plan Metropolis proposals through sampled local move sites and apply the Hastings correction from forward and reverse site counts.
- Add proposal-kernel telemetry with saturating counters for no-site outcomes, site rejections, Metropolis rejections, accepted transitions, and hard failures.
- Replace stringly validation and history fields with typed error categories and move enums.
- Document detailed-balance semantics and add proposal-site benchmark coverage.

BREAKING CHANGE: `CdtConfig`, `CdtError`, triangulation history events, and serialized result/checkpoint shapes now use typed fields and proposal telemetry rather than the previous stringly/public field layout.

Closes #141