### PR TITLE
feat(cdt): add chunked Metropolis checkpoint sweeps (#152)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,9 @@ Key principle:
 - **Unsafe code**: forbidden (`#![forbid(unsafe_code)]`)
 - **Architecture**: `src/geometry/` is the backend interface layer for the `delaunay` crate; `src/cdt/` is the CDT domain layer. Direct `use delaunay::` imports
   are restricted to `src/geometry/` (`backends/delaunay.rs` and `generators.rs`); CDT modules use the trait-based abstractions, crate-owned Delaunay handles,
-  generator utilities, and `DelaunayBackend2D` type alias (see `docs/dev/rust.md § Geometry Backend Isolation`)
+  generator utilities, and `DelaunayBackend2D` type alias (see `docs/dev/rust.md § Geometry Backend Isolation`). Generic Metropolis-Hastings and sampler
+  mechanics should similarly be delegated to the `markov-chain-monte-carlo` crate through thin CDT adapters such as `Target` and `DelayedProposal`;
+  CDT-local generic sampler logic must be issue-linked to an upstream API gap (see `docs/dev/rust.md § MCMC Backend Isolation`)
 - **Modules**: `src/cdt/` (CDT logic: moves, action, Metropolis, foliation, observables, results, triangulation child modules), `src/geometry/` (geometry
   abstractions and backends), `src/config.rs` (simulation configuration)
 - **Foliation**: `src/cdt/foliation.rs` defines foliation bookkeeping and edge/simplex classification. Time labels are stored as vertex data; `from_cdt_strip`

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -168,10 +168,15 @@ The crate is split into two intentionally different layers:
 - `src/geometry/` is the backend interface layer. It is the only layer that talks directly to the `delaunay` crate, wrapping upstream types behind crate-owned
   traits, opaque handles, generators, and backend adapters.
 - `src/cdt/` is the CDT domain layer. It owns causal triangulation semantics: foliation, topology and causality checks, ergodic moves, Regge action, Metropolis
-  sampling, measurements, and observables.
+  sampling adapters, measurements, and observables.
 
 Code outside `src/geometry/` must not import `delaunay::` directly. CDT modules should depend on `TriangulationQuery` / `TriangulationMut`, crate-owned Delaunay
 handle wrappers, `DelaunayBackend2D`, and generator functions from `crate::geometry`.
+
+Generic MCMC mechanics should be delegated to `markov-chain-monte-carlo` through thin CDT adapters. CDT owns domain state, proposal-site enumeration,
+foliation/topology validation, measurements, and result translation; the upstream MCMC crate should own Metropolis-Hastings acceptance, proposal-ratio
+application, chain counters, delayed-proposal commit ordering, and reusable sampler continuation behavior. The current boundary refactor is tracked by
+[`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155).
 
 ## Key Modules
 
@@ -224,11 +229,16 @@ The implementation is split into child modules under `src/cdt/triangulation/`:
 
 ### `cdt/metropolis.rs` — Metropolis move ordering
 
-`MetropolisAlgorithm::run()` proposes a move type, samples an explicit local proposal site from the same universe used for proposal counts, plans that site on a
-cloned triangulation, computes `ΔS` and the forward/reverse Metropolis-Hastings site-count ratio, accepts or rejects the concrete proposal, and only replaces
-the live triangulation after acceptance. Ordinary causal, geometric, and backend edit failures are self-loop proposal outcomes recorded in
-`ProposalStatistics`; hard backend failures remain structured errors. Toroidal move finalization rejects and rolls back candidate sites that would violate χ =
-0 or the closed-S¹ per-slice foliation invariant. See `docs/metropolis.md` for the detailed ordering and detailed-balance contract.
+`MetropolisAlgorithm::run()` is the current CDT production runner for proposal-before-mutation sampling. It proposes a move type, samples an explicit local
+proposal site from the same universe used for proposal counts, plans that site on a cloned triangulation, computes `ΔS` and the forward/reverse
+Metropolis-Hastings site-count ratio, accepts or rejects the concrete proposal, and only replaces the live triangulation after acceptance. Ordinary causal,
+geometric, and backend edit failures are self-loop proposal outcomes recorded in `ProposalStatistics`; hard backend failures remain structured errors.
+Toroidal move finalization rejects and rolls back candidate sites that would violate χ = 0 or the closed-S¹ per-slice foliation invariant.
+
+This direct M-H loop is transitional. The module also contains CDT adapters for `markov-chain-monte-carlo`, and the production runner should migrate toward
+delegating generic acceptance, proposal-ratio application, chain counters, and delayed-proposal commit ordering to that upstream crate while retaining
+CDT-specific telemetry and result conversion. See `docs/metropolis.md` for the detailed ordering and
+[`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155) for the boundary refactor.
 
 ### `cdt/results.rs` — Simulation outputs
 

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -362,13 +362,14 @@ The umbrella recipe currently runs `512/16/10` and `1024/32/1` cases. It is inte
 `debug-large-scale-1p1` recipe directly when you only need a smaller smoke probe.
 
 These debug recipes do not enable volume fixing. Volume drift in the reported final vertex and simplex counts is expected when `(1,3)` and `(3,1)` moves are
-accepted. Treat these runs as unfixed-volume move-kernel stress tests, not as fixed-volume CDT production ensembles. Future fixed-volume recipes should be
+accepted. Treat these runs as unfixed-volume Metropolis debug sweeps, not as fixed-volume CDT production ensembles. Future fixed-volume recipes should be
 explicitly labeled because quadratic volume fixing samples a modified ensemble; see Ambjørn et al.,
 [The Semiclassical Limit of Causal Dynamical Triangulations](https://arxiv.org/abs/1102.3929), and
 [The phase structure of Causal Dynamical Triangulations with toroidal spatial topology](https://arxiv.org/abs/1802.10434).
 
-For unfixed-volume debug runs, the cosmological constant is the volume-control coupling. If a large-scale recipe grows or shrinks too aggressively, tune the
-action parameters rather than interpreting the run as a failed fixed-volume simulation.
+For unfixed-volume Metropolis debug runs, each sweep is sized from the current number of top-dimensional simplices at the start of that sweep, then executed as
+one checkpoint-preserving Metropolis chunk. The cosmological constant is the volume-control coupling. If a large-scale recipe grows or shrinks too aggressively,
+tune the action parameters rather than interpreting the run as a failed fixed-volume simulation.
 
 The recipes set per-case environment variables, and the Rust harness also accepts these variables directly:
 

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -230,8 +230,8 @@ documented:
 - `prelude::moves` for local ergodic move kernels, move results, move types, and move statistics
 - `prelude::action` for standalone action configuration and Regge action calculations
 - `prelude::errors` for crate error types and typed error-category enums needed to pattern-match failures
-- `prelude::simulation` for Metropolis/action simulation workflows, proposal types, simulation result types, and telemetry needed to inspect or debug
-  simulations
+- `prelude::simulation` for Metropolis/action simulation workflows, proposal types, simulation result types, telemetry, and triangulation query traits needed to
+  inspect or debug simulations
 - `prelude::observables` for user-facing analysis APIs that measure triangulations or derived physical observables, such as volume profiles, Hausdorff-dimension
   estimators, and spectral-dimension estimators
 - `prelude::testing` for fixture-only helpers such as the mock backend and its typed error categories
@@ -331,6 +331,38 @@ No module outside `src/geometry/` may import from the `delaunay` crate directly.
 - Generator utilities from `crate::geometry::generators`
 
 This ensures the `delaunay` crate can be upgraded or replaced without touching CDT logic.
+
+---
+
+## MCMC Backend Isolation
+
+`markov-chain-monte-carlo` is the upstream owner of generic Monte Carlo mechanics. CDT code should treat it as the sampler backend in the same way
+`src/geometry/` treats `delaunay` as the triangulation backend.
+
+Delegate generic sampler work to upstream APIs such as `Target`, `DelayedProposal`, `Chain`, `Sampler`, and their successors whenever the API supports it:
+
+- Metropolis-Hastings accept/reject decisions
+- proposal-ratio application
+- chain accepted/rejected counters
+- delayed-proposal commit ordering
+- RNG-driven acceptance draws
+- checkpoint-compatible sampler continuation mechanics
+
+CDT may own thin domain adapters and result plumbing:
+
+- action-to-log-probability mapping (`CdtTarget`)
+- valid CDT proposal-site enumeration and topology/foliation validation (`CdtProposal`)
+- CDT-specific telemetry, measurements, and event history
+- conversion between upstream sampler state and CDT result/checkpoint types
+
+Do not add new local generic M-H loops, direct `exp(log_alpha)` acceptance draws, one-off proposal schedulers, or generic chain counter logic in `src/cdt/` when
+`markov-chain-monte-carlo` can own that behavior. If CDT needs temporary local sampler logic because the upstream API lacks a hook, document the gap in the
+code or nearby docs and open or link an upstream issue before extending the local implementation. The current production migration is tracked by
+[`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155), with upstream delayed-step telemetry tracked by
+[`markov-chain-monte-carlo#61`](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61).
+
+Once the production runner delegates fully to upstream sampler mechanics, add a static check so future CDT changes cannot reintroduce local generic
+Metropolis-Hastings implementations by accident.
 
 ---
 

--- a/docs/metropolis.md
+++ b/docs/metropolis.md
@@ -1,5 +1,11 @@
 # Metropolis Move Ordering And Detailed Balance
 
+> **MCMC backend boundary:** this page describes the current CDT production Metropolis runner. Its proposal-before-mutation contract should be preserved, but
+> generic Metropolis-Hastings mechanics should migrate behind `markov-chain-monte-carlo` adapters rather than remain as CDT-local sampler logic. The boundary
+> refactor is tracked by [`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155); upstream delayed-step hooks and
+> telemetry needs are tracked by
+> [`markov-chain-monte-carlo#61`](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61).
+
 `MetropolisAlgorithm::run()` uses a proposal-before-mutation ordering for CDT Monte Carlo steps.
 
 For each step:
@@ -27,6 +33,25 @@ acceptance draw. Rollback remains inside the move kernels while planning on the 
 after partial invariant refresh work. The recorded `SimulationResultsBackend::move_stats` counts Metropolis-level attempted and applied moves, while
 `SimulationResultsBackend::proposal_stats` records proposal-kernel telemetry such as no-site outcomes, sampled-site failures, Metropolis rejections, and
 accepted transitions.
+
+## Chunked Sweeps
+
+`MetropolisAlgorithm::resume_to_checkpoint()` continues a stored `CdtMcmcCheckpoint` for the configured additional step count and returns another resumable
+checkpoint. This keeps the checkpointed triangulation, Metropolis acceptance RNG, ergodic proposal RNG, counters, measurements, and elapsed-time telemetry
+together between chunks.
+
+The large-scale 1+1 debug harness uses this CDT-local chunking path to run one Metropolis sweep at a time. This behavior should eventually align with the
+upstream resumable sampler pattern tracked by
+[`markov-chain-monte-carlo#60`](https://github.com/acgetchell/markov-chain-monte-carlo/issues/60) and
+[`causal-triangulations#153`](https://github.com/acgetchell/causal-triangulations/issues/153):
+
+1. Read the current number of top-dimensional simplices at the start of the sweep.
+2. Run exactly that many Metropolis proposal steps.
+3. Inspect and log the checkpointed state.
+4. Enforce wall-clock caps between sweeps.
+
+Those debug runs are unfixed-volume Metropolis sweeps. The cosmological constant in the action controls volume growth or shrinkage; the harness does not impose
+a fixed-volume constraint or reuse the initial simplex count as a fixed step budget for later sweeps.
 
 ## Proposal-Ratio Correction
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,9 +24,18 @@ The v0.1.0 foundation work focuses on making the crate a usable, validated 1+1 C
   ([#140](https://github.com/acgetchell/causal-triangulations/issues/140))
 - [ ] Audit public doctests for fallible error handling
   ([#151](https://github.com/acgetchell/causal-triangulations/issues/151))
-- [ ] Use chunked Metropolis sweeps in large-scale 1+1 CDT debug runs
+- [x] Use chunked Metropolis sweeps in large-scale 1+1 CDT debug runs
   ([#152](https://github.com/acgetchell/causal-triangulations/issues/152)). The v0.1.0 scientific-utility bar requires the large-scale debug path to exercise
   Metropolis CDT behavior with literature-style sweeps sized from the current simplex count, not only the raw move kernel.
+- [ ] Align chunked Metropolis continuation with the upstream resumable sampler pattern
+  ([#153](https://github.com/acgetchell/causal-triangulations/issues/153)). Since #155 already requires a new `markov-chain-monte-carlo` release, chunked CDT
+  continuation should also move onto the upstream continuation/checkpoint API before the DOI-backed `v0.1.0` release.
+- [ ] Enforce the MCMC backend boundary
+  ([#155](https://github.com/acgetchell/causal-triangulations/issues/155)). Because GitHub releases are archived by Zenodo, the DOI-backed `v0.1.0` release
+  should not ship with generic Metropolis-Hastings mechanics duplicated in CDT-local code. Complete this after an updated `markov-chain-monte-carlo` release
+  provides the needed upstream resumable-sampler and delayed-step telemetry APIs
+  ([markov-chain-monte-carlo#60](https://github.com/acgetchell/markov-chain-monte-carlo/issues/60),
+  [markov-chain-monte-carlo#61](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61)).
 
 ## 1+1 Maturity
 
@@ -38,9 +47,10 @@ Likely follow-up work before broadening the dimensional surface:
 - Add manual foliation assignment APIs with the same validation and synchronization guarantees as constructor-assigned labels
 - Add tutorial-style examples for open-boundary strips, toroidal runs, observables, and interpreting Metropolis acceptance behavior
 
-## v0.1.1 Ensemble Controls
+## v0.1.1 Maturity And Ensemble Controls
 
-The post-v0.1.0 1+1 track should keep the default ensemble scientifically explicit while adding opt-in controls for finite-volume numerical workflows:
+The post-v0.1.0 1+1 track should keep the default ensemble scientifically explicit while adding opt-in controls, dependency-gated cleanup, and public API
+polish that are useful but not required for the first DOI-backed foundation release:
 
 - Add optional CDT volume fixing for bounded large-scale simulations
   ([#142](https://github.com/acgetchell/causal-triangulations/issues/142)). Volume fixing should be opt-in and documented as a modified action, not the default
@@ -54,9 +64,9 @@ The post-v0.1.0 1+1 track should keep the default ensemble scientifically explic
 - Redesign public error shapes for ergonomic typed diagnostics
   ([#149](https://github.com/acgetchell/causal-triangulations/issues/149)). This should build on the current typed category enums by evaluating richer observed
   values, constraints, and matching patterns without blocking the v0.1.0 correctness work.
-- Align the local chunked Metropolis API with the upstream resumable sampler pattern
-  ([#153](https://github.com/acgetchell/causal-triangulations/issues/153)). This is 1+1 stabilization after the v0.1.0 scientific workflow is functional:
-  `markov-chain-monte-carlo#60` should guide API convergence, but it should not block the local CDT behavior needed for v0.1.0.
+- Use exact Delaunay flip-feasibility validators for proposal-site accounting once `delaunay#419` ships
+  ([#146](https://github.com/acgetchell/causal-triangulations/issues/146)). v0.1.0 should prove CDT's counted proposal sites match the sites sampled by the
+  proposal kernel; backend-provided immutable feasibility checks are post-release dependency-gated tightening that avoids duplicating Delaunay dry-run policy.
 
 ## Higher-Dimensional CDT Tracks
 

--- a/src/cdt/metropolis.rs
+++ b/src/cdt/metropolis.rs
@@ -794,10 +794,12 @@ impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
 /// both RNG streams, and the ergodic move system.
 ///
 /// In-memory checkpoints can be resumed directly with
-/// [`MetropolisAlgorithm::resume_from_checkpoint`]. Serialized checkpoints
-/// restore through the embedded [`CdtTriangulation2D`]'s checked serde path, so
-/// deserialization also requires the stored backend triangulation to satisfy the
-/// current Delaunay reconstruction invariants.
+/// [`MetropolisAlgorithm::resume_from_checkpoint`] when callers want cumulative
+/// results, or [`MetropolisAlgorithm::resume_to_checkpoint`] when chunked
+/// drivers need another resumable checkpoint. Serialized checkpoints restore
+/// through the embedded [`CdtTriangulation2D`]'s checked serde path, so
+/// deserialization also requires the stored backend triangulation to satisfy
+/// the current Delaunay reconstruction invariants.
 ///
 /// # Examples
 ///
@@ -865,6 +867,36 @@ impl CdtMcmcCheckpoint {
     /// ```
     pub const fn chain(&self) -> &ChainCheckpoint<CdtTriangulation2D> {
         &self.chain
+    }
+
+    /// Returns the checkpointed triangulation state.
+    ///
+    /// This accessor is intended for chunked drivers that need to inspect the
+    /// current volume before deciding how many additional Metropolis proposals
+    /// to run.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
+    ///     TriangulationQuery,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let checkpoint = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///         ActionConfig::default(),
+    ///     )
+    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///
+    ///     assert_eq!(checkpoint.triangulation().vertex_count(), 12);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn triangulation(&self) -> &CdtTriangulation2D {
+        self.chain.state()
     }
 
     /// Returns the Metropolis configuration used when the checkpoint was made.
@@ -1189,9 +1221,11 @@ impl MetropolisAlgorithm {
     /// Run the simulation and return both the final results and checkpoint.
     ///
     /// The returned checkpoint can be resumed in memory with
-    /// [`Self::resume_from_checkpoint`]. If callers serialize it, successful
-    /// deserialization also depends on the embedded triangulation passing the
-    /// backend's checked reconstruction.
+    /// [`Self::resume_from_checkpoint`] when callers want cumulative results,
+    /// or [`Self::resume_to_checkpoint`] when chunked drivers need another
+    /// resumable checkpoint. If callers serialize it, successful deserialization
+    /// also depends on the embedded triangulation passing the backend's checked
+    /// reconstruction.
     ///
     /// # Errors
     ///
@@ -1237,10 +1271,11 @@ impl MetropolisAlgorithm {
     /// [`ChainCheckpoint`] and stores CDT-specific proposal state, telemetry,
     /// and RNG streams beside it.
     ///
-    /// Direct in-memory resume does not reserialize the triangulation. Serialized
-    /// restore uses checked backend reconstruction, so snapshots whose evolved
-    /// geometry is no longer Delaunay-valid may fail to deserialize even though
-    /// the in-memory checkpoint can still be resumed.
+    /// Direct in-memory resume through [`Self::resume_from_checkpoint`] or
+    /// [`Self::resume_to_checkpoint`] does not reserialize the triangulation.
+    /// Serialized restore uses checked backend reconstruction, so snapshots
+    /// whose evolved geometry is no longer Delaunay-valid may fail to
+    /// deserialize even though the in-memory checkpoint can still be resumed.
     ///
     /// # Errors
     ///
@@ -1329,6 +1364,58 @@ impl MetropolisAlgorithm {
         &self,
         checkpoint: CdtMcmcCheckpoint,
     ) -> CdtResult<SimulationResultsBackend> {
+        self.resume_to_checkpoint(checkpoint)
+            .map(CdtMcmcCheckpoint::into_results)
+    }
+
+    /// Continue a checkpoint for this algorithm's configured step count.
+    ///
+    /// `self.config.steps` is interpreted as an additional number of steps, and
+    /// the returned checkpoint remains resumable. This supports chunked drivers
+    /// such as sweep-based debug runs that size each chunk from the current
+    /// triangulation volume while preserving RNG streams, counters,
+    /// measurements, and checkpoint-compatible continuation state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidSimulationConfiguration`] if the resumed
+    /// Metropolis configuration is invalid, [`CdtError::InvalidConfiguration`]
+    /// if the action configuration is invalid, or
+    /// [`CdtError::CheckpointResumeFailed`] if the checkpoint is incompatible
+    /// with this algorithm or internally inconsistent. Returns
+    /// [`CdtError::MetropolisMoveApplicationFailed`] or validation errors for
+    /// failures during resumed sampling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let action = ActionConfig::default();
+    ///     let checkpoint = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 2, 0, 1).with_seed(13),
+    ///         action.clone(),
+    ///     )
+    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///
+    ///     let checkpoint = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 3, 0, 1).with_seed(999),
+    ///         action,
+    ///     )
+    ///     .resume_to_checkpoint(checkpoint)?;
+    ///
+    ///     assert_eq!(checkpoint.current_step(), 5);
+    ///     assert_eq!(checkpoint.config().steps, 5);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn resume_to_checkpoint(
+        &self,
+        checkpoint: CdtMcmcCheckpoint,
+    ) -> CdtResult<CdtMcmcCheckpoint> {
         self.config.validate()?;
         self.action_config.validate()?;
         validate_resume_compatible(self, &checkpoint)?;
@@ -1346,9 +1433,7 @@ impl MetropolisAlgorithm {
 
         let mut state = MetropolisRunState::from_checkpoint(checkpoint)?;
         self.run_steps(&mut state, self.config.steps)?;
-        state
-            .into_checkpoint(result_config, self.action_config.clone())
-            .map(CdtMcmcCheckpoint::into_results)
+        state.into_checkpoint(result_config, self.action_config.clone())
     }
 
     fn initial_state(&self, mut triangulation: CdtTriangulation2D) -> MetropolisRunState {
@@ -2159,6 +2244,96 @@ mod tests {
         }
     }
 
+    type CanonicalVertexSignature = (Option<u32>, Vec<u64>);
+    type CanonicalFaceSignature = (Option<i32>, Vec<CanonicalVertexSignature>);
+
+    fn canonical_vertex_signatures(
+        triangulation: &CdtTriangulation2D,
+    ) -> Vec<CanonicalVertexSignature> {
+        let geometry = triangulation.geometry();
+        let mut vertices = geometry
+            .vertices()
+            .map(|vertex| {
+                let coordinates = geometry
+                    .vertex_coordinates(&vertex)
+                    .expect("test vertex coordinates should resolve")
+                    .into_iter()
+                    .map(f64::to_bits)
+                    .collect();
+                (
+                    geometry.vertex_data_by_key(vertex.vertex_key()),
+                    coordinates,
+                )
+            })
+            .collect::<Vec<_>>();
+        vertices.sort();
+        vertices
+    }
+
+    fn canonical_face_signatures(
+        triangulation: &CdtTriangulation2D,
+    ) -> Vec<CanonicalFaceSignature> {
+        let geometry = triangulation.geometry();
+        let mut faces = geometry
+            .faces()
+            .map(|face| {
+                let mut vertices = geometry
+                    .face_vertices(&face)
+                    .expect("test face vertices should resolve")
+                    .into_iter()
+                    .map(|vertex| {
+                        let coordinates = geometry
+                            .vertex_coordinates(&vertex)
+                            .expect("test face vertex coordinates should resolve")
+                            .into_iter()
+                            .map(f64::to_bits)
+                            .collect();
+                        (
+                            geometry.vertex_data_by_key(vertex.vertex_key()),
+                            coordinates,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                vertices.sort();
+                (geometry.simplex_data_by_key(face.simplex_key()), vertices)
+            })
+            .collect::<Vec<_>>();
+        faces.sort();
+        faces
+    }
+
+    fn assert_canonical_triangulations_match(
+        left: &CdtTriangulation2D,
+        right: &CdtTriangulation2D,
+    ) {
+        assert_eq!(left.vertex_count(), right.vertex_count());
+        assert_eq!(left.edge_count(), right.edge_count());
+        assert_eq!(left.face_count(), right.face_count());
+        assert_eq!(left.slice_sizes(), right.slice_sizes());
+        assert_eq!(left.volume_profile(), right.volume_profile());
+        assert_eq!(left.metadata().time_slices, right.metadata().time_slices);
+        assert_eq!(left.metadata().dimension, right.metadata().dimension);
+        assert_eq!(left.metadata().topology, right.metadata().topology);
+        assert_eq!(
+            left.metadata().modification_count,
+            right.metadata().modification_count
+        );
+        assert_eq!(
+            to_value(&left.metadata().simulation_history)
+                .expect("left simulation history should serialize"),
+            to_value(&right.metadata().simulation_history)
+                .expect("right simulation history should serialize")
+        );
+        assert_eq!(
+            canonical_vertex_signatures(left),
+            canonical_vertex_signatures(right)
+        );
+        assert_eq!(
+            canonical_face_signatures(left),
+            canonical_face_signatures(right)
+        );
+    }
+
     fn short_checkpoint() -> CdtMcmcCheckpoint {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
@@ -2228,8 +2403,8 @@ mod tests {
         }
     }
 
-    fn assert_checkpoint_resume_failed(
-        result: CdtResult<SimulationResultsBackend>,
+    fn assert_checkpoint_resume_failed<T>(
+        result: CdtResult<T>,
         expected_reason: CheckpointResumeReason,
         expected_detail: &str,
     ) {
@@ -2499,6 +2674,57 @@ mod tests {
     }
 
     #[test]
+    fn chunked_checkpoint_resume_matches_one_shot_seeded_run() {
+        let action_config = ActionConfig::default();
+        let one_shot = MetropolisAlgorithm::new(
+            MetropolisConfig::new(1.0, 10, 0, 1).with_seed(19),
+            action_config.clone(),
+        )
+        .run(CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build"))
+        .expect("one-shot run should complete");
+
+        let prefix = MetropolisAlgorithm::new(
+            MetropolisConfig::new(1.0, 4, 0, 1).with_seed(19),
+            action_config.clone(),
+        )
+        .run_to_checkpoint(
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build"),
+        )
+        .expect("prefix run should checkpoint");
+
+        let chunked_checkpoint = MetropolisAlgorithm::new(
+            MetropolisConfig::new(1.0, 6, 0, 1).with_seed(999),
+            action_config,
+        )
+        .resume_to_checkpoint(prefix)
+        .expect("chunked checkpoint resume should complete");
+        let chunked = chunked_checkpoint.into_results();
+
+        assert_eq!(chunked.config().steps, 10);
+        assert_eq!(
+            to_value(one_shot.steps()).expect("steps should serialize"),
+            to_value(chunked.steps()).expect("steps should serialize")
+        );
+        assert_eq!(
+            to_value(one_shot.measurements()).expect("measurements should serialize"),
+            to_value(chunked.measurements()).expect("measurements should serialize")
+        );
+        assert_eq!(
+            to_value(one_shot.move_stats()).expect("move stats should serialize"),
+            to_value(chunked.move_stats()).expect("move stats should serialize")
+        );
+        assert_eq!(
+            to_value(one_shot.proposal_stats()).expect("proposal stats should serialize"),
+            to_value(chunked.proposal_stats()).expect("proposal stats should serialize")
+        );
+        assert_canonical_triangulations_match(one_shot.triangulation(), chunked.triangulation());
+        assert_eq!(
+            one_shot.triangulation().volume_profile(),
+            chunked.triangulation().volume_profile()
+        );
+    }
+
+    #[test]
     fn serialized_checkpoint_missing_proposal_stats_defaults_on_restore() {
         let checkpoint = serializable_rejected_checkpoint(ActionConfig::default());
         let mut payload = to_value(&checkpoint).expect("checkpoint should serialize");
@@ -2526,6 +2752,21 @@ mod tests {
 
         assert_checkpoint_resume_failed(
             algorithm.resume_from_checkpoint(checkpoint),
+            CheckpointResumeReason::IncompatibleActionConfiguration,
+            "action configuration",
+        );
+    }
+
+    #[test]
+    fn resume_to_checkpoint_rejects_incompatible_action_config() {
+        let checkpoint = short_checkpoint();
+        let algorithm = MetropolisAlgorithm::new(
+            MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
+            ActionConfig::new(2.0, 1.0, 0.1),
+        );
+
+        assert_checkpoint_resume_failed(
+            algorithm.resume_to_checkpoint(checkpoint),
             CheckpointResumeReason::IncompatibleActionConfiguration,
             "action configuration",
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,9 @@ pub mod prelude {
     ///
     /// This prelude includes [`run_simulation`], the Metropolis runner, delayed
     /// proposal adapter, telemetry structs, result containers, and typed
-    /// proposal errors needed by MCMC workflows.
+    /// proposal errors needed by MCMC workflows. It also includes the
+    /// triangulation query trait so callers can inspect final or checkpointed
+    /// states returned by simulation APIs.
     /// Observable estimators live in [`crate::prelude::observables`].
     pub mod simulation {
         pub use crate::cdt::action::{ActionConfig, compute_regge_action};
@@ -297,6 +299,7 @@ pub mod prelude {
         pub use crate::config::{CdtConfig, CdtTopology};
         pub use crate::errors::{CdtError, CdtResult};
         pub use crate::geometry::CdtTriangulation2D;
+        pub use crate::geometry::traits::TriangulationQuery;
         pub use crate::{CdtTriangulation, run_simulation};
     }
 

--- a/tests/large_scale_debug.rs
+++ b/tests/large_scale_debug.rs
@@ -9,14 +9,14 @@
 //! `just debug-large-scale-*` and `just perf-large-scale-debug` recipes.
 
 #[cfg(feature = "slow-tests")]
-use causal_triangulations::prelude::moves::ErgodicsSystem;
-use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
-use causal_triangulations::prelude::triangulation::{
-    CdtTopology, CdtTriangulation2D, TriangulationQuery,
-};
+use std::time::Instant;
 use std::{env, time::Duration};
-#[cfg(feature = "slow-tests")]
-use std::{hint::black_box, time::Instant};
+
+use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
+use causal_triangulations::prelude::simulation::{
+    ActionConfig, CdtMcmcCheckpoint, CdtTopology, CdtTriangulation2D, MetropolisAlgorithm,
+    MetropolisConfig, ProposalStatistics, TriangulationQuery,
+};
 
 const DEFAULT_TOTAL_VERTICES: u32 = 512;
 const DEFAULT_TIMESLICES: u32 = 16;
@@ -31,6 +31,54 @@ struct MoveAcceptanceCounts {
     move_13: u64,
     move_31: u64,
     edge_flip: u64,
+}
+
+#[derive(Clone, Copy, Default)]
+struct ProposalOutcomeCounts {
+    proposals: u64,
+    accepted: u64,
+    rejected: u64,
+    no_site: u64,
+    site_rejections: u64,
+    metropolis_rejections: u64,
+    hard_failures: u64,
+}
+
+impl ProposalOutcomeCounts {
+    /// Captures cumulative proposal-kernel counters.
+    const fn from_stats(stats: &ProposalStatistics) -> Self {
+        let site_rejections = stats
+            .site_causality_rejections
+            .saturating_add(stats.site_geometric_rejections)
+            .saturating_add(stats.site_backend_rejections);
+        let rejected = stats
+            .no_site_proposals
+            .saturating_add(site_rejections)
+            .saturating_add(stats.metropolis_rejections)
+            .saturating_add(stats.hard_failures);
+        Self {
+            proposals: stats.move_family_proposals,
+            accepted: stats.accepted_transitions,
+            rejected,
+            no_site: stats.no_site_proposals,
+            site_rejections,
+            metropolis_rejections: stats.metropolis_rejections,
+            hard_failures: stats.hard_failures,
+        }
+    }
+
+    /// Returns per-sweep proposal deltas relative to the previous cumulative snapshot.
+    const fn delta_since(self, previous: Self) -> Self {
+        Self {
+            proposals: self.proposals - previous.proposals,
+            accepted: self.accepted - previous.accepted,
+            rejected: self.rejected - previous.rejected,
+            no_site: self.no_site - previous.no_site,
+            site_rejections: self.site_rejections - previous.site_rejections,
+            metropolis_rejections: self.metropolis_rejections - previous.metropolis_rejections,
+            hard_failures: self.hard_failures - previous.hard_failures,
+        }
+    }
 }
 
 impl MoveAcceptanceCounts {
@@ -148,6 +196,37 @@ fn assert_toroidal_invariants(triangulation: &CdtTriangulation2D) {
     assert_eq!(triangulation.geometry().euler_characteristic(), 0);
 }
 
+/// Builds a chunk configuration for one unfixed-volume Metropolis debug sweep.
+fn sweep_config(attempts: usize, seed: u64) -> MetropolisConfig {
+    let steps = u32::try_from(attempts).expect("sweep attempt count should fit in u32");
+    MetropolisConfig::new(1.0, steps, 0, 1).with_seed(seed)
+}
+
+/// Runs one Metropolis chunk and keeps resumable checkpoint state for the next sweep.
+fn run_metropolis_sweep(
+    checkpoint: Option<CdtMcmcCheckpoint>,
+    triangulation: Option<CdtTriangulation2D>,
+    attempts: usize,
+    seed: u64,
+    action_config: &ActionConfig,
+) -> CdtMcmcCheckpoint {
+    let algorithm = MetropolisAlgorithm::new(sweep_config(attempts, seed), action_config.clone());
+    checkpoint.map_or_else(
+        || {
+            algorithm
+                .run_to_checkpoint(
+                    triangulation.expect("initial triangulation is required for the first sweep"),
+                )
+                .expect("large-scale Metropolis sweep should run")
+        },
+        |checkpoint| {
+            algorithm
+                .resume_to_checkpoint(checkpoint)
+                .expect("large-scale Metropolis sweep should resume")
+        },
+    )
+}
+
 /// Reads the accepted counter for one move type.
 const fn accepted_count(stats: &MoveStatistics, move_type: MoveType) -> u64 {
     match move_type {
@@ -160,6 +239,10 @@ const fn accepted_count(stats: &MoveStatistics, move_type: MoveType) -> u64 {
 
 #[cfg(feature = "slow-tests")]
 #[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "debug harness keeps setup, chunk execution, and printed telemetry together"
+)]
 fn debug_large_scale_1p1() {
     let total_vertices = env_u32_prefer(
         "CDT_LARGE_DEBUG_VERTICES_1P1",
@@ -185,57 +268,92 @@ fn debug_large_scale_1p1() {
     let runtime_cap = optional_runtime_cap();
 
     let started_at = Instant::now();
-    let mut triangulation = CdtTriangulation2D::from_toroidal_cdt(vertices_per_slice, timeslices)
+    let triangulation = CdtTriangulation2D::from_toroidal_cdt(vertices_per_slice, timeslices)
         .expect("large-scale toroidal CDT fixture should build");
-    let mut ergodics = ErgodicsSystem::with_seed(seed);
     let initial_profile = triangulation.volume_profile();
     let mut expected_attempts = 0_u64;
     let mut previous_acceptance = MoveAcceptanceCounts::default();
+    let mut previous_proposals = ProposalOutcomeCounts::default();
     let mut previous_elapsed = Duration::ZERO;
     let expected_vertices =
         usize::try_from(total_vertices).expect("vertex count should fit in usize");
+    let action_config = ActionConfig::default();
+    let mut checkpoint: Option<CdtMcmcCheckpoint> = None;
+    let mut pending_initial_triangulation = Some(triangulation);
 
-    assert_eq!(triangulation.vertex_count(), expected_vertices);
-    assert_toroidal_invariants(&triangulation);
+    let initial_triangulation = pending_initial_triangulation
+        .as_ref()
+        .expect("initial triangulation is available before the first sweep");
+    assert_eq!(initial_triangulation.vertex_count(), expected_vertices);
+    assert_toroidal_invariants(initial_triangulation);
 
     println!(
-        "1+1 toroidal CDT large-scale debug: vertices={total_vertices}, timeslices={timeslices}, \
-         vertices_per_slice={vertices_per_slice}, initial_simplices={}, sweeps={sweeps}, seed=0x{seed:X}",
-        triangulation.face_count()
+        "1+1 toroidal CDT large-scale Metropolis debug: vertices={total_vertices}, timeslices={timeslices}, \
+         vertices_per_slice={vertices_per_slice}, initial_simplices={}, sweeps={sweeps}, seed=0x{seed:X}, \
+         ensemble=unfixed-volume",
+        initial_triangulation.face_count()
     );
 
     for sweep in 1..=sweeps {
-        let attempts = triangulation.face_count();
+        let attempts = checkpoint.as_ref().map_or_else(
+            || {
+                pending_initial_triangulation
+                    .as_ref()
+                    .expect("initial triangulation is available before the first sweep")
+                    .face_count()
+            },
+            |checkpoint| checkpoint.triangulation().face_count(),
+        );
         expected_attempts += u64::try_from(attempts).expect("attempt count should fit in u64");
 
-        for _ in 0..attempts {
-            let result = ergodics.attempt_random_move(&mut triangulation);
-            black_box(result);
-        }
+        checkpoint = Some(run_metropolis_sweep(
+            checkpoint,
+            pending_initial_triangulation.take(),
+            attempts,
+            seed,
+            &action_config,
+        ));
 
-        assert_toroidal_invariants(&triangulation);
-        let acceptance = MoveAcceptanceCounts::from_stats(&ergodics.stats);
+        let checkpoint_ref = checkpoint
+            .as_ref()
+            .expect("Metropolis sweep should produce a checkpoint");
+        let triangulation = checkpoint_ref.triangulation();
+        assert_toroidal_invariants(triangulation);
+        let acceptance = MoveAcceptanceCounts::from_stats(checkpoint_ref.move_stats());
         let sweep_acceptance = acceptance.delta_since(previous_acceptance);
+        let proposals = ProposalOutcomeCounts::from_stats(checkpoint_ref.proposal_stats());
+        let sweep_proposals = proposals.delta_since(previous_proposals);
         let elapsed = started_at.elapsed();
         let sweep_elapsed = elapsed.saturating_sub(previous_elapsed);
         println!(
-            "sweep {sweep}/{sweeps}: sweep_attempts={attempts}, final_vertices={}, final_simplices={}, \
+            "sweep {sweep}/{sweeps}: sweep_proposals={}, final_vertices={}, final_edges={}, final_simplices={}, \
+             final_volume_profile={:?}, \
              sweep_accepted={} (Move22={}, Move13Add={}, Move31Remove={}, EdgeFlip={}), \
-             sweep_hard_failures={}, total_accepted={}, total_attempted={}, total_hard_failures={}, \
+             sweep_rejected={}, sweep_no_site={}, sweep_site_rejections={}, sweep_metropolis_rejections={}, \
+             sweep_hard_failures={}, total_accepted={}, total_proposals={}, total_rejected={}, total_hard_failures={}, \
              sweep_elapsed={sweep_elapsed:?}, total_elapsed={elapsed:?}",
+            sweep_proposals.proposals,
             triangulation.vertex_count(),
+            triangulation.edge_count(),
             triangulation.face_count(),
+            triangulation.volume_profile(),
             sweep_acceptance.total,
             sweep_acceptance.move_22,
             sweep_acceptance.move_13,
             sweep_acceptance.move_31,
             sweep_acceptance.edge_flip,
+            sweep_proposals.rejected,
+            sweep_proposals.no_site,
+            sweep_proposals.site_rejections,
+            sweep_proposals.metropolis_rejections,
             sweep_acceptance.hard_failures,
             acceptance.total,
-            expected_attempts,
+            proposals.proposals,
+            proposals.rejected,
             acceptance.hard_failures,
         );
         previous_acceptance = acceptance;
+        previous_proposals = proposals;
         previous_elapsed = elapsed;
 
         if let Some(cap) = runtime_cap {
@@ -247,22 +365,28 @@ fn debug_large_scale_1p1() {
         }
     }
 
-    assert_eq!(ergodics.stats.total_attempted(), expected_attempts);
-    assert!(
-        ergodics.stats.total_accepted() > 0,
-        "large-scale random sweeps should accept at least one move"
+    let checkpoint = checkpoint.expect("at least one sweep should run");
+    let triangulation = checkpoint.triangulation();
+    assert_eq!(checkpoint.move_stats().total_attempted(), expected_attempts);
+    assert_eq!(
+        checkpoint.proposal_stats().move_family_proposals,
+        expected_attempts
     );
     assert!(
-        ergodics.stats.moves_13_accepted > 0,
-        "large-scale random sweeps should exercise toroidal Move13Add"
+        checkpoint.move_stats().total_accepted() > 0,
+        "large-scale Metropolis sweeps should accept at least one move"
     );
     assert!(
-        ergodics.stats.moves_31_accepted > 0,
-        "large-scale random sweeps should exercise toroidal Move31Remove"
+        checkpoint.move_stats().moves_13_accepted > 0,
+        "large-scale Metropolis sweeps should exercise toroidal Move13Add"
+    );
+    assert!(
+        checkpoint.move_stats().moves_31_accepted > 0,
+        "large-scale Metropolis sweeps should exercise toroidal Move31Remove"
     );
     assert_ne!(
         triangulation.volume_profile(),
         initial_profile,
-        "large-scale random sweeps should change the toroidal volume profile"
+        "large-scale Metropolis sweeps should change the toroidal volume profile"
     );
 }


### PR DESCRIPTION
- Add resumable Metropolis checkpoint continuation so chunked drivers can inspect checkpointed triangulations between sweeps.
- Route the large-scale 1+1 debug harness through checkpoint-preserving Metropolis chunks sized from the current simplex count.
- Document the MCMC backend boundary and roadmap blockers for upstream markov-chain-monte-carlo continuation work.

Closes #152