### PR TITLE
feat(api): support fallible public examples (#151)

### DIFF
--- a/benches/cdt_benchmarks.rs
+++ b/benches/cdt_benchmarks.rs
@@ -17,8 +17,42 @@ use causal_triangulations::prelude::simulation::{
 };
 use causal_triangulations::prelude::triangulation::{CdtTriangulation2D, TriangulationQuery};
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hint::black_box;
 use std::time::Duration;
+
+#[derive(Clone, Copy)]
+enum SetupOperation {
+    CreateTriangulation,
+    CreateTestTriangulation,
+    BuildCdtBenchmarkStrip,
+    CreateCdtStrip,
+    RunSimulation,
+    BuildSimulationResults,
+    UpdateMetadata,
+}
+
+impl Display for SetupOperation {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::CreateTriangulation => formatter.write_str("create triangulation"),
+            Self::CreateTestTriangulation => formatter.write_str("create test triangulation"),
+            Self::BuildCdtBenchmarkStrip => formatter.write_str("build CDT benchmark strip"),
+            Self::CreateCdtStrip => formatter.write_str("create CDT strip"),
+            Self::RunSimulation => formatter.write_str("run simulation"),
+            Self::BuildSimulationResults => formatter.write_str("build simulation results"),
+            Self::UpdateMetadata => formatter.write_str("update metadata"),
+        }
+    }
+}
+
+/// Fails fast when benchmark fixture setup cannot satisfy its invariant.
+fn require_result<T, E: Display>(result: Result<T, E>, operation: SetupOperation) -> T {
+    match result {
+        Ok(value) => value,
+        Err(error) => panic!("{operation}: {error}"),
+    }
+}
 
 /// Benchmark triangulation creation with different vertex counts
 fn bench_triangulation_creation(c: &mut Criterion) {
@@ -31,12 +65,14 @@ fn bench_triangulation_creation(c: &mut Criterion) {
             &vertex_count,
             |b, &vertex_count| {
                 b.iter(|| {
-                    let triangulation = CdtTriangulation2D::from_random_points(
-                        black_box(vertex_count),
-                        black_box(1),
-                        black_box(2),
-                    )
-                    .expect("Failed to create triangulation");
+                    let triangulation = require_result(
+                        CdtTriangulation2D::from_random_points(
+                            black_box(vertex_count),
+                            black_box(1),
+                            black_box(2),
+                        ),
+                        SetupOperation::CreateTriangulation,
+                    );
                     black_box(triangulation)
                 });
             },
@@ -92,8 +128,10 @@ fn bench_edge_counting(c: &mut Criterion) {
 
 /// Benchmark geometry query operations
 fn bench_geometry_queries(c: &mut Criterion) {
-    let triangulation = CdtTriangulation2D::from_random_points(50, 1, 2)
-        .expect("Failed to create test triangulation");
+    let triangulation = require_result(
+        CdtTriangulation2D::from_random_points(50, 1, 2),
+        SetupOperation::CreateTestTriangulation,
+    );
 
     let geometry = triangulation.geometry();
 
@@ -188,8 +226,12 @@ fn bench_action_calculations(c: &mut Criterion) {
 fn bench_ergodic_moves(c: &mut Criterion) {
     let mut group = c.benchmark_group("ergodic_moves");
 
-    let seed_triangulation =
-        || CdtTriangulation2D::from_cdt_strip(4, 3).expect("build CDT benchmark strip");
+    let seed_triangulation = || {
+        require_result(
+            CdtTriangulation2D::from_cdt_strip(4, 3),
+            SetupOperation::BuildCdtBenchmarkStrip,
+        )
+    };
 
     // Benchmark different move types
     let move_types = [
@@ -258,16 +300,19 @@ fn bench_metropolis_simulation(c: &mut Criterion) {
             &steps,
             |b, &steps| {
                 b.iter(|| {
-                    let triangulation = CdtTriangulation2D::from_cdt_strip(4, 5)
-                        .expect("Failed to create CDT strip");
+                    let triangulation = require_result(
+                        CdtTriangulation2D::from_cdt_strip(4, 5),
+                        SetupOperation::CreateCdtStrip,
+                    );
 
                     let config = MetropolisConfig::new(1.0, steps, 5, 5).with_seed(42);
                     let action_config = ActionConfig::default();
                     let algorithm = MetropolisAlgorithm::new(config, action_config);
 
-                    let results = algorithm
-                        .run(black_box(triangulation))
-                        .expect("simulation should run");
+                    let results = require_result(
+                        algorithm.run(black_box(triangulation)),
+                        SetupOperation::RunSimulation,
+                    );
                     black_box(results)
                 });
             },
@@ -282,8 +327,10 @@ fn bench_simulation_analysis(c: &mut Criterion) {
     let mut group = c.benchmark_group("simulation_analysis");
 
     // Create a sample simulation result
-    let triangulation =
-        CdtTriangulation2D::from_cdt_strip(5, 3).expect("Failed to create CDT strip");
+    let triangulation = require_result(
+        CdtTriangulation2D::from_cdt_strip(5, 3),
+        SetupOperation::CreateCdtStrip,
+    );
 
     let config = MetropolisConfig::new(1.0, 100, 10, 5);
     let action_config = ActionConfig::default();
@@ -325,8 +372,8 @@ fn bench_simulation_analysis(c: &mut Criterion) {
         ],
         Duration::from_millis(37),
         triangulation,
-    )
-    .expect("benchmark result fixture should validate");
+    );
+    let results = require_result(results, SetupOperation::BuildSimulationResults);
 
     group.bench_function("acceptance_rate", |b| {
         b.iter(|| {
@@ -386,8 +433,10 @@ fn bench_cache_operations(c: &mut Criterion) {
 
     group.bench_function("refresh_cache", |b| {
         b.iter(|| {
-            let mut triangulation =
-                CdtTriangulation2D::from_cdt_strip(10, 5).expect("Failed to create CDT strip");
+            let mut triangulation = require_result(
+                CdtTriangulation2D::from_cdt_strip(10, 5),
+                SetupOperation::CreateCdtStrip,
+            );
             triangulation.refresh_cache();
             black_box(triangulation)
         });
@@ -396,15 +445,18 @@ fn bench_cache_operations(c: &mut Criterion) {
     group.bench_function("metadata_cache_invalidation", |b| {
         b.iter_batched(
             || {
-                let mut triangulation =
-                    CdtTriangulation2D::from_cdt_strip(10, 5).expect("Failed to create CDT strip");
+                let mut triangulation = require_result(
+                    CdtTriangulation2D::from_cdt_strip(10, 5),
+                    SetupOperation::CreateCdtStrip,
+                );
                 triangulation.refresh_cache();
                 triangulation
             },
             |mut triangulation| {
-                triangulation
-                    .set_time_slices(2)
-                    .expect("metadata update should remain valid");
+                require_result(
+                    triangulation.set_time_slices(2),
+                    SetupOperation::UpdateMetadata,
+                );
                 black_box(triangulation)
             },
             BatchSize::SmallInput,
@@ -416,8 +468,10 @@ fn bench_cache_operations(c: &mut Criterion) {
 
 /// Benchmark triangulation validation
 fn bench_validation(c: &mut Criterion) {
-    let triangulation =
-        CdtTriangulation2D::from_random_points(30, 1, 2).expect("Failed to create triangulation");
+    let triangulation = require_result(
+        CdtTriangulation2D::from_random_points(30, 1, 2),
+        SetupOperation::CreateTriangulation,
+    );
 
     let mut group = c.benchmark_group("validation");
 

--- a/benches/ci_performance_suite.rs
+++ b/benches/ci_performance_suite.rs
@@ -20,6 +20,7 @@ use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveStatistics, Move
 use causal_triangulations::prelude::simulation::{MetropolisAlgorithm, MetropolisConfig};
 use causal_triangulations::prelude::triangulation::CdtTriangulation2D;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hint::black_box;
 use std::time::Duration;
 
@@ -45,6 +46,41 @@ struct PreparedFixture {
     triangulation: CdtTriangulation2D,
     vertices: usize,
     simplices: usize,
+}
+
+#[derive(Clone, Copy)]
+enum SetupOperation {
+    BuildCdtFixture,
+    RunSingleMetropolisProposal,
+    ConvertBenchmarkSize,
+    ConvertSweepStepCount,
+    ConvertSweepCount,
+    ComputeSweepStepCount,
+    ValidateRandomSweepWorkload,
+    RunTenSweepMetropolis,
+}
+
+impl Display for SetupOperation {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::BuildCdtFixture => formatter.write_str("build CDT benchmark fixture"),
+            Self::RunSingleMetropolisProposal => {
+                formatter.write_str("run single-step Metropolis proposal workload")
+            }
+            Self::ConvertBenchmarkSize => formatter.write_str("convert benchmark size"),
+            Self::ConvertSweepStepCount => {
+                formatter.write_str("convert benchmark sweep step count")
+            }
+            Self::ConvertSweepCount => formatter.write_str("convert sweep count"),
+            Self::ComputeSweepStepCount => {
+                formatter.write_str("compute benchmark sweep step count")
+            }
+            Self::ValidateRandomSweepWorkload => {
+                formatter.write_str("validate random sweep workload")
+            }
+            Self::RunTenSweepMetropolis => formatter.write_str("run ten-sweep Metropolis workload"),
+        }
+    }
 }
 
 const GENERATION_FIXTURES: &[CdtFixture] = &[
@@ -122,18 +158,34 @@ const PROPOSAL_FIXTURES: &[CdtFixture] = &[
     },
 ];
 
+/// Fails fast when benchmark fixture setup cannot satisfy its invariant.
+fn require_result<T, E: Display>(result: Result<T, E>, operation: SetupOperation) -> T {
+    match result {
+        Ok(value) => value,
+        Err(error) => panic!("{operation}: {error}"),
+    }
+}
+
+/// Fails fast when benchmark fixture setup cannot produce a required value.
+fn require_option<T>(value: Option<T>, operation: SetupOperation) -> T {
+    let Some(value) = value else {
+        panic!("{operation}");
+    };
+    value
+}
+
 impl CdtFixture {
     /// Builds the requested CDT topology for a benchmark fixture.
     fn build(self) -> CdtTriangulation2D {
-        match self.topology {
+        let result = match self.topology {
             TopologyFixture::OpenStrip => {
                 CdtTriangulation2D::from_cdt_strip(self.vertices_per_slice, self.time_slices)
             }
             TopologyFixture::Toroidal => {
                 CdtTriangulation2D::from_toroidal_cdt(self.vertices_per_slice, self.time_slices)
             }
-        }
-        .expect("CDT benchmark fixture should build")
+        };
+        require_result(result, SetupOperation::BuildCdtFixture)
     }
 }
 
@@ -168,29 +220,36 @@ fn prepare_fixture(fixture: CdtFixture) -> PreparedFixture {
 /// Runs one Metropolis proposal step through the public simulation driver.
 fn run_single_metropolis_proposal(triangulation: CdtTriangulation2D) {
     let config = MetropolisConfig::new(1.0, 1, 0, 1).with_seed(BENCH_SEED);
-    let results = MetropolisAlgorithm::new(config, ActionConfig::default())
-        .run(triangulation)
-        .expect("single-step Metropolis proposal workload should run");
+    let results = require_result(
+        MetropolisAlgorithm::new(config, ActionConfig::default()).run(triangulation),
+        SetupOperation::RunSingleMetropolisProposal,
+    );
     black_box(results.proposal_stats());
 }
 
 /// Converts Criterion throughput element counts without silently truncating.
 fn usize_to_u64(value: usize) -> u64 {
-    u64::try_from(value).expect("benchmark size should fit in u64")
+    require_result(u64::try_from(value), SetupOperation::ConvertBenchmarkSize)
 }
 
 /// Computes the Metropolis step budget for the ten-sweep CI workload.
 fn ten_sweep_step_count(simplices: usize) -> u32 {
-    u32::try_from(sweep_attempt_count(simplices))
-        .expect("benchmark sweep step count should fit in u32")
+    require_result(
+        u32::try_from(sweep_attempt_count(simplices)),
+        SetupOperation::ConvertSweepStepCount,
+    )
 }
 
 /// Encodes the CDT convention that one sweep attempts one move per simplex.
 fn sweep_attempt_count(simplices: usize) -> usize {
-    let sweeps = usize::try_from(SWEEP_COUNT).expect("sweep count should fit in usize");
-    simplices
-        .checked_mul(sweeps)
-        .expect("benchmark sweep step count should not overflow")
+    let sweeps = require_result(
+        usize::try_from(SWEEP_COUNT),
+        SetupOperation::ConvertSweepCount,
+    );
+    require_option(
+        simplices.checked_mul(sweeps),
+        SetupOperation::ComputeSweepStepCount,
+    )
 }
 
 /// Runs ten random-move sweeps and validates the evolved triangulation.
@@ -205,9 +264,10 @@ fn run_random_move_sweeps(mut triangulation: CdtTriangulation2D, seed: u64) -> M
         }
     }
 
-    triangulation
-        .validate()
-        .expect("random sweep workload should preserve CDT invariants");
+    require_result(
+        triangulation.validate(),
+        SetupOperation::ValidateRandomSweepWorkload,
+    );
     black_box(triangulation.face_count());
     ergodics.stats
 }
@@ -216,9 +276,10 @@ fn run_random_move_sweeps(mut triangulation: CdtTriangulation2D, seed: u64) -> M
 fn run_metropolis_ten_sweeps(triangulation: CdtTriangulation2D, simplices: usize) -> usize {
     let steps = ten_sweep_step_count(simplices);
     let config = MetropolisConfig::new(1.0, steps, 0, steps).with_seed(BENCH_SEED);
-    let results = MetropolisAlgorithm::new(config, ActionConfig::default())
-        .run(triangulation)
-        .expect("ten-sweep Metropolis workload should run");
+    let results = require_result(
+        MetropolisAlgorithm::new(config, ActionConfig::default()).run(triangulation),
+        SetupOperation::RunTenSweepMetropolis,
+    );
     black_box(results.acceptance_rate());
     results.steps().len()
 }

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -117,11 +117,14 @@ causal-triangulations/
 │   │   │       └── action_policy.yml
 │   │   ├── docs/
 │   │   │   └── command_order.sh
+│   │   ├── doctests/
+│   │   │   └── unwrap_expect.txt
 │   │   ├── scripts/
 │   │   │   └── tests/
 │   │   │       └── python_exceptions.py
 │   │   └── src/
 │   │       └── project_rules/
+│   │           ├── bench_example_usage.rs
 │   │           └── rust_style.rs
 │   ├── cli.rs
 │   ├── integration_tests.rs

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -82,9 +82,11 @@ Public APIs must **not panic**.
 
 Use explicit error propagation.
 
-Production `src/` code must not use bare `unwrap()` or explicit `panic!`. Use `?`, typed errors, `Option`, or an intentional fallback instead. Tests, doctests,
-examples, and benchmark setup may fail fast when a broken fixture should stop execution immediately; prefer `expect("reason")` over bare `unwrap()` in
-user-facing examples so failures remain diagnosable.
+Production `src/` code must not use bare `unwrap()` or explicit `panic!`. Use `?`, typed errors, `Option`, or an intentional fallback instead.
+
+Public doctests, Cargo examples, and benchmarks must not use `unwrap()` or `expect()`. Doctests and examples should normally return `CdtResult<()>` and use
+`?`; benchmarks should use small local fixture helpers that preserve the failed operation in their panic message. Unit and integration tests may still fail
+fast with `expect("reason")` when a broken fixture should stop execution immediately.
 
 ### Fallible public functions
 

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -64,6 +64,11 @@ The useful updates ported from MCMC are:
   unit and integration tests.
 - public-surface Rust Semgrep rules that reject `unwrap()` and `expect()` in public doctests, Cargo examples, and benchmark harnesses, with benchmarks using
   explicit fixture helpers so failed setup still reports the operation that failed.
+- The `causal-triangulations.rust.no-unwrap-expect-in-doctests` rule now distinguishes code-like `.unwrap()` and `.expect(...)` calls from prose mentions, and
+  `causal-triangulations.rust.no-unwrap-expect-in-benches-examples` keeps Semgrep fixture cross-matches scoped to the
+  `tests/semgrep/src/project_rules/rust_style.rs` fixture shape. Before this refinement, prose such as "do not use `.unwrap()`" could be reported and Semgrep
+  test mode needed broader name-based exclusions; after it, public-surface checks still reject panic-style calls while fixture-only exceptions are explicitly
+  anchored.
 - an `examples-validate` recipe that runs Cargo examples and verifies stable output markers for the user-facing example contracts.
 
 The useful Semgrep updates ported from the sibling `delaunay` repository are:

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -61,7 +61,9 @@ The useful updates ported from MCMC are:
   release tags;
 - a Semgrep rule that rejects `NaN` and infinity defaults after failed floating-point conversions, with a regression fixture under `tests/semgrep/`.
 - production-only Rust Semgrep rules that reject bare `unwrap()` and explicit `panic!` in non-test `src/` code while preserving idiomatic fail-fast usage in
-  tests, doctests, examples, and benchmark setup.
+  unit and integration tests.
+- public-surface Rust Semgrep rules that reject `unwrap()` and `expect()` in public doctests, Cargo examples, and benchmark harnesses, with benchmarks using
+  explicit fixture helpers so failed setup still reports the operation that failed.
 - an `examples-validate` recipe that runs Cargo examples and verifies stable output markers for the user-facing example contracts.
 
 The useful Semgrep updates ported from the sibling `delaunay` repository are:

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -371,17 +371,20 @@ rules:
           - pattern: $VALUE.expect(...)
       - pattern-not-inside: |
           fn production_unwrap_and_panic_fixture(result: Result<u32, &'static str>, value: Option<u32>) {
+              // Fixture path: tests/semgrep/src/project_rules/rust_style.rs.
               ...
           }
       - pattern-not-inside: |
           #[cfg(test)]
           fn test_only_unwrap_and_panic_fixture(result: Result<u32, &'static str>) {
+              // Fixture path: tests/semgrep/src/project_rules/rust_style.rs.
               ...
           }
       - pattern-not-inside: |
           #[cfg(test)]
           mod prop_tests {
               fn helper(result: Result<u32, &'static str>) {
+                  // Fixture path: tests/semgrep/src/project_rules/rust_style.rs.
                   ...
               }
           }

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -286,6 +286,8 @@ rules:
       include:
         - "/src/**/*.rs"
         - "/tests/semgrep/src/**/*.rs"
+      exclude:
+        - "/tests/semgrep/src/project_rules/bench_example_usage.rs"
     patterns:
       - pattern: $VALUE.unwrap()
       - pattern-not-inside: |
@@ -330,6 +332,42 @@ rules:
           impl $TYPE {
               ...
           }
+
+  - id: causal-triangulations.rust.no-unwrap-expect-in-doctests
+    languages:
+      - generic
+    severity: WARNING
+    message: "Use fallible doctest flow instead of unwrap() or expect() in public documentation examples."
+    metadata:
+      category: correctness
+      rationale: >-
+        Public Rust documentation examples should model typed error handling
+        with CdtResult and ? rather than teaching panic-based control flow.
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/doctests/**/*.txt"
+    pattern-regex: '^\s*//[!/].*\.(unwrap|expect)\s*\('
+
+  - id: causal-triangulations.rust.no-unwrap-expect-in-benches-examples
+    languages:
+      - rust
+    severity: WARNING
+    message: "Use explicit fixture error handling instead of unwrap() or expect() in benchmarks and examples."
+    metadata:
+      category: correctness
+      rationale: >-
+        Benchmarks and public examples should keep failure modes explicit so
+        users and CI see the operation that failed instead of a panic-only
+        unwrap/expect path.
+    paths:
+      include:
+        - "/benches/**/*.rs"
+        - "/examples/**/*.rs"
+        - "/tests/semgrep/src/project_rules/bench_example_usage.rs"
+    pattern-either:
+      - pattern: $VALUE.unwrap()
+      - pattern: $VALUE.expect(...)
 
   - id: causal-triangulations.rust.no-panic-in-src
     languages:

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -347,7 +347,7 @@ rules:
       include:
         - "/src/**/*.rs"
         - "/tests/semgrep/doctests/**/*.txt"
-    pattern-regex: '^\s*//[!/].*\.(unwrap|expect)\s*\('
+    pattern-regex: '^\s*//[!/]\s*(?:#\s*)?.*(?:\b[\w:]+|[\]\)])\.(unwrap|expect)\s*\('
 
   - id: causal-triangulations.rust.no-unwrap-expect-in-benches-examples
     languages:
@@ -365,9 +365,23 @@ rules:
         - "/benches/**/*.rs"
         - "/examples/**/*.rs"
         - "/tests/semgrep/src/project_rules/bench_example_usage.rs"
-    pattern-either:
-      - pattern: $VALUE.unwrap()
-      - pattern: $VALUE.expect(...)
+    patterns:
+      - pattern-either:
+          - pattern: $VALUE.unwrap()
+          - pattern: $VALUE.expect(...)
+      - pattern-not-inside: |
+          fn production_unwrap_and_panic_fixture(...) {
+              ...
+          }
+      - pattern-not-inside: |
+          fn test_only_unwrap_and_panic_fixture(...) {
+              ...
+          }
+      - pattern-not-inside: |
+          #[cfg(test)]
+          mod prop_tests {
+              ...
+          }
 
   - id: causal-triangulations.rust.no-panic-in-src
     languages:

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -370,17 +370,20 @@ rules:
           - pattern: $VALUE.unwrap()
           - pattern: $VALUE.expect(...)
       - pattern-not-inside: |
-          fn production_unwrap_and_panic_fixture(...) {
+          fn production_unwrap_and_panic_fixture(result: Result<u32, &'static str>, value: Option<u32>) {
               ...
           }
       - pattern-not-inside: |
-          fn test_only_unwrap_and_panic_fixture(...) {
+          #[cfg(test)]
+          fn test_only_unwrap_and_panic_fixture(result: Result<u32, &'static str>) {
               ...
           }
       - pattern-not-inside: |
           #[cfg(test)]
           mod prop_tests {
-              ...
+              fn helper(result: Result<u32, &'static str>) {
+                  ...
+              }
           }
 
   - id: causal-triangulations.rust.no-panic-in-src

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -656,26 +656,32 @@ impl ErgodicsSystem {
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::moves::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
-    /// let dt = build_delaunay2_from_simplices(
-    ///     &[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.0, 1.0], 1), ([1.0, 1.0], 1)],
-    ///     &[vec![0, 1, 2], vec![1, 3, 2]],
-    /// )
-    /// .expect("build square CDT");
-    /// let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
-    /// let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)
-    ///     .expect("wrap labeled square");
-    /// let mut system = ErgodicsSystem::new();
-    /// let result = system.attempt_22_move(&mut triangulation);
-    /// assert!(matches!(
-    ///     result,
-    ///     MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
-    /// ));
-    /// assert_eq!(system.stats.moves_22_attempted, 1);
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_from_simplices(
+    ///         &[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.0, 1.0], 1), ([1.0, 1.0], 1)],
+    ///         &[vec![0, 1, 2], vec![1, 3, 2]],
+    ///     )?;
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
+    ///     let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)?;
+    ///     let mut system = ErgodicsSystem::new();
+    ///     let result = system.attempt_22_move(&mut triangulation);
+    ///     assert!(matches!(
+    ///         result,
+    ///         MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
+    ///     ));
+    ///     assert_eq!(system.stats.moves_22_attempted, 1);
+    ///     Ok(())
+    /// }
     /// ```
     pub fn attempt_22_move(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
         self.stats.record_attempt(MoveType::Move22);
@@ -699,24 +705,30 @@ impl ErgodicsSystem {
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::moves::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
-    /// let dt = build_delaunay2_with_data(&[
-    ///     ([0.0, 0.0], 0),
-    ///     ([1.0, 0.0], 0),
-    ///     ([0.5, 1.0], 1),
-    /// ])
-    /// .expect("build labeled triangle");
-    /// let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
-    /// let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)
-    ///     .expect("wrap labeled triangle");
-    /// let mut system = ErgodicsSystem::new();
-    /// let result = system.attempt_13_move(&mut triangulation);
-    /// assert!(matches!(result, MoveResult::Success | MoveResult::GeometricViolation));
-    /// assert_eq!(system.stats.moves_13_attempted, 1);
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_with_data(&[
+    ///         ([0.0, 0.0], 0),
+    ///         ([1.0, 0.0], 0),
+    ///         ([0.5, 1.0], 1),
+    ///     ])?;
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
+    ///     let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)?;
+    ///     let mut system = ErgodicsSystem::new();
+    ///     let result = system.attempt_13_move(&mut triangulation);
+    ///     assert!(matches!(result, MoveResult::Success | MoveResult::GeometricViolation));
+    ///     assert_eq!(system.stats.moves_13_attempted, 1);
+    ///     Ok(())
+    /// }
     /// ```
     pub fn attempt_13_move(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
         self.stats.record_attempt(MoveType::Move13Add);
@@ -754,28 +766,34 @@ impl ErgodicsSystem {
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::moves::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
-    /// let dt = build_delaunay2_with_data(&[
-    ///     ([0.0, 0.0], 0),
-    ///     ([1.0, 0.0], 0),
-    ///     ([0.5, 1.0], 1),
-    /// ])
-    /// .expect("build labeled triangle");
-    /// let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
-    /// let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)
-    ///     .expect("wrap labeled triangle");
-    /// let mut system = ErgodicsSystem::new();
-    /// let _ = system.attempt_13_move(&mut triangulation);
-    /// let result = system.attempt_31_move(&mut triangulation);
-    /// assert!(matches!(
-    ///     result,
-    ///     MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
-    /// ));
-    /// assert_eq!(system.stats.moves_31_attempted, 1);
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_with_data(&[
+    ///         ([0.0, 0.0], 0),
+    ///         ([1.0, 0.0], 0),
+    ///         ([0.5, 1.0], 1),
+    ///     ])?;
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
+    ///     let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)?;
+    ///     let mut system = ErgodicsSystem::new();
+    ///     let _ = system.attempt_13_move(&mut triangulation);
+    ///     let result = system.attempt_31_move(&mut triangulation);
+    ///     assert!(matches!(
+    ///         result,
+    ///         MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
+    ///     ));
+    ///     assert_eq!(system.stats.moves_31_attempted, 1);
+    ///     Ok(())
+    /// }
     /// ```
     pub fn attempt_31_move(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
         self.stats.record_attempt(MoveType::Move31Remove);
@@ -806,26 +824,32 @@ impl ErgodicsSystem {
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::moves::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
-    /// let dt = build_delaunay2_from_simplices(
-    ///     &[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.0, 1.0], 1), ([1.0, 1.0], 1)],
-    ///     &[vec![0, 1, 2], vec![1, 3, 2]],
-    /// )
-    /// .expect("build square CDT");
-    /// let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
-    /// let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)
-    ///     .expect("wrap labeled square");
-    /// let mut system = ErgodicsSystem::new();
-    /// let result = system.attempt_edge_flip(&mut triangulation);
-    /// assert!(matches!(
-    ///     result,
-    ///     MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
-    /// ));
-    /// assert_eq!(system.stats.edge_flips_attempted, 1);
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_from_simplices(
+    ///         &[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.0, 1.0], 1), ([1.0, 1.0], 1)],
+    ///         &[vec![0, 1, 2], vec![1, 3, 2]],
+    ///     )?;
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
+    ///     let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)?;
+    ///     let mut system = ErgodicsSystem::new();
+    ///     let result = system.attempt_edge_flip(&mut triangulation);
+    ///     assert!(matches!(
+    ///         result,
+    ///         MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
+    ///     ));
+    ///     assert_eq!(system.stats.edge_flips_attempted, 1);
+    ///     Ok(())
+    /// }
     /// ```
     pub fn attempt_edge_flip(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
         self.stats.record_attempt(MoveType::EdgeFlip);
@@ -838,26 +862,32 @@ impl ErgodicsSystem {
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::moves::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
-    /// let dt = build_delaunay2_with_data(&[
-    ///     ([0.0, 0.0], 0),
-    ///     ([1.0, 0.0], 0),
-    ///     ([0.5, 1.0], 1),
-    /// ])
-    /// .expect("build labeled triangle");
-    /// let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
-    /// let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)
-    ///     .expect("wrap labeled triangle");
-    /// let mut system = ErgodicsSystem::new();
-    /// let result = system.attempt_random_move(&mut triangulation);
-    /// assert!(matches!(
-    ///     result,
-    ///     MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
-    /// ));
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_with_data(&[
+    ///         ([0.0, 0.0], 0),
+    ///         ([1.0, 0.0], 0),
+    ///         ([0.5, 1.0], 1),
+    ///     ])?;
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
+    ///     let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)?;
+    ///     let mut system = ErgodicsSystem::new();
+    ///     let result = system.attempt_random_move(&mut triangulation);
+    ///     assert!(matches!(
+    ///         result,
+    ///         MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
+    ///     ));
+    ///     Ok(())
+    /// }
     /// ```
     pub fn attempt_random_move(&mut self, triangulation: &mut CdtTriangulation2D) -> MoveResult {
         let move_type = self.select_random_move();

--- a/src/cdt/foliation.rs
+++ b/src/cdt/foliation.rs
@@ -393,15 +393,17 @@ impl Foliation {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{Foliation, FoliationError};
+    /// use causal_triangulations::{CdtResult, Foliation, FoliationError};
     ///
-    /// let foliation = Foliation::from_slice_sizes(vec![3, 4], 2)
-    ///     .expect("both slices are non-empty");
-    /// assert_eq!(foliation.num_slices(), 2);
-    /// assert_eq!(foliation.labeled_vertex_count(), 7);
+    /// fn main() -> CdtResult<()> {
+    ///     let foliation = Foliation::from_slice_sizes(vec![3, 4], 2)?;
+    ///     assert_eq!(foliation.num_slices(), 2);
+    ///     assert_eq!(foliation.labeled_vertex_count(), 7);
     ///
-    /// let err = Foliation::from_slice_sizes(vec![], 0).expect_err("zero slices are invalid");
-    /// assert_eq!(err, FoliationError::EmptyFoliation);
+    ///     let err = Foliation::from_slice_sizes(vec![], 0).expect_err("zero slices are invalid");
+    ///     assert_eq!(err, FoliationError::EmptyFoliation);
+    ///     Ok(())
+    /// }
     /// ```
     pub fn from_slice_sizes(
         slice_sizes: Vec<usize>,
@@ -430,10 +432,13 @@ impl Foliation {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::Foliation;
+    /// use causal_triangulations::{CdtResult, Foliation};
     ///
-    /// let foliation = Foliation::from_slice_sizes(vec![3, 4], 2).unwrap();
-    /// assert_eq!(foliation.slice_sizes(), &[3, 4]);
+    /// fn main() -> CdtResult<()> {
+    ///     let foliation = Foliation::from_slice_sizes(vec![3, 4], 2)?;
+    ///     assert_eq!(foliation.slice_sizes(), &[3, 4]);
+    ///     Ok(())
+    /// }
     /// ```
     #[must_use]
     pub fn slice_sizes(&self) -> &[usize] {
@@ -445,10 +450,13 @@ impl Foliation {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::Foliation;
+    /// use causal_triangulations::{CdtResult, Foliation};
     ///
-    /// let foliation = Foliation::from_slice_sizes(vec![3, 4], 2).unwrap();
-    /// assert_eq!(foliation.num_slices(), 2);
+    /// fn main() -> CdtResult<()> {
+    ///     let foliation = Foliation::from_slice_sizes(vec![3, 4], 2)?;
+    ///     assert_eq!(foliation.num_slices(), 2);
+    ///     Ok(())
+    /// }
     /// ```
     #[must_use]
     pub const fn num_slices(&self) -> u32 {
@@ -460,10 +468,13 @@ impl Foliation {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::Foliation;
+    /// use causal_triangulations::{CdtResult, Foliation};
     ///
-    /// let foliation = Foliation::from_slice_sizes(vec![3, 4], 2).unwrap();
-    /// assert_eq!(foliation.labeled_vertex_count(), 7);
+    /// fn main() -> CdtResult<()> {
+    ///     let foliation = Foliation::from_slice_sizes(vec![3, 4], 2)?;
+    ///     assert_eq!(foliation.labeled_vertex_count(), 7);
+    ///     Ok(())
+    /// }
     /// ```
     #[must_use]
     pub fn labeled_vertex_count(&self) -> usize {

--- a/src/cdt/metropolis.rs
+++ b/src/cdt/metropolis.rs
@@ -263,17 +263,16 @@ impl Target<CdtTriangulation2D> for CdtTarget {
 ///
 /// ```
 /// use causal_triangulations::prelude::action::ActionConfig;
+/// use causal_triangulations::prelude::errors::CdtResult;
 /// use causal_triangulations::prelude::moves::MoveType;
 /// use causal_triangulations::prelude::simulation::{
-///     CdtProposal, CdtProposalError, CdtTriangulation,
+///     CdtProposal, CdtTriangulation, DelayedProposal,
 /// };
-/// use markov_chain_monte_carlo::DelayedProposal;
 /// use rand::{SeedableRng, rngs::StdRng};
 ///
-/// # fn main() -> Result<(), CdtProposalError> {
-/// let tri = CdtTriangulation::from_cdt_strip(4, 3).expect("valid CDT strip");
-/// let mut proposal =
-///     CdtProposal::with_seed(ActionConfig::default(), 7).expect("valid action config");
+/// # fn main() -> CdtResult<()> {
+/// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+/// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
 /// let mut rng = StdRng::seed_from_u64(11);
 ///
 /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
@@ -351,16 +350,15 @@ impl CdtProposalPlan {
 ///
 /// ```
 /// use causal_triangulations::prelude::action::ActionConfig;
+/// use causal_triangulations::prelude::errors::CdtResult;
 /// use causal_triangulations::prelude::simulation::{
-///     CdtProposal, CdtProposalError, CdtTriangulation,
+///     CdtProposal, CdtTriangulation, DelayedProposal,
 /// };
-/// use markov_chain_monte_carlo::DelayedProposal;
 /// use rand::{SeedableRng, rngs::StdRng};
 ///
-/// # fn main() -> Result<(), CdtProposalError> {
-/// let tri = CdtTriangulation::from_cdt_strip(4, 3).expect("valid CDT strip");
-/// let mut proposal =
-///     CdtProposal::with_seed(ActionConfig::default(), 7).expect("valid action config");
+/// # fn main() -> CdtResult<()> {
+/// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+/// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
 /// let mut rng = StdRng::seed_from_u64(11);
 /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
 ///     return Ok(());
@@ -611,6 +609,22 @@ impl Error for CdtProposalError {
     }
 }
 
+impl From<CdtProposalError> for CdtError {
+    fn from(error: CdtProposalError) -> Self {
+        match error {
+            CdtProposalError::ApplicationFailed {
+                move_type,
+                attempt,
+                source,
+            } => Self::ProposalApplicationFailed {
+                move_type,
+                attempt,
+                source: MetropolisMoveApplicationFailure::from(source),
+            },
+        }
+    }
+}
+
 /// Delayed-commit CDT proposal distribution.
 ///
 /// This adapter exposes CDT's clone-plan-commit move ordering through the
@@ -624,15 +638,15 @@ impl Error for CdtProposalError {
 ///
 /// ```
 /// use causal_triangulations::prelude::action::ActionConfig;
+/// use causal_triangulations::prelude::errors::CdtResult;
 /// use causal_triangulations::prelude::simulation::{
-///     CdtProposal, CdtProposalError, CdtTriangulation,
+///     CdtProposal, CdtTriangulation, DelayedProposal,
 /// };
-/// use markov_chain_monte_carlo::DelayedProposal;
 /// use rand::{SeedableRng, rngs::StdRng};
 ///
-/// # fn main() -> Result<(), CdtProposalError> {
-/// let tri = CdtTriangulation::from_cdt_strip(4, 3).expect("valid CDT strip");
-/// let mut proposal = CdtProposal::new(ActionConfig::default()).expect("valid action config");
+/// # fn main() -> CdtResult<()> {
+/// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+/// let mut proposal = CdtProposal::new(ActionConfig::default())?;
 /// let mut rng = StdRng::seed_from_u64(7);
 ///
 /// let plan = proposal.propose_plan(&tri, &mut rng)?;
@@ -3552,6 +3566,19 @@ mod tests {
         );
         assert!(err.to_string().contains("Move13Add"));
         assert!(err.to_string().contains("attempt 2"));
+
+        let cdt_error = CdtError::from(err);
+        assert!(matches!(
+            cdt_error,
+            CdtError::ProposalApplicationFailed {
+                move_type: MoveType::Move13Add,
+                attempt: 2,
+                source: MetropolisMoveApplicationFailure::BackendMutation {
+                    operation: BackendMutationOperation::SetVertexDataByKey,
+                    ..
+                },
+            }
+        ));
 
         let site_rejection = CdtProposalSiteRejection::Kernel(source.clone());
         assert_eq!(

--- a/src/cdt/triangulation.rs
+++ b/src/cdt/triangulation.rs
@@ -277,12 +277,14 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///
     /// ```
     /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::CdtTriangulation;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
     ///
-    /// let backend = MockBackend::create_triangle();
-    /// let tri = CdtTriangulation::try_new(backend, 2, 2)
-    ///     .expect("metadata matches backend");
-    /// assert_eq!(tri.time_slices(), 2);
+    /// fn main() -> CdtResult<()> {
+    ///     let backend = MockBackend::create_triangle();
+    ///     let tri = CdtTriangulation::try_new(backend, 2, 2)?;
+    ///     assert_eq!(tri.time_slices(), 2);
+    ///     Ok(())
+    /// }
     /// ```
     pub fn try_new(geometry: B, time_slices: u32, dimension: u8) -> CdtResult<Self> {
         let tri = Self::from_parts_before_validation(
@@ -315,80 +317,100 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
-    /// let dt = build_delaunay2_with_data(&[
-    ///     ([0.0, 0.0], 0),
-    ///     ([1.0, 0.0], 0),
-    ///     ([0.5, 1.0], 1),
-    /// ])
-    /// .expect("build labeled triangle");
-    /// let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_with_data(&[
+    ///         ([0.0, 0.0], 0),
+    ///         ([1.0, 0.0], 0),
+    ///         ([0.5, 1.0], 1),
+    ///     ])?;
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
     ///
-    /// let tri = CdtTriangulation::with_topology(backend, 2, 2, CdtTopology::OpenBoundary)
-    ///     .expect("open-boundary metadata is valid");
-    /// assert!(matches!(tri.metadata().topology, CdtTopology::OpenBoundary));
-    /// assert_eq!(tri.time_slices(), 2);
-    /// assert_eq!(tri.dimension(), 2);
+    ///     let tri = CdtTriangulation::with_topology(backend, 2, 2, CdtTopology::OpenBoundary)?;
+    ///     assert!(matches!(tri.metadata().topology, CdtTopology::OpenBoundary));
+    ///     assert_eq!(tri.time_slices(), 2);
+    ///     assert_eq!(tri.dimension(), 2);
+    ///     Ok(())
+    /// }
     /// ```
     ///
     /// ```rust
-    /// use causal_triangulations::prelude::errors::{CdtError, TriangulationMetadataField};
+    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
+    /// use causal_triangulations::prelude::errors::TriangulationMetadataField;
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
-    /// let dt = build_delaunay2_with_data(&[
-    ///     ([0.0, 0.0], 0),
-    ///     ([1.0, 0.0], 0),
-    ///     ([0.5, 1.0], 1),
-    /// ])
-    /// .expect("build labeled triangle");
-    /// let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_with_data(&[
+    ///         ([0.0, 0.0], 0),
+    ///         ([1.0, 0.0], 0),
+    ///         ([0.5, 1.0], 1),
+    ///     ])?;
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
     ///
-    /// let err = CdtTriangulation::with_topology(backend, 2, 3, CdtTopology::Toroidal)
-    ///     .expect_err("toroidal metadata requires at least three time slices");
-    /// assert!(matches!(
-    ///     err,
-    ///     CdtError::InvalidTriangulationMetadata {
-    ///         field,
-    ///         topology,
-    ///         provided_value,
-    ///         expected,
-    ///     } if field == TriangulationMetadataField::Timeslices
-    ///         && topology == CdtTopology::Toroidal
-    ///         && provided_value == "2"
-    ///         && expected == "≥ 3"
-    /// ));
+    ///     let err = CdtTriangulation::with_topology(backend, 2, 3, CdtTopology::Toroidal)
+    ///         .expect_err("toroidal metadata requires at least three time slices");
+    ///     assert!(matches!(
+    ///         err,
+    ///         CdtError::InvalidTriangulationMetadata {
+    ///             field,
+    ///             topology,
+    ///             provided_value,
+    ///             expected,
+    ///         } if field == TriangulationMetadataField::Timeslices
+    ///             && topology == CdtTopology::Toroidal
+    ///             && provided_value == "2"
+    ///             && expected == "≥ 3"
+    ///     ));
+    ///     Ok(())
+    /// }
     /// ```
     ///
     /// ```rust
-    /// use causal_triangulations::prelude::errors::{CdtError, TriangulationMetadataField};
+    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
+    /// use causal_triangulations::prelude::errors::TriangulationMetadataField;
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
-    /// let dt = build_delaunay2_with_data(&[
-    ///     ([0.0, 0.0], 0),
-    ///     ([1.0, 0.0], 0),
-    ///     ([0.5, 1.0], 1),
-    /// ])
-    /// .expect("build labeled triangle");
-    /// let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_with_data(&[
+    ///         ([0.0, 0.0], 0),
+    ///         ([1.0, 0.0], 0),
+    ///         ([0.5, 1.0], 1),
+    ///     ])?;
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
     ///
-    /// let err = CdtTriangulation::with_topology(backend, 3, 2, CdtTopology::Toroidal)
-    ///     .expect_err("a planar triangle cannot be published as toroidal");
-    /// assert!(matches!(
-    ///     err,
-    ///     CdtError::TopologyMismatch {
-    ///         topology,
-    ///         euler_characteristic: 1,
-    ///         expected_euler_characteristics,
-    ///         ..
-    ///     } if topology == CdtTopology::Toroidal && expected_euler_characteristics == vec![0]
-    /// ));
+    ///     let err = CdtTriangulation::with_topology(backend, 3, 2, CdtTopology::Toroidal)
+    ///         .expect_err("a planar triangle cannot be published as toroidal");
+    ///     assert!(matches!(
+    ///         err,
+    ///         CdtError::TopologyMismatch {
+    ///             topology,
+    ///             euler_characteristic: 1,
+    ///             expected_euler_characteristics,
+    ///             ..
+    ///         } if topology == CdtTopology::Toroidal && expected_euler_characteristics.as_slice() == [0]
+    ///     ));
+    ///     Ok(())
+    /// }
     /// ```
     pub fn with_topology(
         geometry: B,
@@ -481,11 +503,13 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///
     /// ```
     /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::CdtTriangulation;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
     ///
-    /// let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)
-    ///     .expect("metadata is valid");
-    /// assert_eq!(tri.geometry().vertex_count(), 3);
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.geometry().vertex_count(), 3);
+    ///     Ok(())
+    /// }
     /// ```
     #[must_use]
     pub const fn geometry(&self) -> &B {
@@ -498,11 +522,13 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///
     /// ```
     /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::CdtTriangulation;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
     ///
-    /// let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)
-    ///     .expect("metadata is valid");
-    /// assert_eq!(tri.vertex_count(), 3);
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.vertex_count(), 3);
+    ///     Ok(())
+    /// }
     /// ```
     pub fn vertex_count(&self) -> usize {
         self.geometry.vertex_count()
@@ -514,11 +540,13 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///
     /// ```
     /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::CdtTriangulation;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
     ///
-    /// let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)
-    ///     .expect("metadata is valid");
-    /// assert_eq!(tri.face_count(), 1);
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.face_count(), 1);
+    ///     Ok(())
+    /// }
     /// ```
     pub fn face_count(&self) -> usize {
         self.geometry.face_count()
@@ -530,11 +558,13 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///
     /// ```
     /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::CdtTriangulation;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
     ///
-    /// let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)
-    ///     .expect("metadata is valid");
-    /// assert_eq!(tri.time_slices(), 2);
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.time_slices(), 2);
+    ///     Ok(())
+    /// }
     /// ```
     #[must_use]
     pub const fn time_slices(&self) -> u32 {
@@ -547,11 +577,13 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///
     /// ```
     /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::CdtTriangulation;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
     ///
-    /// let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)
-    ///     .expect("metadata is valid");
-    /// assert_eq!(tri.dimension(), 2);
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.dimension(), 2);
+    ///     Ok(())
+    /// }
     /// ```
     #[must_use]
     pub const fn dimension(&self) -> u8 {
@@ -564,11 +596,13 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///
     /// ```
     /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::CdtTriangulation;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
     ///
-    /// let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)
-    ///     .expect("metadata is valid");
-    /// assert_eq!(tri.metadata().time_slices, 2);
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.metadata().time_slices, 2);
+    ///     Ok(())
+    /// }
     /// ```
     #[must_use]
     pub const fn metadata(&self) -> &CdtMetadata {
@@ -598,11 +632,13 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///
     /// ```
     /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::CdtTriangulation;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
     ///
-    /// let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)
-    ///     .expect("metadata is valid");
-    /// assert_eq!(tri.edge_count(), 3);
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.edge_count(), 3);
+    ///     Ok(())
+    /// }
     /// ```
     pub fn edge_count(&self) -> usize {
         if let Some(cached) = &self.cache.edge_count
@@ -620,12 +656,14 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///
     /// ```
     /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::CdtTriangulation;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
     ///
-    /// let mut tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)
-    ///     .expect("metadata is valid");
-    /// tri.refresh_cache();
-    /// assert_eq!(tri.edge_count(), 3);
+    /// fn main() -> CdtResult<()> {
+    ///     let mut tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     tri.refresh_cache();
+    ///     assert_eq!(tri.edge_count(), 3);
+    ///     Ok(())
+    /// }
     /// ```
     pub fn refresh_cache(&mut self) {
         let mod_count = self.metadata.modification_count;
@@ -657,9 +695,11 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// ```
     /// use causal_triangulations::prelude::triangulation::*;
     ///
-    /// let tri = CdtTriangulation::from_seeded_points(5, 1, 2, 53)
-    ///     .expect("create triangulation");
-    /// assert!(tri.validate_topology().is_ok());
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::from_seeded_points(5, 1, 2, 53)?;
+    ///     tri.validate_topology()?;
+    ///     Ok(())
+    /// }
     /// ```
     pub fn validate_topology(&self) -> CdtResult<()> {
         self.validate_metadata()?;
@@ -751,8 +791,8 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// use causal_triangulations::prelude::errors::{CdtError, TriangulationMetadataField};
     /// use causal_triangulations::prelude::triangulation::{CdtTopology, CdtTriangulation};
     ///
-    /// let mut tri = CdtTriangulation::from_toroidal_cdt(4, 3)
-    ///     .expect("build toroidal triangulation");
+    /// fn main() -> causal_triangulations::CdtResult<()> {
+    /// let mut tri = CdtTriangulation::from_toroidal_cdt(4, 3)?;
     ///
     /// let err = tri.set_time_slices(2).expect_err("T < 3 is invalid");
     /// assert!(matches!(
@@ -767,6 +807,8 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///         && provided_value == "2"
     ///         && expected == "≥ 3"
     /// ));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn set_time_slices(&mut self, time_slices: u32) -> CdtResult<()> {
         if self.metadata.time_slices == time_slices {

--- a/src/cdt/triangulation/builders.rs
+++ b/src/cdt/triangulation/builders.rs
@@ -554,6 +554,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{CdtError, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
@@ -563,8 +564,12 @@ impl CdtTriangulation<DelaunayBackend2D> {
     ///         ([1.0, 0.0], 0),
     ///         ([0.5, 1.0], 1),
     ///     ])?;
-    ///     let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///         .expect("three non-collinear labeled points should validate");
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
     ///     let tri = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)?;
     ///
     ///     assert!(tri.has_foliation());

--- a/src/cdt/triangulation/validation.rs
+++ b/src/cdt/triangulation/validation.rs
@@ -124,6 +124,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{CdtError, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
@@ -133,8 +134,12 @@ impl CdtTriangulation<DelaunayBackend2D> {
     ///         ([1.0, 0.0], 0),
     ///         ([0.5, 1.0], 1),
     ///     ])?;
-    ///     let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///         .expect("three non-collinear labeled points should validate");
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
     ///     let tri = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)?;
     ///     tri.validate_causality()?;
     ///     Ok(())
@@ -166,6 +171,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{CdtError, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
@@ -175,8 +181,12 @@ impl CdtTriangulation<DelaunayBackend2D> {
     ///         ([1.0, 0.0], 0),
     ///         ([0.5, 1.0], 1),
     ///     ])?;
-    ///     let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///         .expect("three non-collinear labeled points should validate");
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
     ///     let tri = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)?;
     ///     tri.validate_causality_delaunay()?;
     ///     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -823,17 +823,19 @@ impl CdtConfig {
     /// ```
     /// use causal_triangulations::CdtConfig;
     ///
-    /// let config = CdtConfig::try_from_args([
-    ///     "cdt",
-    ///     "--vertices-per-slice",
-    ///     "4",
-    ///     "--timeslices",
-    ///     "4",
-    /// ])
-    /// .expect("valid CLI arguments");
+    /// fn main() -> Result<(), clap::Error> {
+    ///     let config = CdtConfig::try_from_args([
+    ///         "cdt",
+    ///         "--vertices-per-slice",
+    ///         "4",
+    ///         "--timeslices",
+    ///         "4",
+    ///     ])?;
     ///
-    /// assert_eq!(config.vertices, 16);
-    /// assert_eq!(config.timeslices, 4);
+    ///     assert_eq!(config.vertices, 16);
+    ///     assert_eq!(config.timeslices, 4);
+    ///     Ok(())
+    /// }
     /// ```
     pub fn try_from_args<I, T>(args: I) -> Result<Self, ClapError>
     where

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -708,7 +708,8 @@ impl From<CdtError> for MetropolisMoveApplicationFailure {
                 time_1,
                 step_distance,
             },
-            CdtError::MetropolisMoveApplicationFailed { source, .. } => source,
+            CdtError::MetropolisMoveApplicationFailed { source, .. }
+            | CdtError::ProposalApplicationFailed { source, .. } => source,
             error => Self::Unexpected {
                 detail: error.to_string(),
             },
@@ -797,6 +798,16 @@ pub enum CdtError {
         move_type: MoveType,
         /// Number of application attempts made before failing.
         attempts: usize,
+        /// Most specific lower-level rejection or failure observed.
+        source: MetropolisMoveApplicationFailure,
+    },
+    /// Planning or committing a standalone delayed CDT proposal hit a hard failure.
+    #[error("CDT proposal failed while applying {move_type:?} on attempt {attempt}: {source}")]
+    ProposalApplicationFailed {
+        /// Move type whose concrete proposal application failed.
+        move_type: MoveType,
+        /// Local-site attempt that hit the hard failure.
+        attempt: usize,
         /// Most specific lower-level rejection or failure observed.
         source: MetropolisMoveApplicationFailure,
     },
@@ -1504,6 +1515,29 @@ mod tests {
         assert_eq!(
             display,
             "Metropolis accepted Move31Remove at step 17, but applying it failed after 8 attempts; source: backend mutation failed [set_vertex_data] on vertex VertexKey(123v1): backend reported invalid vertex key"
+        );
+        assert_eq!(
+            Error::source(&error).map(ToString::to_string),
+            Some(source.to_string())
+        );
+    }
+
+    #[test]
+    fn test_proposal_application_failed_error() {
+        let source = MetropolisMoveApplicationFailure::BackendMutation {
+            operation: BackendMutationOperation::SetVertexDataByKey,
+            target: "vertex VertexKey(123v1)".to_string(),
+            detail: "backend reported invalid vertex key".to_string(),
+        };
+        let error = CdtError::ProposalApplicationFailed {
+            move_type: MoveType::Move13Add,
+            attempt: 2,
+            source: source.clone(),
+        };
+        let display = format!("{error}");
+        assert_eq!(
+            display,
+            "CDT proposal failed while applying Move13Add on attempt 2: backend mutation failed [set_vertex_data_by_key] on vertex VertexKey(123v1): backend reported invalid vertex key"
         );
         assert_eq!(
             Error::source(&error).map(ToString::to_string),

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -614,11 +614,10 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::geometry::backends::delaunay::{
-    ///     DelaunayBackend, DelaunayError,
-    /// };
+    /// use causal_triangulations::geometry::backends::delaunay::{DelaunayBackend, DelaunayError};
     /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
     /// use causal_triangulations::geometry::traits::TriangulationQuery;
+    /// use causal_triangulations::DelaunayValidationLevel;
     ///
     /// fn main() -> Result<(), DelaunayError> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -626,7 +625,10 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///         ([1.0, 0.0], 0),
     ///         ([0.5, 1.0], 1),
     ///     ])
-    ///     .expect("finite non-collinear triangle should build");
+    ///     .map_err(|err| DelaunayError::ValidationFailed {
+    ///         level: DelaunayValidationLevel::Four,
+    ///         detail: err.to_string(),
+    ///     })?;
     ///
     ///     let backend = DelaunayBackend::<u32, i32, 2>::from_triangulation(dt)?;
     ///     assert_eq!(backend.vertex_count(), 3);
@@ -650,9 +652,10 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::geometry::backends::delaunay::DelaunayError;
     /// use causal_triangulations::geometry::DelaunayBackend2D;
+    /// use causal_triangulations::geometry::backends::delaunay::DelaunayError;
     /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
+    /// use causal_triangulations::DelaunayValidationLevel;
     ///
     /// fn main() -> Result<(), DelaunayError> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -660,7 +663,10 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///         ([1.0, 0.0], 0),
     ///         ([0.5, 1.0], 1),
     ///     ])
-    ///     .expect("finite non-collinear triangle should build");
+    ///     .map_err(|err| DelaunayError::ValidationFailed {
+    ///         level: DelaunayValidationLevel::Four,
+    ///         detail: err.to_string(),
+    ///     })?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt)?;
     ///     assert_eq!(backend.triangulation().number_of_vertices(), 3);
     ///     Ok(())
@@ -682,9 +688,10 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::geometry::backends::delaunay::DelaunayError;
     /// use causal_triangulations::geometry::DelaunayBackend2D;
+    /// use causal_triangulations::geometry::backends::delaunay::DelaunayError;
     /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
+    /// use causal_triangulations::DelaunayValidationLevel;
     ///
     /// fn main() -> Result<(), DelaunayError> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -692,7 +699,10 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///         ([1.0, 0.0], 0),
     ///         ([0.5, 1.0], 1),
     ///     ])
-    ///     .expect("finite non-collinear triangle should build");
+    ///     .map_err(|err| DelaunayError::ValidationFailed {
+    ///         level: DelaunayValidationLevel::Four,
+    ///         detail: err.to_string(),
+    ///     })?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt)?;
     ///     assert!(backend.is_delaunay());
     ///     Ok(())
@@ -718,9 +728,10 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::geometry::backends::delaunay::DelaunayError;
     /// use causal_triangulations::geometry::DelaunayBackend2D;
+    /// use causal_triangulations::geometry::backends::delaunay::DelaunayError;
     /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
+    /// use causal_triangulations::DelaunayValidationLevel;
     ///
     /// fn main() -> Result<(), DelaunayError> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -728,7 +739,10 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///         ([1.0, 0.0], 0),
     ///         ([0.5, 1.0], 1),
     ///     ])
-    ///     .expect("finite non-collinear triangle should build");
+    ///     .map_err(|err| DelaunayError::ValidationFailed {
+    ///         level: DelaunayValidationLevel::Four,
+    ///         detail: err.to_string(),
+    ///     })?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt)?;
     ///     backend.validate_delaunay()?;
     ///     Ok(())
@@ -803,7 +817,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::CdtResult;
+    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::geometry::DelaunayBackend2D;
     /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
     /// use std::num::NonZeroUsize;
@@ -814,8 +828,12 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///         ([1.0, 0.0], 0),
     ///         ([0.5, 1.0], 1),
     ///     ])?;
-    ///     let mut backend = DelaunayBackend2D::from_triangulation(dt)
-    ///         .expect("Delaunay input should validate");
+    ///     let mut backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
     ///
     ///     backend.set_delaunay_check_interval(NonZeroUsize::new(16));
     ///     backend.set_delaunay_check_interval(None);
@@ -847,17 +865,25 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::geometry::DelaunayBackend2D;
     /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
     ///
-    /// let dt = build_delaunay2_with_data(&[
-    ///     ([0.0, 0.0], 0_u32),
-    ///     ([1.0, 0.0], 0),
-    ///     ([0.5, 1.0], 1),
-    /// ]).unwrap();
-    /// let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
-    /// let _kind = backend.topology_kind();
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_with_data(&[
+    ///         ([0.0, 0.0], 0_u32),
+    ///         ([1.0, 0.0], 0),
+    ///         ([0.5, 1.0], 1),
+    ///     ])?;
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
+    ///     let _kind = backend.topology_kind();
+    ///     Ok(())
+    /// }
     /// ```
     #[must_use]
     pub const fn topology_kind(&self) -> TopologyKind {
@@ -869,10 +895,14 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::CdtResult;
     /// use causal_triangulations::prelude::triangulation::*;
     ///
-    /// let tri = CdtTriangulation::from_toroidal_cdt(3, 3).unwrap();
-    /// assert_eq!(tri.geometry().periodic_domain(), Some([3.0, 3.0]));
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::from_toroidal_cdt(3, 3)?;
+    ///     assert_eq!(tri.geometry().periodic_domain(), Some([3.0, 3.0]));
+    ///     Ok(())
+    /// }
     /// ```
     #[must_use]
     pub const fn periodic_domain(&self) -> Option<[f64; D]> {
@@ -889,18 +919,38 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{
+    ///     CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure, DelaunayValidationLevel,
+    /// };
     /// use causal_triangulations::geometry::DelaunayBackend2D;
     /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
     ///
-    /// let dt = build_delaunay2_with_data(&[
-    ///     ([0.0, 0.0], 0_u32),
-    ///     ([1.0, 0.0], 0),
-    ///     ([0.5, 1.0], 1),
-    /// ]).unwrap();
-    /// let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
-    /// let (key, _) = backend.triangulation().vertices().next().unwrap();
-    /// assert!(backend.vertex_data_by_key(key).is_some());
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_with_data(&[
+    ///         ([0.0, 0.0], 0_u32),
+    ///         ([1.0, 0.0], 0),
+    ///         ([0.5, 1.0], 1),
+    ///     ])?;
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
+    ///     let key = backend
+    ///         .triangulation()
+    ///         .vertices()
+    ///         .next()
+    ///         .map(|(key, _)| key)
+    ///         .ok_or_else(|| CdtError::ValidationFailed {
+    ///             check: CdtValidationCheck::Geometry,
+    ///             failure: CdtValidationFailure::BackendGeometry {
+    ///                 detail: "validated triangle should contain a vertex".to_string(),
+    ///             },
+    ///         })?;
+    ///     assert!(backend.vertex_data_by_key(key).is_some());
+    ///     Ok(())
+    /// }
     /// ```
     #[must_use]
     pub fn vertex_data_by_key(&self, key: VertexKey) -> Option<VertexData> {
@@ -912,18 +962,38 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{
+    ///     CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure, DelaunayValidationLevel,
+    /// };
     /// use causal_triangulations::geometry::DelaunayBackend2D;
     /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
     ///
-    /// let dt = build_delaunay2_with_data(&[
-    ///     ([0.0, 0.0], 0_u32),
-    ///     ([1.0, 0.0], 0),
-    ///     ([0.5, 1.0], 1),
-    /// ]).unwrap();
-    /// let backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
-    /// let (key, _) = backend.triangulation().simplices().next().unwrap();
-    /// assert_eq!(backend.simplex_data_by_key(key), None);
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_with_data(&[
+    ///         ([0.0, 0.0], 0_u32),
+    ///         ([1.0, 0.0], 0),
+    ///         ([0.5, 1.0], 1),
+    ///     ])?;
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
+    ///     let key = backend
+    ///         .triangulation()
+    ///         .simplices()
+    ///         .next()
+    ///         .map(|(key, _)| key)
+    ///         .ok_or_else(|| CdtError::ValidationFailed {
+    ///             check: CdtValidationCheck::Geometry,
+    ///             failure: CdtValidationFailure::BackendGeometry {
+    ///                 detail: "validated triangle should contain a simplex".to_string(),
+    ///             },
+    ///         })?;
+    ///     assert_eq!(backend.simplex_data_by_key(key), None);
+    ///     Ok(())
+    /// }
     /// ```
     #[must_use]
     pub fn simplex_data_by_key(&self, key: SimplexKey) -> Option<SimplexData> {
@@ -941,20 +1011,47 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{
+    ///     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck,
+    ///     CdtValidationFailure, DelaunayValidationLevel,
+    /// };
     /// use causal_triangulations::geometry::DelaunayBackend2D;
     /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
     ///
-    /// let dt = build_delaunay2_with_data(&[
-    ///     ([0.0, 0.0], 0_u32),
-    ///     ([1.0, 0.0], 0),
-    ///     ([0.5, 1.0], 1),
-    /// ]).unwrap();
-    /// let mut backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
-    /// let (key, _) = backend.triangulation().vertices().next().unwrap();
-    /// let previous = backend.set_vertex_data_by_key(key, Some(3)).unwrap();
-    /// assert!(previous.is_some());
-    /// assert_eq!(backend.vertex_data_by_key(key), Some(3));
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_with_data(&[
+    ///         ([0.0, 0.0], 0_u32),
+    ///         ([1.0, 0.0], 0),
+    ///         ([0.5, 1.0], 1),
+    ///     ])?;
+    ///     let mut backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
+    ///     let key = backend
+    ///         .triangulation()
+    ///         .vertices()
+    ///         .next()
+    ///         .map(|(key, _)| key)
+    ///         .ok_or_else(|| CdtError::ValidationFailed {
+    ///             check: CdtValidationCheck::Geometry,
+    ///             failure: CdtValidationFailure::BackendGeometry {
+    ///                 detail: "validated triangle should contain a vertex".to_string(),
+    ///             },
+    ///         })?;
+    ///     let previous = backend.set_vertex_data_by_key(key, Some(3)).map_err(|err| {
+    ///         CdtError::BackendMutationFailed {
+    ///             operation: BackendMutationOperation::SetVertexDataByKey,
+    ///             target: format!("vertex {key:?}"),
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
+    ///     assert!(previous.is_some());
+    ///     assert_eq!(backend.vertex_data_by_key(key), Some(3));
+    ///     Ok(())
+    /// }
     /// ```
     pub fn set_vertex_data_by_key(
         &mut self,
@@ -977,20 +1074,47 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::{
+    ///     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck,
+    ///     CdtValidationFailure, DelaunayValidationLevel,
+    /// };
     /// use causal_triangulations::geometry::DelaunayBackend2D;
     /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
     ///
-    /// let dt = build_delaunay2_with_data(&[
-    ///     ([0.0, 0.0], 0_u32),
-    ///     ([1.0, 0.0], 0),
-    ///     ([0.5, 1.0], 1),
-    /// ]).unwrap();
-    /// let mut backend = DelaunayBackend2D::from_triangulation(dt)
-    ///     .expect("Delaunay input should validate");
-    /// let (key, _) = backend.triangulation().simplices().next().unwrap();
-    /// let previous = backend.set_simplex_data_by_key(key, Some(1)).unwrap();
-    /// assert_eq!(previous, None);
-    /// assert_eq!(backend.simplex_data_by_key(key), Some(1));
+    /// fn main() -> CdtResult<()> {
+    ///     let dt = build_delaunay2_with_data(&[
+    ///         ([0.0, 0.0], 0_u32),
+    ///         ([1.0, 0.0], 0),
+    ///         ([0.5, 1.0], 1),
+    ///     ])?;
+    ///     let mut backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
+    ///     let key = backend
+    ///         .triangulation()
+    ///         .simplices()
+    ///         .next()
+    ///         .map(|(key, _)| key)
+    ///         .ok_or_else(|| CdtError::ValidationFailed {
+    ///             check: CdtValidationCheck::Geometry,
+    ///             failure: CdtValidationFailure::BackendGeometry {
+    ///                 detail: "validated triangle should contain a simplex".to_string(),
+    ///             },
+    ///         })?;
+    ///     let previous = backend.set_simplex_data_by_key(key, Some(1)).map_err(|err| {
+    ///         CdtError::BackendMutationFailed {
+    ///             operation: BackendMutationOperation::SetSimplexDataByKey,
+    ///             target: format!("simplex {key:?}"),
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
+    ///     assert_eq!(previous, None);
+    ///     assert_eq!(backend.simplex_data_by_key(key), Some(1));
+    ///     Ok(())
+    /// }
     /// ```
     pub fn set_simplex_data_by_key(
         &mut self,

--- a/src/geometry/generators.rs
+++ b/src/geometry/generators.rs
@@ -108,11 +108,14 @@ fn validate_toroidal_domain(domain: [f64; 2]) -> CdtResult<()> {
 /// # Examples
 ///
 /// ```
+/// use causal_triangulations::CdtResult;
 /// use causal_triangulations::prelude::geometry::*;
 ///
-/// let dt = generate_delaunay2(5, (0.0, 1.0), Some(7))
-///     .expect("seeded generation succeeds");
-/// assert_eq!(dt.number_of_vertices(), 5);
+/// fn main() -> CdtResult<()> {
+///     let dt = generate_delaunay2(5, (0.0, 1.0), Some(7))?;
+///     assert_eq!(dt.number_of_vertices(), 5);
+///     Ok(())
+/// }
 /// ```
 pub fn generate_delaunay2(
     number_of_vertices: u32,
@@ -180,15 +183,18 @@ pub fn generate_delaunay2(
 /// # Examples
 ///
 /// ```
+/// use causal_triangulations::CdtResult;
 /// use causal_triangulations::prelude::geometry::*;
 ///
-/// let dt = build_delaunay2_with_data(&[
-///     ([0.0, 0.0], 0),
-///     ([1.0, 0.0], 0),
-///     ([0.5, 1.0], 1),
-/// ])
-/// .expect("build labeled triangle");
-/// assert_eq!(dt.number_of_vertices(), 3);
+/// fn main() -> CdtResult<()> {
+///     let dt = build_delaunay2_with_data(&[
+///         ([0.0, 0.0], 0),
+///         ([1.0, 0.0], 0),
+///         ([0.5, 1.0], 1),
+///     ])?;
+///     assert_eq!(dt.number_of_vertices(), 3);
+///     Ok(())
+/// }
 /// ```
 pub fn build_delaunay2_with_data(
     coords_with_data: &[([f64; 2], u32)],
@@ -257,16 +263,19 @@ pub fn build_delaunay2_with_data(
 /// # Examples
 ///
 /// ```
+/// use causal_triangulations::CdtResult;
 /// use causal_triangulations::prelude::geometry::*;
 ///
-/// // Single labeled triangle (PL-manifold-with-boundary, Euclidean):
-/// let vertices = [([0.0, 0.0], 0u32), ([1.0, 0.0], 0), ([0.5, 1.0], 1)];
-/// let simplices = vec![vec![0, 1, 2]];
+/// fn main() -> CdtResult<()> {
+///     // Single labeled triangle (PL-manifold-with-boundary, Euclidean):
+///     let vertices = [([0.0, 0.0], 0u32), ([1.0, 0.0], 0), ([0.5, 1.0], 1)];
+///     let simplices = vec![vec![0, 1, 2]];
 ///
-/// let dt = build_delaunay2_from_simplices(&vertices, &simplices)
-///     .expect("explicit single-triangle mesh");
-/// assert_eq!(dt.number_of_vertices(), 3);
-/// assert_eq!(dt.number_of_simplices(), 1);
+///     let dt = build_delaunay2_from_simplices(&vertices, &simplices)?;
+///     assert_eq!(dt.number_of_vertices(), 3);
+///     assert_eq!(dt.number_of_simplices(), 1);
+///     Ok(())
+/// }
 /// ```
 pub fn build_delaunay2_from_simplices(
     coords_with_data: &[([f64; 2], u32)],
@@ -302,21 +311,24 @@ pub fn build_delaunay2_from_simplices(
 /// Import topology metadata from this crate's geometry prelude:
 ///
 /// ```
+/// use causal_triangulations::CdtResult;
 /// use causal_triangulations::prelude::geometry::*;
 ///
-/// // Single labeled triangle, default PL-manifold guarantee, Euclidean global topology.
-/// let vertices = [([0.0, 0.0], 0u32), ([1.0, 0.0], 0), ([0.5, 1.0], 1)];
-/// let simplices = vec![vec![0, 1, 2]];
+/// fn main() -> CdtResult<()> {
+///     // Single labeled triangle, default PL-manifold guarantee, Euclidean global topology.
+///     let vertices = [([0.0, 0.0], 0u32), ([1.0, 0.0], 0), ([0.5, 1.0], 1)];
+///     let simplices = vec![vec![0, 1, 2]];
 ///
-/// let dt = build_delaunay2_with_topology(
-///     &vertices,
-///     &simplices,
-///     TopologyGuarantee::DEFAULT,
-///     GlobalTopology::Euclidean,
-/// )
-/// .expect("explicit single-triangle mesh");
-/// assert_eq!(dt.number_of_vertices(), 3);
-/// assert_eq!(dt.number_of_simplices(), 1);
+///     let dt = build_delaunay2_with_topology(
+///         &vertices,
+///         &simplices,
+///         TopologyGuarantee::DEFAULT,
+///         GlobalTopology::Euclidean,
+///     )?;
+///     assert_eq!(dt.number_of_vertices(), 3);
+///     assert_eq!(dt.number_of_simplices(), 1);
+///     Ok(())
+/// }
 /// ```
 pub fn build_delaunay2_with_topology(
     coords_with_data: &[([f64; 2], u32)],
@@ -389,40 +401,43 @@ pub fn build_delaunay2_with_topology(
 /// connectivity to `delaunay`:
 ///
 /// ```
+/// use causal_triangulations::{CdtError, CdtResult};
 /// use causal_triangulations::prelude::geometry::*;
-/// use causal_triangulations::CdtError;
 ///
-/// const N: usize = 3;
-/// const T: usize = 3;
+/// fn main() -> CdtResult<()> {
+///     const N: usize = 3;
+///     const LABELS: [u32; 3] = [0, 1, 2];
+///     const T: usize = LABELS.len();
 ///
-/// // Vertex (i, t) lives at index i + t*N, with x = i/N, y = t/T, label = t.
-/// let mut vertices: Vec<([f64; 2], u32)> = Vec::with_capacity(N * T);
-/// for t in 0..T {
-///     for i in 0..N {
-///         #[allow(clippy::cast_precision_loss)]
-///         let coord = [i as f64 / N as f64, t as f64 / T as f64];
-///         let label = u32::try_from(t).expect("slice index fits in u32");
-///         vertices.push((coord, label));
+///     // Vertex (i, t) lives at index i + t*N, with x = i/N, y = t/T, label = t.
+///     let mut vertices: Vec<([f64; 2], u32)> = Vec::with_capacity(N * T);
+///     for (t, label) in LABELS.into_iter().enumerate() {
+///         for i in 0..N {
+///             #[allow(clippy::cast_precision_loss)]
+///             let coord = [i as f64 / N as f64, t as f64 / T as f64];
+///             vertices.push((coord, label));
+///         }
 ///     }
-/// }
 ///
-/// // Each (i, t) quad contributes one Up and one Down triangle.
-/// let mut simplices: Vec<Vec<usize>> = Vec::with_capacity(2 * N * T);
-/// for t in 0..T {
-///     let t_next = (t + 1) % T;
-///     for i in 0..N {
-///         let i_next = (i + 1) % N;
-///         simplices.push(vec![i + t * N, i_next + t * N, i + t_next * N]);
-///         simplices.push(vec![i_next + t * N, i_next + t_next * N, i + t_next * N]);
+///     // Each (i, t) quad contributes one Up and one Down triangle.
+///     let mut simplices: Vec<Vec<usize>> = Vec::with_capacity(2 * N * T);
+///     for t in 0..T {
+///         let t_next = (t + 1) % T;
+///         for i in 0..N {
+///             let i_next = (i + 1) % N;
+///             simplices.push(vec![i + t * N, i_next + t * N, i + t_next * N]);
+///             simplices.push(vec![i_next + t * N, i_next + t_next * N, i + t_next * N]);
+///         }
 ///     }
-/// }
 ///
-/// let result = build_toroidal_delaunay2(&vertices, &simplices, [1.0, 1.0]);
-/// assert!(matches!(
-///     result,
-///     Err(CdtError::DelaunayGenerationFailed { ref underlying_error, .. })
-///         if underlying_error.contains("Explicit non-Euclidean connectivity")
-/// ));
+///     let result = build_toroidal_delaunay2(&vertices, &simplices, [1.0, 1.0]);
+///     assert!(matches!(
+///         result,
+///         Err(CdtError::DelaunayGenerationFailed { ref underlying_error, .. })
+///             if underlying_error.contains("Explicit non-Euclidean connectivity")
+///     ));
+///     Ok(())
+/// }
 /// ```
 pub fn build_toroidal_delaunay2(
     coords_with_data: &[([f64; 2], u32)],
@@ -465,19 +480,19 @@ pub fn build_toroidal_delaunay2(
 /// and validate it with the upstream Level 1-4 checks:
 ///
 /// ```
-/// use causal_triangulations::CdtResult;
+/// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
 /// use causal_triangulations::prelude::geometry::*;
 ///
 /// fn main() -> CdtResult<()> {
 ///     const N: usize = 3;
-///     const T: usize = 3;
+///     const LABELS: [u32; 3] = [0, 1, 2];
+///     const T: usize = LABELS.len();
 ///     let mut vertices: Vec<([f64; 2], u32)> = Vec::with_capacity(N * T);
 ///
-///     for t in 0..T {
+///     for (t, label) in LABELS.into_iter().enumerate() {
 ///         for i in 0..N {
 ///             #[allow(clippy::cast_precision_loss)]
 ///             let coord = [i as f64, t as f64];
-///             let label = u32::try_from(t).expect("slice index fits in u32");
 ///             vertices.push((coord, label));
 ///         }
 ///     }
@@ -486,11 +501,16 @@ pub fn build_toroidal_delaunay2(
 ///     assert_eq!(dt.number_of_vertices(), N * T);
 ///     assert_eq!(dt.number_of_simplices(), 2 * N * T);
 ///
-///     let backend = DelaunayBackend2D::from_triangulation(dt)
-///         .expect("Delaunay input should validate");
-///     backend
-///         .validate_delaunay()
-///         .expect("periodic toroidal mesh passes Level 1-4 validation");
+///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+///         CdtError::DelaunayValidationFailed {
+///             level: DelaunayValidationLevel::Four,
+///             detail: err.to_string(),
+///         }
+///     })?;
+///     backend.validate_delaunay().map_err(|err| CdtError::DelaunayValidationFailed {
+///         level: DelaunayValidationLevel::Four,
+///         detail: err.to_string(),
+///     })?;
 ///     Ok(())
 /// }
 /// ```

--- a/src/geometry/traits.rs
+++ b/src/geometry/traits.rs
@@ -105,9 +105,10 @@ pub trait TriangulationQuery: GeometryBackend {
     /// use causal_triangulations::prelude::testing::*;
     ///
     /// let backend = MockBackend::create_triangle();
-    /// let edge = backend.edges().next().expect("triangle should have an edge");
-    /// let endpoints = backend.edge_endpoints(&edge);
-    /// assert!(endpoints.is_some());
+    /// assert!(backend
+    ///     .edges()
+    ///     .next()
+    ///     .is_some_and(|edge| backend.edge_endpoints(&edge).is_some()));
     /// ```
     fn edge_endpoints(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,13 +33,23 @@
 //! transient caches and timestamps on load.
 //!
 //! ```
+//! use causal_triangulations::{CheckpointOperation, CdtError};
 //! use causal_triangulations::prelude::triangulation::*;
 //! use serde_json::{from_str, to_string};
 //!
 //! fn main() -> CdtResult<()> {
 //!     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-//!     let json = to_string(&tri).expect("serialize checkpoint");
-//!     let restored: CdtTriangulation2D = from_str(&json).expect("deserialize checkpoint");
+//!     let json = to_string(&tri).map_err(|err| CdtError::CheckpointSerializationFailed {
+//!         operation: CheckpointOperation::Serialize,
+//!         target: "triangulation".to_string(),
+//!         detail: err.to_string(),
+//!     })?;
+//!     let restored: CdtTriangulation2D =
+//!         from_str(&json).map_err(|err| CdtError::CheckpointSerializationFailed {
+//!             operation: CheckpointOperation::Deserialize,
+//!             target: "triangulation".to_string(),
+//!             detail: err.to_string(),
+//!         })?;
 //!     restored.validate_topology()?;
 //!     restored.validate_foliation()?;
 //!     restored.validate_causality()?;
@@ -285,7 +295,10 @@ pub mod prelude {
     /// proposal adapter, telemetry structs, result containers, and typed
     /// proposal errors needed by MCMC workflows. It also includes the
     /// triangulation query trait so callers can inspect final or checkpointed
-    /// states returned by simulation APIs.
+    /// states returned by simulation APIs. The upstream MCMC traits are
+    /// re-exported here because [`CdtProposal`](crate::cdt::metropolis::CdtProposal)
+    /// and [`CdtTarget`](crate::cdt::metropolis::CdtTarget) expose their primary
+    /// behavior through those trait implementations.
     /// Observable estimators live in [`crate::prelude::observables`].
     pub mod simulation {
         pub use crate::cdt::action::{ActionConfig, compute_regge_action};
@@ -301,6 +314,7 @@ pub mod prelude {
         pub use crate::geometry::CdtTriangulation2D;
         pub use crate::geometry::traits::TriangulationQuery;
         pub use crate::{CdtTriangulation, run_simulation};
+        pub use markov_chain_monte_carlo::{ChainCheckpoint, DelayedProposal, Target};
     }
 
     /// Focused exports for CDT observables and post-simulation analysis.
@@ -341,7 +355,7 @@ pub mod prelude {
     /// queries), without pulling in simulation-specific symbols.
     ///
     /// ```
-    /// use causal_triangulations::CdtResult;
+    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
     ///
     /// fn main() -> CdtResult<()> {
@@ -351,8 +365,12 @@ pub mod prelude {
     ///         ([0.5, 1.0], 1),
     ///     ])?;
     ///
-    ///     let mut backend = DelaunayBackend2D::from_triangulation(dt)
-    ///         .expect("Delaunay input should validate");
+    ///     let mut backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
+    ///         CdtError::DelaunayValidationFailed {
+    ///             level: DelaunayValidationLevel::Four,
+    ///             detail: err.to_string(),
+    ///         }
+    ///     })?;
     ///     assert!(backend.is_valid());
     ///
     ///     let topology: GlobalTopology<2> = GlobalTopology::Toroidal {

--- a/tests/proptest_metropolis.rs
+++ b/tests/proptest_metropolis.rs
@@ -3,9 +3,8 @@
 
 use approx::relative_eq;
 use causal_triangulations::prelude::action::ActionConfig;
-use causal_triangulations::prelude::simulation::CdtTarget;
+use causal_triangulations::prelude::simulation::{CdtTarget, Target};
 use causal_triangulations::prelude::triangulation::{CdtTriangulation, CdtTriangulation2D};
-use markov_chain_monte_carlo::Target;
 use proptest::prelude::*;
 
 /// Shared triangulation created once (fixed seed, cheap).

--- a/tests/semgrep/doctests/unwrap_expect.txt
+++ b/tests/semgrep/doctests/unwrap_expect.txt
@@ -1,0 +1,8 @@
+// ruleid: causal-triangulations.rust.no-unwrap-expect-in-doctests
+/// let value = Some(1_u32).unwrap();
+
+// ruleid: causal-triangulations.rust.no-unwrap-expect-in-doctests
+//! let value = Ok::<u32, &'static str>(1).expect("doctest should not panic");
+
+// ok: causal-triangulations.rust.no-unwrap-expect-in-doctests
+/// # fn main() -> causal_triangulations::CdtResult<()> { Ok(()) }

--- a/tests/semgrep/doctests/unwrap_expect.txt
+++ b/tests/semgrep/doctests/unwrap_expect.txt
@@ -6,3 +6,9 @@
 
 // ok: causal-triangulations.rust.no-unwrap-expect-in-doctests
 /// # fn main() -> causal_triangulations::CdtResult<()> { Ok(()) }
+
+// ok: causal-triangulations.rust.no-unwrap-expect-in-doctests
+/// Do not use `.unwrap()` in public examples.
+
+// ok: causal-triangulations.rust.no-unwrap-expect-in-doctests
+/// Prefer `?` to `.expect("message")` in public examples.

--- a/tests/semgrep/src/project_rules/bench_example_usage.rs
+++ b/tests/semgrep/src/project_rules/bench_example_usage.rs
@@ -1,0 +1,13 @@
+#![forbid(unsafe_code)]
+#![allow(dead_code)]
+
+fn benchmark_and_example_fixture(result: Result<u32, &'static str>, value: Option<u32>) {
+    // ruleid: causal-triangulations.rust.no-unwrap-expect-in-benches-examples, causal-triangulations.rust.no-bare-unwrap-in-src
+    let _ = result.unwrap();
+
+    // ruleid: causal-triangulations.rust.no-unwrap-expect-in-benches-examples
+    let _ = value.expect("benchmarks and examples should avoid expect");
+
+    // ok: causal-triangulations.rust.no-unwrap-expect-in-benches-examples
+    let _ = result.unwrap_or(0);
+}

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -101,10 +101,10 @@ mod tests {
 }
 
 fn production_unwrap_and_panic_fixture(result: Result<u32, &'static str>, value: Option<u32>) {
-    // ruleid: causal-triangulations.rust.no-bare-unwrap-in-src, causal-triangulations.rust.no-unwrap-expect-in-benches-examples
+    // ruleid: causal-triangulations.rust.no-bare-unwrap-in-src
     let _ = result.unwrap();
 
-    // ruleid: causal-triangulations.rust.no-bare-unwrap-in-src, causal-triangulations.rust.no-unwrap-expect-in-benches-examples
+    // ruleid: causal-triangulations.rust.no-bare-unwrap-in-src
     let _ = value.unwrap();
 
     // ok: causal-triangulations.rust.no-bare-unwrap-in-src
@@ -117,7 +117,6 @@ fn production_unwrap_and_panic_fixture(result: Result<u32, &'static str>, value:
 #[cfg(test)]
 fn test_only_unwrap_and_panic_fixture(result: Result<u32, &'static str>) {
     // ok: causal-triangulations.rust.no-bare-unwrap-in-src
-    // ruleid: causal-triangulations.rust.no-unwrap-expect-in-benches-examples
     let _ = result.unwrap();
 
     // ok: causal-triangulations.rust.no-panic-in-src
@@ -128,7 +127,6 @@ fn test_only_unwrap_and_panic_fixture(result: Result<u32, &'static str>) {
 mod prop_tests {
     fn helper(result: Result<u32, &'static str>) {
         // ok: causal-triangulations.rust.no-bare-unwrap-in-src
-        // ruleid: causal-triangulations.rust.no-unwrap-expect-in-benches-examples
         let _ = result.unwrap();
 
         // ok: causal-triangulations.rust.no-panic-in-src

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -101,6 +101,7 @@ mod tests {
 }
 
 fn production_unwrap_and_panic_fixture(result: Result<u32, &'static str>, value: Option<u32>) {
+    // Fixture path: tests/semgrep/src/project_rules/rust_style.rs.
     // ruleid: causal-triangulations.rust.no-bare-unwrap-in-src
     let _ = result.unwrap();
 
@@ -116,6 +117,7 @@ fn production_unwrap_and_panic_fixture(result: Result<u32, &'static str>, value:
 
 #[cfg(test)]
 fn test_only_unwrap_and_panic_fixture(result: Result<u32, &'static str>) {
+    // Fixture path: tests/semgrep/src/project_rules/rust_style.rs.
     // ok: causal-triangulations.rust.no-bare-unwrap-in-src
     let _ = result.unwrap();
 
@@ -126,6 +128,7 @@ fn test_only_unwrap_and_panic_fixture(result: Result<u32, &'static str>) {
 #[cfg(test)]
 mod prop_tests {
     fn helper(result: Result<u32, &'static str>) {
+        // Fixture path: tests/semgrep/src/project_rules/rust_style.rs.
         // ok: causal-triangulations.rust.no-bare-unwrap-in-src
         let _ = result.unwrap();
 

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -101,10 +101,10 @@ mod tests {
 }
 
 fn production_unwrap_and_panic_fixture(result: Result<u32, &'static str>, value: Option<u32>) {
-    // ruleid: causal-triangulations.rust.no-bare-unwrap-in-src
+    // ruleid: causal-triangulations.rust.no-bare-unwrap-in-src, causal-triangulations.rust.no-unwrap-expect-in-benches-examples
     let _ = result.unwrap();
 
-    // ruleid: causal-triangulations.rust.no-bare-unwrap-in-src
+    // ruleid: causal-triangulations.rust.no-bare-unwrap-in-src, causal-triangulations.rust.no-unwrap-expect-in-benches-examples
     let _ = value.unwrap();
 
     // ok: causal-triangulations.rust.no-bare-unwrap-in-src
@@ -117,6 +117,7 @@ fn production_unwrap_and_panic_fixture(result: Result<u32, &'static str>, value:
 #[cfg(test)]
 fn test_only_unwrap_and_panic_fixture(result: Result<u32, &'static str>) {
     // ok: causal-triangulations.rust.no-bare-unwrap-in-src
+    // ruleid: causal-triangulations.rust.no-unwrap-expect-in-benches-examples
     let _ = result.unwrap();
 
     // ok: causal-triangulations.rust.no-panic-in-src
@@ -127,6 +128,7 @@ fn test_only_unwrap_and_panic_fixture(result: Result<u32, &'static str>) {
 mod prop_tests {
     fn helper(result: Result<u32, &'static str>) {
         // ok: causal-triangulations.rust.no-bare-unwrap-in-src
+        // ruleid: causal-triangulations.rust.no-unwrap-expect-in-benches-examples
         let _ = result.unwrap();
 
         // ok: causal-triangulations.rust.no-panic-in-src


### PR DESCRIPTION
- Convert public Rust doctests to CdtResult-based flows with typed error propagation.
- Add Semgrep guardrails for unwrap/expect in doctests, benches, and examples.
- Preserve standalone CDT proposal application failures as typed CdtError variants.
- Re-export MCMC simulation traits from the simulation prelude for proposal workflows.
- Replace benchmark fixture expect paths with operation-aware setup helpers.

Closes #151