### PR TITLE
refactor(cdt)!: split Metropolis into module tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,13 +139,14 @@ Commit bodies appear **verbatim** in `CHANGELOG.md` (indented by git‑cliff's t
 - The **type** determines the changelog section (`feat` → Added, `fix` → Fixed, `refactor`/`test`/`style` → Changed, `perf` → Performance, `docs` →
   Documentation, `build`/`chore`/`ci` → Maintenance).
 - Include **PR references** as `(#N)` in the subject — cliff auto‑links them (e.g. `feat: add foo (#42)`).
-- **Avoid headings** `#`–`###` in the body — they conflict with changelog structure (`##` = release, `###` = section). Use `####` if a heading is truly needed.
+- **Avoid headings** `#`–`###` in the body — they conflict with changelog structure (`##` = release, `###` = section). Use `####` if a heading is truly
+  needed.
 - Body text should be **plain prose or simple lists**. Numbered lists and sub‑items are fine but avoid deep nesting.
 
 #### Breaking Changes
 
-Breaking changes **must** use one of these conventional commit markers so that `git‑cliff` can detect them and generate the `### ⚠️ Breaking Changes` section in
-`CHANGELOG.md`:
+Breaking changes **must** use one of these conventional commit markers so that `git‑cliff` can detect them and generate the `### ⚠️ Breaking Changes`
+section in `CHANGELOG.md`:
 
 - **Bang notation**: `feat!: remove deprecated API` (append `!` after the type/scope)
 - **Footer trailer**: add `BREAKING CHANGE: <description>` as a [git trailer](https://git-scm.com/docs/git-interpret-trailers) at the end of the commit body

--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ cargo build --release
   --output-json toroidal-summary.json
 ```
 
-Prefer `--vertices-per-slice` for regular equal-slice initial data; the binary computes the total initial vertex count as `vertices_per_slice × timeslices`. Use
-`--volume-profile N0,N1,...` for explicit nonuniform spatial slice volumes; when supplied without `--timeslices`, the number of profile entries defines the
-time-slice count. `--vertices` is still accepted when you already know the total for regular data, but it must divide evenly by `--timeslices`. Open-boundary
-runs require at least 4 vertices per slice and toroidal runs require at least 3 vertices per slice. Without `--simulate`, the binary only builds the initial
-triangulation and writes the step-0 measurement.
+Prefer `--vertices-per-slice` for regular equal-slice initial data; the binary computes the total initial vertex count as
+`vertices_per_slice × timeslices`. Use `--volume-profile N0,N1,...` for explicit nonuniform spatial slice volumes; when supplied without `--timeslices`, the
+number of profile entries defines the time-slice count. `--vertices` is still accepted when you already know the total for regular data, but it must divide
+evenly by `--timeslices`. Open-boundary runs require at least 4 vertices per slice and toroidal runs require at least 3 vertices per slice. Without
+`--simulate`, the binary only builds the initial triangulation and writes the step-0 measurement.
 
 ### Ensemble And Volume Behavior
 
@@ -106,6 +106,11 @@ volume term in the action. Use `--cosmological-constant` to tune that behavior. 
 minimum-volume configurations or toward rapid growth; this is expected physics for the unfixed ensemble, not volume fixing.
 Automated λ-scan utilities for finding practical finite-volume windows are planned as [#143](https://github.com/acgetchell/causal-triangulations/issues/143);
 for v0.1.0, tune `--cosmological-constant` manually and inspect the reported volume and acceptance diagnostics.
+
+The default 1+1 action constants use `κ0 = 0`, `κ2 = 0`, and an edge-count cosmological constant `(2 / 3) ln 2`, mapping the crate's `λ N1` convention to the
+standard 2D CDT critical triangle-volume coupling `λc = ln 2` for closed toroidal triangulations. The Delaunay backend supplies construction and validation
+infrastructure for a well-formed initial PL triangulation; the simulation ensemble is defined by CDT moves, constraints, action, and Metropolis-Hastings
+acceptance, not by maintaining Delaunayhood after every move.
 
 Higher-dimensional CDT studies often use explicit approximate volume fixing for finite-size numerical work. For example, Ambjørn et al. discuss quadratic
 volume fixing in [The Semiclassical Limit of Causal Dynamical Triangulations](https://arxiv.org/abs/1102.3929), and the toroidal phase-structure study uses

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -75,9 +75,9 @@ This section contains the seminal papers and foundational work that established 
 - Ambjørn, J., Budd, T., and Watabiki, Y. "Scale-dependent Hausdorff dimensions in 2d gravity." _Physics Letters B_ 736 (2014): 339-343. DOI:
   [10.1016/j.physletb.2014.07.047](https://doi.org/10.1016/j.physletb.2014.07.047). arXiv: [1406.6251](https://arxiv.org/abs/1406.6251)
 
-- Ambjørn, J., Gizbert-Studnicki, J., Görlich, A., Jurkiewicz, J., and Németh, D. "The phase structure of causal dynamical triangulations with toroidal spatial
-  topology." _Journal of High Energy Physics_ 2018, no. 6 (2018): 111. DOI: [10.1007/JHEP06(2018)111](https://doi.org/10.1007/JHEP06(2018)111). arXiv:
-  [1802.10434](https://arxiv.org/abs/1802.10434)
+- Ambjørn, J., Gizbert-Studnicki, J., Görlich, A., Jurkiewicz, J., and Németh, D. "The phase structure of causal dynamical triangulations with toroidal
+  spatial topology." _Journal of High Energy Physics_ 2018, no. 6 (2018): 111. DOI:
+  [10.1007/JHEP06(2018)111](https://doi.org/10.1007/JHEP06(2018)111). arXiv: [1802.10434](https://arxiv.org/abs/1802.10434)
 
 - Ambjørn, J., Görlich, A. T., Jurkiewicz, J., Loll, R., Gizbert-Studnicki, J., and Trześniewski, T. "The semiclassical limit of causal dynamical
   triangulations." _Nuclear Physics B_ 849, no. 1 (2011): 144-165. DOI:
@@ -130,6 +130,13 @@ improvements to the `markov-chain-monte-carlo` crate. Refer to that crate and it
 
 - Hastings, W. K. "Monte Carlo sampling methods using Markov chains and their applications." _Biometrika_ 57, no. 1 (1970): 97-109. DOI:
   [10.1093/biomet/57.1.97](https://doi.org/10.1093/biomet/57.1.97)
+
+### 1+1 CDT Coupling Calibration
+
+- The default non-volume-fixed 1+1 CDT action constants use the critical 2D CDT cosmological coupling `lambda_c = ln 2` from the exactly solved model described
+  by Ambjørn and Loll (1998) and reviewed by Ambjørn, Görlich, Jurkiewicz, and Loll (2012). Because this crate's action writes the cosmological term as
+  `lambda_edge N1` while the standard 2D CDT convention weights triangle volume `N2`, the default toroidal edge-count value is
+  `lambda_edge = (2 / 3) ln 2`, using the closed 1+1 relation `N1 = 3 N2 / 2`.
 
 ### Regge Calculus and Discrete Action
 

--- a/docs/CLI_EXAMPLES.md
+++ b/docs/CLI_EXAMPLES.md
@@ -42,7 +42,7 @@ The `cdt` binary accepts various command-line arguments to configure and run CDT
 
 - `--coupling-0 <κ₀>`: Coupling constant for vertices (default: 1.0)
 - `--coupling-2 <κ₂>`: Coupling constant for triangles (default: 1.0)
-- `--cosmological-constant <λ>`: Cosmological constant (default: 0.1)
+- `--cosmological-constant <λ>`: Edge-count cosmological constant (default: `(2 / 3) ln 2`)
 
 ### Additional Options
 

--- a/docs/PERFORMANCE_TESTING.md
+++ b/docs/PERFORMANCE_TESTING.md
@@ -377,16 +377,16 @@ just perf-check 5.0   # Strict threshold before completion
 ### Data Flow
 
 ```text
-┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
-│ Criterion       │───▶│ Performance      │───▶│ Reports &       │
-│ Benchmarks      │    │ Analysis Script  │    │ Comparisons     │
-└─────────────────┘    └──────────────────┘    └─────────────────┘
-         │                       │                        │
-         ▼                       ▼                        ▼
-┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
-│ JSON Results    │    │ Baseline         │    │ CI Comments &   │
-│ (target/criterion)│    │ Storage          │    │ Artifacts       │
-└─────────────────┘    └──────────────────┘    └─────────────────┘
+┌───────────┐     ┌──────────┐     ┌─────────────┐
+│ Criterion │───▶│ Analysis │───▶│ Reports     │
+│ benches   │     │ script   │     │ comparisons │
+└───────────┘     └──────────┘     └─────────────┘
+      │                │                 │
+      ▼                ▼                 ▼
+┌───────────┐     ┌──────────┐     ┌─────────────┐
+│ JSON      │     │ Baseline │     │ CI comments │
+│ results   │     │ storage  │     │ artifacts   │
+└───────────┘     └──────────┘     └─────────────┘
 ```
 
 This system provides comprehensive performance monitoring while remaining easy to use for both contributors and maintainers.

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -89,7 +89,12 @@ causal-triangulations/
 │   │   ├── action.rs
 │   │   ├── ergodic_moves.rs
 │   │   ├── foliation.rs
-│   │   ├── metropolis.rs
+│   │   ├── metropolis/
+│   │   │   ├── adapter.rs
+│   │   │   ├── checkpoint.rs
+│   │   │   ├── helpers.rs
+│   │   │   ├── runner.rs
+│   │   │   └── telemetry.rs
 │   │   ├── observables.rs
 │   │   ├── results.rs
 │   │   ├── triangulation.rs
@@ -227,10 +232,10 @@ The implementation is split into child modules under `src/cdt/triangulation/`:
 - `OpenBoundary` (default) — finite strip with boundary, χ ∈ {1, 2}
 - `Toroidal` — periodic in space and time, S¹×S¹, χ = 0
 - Wired through `CdtConfig.topology`, `CdtConfigOverrides.topology`, the CLI `--topology` flag, and `CdtMetadata.topology`
-- `run_simulation()` dispatches on topology and profile mode: regular `Toroidal` → `from_toroidal_cdt`, regular `OpenBoundary` → `from_cdt_strip`, and explicit
-  `CdtConfig.volume_profile` → the matching profile constructor; `vertices` is always the total vertex count
+- `run_simulation()` dispatches on topology and profile mode: regular `Toroidal` → `from_toroidal_cdt`, regular `OpenBoundary` → `from_cdt_strip`, and
+  explicit `CdtConfig.volume_profile` → the matching profile constructor; `vertices` is always the total vertex count
 
-### `cdt/metropolis.rs` — Metropolis move ordering
+### `cdt/metropolis/` — Metropolis move ordering
 
 `MetropolisAlgorithm::run()` is the current CDT production runner for proposal-before-mutation sampling. It proposes a move type, samples an explicit local
 proposal site from the same universe used for proposal counts, plans that site on a cloned triangulation, computes `ΔS` and the forward/reverse
@@ -238,9 +243,13 @@ Metropolis-Hastings site-count ratio, accepts or rejects the concrete proposal, 
 geometric, and backend edit failures are self-loop proposal outcomes recorded in `ProposalStatistics`; hard backend failures remain structured errors.
 Toroidal move finalization rejects and rolls back candidate sites that would violate χ = 0 or the closed-S¹ per-slice foliation invariant.
 
-This direct M-H loop is transitional. The module also contains CDT adapters for `markov-chain-monte-carlo`, and the production runner should migrate toward
-delegating generic acceptance, proposal-ratio application, chain counters, and delayed-proposal commit ordering to that upstream crate while retaining
-CDT-specific telemetry and result conversion. See `docs/metropolis.md` for the detailed ordering and
+The module tree is declared from `src/lib.rs` to avoid the `metropolis.rs` plus `metropolis/` layout pattern. `adapter.rs` is the single CDT adapter boundary
+for `markov-chain-monte-carlo` proposal and target traits. `runner.rs` keeps the transitional production step loop, `checkpoint.rs` owns resumable checkpoint
+state and resume validation, `telemetry.rs` owns public step/proposal telemetry, and `helpers.rs` holds shared CDT-domain calculations.
+
+This direct M-H loop is transitional. The production runner should migrate toward delegating generic acceptance, proposal-ratio application, chain counters, and
+delayed-proposal commit ordering to the upstream MCMC crate while retaining CDT-specific telemetry and result conversion. See `docs/metropolis.md` for the
+detailed ordering and
 [`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155) for the boundary refactor.
 
 ### `cdt/results.rs` — Simulation outputs
@@ -252,8 +261,8 @@ CDT-specific telemetry and result conversion. See `docs/metropolis.md` for the d
 
 ### `cdt/observables.rs` — User-facing estimators
 
-- `estimate_hausdorff_dimension` — estimates Hausdorff dimension from combinatorial dual-graph geodesic ball growth, returning `None` when the triangulation is
-  too small or live face adjacency cannot be resolved
+- `estimate_hausdorff_dimension` — estimates Hausdorff dimension from combinatorial dual-graph geodesic ball growth, returning `None` when the triangulation
+  is too small or live face adjacency cannot be resolved
 - `estimate_spectral_dimension` — estimates spectral dimension from dual-graph diffusion return probability, returning `None` when the graph is too small or
   lacks enough positive return-probability samples for a fit
 - `CdtTriangulation::volume_profile` measures per-slice triangle counts on a triangulation; `SimulationResultsBackend` provides aggregate volume-profile
@@ -280,8 +289,8 @@ CDT-specific telemetry and result conversion. See `docs/metropolis.md` for the d
 
 - `generate_delaunay2` — builds a 2D Delaunay triangulation with optional seed
 - `build_delaunay2_with_data` — builds from coordinate + vertex-data pairs
-- `build_delaunay2_from_simplices` / `build_delaunay2_with_topology` — builds from explicit simplex connectivity (no Delaunay point insertion); the latter also
-  accepts `TopologyGuarantee` and `GlobalTopology` metadata for supported explicit topologies
+- `build_delaunay2_from_simplices` / `build_delaunay2_with_topology` — builds from explicit simplex connectivity (no Delaunay point insertion); the latter
+  also accepts `TopologyGuarantee` and `GlobalTopology` metadata for supported explicit topologies
 - `build_toroidal_delaunay2` — API-compatibility wrapper for explicit toroidal meshes; with `delaunay` v0.7.8 it validates the domain and reports the upstream
   explicit-toroidal topology limitation
 - `build_periodic_toroidal_delaunay2` — builds true periodic toroidal Delaunay meshes through the upstream image-point constructor

--- a/docs/foliation.md
+++ b/docs/foliation.md
@@ -4,8 +4,8 @@ Per-vertex time labels, edge classification, and causal validation for 1+1 CDT.
 
 ## Background
 
-In Causal Dynamical Triangulations (Ambjørn, Jurkiewicz, Loll 2001), spacetime is built from simplices arranged in a **foliation** — a layered structure where
-each time slice is a spatial manifold and adjacent slices are connected by timelike edges.
+In Causal Dynamical Triangulations (Ambjørn, Jurkiewicz, Loll 2001), spacetime is built from simplices arranged in a **foliation** — a layered structure
+where each time slice is a spatial manifold and adjacent slices are connected by timelike edges.
 
 For the periodic 1+1 CDT cases:
 
@@ -14,10 +14,10 @@ For the periodic 1+1 CDT cases:
 - **Edge classification**: spacelike (both endpoints at same t) or timelike (endpoints at t and t±1)
 - **Causality constraint**: no edge may span more than one time slice (|Δt| ≤ 1)
 
-This implementation also supports open-boundary strip variants. `from_toroidal_cdt()` builds the periodic S¹ × S¹ toroidal case, while `from_cdt_strip()` builds
-regular open spatial-interval strip geometries over discrete time. Profile constructors, `from_cdt_strip_profile()` and `from_toroidal_cdt_profile()`, accept
-explicit per-slice spatial volumes `N(t)` for nonuniform initial data. All constructor families use the same edge classification and causality constraint, but
-their topology metadata and boundary expectations differ.
+This implementation also supports open-boundary strip variants. `from_toroidal_cdt()` builds the periodic S¹ × S¹ toroidal case, while `from_cdt_strip()`
+builds regular open spatial-interval strip geometries over discrete time. Profile constructors, `from_cdt_strip_profile()` and `from_toroidal_cdt_profile()`,
+accept explicit per-slice spatial volumes `N(t)` for nonuniform initial data. All constructor families use the same edge classification and causality
+constraint, but their topology metadata and boundary expectations differ.
 
 ## Architecture
 
@@ -38,8 +38,8 @@ CdtTriangulation<B>
 ```
 
 Vertex data is set at construction time via `VertexBuilder::data(t)`. For post-construction labeling (e.g., `assign_foliation_by_y`), labels are written
-in-place through CDT-owned helper paths — an O(1) operation per vertex that does not affect geometry or topology. Public callers do not receive mutable backend
-access; CDT mutation paths are narrow so cache and foliation synchronization state are invalidated consistently.
+in-place through CDT-owned helper paths — an O(1) operation per vertex that does not affect geometry or topology. Public callers do not receive mutable
+backend access; CDT mutation paths are narrow so cache and foliation synchronization state are invalidated consistently.
 
 ## Time Label Assignment
 
@@ -98,8 +98,8 @@ Classification is done by `classify_edge(t0, t1)`, which reads time labels from 
 - `Up` (2,1) — two vertices at time _t_, one at _t + 1_. The spacelike base is in the lower slice.
 - `Down` (1,2) — one vertex at time _t_, two at _t + 1_. The spacelike base is in the upper slice.
 
-Classification is done by `classify_simplex(t0, t1, t2)`. Triangles that don’t span exactly one time slice (e.g., all vertices at the same time, or spanning >1
-slice) return `None`.
+Classification is done by `classify_simplex(t0, t1, t2)`. Triangles that don’t span exactly one time slice (e.g., all vertices at the same time, or spanning
+>1 slice) return `None`.
 
 Simplex types are encoded as `i32` simplex data (`Up = 1`, `Down = -1`) and can be bulk-written via `classify_all_simplices()` using `set_simplex_data`. For
 foliated triangulations this bulk path is strict: every face must classify as `Up` or `Down`, otherwise `classify_all_simplices()` and
@@ -143,7 +143,8 @@ Strict simplex-classification check:
 
 - `CdtError::CausalityViolation { time_0, time_1 }` — structured error for time labels spanning more than one slice step
 - `CdtError::DelaunayGenerationFailed` — from explicit CDT constructors when builder output is inconsistent, with detailed construction context
-- `CdtError::ValidationFailed { check, detail }` — for structural foliation issues and foliation-assignment failures (for example unreadable vertex coordinates)
+- `CdtError::ValidationFailed { check, detail }` — for structural foliation issues and foliation-assignment failures, for example unreadable vertex
+  coordinates
 - `CdtError::InvalidGenerationParameters` — for invalid constructor parameters
 
 ## Regression Coverage

--- a/docs/metropolis.md
+++ b/docs/metropolis.md
@@ -34,6 +34,38 @@ after partial invariant refresh work. The recorded `SimulationResultsBackend::mo
 `SimulationResultsBackend::proposal_stats` records proposal-kernel telemetry such as no-site outcomes, sampled-site failures, Metropolis rejections, and
 accepted transitions.
 
+## Scientific Calibration And Geometry Backend Role
+
+The Delaunay backend is an implementation substrate, not the sampled physics ensemble. It gives the crate a robust way to construct an initial piecewise-linear
+manifold, validate topology and adjacency, and perform checked local edit primitives. After initialization, the simulation does not enforce the Delaunay
+condition as part of the Markov-chain state. The sampled ensemble is defined by the CDT move set, foliation/topology/causality validation, the configured
+action, and the Metropolis-Hastings acceptance rule.
+
+The default action constants are calibrated for the non-volume-fixed 1+1 CDT baseline. In pure 1+1 gravity the curvature/Newton term is topological at fixed
+topology, so the default vertex and triangle couplings are zero:
+
+```text
+kappa_0 = 0
+kappa_2 = 0
+```
+
+The exactly solved 2D CDT model has critical cosmological coupling `lambda_c = ln 2` in the triangle-volume convention where configurations are weighted by
+`exp(-lambda N2)`. This crate's historical action writes the cosmological term as `lambda_edge N1`. For closed toroidal 1+1 triangulations,
+`N1 = 3 N2 / 2`, so the default edge-count coupling is
+
+```text
+lambda_edge = (2 / 3) ln 2 ~= 0.46209812037329684
+```
+
+With these defaults, toroidal 1+1 runs map the edge-count action convention to the standard critical triangle-volume coupling. Non-volume-fixed finite runs may
+still drift because the critical point is a continuum-limit statement and there is no volume-fixing penalty. The follow-up volume-fixing work in
+[`causal-triangulations#142`](https://github.com/acgetchell/causal-triangulations/issues/142) should add an explicit modified-action ensemble for production
+fixed-volume studies.
+
+The calibration is based on Ambjørn and Loll's original 2D CDT construction and the Ambjørn, Görlich, Jurkiewicz, and Loll review. The volume-fixing follow-up
+should cite the higher-dimensional CDT simulation literature where quadratic fixing terms are added deliberately. See [REFERENCES.md](../REFERENCES.md) for the
+full citations.
+
 ## Chunked Sweeps
 
 `MetropolisAlgorithm::resume_to_checkpoint()` continues a stored `CdtMcmcCheckpoint` for the configured additional step count and returns another resumable

--- a/docs/moves.md
+++ b/docs/moves.md
@@ -12,8 +12,8 @@ with `prelude::triangulation::*` for CDT wrappers and `prelude::geometry::*` whe
 
 Enumerates the available move types:
 
-- `Move22` — (2,2) move: flip the shared edge between two triangles, preserving vertex count; causality-aware — the CDT layer validates and rejects moves that
-  break causal layering
+- `Move22` — (2,2) move: flip the shared edge between two triangles, preserving vertex count; causality-aware — the CDT layer validates and rejects moves
+  that break causal layering
 - `Move13Add` — (1,3) move: insert a new vertex by adding local CDT volume; open-boundary and unfoliated runs subdivide one triangle into three, while
   toroidal foliated runs split a spacelike link by subdividing an adjacent face and flipping the original spacelike link away. Inserted vertices receive the
   time label needed to keep the replacement simplices causal.
@@ -85,7 +85,8 @@ non-success `MoveResult`. Toroidal post-move topology or closed-ring foliation f
 site was geometrically editable but would break the periodic CDT contract.
 
 The Metropolis loop first selects an explicit local proposal site, clones the current triangulation, and applies that exact site on the cloned proposed state;
-see `src/cdt/metropolis.rs`. It then performs the accept/reject decision from the proposed move metadata; see `docs/metropolis.md`. Only accepted proposals
+see `src/cdt/metropolis/runner.rs` and `src/cdt/metropolis/adapter.rs`. It then performs the accept/reject decision from the proposed move metadata; see
+`docs/metropolis.md`. Only accepted proposals
 swap the cloned, mutated state into the live simulation. Ordinary causal, geometric, or backend edit failures on the cloned state are self-loop proposal
 outcomes recorded in `ProposalStatistics`; hard backend mutation or invariant-refresh failures still return `CdtError::MetropolisMoveApplicationFailed`.
 
@@ -102,6 +103,9 @@ detailed balance and the cosmological constant controls whether the universe siz
 For unfixed-volume runs, tune the cosmological constant rather than expecting the move kernels to preserve volume. The cosmological constant is conjugate to
 the lattice volume term, so changing it changes the relative acceptance of volume-increasing and volume-decreasing trajectories through the ordinary action
 difference. The current binary exposes this as `--cosmological-constant`, and programmatic callers set it through `ActionConfig`.
+
+The default 1+1 action constants are calibrated to the standard 2D CDT critical cosmological coupling. They use zero curvature couplings and set the edge-count
+cosmological constant to `(2 / 3) ln 2`, mapping this crate's `λ N1` action convention to `λc N2` with `λc = ln 2` on closed toroidal triangulations.
 
 Approximate volume fixing is also standard in higher-dimensional CDT when the scientific goal is a finite-size ensemble at a chosen lattice volume. In that
 case the fixing term is part of the sampled action, for example a quadratic penalty around a target volume, and detailed balance is with respect to the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,7 +54,7 @@ polish that are useful but not required for the first DOI-backed foundation rele
 
 - Add optional CDT volume fixing for bounded large-scale simulations
   ([#142](https://github.com/acgetchell/causal-triangulations/issues/142)). Volume fixing should be opt-in and documented as a modified action, not the default
-  unfixed-volume ensemble.
+  unfixed-volume ensemble calibrated to the 1+1 CDT `lambda_c = ln 2` critical coupling.
 - Add λ scan utilities for unfixed-volume 1+1 CDT runs
   ([#143](https://github.com/acgetchell/causal-triangulations/issues/143)). These should help users tune the cosmological constant, which is conjugate to the
   lattice volume term and controls volume growth or shrinkage in unfixed-volume runs.
@@ -78,8 +78,8 @@ The next CDT dimensions should advance as explicit topology tracks rather than a
   support.
 - v0.3.0 should add 2+1 CDT with spherical spatial slices (S²) after spherical topology lands in the `delaunay` crate. Treat this as a separate topology track
   rather than as a prerequisite for the first usable 2+1 toroidal release.
-- 3+1 CDT with spherical spatial slices (S³) and toroidal spatial slices (T³), following the same staged path after the required geometry-backend operations and
-  invariants are available
+- 3+1 CDT with spherical spatial slices (S³) and toroidal spatial slices (T³), following the same staged path after the required geometry-backend operations
+  and invariants are available
 - Periodic-time variants where the topology contract is well defined and the backend can validate the corresponding Euler/Poincaré-style invariants cleanly
 - Dimension-specific action terms, simplex-count bookkeeping, volume profiles, and acceptance diagnostics
 

--- a/examples/basic_cdt.rs
+++ b/examples/basic_cdt.rs
@@ -44,9 +44,6 @@ fn main() -> CdtResult<()> {
     config.steps = 100;
     config.thermalization_steps = 20;
     config.measurement_frequency = 5;
-    config.coupling_0 = 1.0;
-    config.coupling_2 = 1.0;
-    config.cosmological_constant = 0.1;
 
     // Extract individual configs
     let metropolis_config = config.to_metropolis_config();

--- a/src/cdt/action.rs
+++ b/src/cdt/action.rs
@@ -8,6 +8,22 @@
 use crate::errors::{CdtError, CdtResult, ConfigurationSetting};
 use serde::{Deserialize, Serialize};
 
+/// Critical cosmological coupling for pure 1+1 CDT in the triangle-volume convention.
+///
+/// The exactly solved 2D CDT transfer matrix has critical point `λ_c = ln 2`
+/// when triangulations are weighted by `exp(-λ N2)`, where `N2` is the number
+/// of triangles.
+pub const CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT: f64 = std::f64::consts::LN_2;
+
+/// Default edge-count cosmological coupling for toroidal 1+1 CDT runs.
+///
+/// This crate's historical action writes the cosmological term as `λ N1`.
+/// For closed toroidal 1+1 CDT triangulations, `N1 = 3 N2 / 2`, so this value
+/// maps the edge-count convention to the standard 2D CDT critical triangle
+/// coupling `λ_c = ln 2`.
+pub const DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT: f64 =
+    2.0 * CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT / 3.0;
+
 /// Calculates the 2D Regge Action for a given triangulation.
 ///
 /// The 2D Regge Action in CDT is given by:
@@ -69,12 +85,17 @@ pub struct ActionConfig {
 }
 
 impl Default for ActionConfig {
-    /// Default CDT action parameters for 2D simulations.
+    /// Default CDT action parameters for 1+1 CDT simulations.
+    ///
+    /// In pure 1+1 gravity the curvature/Newton term is topological at fixed
+    /// topology. The defaults therefore leave the vertex and triangle couplings
+    /// at zero and use the edge-count cosmological coupling that maps to the
+    /// standard 2D CDT critical value `λ_c = ln 2` for toroidal triangulations.
     fn default() -> Self {
         Self {
-            coupling_0: 1.0,
-            coupling_2: 1.0,
-            cosmological_constant: 0.1,
+            coupling_0: 0.0,
+            coupling_2: 0.0,
+            cosmological_constant: DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
         }
     }
 }
@@ -193,9 +214,12 @@ mod tests {
     #[test]
     fn test_action_config_default() {
         let config = ActionConfig::default();
-        assert_relative_eq!(config.coupling_0, 1.0);
-        assert_relative_eq!(config.coupling_2, 1.0);
-        assert_relative_eq!(config.cosmological_constant, 0.1);
+        assert_relative_eq!(config.coupling_0, 0.0);
+        assert_relative_eq!(config.coupling_2, 0.0);
+        assert_relative_eq!(
+            config.cosmological_constant,
+            DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT
+        );
     }
 
     #[test]

--- a/src/cdt/metropolis/adapter.rs
+++ b/src/cdt/metropolis/adapter.rs
@@ -1,0 +1,655 @@
+//! Adapter boundary between CDT state and `markov-chain-monte-carlo`.
+
+use crate::cdt::action::ActionConfig;
+use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveType, proposal_site_count};
+use crate::errors::{CdtError, CdtResult, MetropolisMoveApplicationFailure};
+use crate::geometry::CdtTriangulation2D;
+use markov_chain_monte_carlo::{Chain, ChainCheckpoint, DelayedProposal, McmcError, Target};
+use rand::Rng;
+use std::error::Error;
+use std::fmt;
+use std::hint::cold_path;
+
+use super::helpers::{action_for, proposed_delta_action, simplex_counts, validate_temperature};
+use super::telemetry::{CdtProposalSiteRejection, ProposalStatistics};
+
+/// Target distribution for CDT: log-probability from the Regge action.
+///
+/// Computes `log_prob = -S / T` where `S` is the discrete Regge action
+/// and `T` is the temperature.
+pub struct CdtTarget {
+    action_config: ActionConfig,
+    temperature: f64,
+}
+
+impl CdtTarget {
+    /// Creates a new CDT target distribution.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidConfiguration`] if the action couplings are
+    /// non-finite, or [`CdtError::InvalidSimulationConfiguration`] if
+    /// `temperature` is not finite and positive.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{ActionConfig, CdtTarget};
+    ///
+    /// let _target = CdtTarget::new(ActionConfig::default(), 1.0)?;
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    pub fn new(action_config: ActionConfig, temperature: f64) -> CdtResult<Self> {
+        action_config.validate()?;
+        validate_temperature(temperature)?;
+        Ok(Self {
+            action_config,
+            temperature,
+        })
+    }
+}
+
+impl Target<CdtTriangulation2D> for CdtTarget {
+    fn log_prob(&self, state: &CdtTriangulation2D) -> f64 {
+        let counts = simplex_counts(state);
+        let action =
+            self.action_config
+                .calculate_action(counts.vertices, counts.edges, counts.triangles);
+        -action / self.temperature
+    }
+}
+
+/// Concrete delayed CDT move proposal selected before committing live state.
+///
+/// A plan records the selected [`MoveType`], the action before and after the
+/// move, and a cloned triangulation containing the proposed mutation. Planning
+/// may mutate that clone to realize a concrete local site, but it never mutates
+/// the live simulation state. The delayed proposal API scores this plan with
+/// the Metropolis-Hastings forward/reverse proposal-site ratio, then commits
+/// the cloned state only if the Metropolis step accepts it.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::simulation::{
+///     ActionConfig, CdtProposal, CdtResult, CdtTriangulation, DelayedProposal, MoveType,
+/// };
+/// use rand::{SeedableRng, rngs::StdRng};
+///
+/// # fn main() -> CdtResult<()> {
+/// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+/// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
+/// let mut rng = StdRng::seed_from_u64(11);
+///
+/// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
+///     return Ok(());
+/// };
+/// assert!(matches!(
+///     plan.move_type(),
+///     MoveType::Move22 | MoveType::Move13Add | MoveType::Move31Remove | MoveType::EdgeFlip
+/// ));
+/// assert!(plan.action_before().is_finite());
+/// if let (Some(delta), Some(action_after)) = (plan.delta_action(), plan.action_after()) {
+///     approx::assert_relative_eq!(
+///         action_after,
+///         plan.action_before() + delta,
+///         epsilon = 1e-12
+///     );
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct CdtProposalPlan {
+    pub(crate) move_type: MoveType,
+    pub(crate) action_before: f64,
+    pub(crate) action_after: Option<f64>,
+    pub(crate) delta_action: Option<f64>,
+    pub(crate) forward_site_count: usize,
+    /// Reverse proposal-site denominator for the realized proposed state.
+    ///
+    /// This is the number of valid inverse-move local sites used to normalize
+    /// the reverse proposal probability in the Metropolis-Hastings site-count
+    /// ratio. It is a count of sites and must be greater than zero for a
+    /// realized proposal to have finite reverse weight.
+    pub(crate) reverse_site_count: usize,
+    pub(crate) proposed_state: CdtTriangulation2D,
+}
+
+impl CdtProposalPlan {
+    /// Returns the proposed move type.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtProposal, CdtResult, CdtTriangulation, DelayedProposal, MoveType,
+    /// };
+    /// use rand::{SeedableRng, rngs::StdRng};
+    ///
+    /// # fn main() -> CdtResult<()> {
+    /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
+    /// let mut rng = StdRng::seed_from_u64(11);
+    /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
+    ///     return Ok(());
+    /// };
+    /// assert!(matches!(
+    ///     plan.move_type(),
+    ///     MoveType::Move22 | MoveType::Move13Add | MoveType::Move31Remove | MoveType::EdgeFlip
+    /// ));
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub const fn move_type(&self) -> MoveType {
+        self.move_type
+    }
+
+    /// Returns the current action used to score this proposal.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtProposal, CdtResult, CdtTriangulation, DelayedProposal,
+    /// };
+    /// use rand::{SeedableRng, rngs::StdRng};
+    ///
+    /// # fn main() -> CdtResult<()> {
+    /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
+    /// let mut rng = StdRng::seed_from_u64(11);
+    /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
+    ///     return Ok(());
+    /// };
+    /// assert!(plan.action_before().is_finite());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub const fn action_before(&self) -> f64 {
+        self.action_before
+    }
+
+    /// Returns the action of the concrete proposed state, if one was realized.
+    ///
+    /// A value of `None` means the selected move could not be scored or
+    /// realized, so [`DelayedProposal::proposed_log_prob`] treats the plan as
+    /// impossible.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtProposal, CdtResult, CdtTriangulation, DelayedProposal,
+    /// };
+    /// use rand::{SeedableRng, rngs::StdRng};
+    ///
+    /// # fn main() -> CdtResult<()> {
+    /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
+    /// let mut rng = StdRng::seed_from_u64(11);
+    /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
+    ///     return Ok(());
+    /// };
+    /// assert_eq!(plan.action_after().is_some(), plan.delta_action().is_some());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub const fn action_after(&self) -> Option<f64> {
+        self.action_after
+    }
+
+    /// Returns the concrete proposal action change, if it can be evaluated.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtProposal, CdtResult, CdtTriangulation, DelayedProposal,
+    /// };
+    /// use rand::{SeedableRng, rngs::StdRng};
+    ///
+    /// # fn main() -> CdtResult<()> {
+    /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
+    /// let mut rng = StdRng::seed_from_u64(11);
+    /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
+    ///     return Ok(());
+    /// };
+    /// if let (Some(delta), Some(action_after)) = (plan.delta_action(), plan.action_after()) {
+    ///     approx::assert_relative_eq!(
+    ///         action_after,
+    ///         plan.action_before() + delta,
+    ///         epsilon = 1e-12
+    ///     );
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub const fn delta_action(&self) -> Option<f64> {
+        self.delta_action
+    }
+}
+
+/// Telemetry returned by delayed CDT proposal steps.
+///
+/// The sampler receives this compact record after a plan has been scored. It is
+/// intended for diagnostics and measurement backends that need to report which
+/// move family was proposed without exposing the private plan fields.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::simulation::{
+///     ActionConfig, CdtProposal, CdtResult, CdtTriangulation, DelayedProposal,
+/// };
+/// use rand::{SeedableRng, rngs::StdRng};
+///
+/// # fn main() -> CdtResult<()> {
+/// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+/// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
+/// let mut rng = StdRng::seed_from_u64(11);
+/// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
+///     return Ok(());
+/// };
+///
+/// let info = proposal.info(&plan);
+/// assert_eq!(info.move_type, plan.move_type());
+/// assert_eq!(info.delta_action.is_some(), plan.delta_action().is_some());
+/// if let (Some(info_delta), Some(plan_delta)) = (info.delta_action, plan.delta_action()) {
+///     approx::assert_relative_eq!(info_delta, plan_delta, epsilon = 1e-12);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CdtProposalInfo {
+    /// Move type selected for the proposal.
+    pub move_type: MoveType,
+    /// Action before the proposal.
+    pub action_before: f64,
+    /// Action after the proposal if the count-level delta is valid.
+    pub action_after: Option<f64>,
+    /// Proposed action change.
+    pub delta_action: Option<f64>,
+}
+
+/// Error reported by delayed CDT proposal planning or commit.
+///
+/// No-site outcomes are ordinary proposal absence and are reported from
+/// [`DelayedProposal::propose_plan`] as `Ok(None)`, matching the upstream
+/// delayed-commit contract. `ApplicationFailed` represents a hard backend or
+/// invariant failure while constructing or committing a concrete proposal, and
+/// preserves the typed [`CdtError`] that caused the failed application.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::errors::{BackendMutationOperation, CdtError};
+/// use causal_triangulations::prelude::simulation::{CdtProposalError, MoveType};
+///
+/// let err = CdtProposalError::ApplicationFailed {
+///     move_type: MoveType::Move13Add,
+///     attempt: 2,
+///     source: CdtError::BackendMutationFailed {
+///         operation: BackendMutationOperation::SetVertexDataByKey,
+///         target: "vertex VertexKey(7)".to_string(),
+///         detail: "backend rejected mutation".to_string(),
+///     },
+/// };
+/// assert!(err.to_string().contains("Move13Add"));
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum CdtProposalError {
+    /// Constructing or applying a concrete proposal hit a hard backend or invariant failure.
+    ApplicationFailed {
+        /// Move type whose concrete application failed.
+        move_type: MoveType,
+        /// Local-site attempt that hit the hard failure.
+        attempt: usize,
+        /// Typed lower-level failure observed while committing the accepted move.
+        source: CdtError,
+    },
+}
+
+impl fmt::Display for CdtProposalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ApplicationFailed {
+                move_type,
+                attempt,
+                source,
+            } => write!(
+                f,
+                "failed to apply {move_type:?} on attempt {attempt}: {source}"
+            ),
+        }
+    }
+}
+
+impl Error for CdtProposalError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::ApplicationFailed { source, .. } => Some(source),
+        }
+    }
+}
+
+impl From<CdtProposalError> for CdtError {
+    fn from(error: CdtProposalError) -> Self {
+        match error {
+            CdtProposalError::ApplicationFailed {
+                move_type,
+                attempt,
+                source,
+            } => Self::ProposalApplicationFailed {
+                move_type,
+                attempt,
+                source: MetropolisMoveApplicationFailure::from(source),
+            },
+        }
+    }
+}
+
+/// Delayed-commit CDT proposal distribution.
+///
+/// This adapter exposes CDT's clone-plan-commit move ordering through the
+/// [`DelayedProposal`] API. It plans a concrete local move on a cloned
+/// triangulation, scores the proposed state with the same [`ActionConfig`] as
+/// the matching [`CdtTarget`] or [`MetropolisAlgorithm`](super::MetropolisAlgorithm), corrects for
+/// forward/reverse proposal-site counts, and commits the clone only after
+/// acceptance.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::simulation::{
+///     ActionConfig, CdtProposal, CdtResult, CdtTriangulation, DelayedProposal,
+/// };
+/// use rand::{SeedableRng, rngs::StdRng};
+///
+/// # fn main() -> CdtResult<()> {
+/// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+/// let mut proposal = CdtProposal::new(ActionConfig::default())?;
+/// let mut rng = StdRng::seed_from_u64(7);
+///
+/// let plan = proposal.propose_plan(&tri, &mut rng)?;
+/// if let Some(plan) = plan {
+///     assert!(plan.action_before().is_finite());
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub struct CdtProposal {
+    action_config: ActionConfig,
+    moves: ErgodicsSystem,
+}
+
+impl CdtProposal {
+    /// Creates a new unseeded delayed CDT proposal distribution.
+    ///
+    /// Delayed scoring is delegated to the target passed to
+    /// [`DelayedProposal::proposed_log_prob`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidConfiguration`] if the action couplings are
+    /// non-finite.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{ActionConfig, CdtProposal};
+    ///
+    /// let _proposal = CdtProposal::new(ActionConfig::default())?;
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    pub fn new(action_config: ActionConfig) -> CdtResult<Self> {
+        action_config.validate()?;
+        Ok(Self {
+            action_config,
+            moves: ErgodicsSystem::new(),
+        })
+    }
+
+    /// Creates a seeded delayed CDT proposal distribution.
+    ///
+    /// The seed controls the internal move-family selector. The `rng` passed to
+    /// [`DelayedProposal::propose_plan`] is still accepted for compatibility
+    /// with generic MCMC drivers.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidConfiguration`] if the action couplings are
+    /// non-finite.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{ActionConfig, CdtProposal};
+    ///
+    /// let _proposal = CdtProposal::with_seed(ActionConfig::default(), 42)?;
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    pub fn with_seed(action_config: ActionConfig, seed: u64) -> CdtResult<Self> {
+        action_config.validate()?;
+        Ok(Self {
+            action_config,
+            moves: ErgodicsSystem::with_seed(seed),
+        })
+    }
+}
+
+impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
+    type Plan = CdtProposalPlan;
+    type Info = CdtProposalInfo;
+    type Error = CdtProposalError;
+
+    fn propose_plan<R: Rng + ?Sized>(
+        &mut self,
+        state: &CdtTriangulation2D,
+        _rng: &mut R,
+    ) -> Result<Option<Self::Plan>, Self::Error> {
+        let move_type = self.moves.select_random_move();
+        let action_before = action_for(&self.action_config, state);
+        let mut proposal_stats = ProposalStatistics::new();
+        let plan = match propose_concrete_plan(
+            state,
+            &mut self.moves,
+            &mut proposal_stats,
+            &self.action_config,
+            move_type,
+            action_before,
+        ) {
+            Ok(Some(plan)) => plan,
+            Ok(None) => {
+                cold_path();
+                return Ok(None);
+            }
+            Err(err) => {
+                cold_path();
+                return Err(CdtProposalError::ApplicationFailed {
+                    move_type,
+                    attempt: err.attempt,
+                    source: err.source,
+                });
+            }
+        };
+        Ok(Some(plan))
+    }
+
+    fn proposed_log_prob<T: Target<CdtTriangulation2D>>(
+        &self,
+        _state: &CdtTriangulation2D,
+        plan: &Self::Plan,
+        target: &T,
+    ) -> Result<f64, Self::Error> {
+        Ok(plan
+            .action_after
+            .map_or(f64::NEG_INFINITY, |_| target.log_prob(&plan.proposed_state)))
+    }
+
+    fn log_q_ratio(
+        &self,
+        state: &CdtTriangulation2D,
+        plan: &Self::Plan,
+    ) -> Result<f64, Self::Error> {
+        Ok(concrete_log_q_ratio(state, plan))
+    }
+
+    fn info(&self, plan: &Self::Plan) -> Self::Info {
+        CdtProposalInfo {
+            move_type: plan.move_type,
+            action_before: plan.action_before,
+            action_after: plan.action_after,
+            delta_action: plan.delta_action,
+        }
+    }
+
+    fn commit<R: Rng + ?Sized>(
+        &mut self,
+        state: &mut CdtTriangulation2D,
+        plan: Self::Plan,
+        _rng: &mut R,
+    ) -> Result<(), Self::Error> {
+        *state = plan.proposed_state;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct MoveApplicationError {
+    pub(crate) attempt: usize,
+    pub(crate) source: CdtError,
+}
+
+/// Plans one concrete CDT proposal without mutating the live chain state.
+///
+/// The helper samples a local site, applies it to a cloned triangulation, and
+/// records the forward and reverse proposal-site counts needed for the
+/// Hastings correction. Ordinary no-site, causality, geometry, and recoverable
+/// backend rejections return `Ok(None)` so the public delayed proposal API can
+/// expose them as self-loop proposals.
+///
+/// # Errors
+///
+/// Returns [`MoveApplicationError`] only for hard backend or invariant failures
+/// that must surface through [`CdtProposalError::ApplicationFailed`].
+pub(crate) fn propose_concrete_plan(
+    state: &CdtTriangulation2D,
+    moves: &mut ErgodicsSystem,
+    proposal_stats: &mut ProposalStatistics,
+    action_config: &ActionConfig,
+    move_type: MoveType,
+    action_before: f64,
+) -> Result<Option<CdtProposalPlan>, MoveApplicationError> {
+    if proposed_delta_action(action_config, simplex_counts(state), move_type).is_none() {
+        proposal_stats.record_move_family(0);
+        proposal_stats.record_no_site();
+        return Ok(None);
+    }
+    let selection = moves.select_proposal_site(state, move_type);
+    let forward_site_count = selection.site_count;
+    proposal_stats.record_move_family(forward_site_count);
+    let Some(site) = selection.site else {
+        proposal_stats.record_no_site();
+        return Ok(None);
+    };
+
+    let mut proposed_state = state.clone();
+    let move_stats_before = moves.stats.clone();
+    let result = moves.apply_proposal_site(&mut proposed_state, move_type, site);
+    moves.stats = move_stats_before;
+    let action_after = match result {
+        MoveResult::Success => action_for(action_config, &proposed_state),
+        MoveResult::HardFailure(err) => {
+            return Err(MoveApplicationError {
+                attempt: 1,
+                source: err,
+            });
+        }
+        MoveResult::CausalityViolation => {
+            proposal_stats.record_site_rejection(&CdtProposalSiteRejection::CausalityViolation);
+            return Ok(None);
+        }
+        MoveResult::GeometricViolation => {
+            proposal_stats.record_site_rejection(&CdtProposalSiteRejection::GeometricViolation);
+            return Ok(None);
+        }
+        MoveResult::Rejected(err) => {
+            proposal_stats.record_site_rejection(&CdtProposalSiteRejection::Kernel(err));
+            return Ok(None);
+        }
+    };
+    let delta_action = action_after - action_before;
+    let reverse_site_count = proposal_site_count(&proposed_state, reverse_move_type(move_type));
+
+    Ok(Some(CdtProposalPlan {
+        move_type,
+        action_before,
+        action_after: Some(action_after),
+        delta_action: Some(delta_action),
+        forward_site_count,
+        reverse_site_count,
+        proposed_state,
+    }))
+}
+
+/// Computes the Hastings proposal-density correction for a concrete plan.
+///
+/// The ratio uses the instantaneous forward and reverse local-site counts from
+/// the selected move family. Zero denominators represent impossible proposal
+/// weights and are scored as negative infinity rather than panicking.
+pub(crate) fn concrete_log_q_ratio(_state: &CdtTriangulation2D, plan: &CdtProposalPlan) -> f64 {
+    let forward_sites = plan.forward_site_count;
+    if forward_sites == 0 {
+        return f64::NEG_INFINITY;
+    }
+
+    let reverse_sites = plan.reverse_site_count;
+    if reverse_sites == 0 {
+        return f64::NEG_INFINITY;
+    }
+
+    site_count_to_f64(forward_sites).ln() - site_count_to_f64(reverse_sites).ln()
+}
+
+/// Restores a checkpointed triangulation through the upstream MCMC chain type.
+///
+/// The conversion reuses `markov-chain-monte-carlo` target validation before
+/// CDT resume logic rebuilds domain-specific run state.
+///
+/// # Errors
+///
+/// Returns an upstream checkpoint error when the checkpointed state is
+/// incompatible with the supplied [`CdtTarget`].
+pub(crate) fn restore_checkpoint_state(
+    checkpoint: ChainCheckpoint<CdtTriangulation2D>,
+    target: &CdtTarget,
+) -> Result<CdtTriangulation2D, McmcError> {
+    Chain::from_checkpoint(checkpoint, target).map(Chain::into_state)
+}
+
+/// Returns the inverse CDT move family used for reverse proposal accounting.
+const fn reverse_move_type(move_type: MoveType) -> MoveType {
+    match move_type {
+        MoveType::Move22 => MoveType::Move22,
+        MoveType::Move13Add => MoveType::Move31Remove,
+        MoveType::Move31Remove => MoveType::Move13Add,
+        MoveType::EdgeFlip => MoveType::EdgeFlip,
+    }
+}
+
+/// Converts local-site counts to finite values for proposal-ratio accounting.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "site counts are converted only for logarithmic Metropolis-Hastings ratios"
+)]
+pub(crate) const fn site_count_to_f64(count: usize) -> f64 {
+    count as f64
+}

--- a/src/cdt/metropolis/checkpoint.rs
+++ b/src/cdt/metropolis/checkpoint.rs
@@ -1,0 +1,713 @@
+//! Checkpoint and resume validation for CDT Metropolis sampling.
+
+use crate::cdt::action::ActionConfig;
+use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveStatistics, MoveType};
+use crate::cdt::results::{Measurement, SimulationResultsBackend, SimulationResultsParts};
+use crate::errors::{CdtError, CdtResult, CheckpointMoveCounter, CheckpointResumeFailure};
+use crate::geometry::CdtTriangulation2D;
+use markov_chain_monte_carlo::ChainCheckpoint;
+use rand::rngs::Xoshiro256PlusPlus;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use super::helpers::actions_match;
+use super::runner::{MetropolisAlgorithm, MetropolisConfig};
+use super::telemetry::{MonteCarloStep, ProposalStatistics};
+
+pub(crate) struct CdtMcmcCheckpointParts {
+    pub(crate) triangulation: CdtTriangulation2D,
+    pub(crate) accepted: usize,
+    pub(crate) rejected: usize,
+    pub(crate) config: MetropolisConfig,
+    pub(crate) action_config: ActionConfig,
+    pub(crate) current_step: u32,
+    pub(crate) current_action: f64,
+    pub(crate) move_stats: MoveStatistics,
+    pub(crate) proposal_stats: ProposalStatistics,
+    pub(crate) steps: Vec<MonteCarloStep>,
+    pub(crate) measurements: Vec<Measurement>,
+    pub(crate) elapsed_time: Duration,
+    pub(crate) acceptance_rng: Xoshiro256PlusPlus,
+    pub(crate) ergodics: ErgodicsSystem,
+}
+
+/// Resumable checkpoint for a CDT Metropolis-Hastings run.
+///
+/// The embedded [`ChainCheckpoint`] stores the current triangulation and
+/// accepted/rejected chain counters using the shared MCMC crate's portable
+/// checkpoint type. CDT adds the domain-specific runtime state needed for
+/// scientific continuation: action/config metadata, accumulated telemetry,
+/// both RNG streams, and the ergodic move system.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::simulation::{
+///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
+/// };
+///
+/// fn main() -> CdtResult<()> {
+///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+///     let checkpoint = MetropolisAlgorithm::new(
+///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+///         ActionConfig::default(),
+///     )
+///     .run_to_checkpoint(tri)?;
+///
+///     assert_eq!(checkpoint.current_step(), 1);
+///     assert_eq!(checkpoint.measurements().len(), 2);
+///     Ok(())
+/// }
+/// ```
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CdtMcmcCheckpoint {
+    pub(crate) chain: ChainCheckpoint<CdtTriangulation2D>,
+    pub(crate) config: MetropolisConfig,
+    pub(crate) action_config: ActionConfig,
+    pub(crate) current_step: u32,
+    pub(crate) current_action: f64,
+    pub(crate) move_stats: MoveStatistics,
+    #[serde(default)]
+    pub(crate) proposal_stats: ProposalStatistics,
+    pub(crate) steps: Vec<MonteCarloStep>,
+    pub(crate) measurements: Vec<Measurement>,
+    pub(crate) elapsed_time: Duration,
+    pub(crate) acceptance_rng: Xoshiro256PlusPlus,
+    pub(crate) ergodics: ErgodicsSystem,
+}
+
+impl CdtMcmcCheckpoint {
+    pub(crate) fn from_parts(parts: CdtMcmcCheckpointParts) -> Self {
+        Self {
+            chain: ChainCheckpoint::new(parts.triangulation, parts.accepted, parts.rejected),
+            config: parts.config,
+            action_config: parts.action_config,
+            current_step: parts.current_step,
+            current_action: parts.current_action,
+            move_stats: parts.move_stats,
+            proposal_stats: parts.proposal_stats,
+            steps: parts.steps,
+            measurements: parts.measurements,
+            elapsed_time: parts.elapsed_time,
+            acceptance_rng: parts.acceptance_rng,
+            ergodics: parts.ergodics,
+        }
+    }
+
+    /// Returns the generic MCMC chain checkpoint for upstream interop.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtMcmcCheckpoint, CdtResult, CdtTriangulation,
+    ///     MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
+    /// MetropolisAlgorithm::new(
+    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     ActionConfig::default(),
+    /// )
+    /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
+    /// # }
+    /// # let checkpoint = checkpoint()?;
+    /// assert_eq!(checkpoint.chain().total_steps(), 1);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    pub const fn chain(&self) -> &ChainCheckpoint<CdtTriangulation2D> {
+        &self.chain
+    }
+
+    /// Returns the checkpointed triangulation state.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtMcmcCheckpoint, CdtResult, CdtTriangulation,
+    ///     MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
+    /// MetropolisAlgorithm::new(
+    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     ActionConfig::default(),
+    /// )
+    /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
+    /// # }
+    /// # let checkpoint = checkpoint()?;
+    /// assert_eq!(checkpoint.triangulation().time_slices(), 3);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn triangulation(&self) -> &CdtTriangulation2D {
+        self.chain.state()
+    }
+
+    /// Returns the Metropolis configuration used when the checkpoint was made.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtMcmcCheckpoint, CdtResult, CdtTriangulation,
+    ///     MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
+    /// MetropolisAlgorithm::new(
+    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     ActionConfig::default(),
+    /// )
+    /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
+    /// # }
+    /// # let checkpoint = checkpoint()?;
+    /// assert_eq!(checkpoint.config().steps, 1);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn config(&self) -> &MetropolisConfig {
+        &self.config
+    }
+
+    /// Returns the action configuration used when the checkpoint was made.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtMcmcCheckpoint, CdtResult, CdtTriangulation,
+    ///     MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
+    /// MetropolisAlgorithm::new(
+    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     ActionConfig::default(),
+    /// )
+    /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
+    /// # }
+    /// # let checkpoint = checkpoint()?;
+    /// assert_eq!(checkpoint.action_config(), &ActionConfig::default());
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn action_config(&self) -> &ActionConfig {
+        &self.action_config
+    }
+
+    /// Returns the last completed Monte Carlo step.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtMcmcCheckpoint, CdtResult, CdtTriangulation,
+    ///     MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
+    /// MetropolisAlgorithm::new(
+    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     ActionConfig::default(),
+    /// )
+    /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
+    /// # }
+    /// # let checkpoint = checkpoint()?;
+    /// assert_eq!(checkpoint.current_step(), 1);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn current_step(&self) -> u32 {
+        self.current_step
+    }
+
+    /// Returns the action of the checkpointed triangulation.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtMcmcCheckpoint, CdtResult, CdtTriangulation,
+    ///     MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
+    /// MetropolisAlgorithm::new(
+    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     ActionConfig::default(),
+    /// )
+    /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
+    /// # }
+    /// # let checkpoint = checkpoint()?;
+    /// assert!(checkpoint.current_action().is_finite());
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn current_action(&self) -> f64 {
+        self.current_action
+    }
+
+    /// Returns accumulated move statistics through the checkpoint step.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtMcmcCheckpoint, CdtResult, CdtTriangulation,
+    ///     MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
+    /// MetropolisAlgorithm::new(
+    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     ActionConfig::default(),
+    /// )
+    /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
+    /// # }
+    /// # let checkpoint = checkpoint()?;
+    /// assert_eq!(checkpoint.move_stats().total_attempted(), 1);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn move_stats(&self) -> &MoveStatistics {
+        &self.move_stats
+    }
+
+    /// Returns accumulated proposal-kernel telemetry through the checkpoint step.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtMcmcCheckpoint, CdtResult, CdtTriangulation,
+    ///     MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
+    /// MetropolisAlgorithm::new(
+    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     ActionConfig::default(),
+    /// )
+    /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
+    /// # }
+    /// # let checkpoint = checkpoint()?;
+    /// assert_eq!(checkpoint.proposal_stats().move_family_proposals, 1);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn proposal_stats(&self) -> &ProposalStatistics {
+        &self.proposal_stats
+    }
+
+    /// Returns accumulated step telemetry through the checkpoint step.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtMcmcCheckpoint, CdtResult, CdtTriangulation,
+    ///     MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
+    /// MetropolisAlgorithm::new(
+    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     ActionConfig::default(),
+    /// )
+    /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
+    /// # }
+    /// # let checkpoint = checkpoint()?;
+    /// assert_eq!(checkpoint.steps().len(), checkpoint.current_step() as usize);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub fn steps(&self) -> &[MonteCarloStep] {
+        &self.steps
+    }
+
+    /// Returns accumulated measurements through the checkpoint step.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtMcmcCheckpoint, CdtResult, CdtTriangulation,
+    ///     MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
+    /// MetropolisAlgorithm::new(
+    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     ActionConfig::default(),
+    /// )
+    /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
+    /// # }
+    /// # let checkpoint = checkpoint()?;
+    /// assert_eq!(checkpoint.measurements().first().map(|m| m.step), Some(0));
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub fn measurements(&self) -> &[Measurement] {
+        &self.measurements
+    }
+
+    /// Converts the checkpoint into a complete simulation result snapshot.
+    ///
+    /// This consumes the checkpoint and keeps all accumulated steps,
+    /// measurements, move statistics, proposal statistics, elapsed time, and the
+    /// checkpointed triangulation in the returned [`SimulationResultsBackend`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let checkpoint = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///         ActionConfig::default(),
+    ///     )
+    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///
+    ///     let results = checkpoint.into_results();
+    ///     assert_eq!(results.steps().len(), 1);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub fn into_results(self) -> SimulationResultsBackend {
+        let (triangulation, _, _) = self.chain.into_parts();
+        SimulationResultsBackend::from_parts(SimulationResultsParts {
+            config: self.config,
+            action_config: self.action_config,
+            move_stats: self.move_stats,
+            proposal_stats: self.proposal_stats,
+            steps: self.steps,
+            measurements: self.measurements,
+            elapsed_time: self.elapsed_time,
+            triangulation,
+        })
+    }
+}
+
+/// Builds the public checkpoint-resume error wrapper for CDT-owned resume invariants.
+pub(crate) const fn checkpoint_resume_failed(failure: CheckpointResumeFailure) -> CdtError {
+    CdtError::CheckpointResumeFailed { failure }
+}
+
+/// Verifies that a checkpoint can be resumed by the requested algorithm.
+///
+/// Resume accepts a different fresh seed because serialized checkpoints carry
+/// their own RNG streams, but rejects physics and sampling schedule changes
+/// that would make the cumulative chain scientifically ambiguous.
+///
+/// # Errors
+///
+/// Returns [`CdtError::CheckpointResumeFailed`] when physics settings or
+/// sampling schedule settings differ from the checkpoint, or when the
+/// checkpoint counters and telemetry fail validation.
+pub(crate) fn validate_resume_compatible(
+    algorithm: &MetropolisAlgorithm,
+    checkpoint: &CdtMcmcCheckpoint,
+) -> CdtResult<()> {
+    if !action_configs_match(algorithm.action_config(), &checkpoint.action_config) {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::IncompatibleActionConfiguration,
+        ));
+    }
+    if algorithm.config().temperature.to_bits() != checkpoint.config.temperature.to_bits() {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::IncompatibleTemperature,
+        ));
+    }
+    if algorithm.config().thermalization_steps != checkpoint.config.thermalization_steps {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::IncompatibleThermalizationSchedule,
+        ));
+    }
+    if algorithm.config().measurement_frequency != checkpoint.config.measurement_frequency {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::IncompatibleMeasurementFrequency,
+        ));
+    }
+    validate_checkpoint_counters(checkpoint)
+}
+
+/// Compares action couplings with the same tolerance used for persisted action values.
+fn action_configs_match(left: &ActionConfig, right: &ActionConfig) -> bool {
+    actions_match(left.coupling_0, right.coupling_0)
+        && actions_match(left.coupling_2, right.coupling_2)
+        && actions_match(left.cosmological_constant, right.cosmological_constant)
+}
+
+/// Checks that serialized chain counters and CDT telemetry agree.
+///
+/// This protects the public resume contract by rejecting checkpoints whose
+/// generic MCMC counters, CDT move counters, step telemetry, or measurement
+/// schedule cannot all describe the same chain prefix.
+///
+/// # Errors
+///
+/// Returns [`CdtError::InvalidSimulationConfiguration`] for invalid
+/// Metropolis settings, [`CdtError::InvalidConfiguration`] for invalid action
+/// couplings, or [`CdtError::CheckpointResumeFailed`] when serialized chain
+/// counters, step telemetry, or measurements do not match the configured
+/// sampling schedule.
+pub(crate) fn validate_checkpoint_counters(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
+    checkpoint.config.validate()?;
+    checkpoint.action_config.validate()?;
+
+    let (accepted, rejected) = chain_counters(&checkpoint.move_stats)?;
+    if checkpoint.chain.accepted() != accepted || checkpoint.chain.rejected() != rejected {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ChainCounterMismatch {
+                chain_accepted: checkpoint.chain.accepted(),
+                chain_rejected: checkpoint.chain.rejected(),
+                move_accepted: accepted,
+                move_rejected: rejected,
+            },
+        ));
+    }
+    let checkpoint_step = usize::try_from(checkpoint.current_step).unwrap_or(usize::MAX);
+    if checkpoint.chain.total_steps() != checkpoint_step {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ChainStepMismatch {
+                chain_steps: checkpoint.chain.total_steps(),
+                checkpoint_step: checkpoint.current_step,
+            },
+        ));
+    }
+    if checkpoint.steps.len() != checkpoint.chain.total_steps() {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::StepTelemetryLengthMismatch {
+                actual: checkpoint.steps.len(),
+                expected: checkpoint.chain.total_steps(),
+            },
+        ));
+    }
+    validate_checkpoint_steps(checkpoint)?;
+    validate_checkpoint_measurements(checkpoint)?;
+    Ok(())
+}
+
+/// Checks that serialized per-step telemetry forms the exact prefix being resumed.
+fn validate_checkpoint_steps(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
+    let accepted_steps = checkpoint.steps.iter().filter(|step| step.accepted).count();
+    if accepted_steps != checkpoint.chain.accepted() {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::StepTelemetryAcceptedCountMismatch {
+                actual: accepted_steps,
+                expected: checkpoint.chain.accepted(),
+            },
+        ));
+    }
+
+    for (index, step) in checkpoint.steps.iter().enumerate() {
+        let expected_step = u32::try_from(index + 1).map_err(|_| {
+            checkpoint_resume_failed(CheckpointResumeFailure::StepTelemetryIndexOverflow)
+        })?;
+        if step.step != expected_step {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::StepTelemetrySequenceMismatch {
+                    actual: step.step,
+                    expected: expected_step,
+                },
+            ));
+        }
+        if !step.action_before.is_finite() {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::NonFiniteStepActionBefore { step: step.step },
+            ));
+        }
+        if let Some(delta_action) = step.delta_action
+            && !delta_action.is_finite()
+        {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::NonFiniteStepDeltaAction { step: step.step },
+            ));
+        }
+        if step.accepted && step.delta_action.is_none() {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::AcceptedStepMissingDeltaAction { step: step.step },
+            ));
+        }
+        match (step.accepted, step.action_after) {
+            (true, Some(action_after)) if action_after.is_finite() => {
+                if let Some(delta_action) = step.delta_action
+                    && !actions_match(action_after, step.action_before + delta_action)
+                {
+                    return Err(checkpoint_resume_failed(
+                        CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: step.step },
+                    ));
+                }
+            }
+            (true, Some(_)) => {
+                return Err(checkpoint_resume_failed(
+                    CheckpointResumeFailure::NonFiniteStepActionAfter { step: step.step },
+                ));
+            }
+            (true, None) => {
+                return Err(checkpoint_resume_failed(
+                    CheckpointResumeFailure::AcceptedStepMissingActionAfter { step: step.step },
+                ));
+            }
+            (false, Some(_)) => {
+                return Err(checkpoint_resume_failed(
+                    CheckpointResumeFailure::RejectedStepHasActionAfter { step: step.step },
+                ));
+            }
+            (false, None) => {}
+        }
+    }
+    Ok(())
+}
+
+/// Checks that serialized measurements match the configured sampling schedule.
+fn validate_checkpoint_measurements(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
+    let expected_measurements = usize::try_from(
+        u64::from(checkpoint.current_step) / u64::from(checkpoint.config.measurement_frequency) + 1,
+    )
+    .map_err(|_| checkpoint_resume_failed(CheckpointResumeFailure::MeasurementCountOverflow))?;
+    if checkpoint.measurements.len() != expected_measurements {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::MeasurementCountMismatch {
+                actual: checkpoint.measurements.len(),
+                expected: expected_measurements,
+            },
+        ));
+    }
+
+    for (index, measurement) in checkpoint.measurements.iter().enumerate() {
+        let expected_step = u64::try_from(index)
+            .ok()
+            .and_then(|index| index.checked_mul(u64::from(checkpoint.config.measurement_frequency)))
+            .and_then(|step| u32::try_from(step).ok())
+            .ok_or_else(|| {
+                checkpoint_resume_failed(CheckpointResumeFailure::MeasurementStepOverflow)
+            })?;
+        if measurement.step != expected_step {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::MeasurementStepMismatch {
+                    actual: measurement.step,
+                    expected: expected_step,
+                },
+            ));
+        }
+        if !measurement.action.is_finite() {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::NonFiniteMeasurementAction {
+                    step: measurement.step,
+                },
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Sums move counters without allowing invalid serialized telemetry to wrap.
+fn checked_move_counter_sum(counter: CheckpointMoveCounter, counters: [u64; 4]) -> CdtResult<u64> {
+    counters.into_iter().try_fold(0_u64, |total, count| {
+        total.checked_add(count).ok_or_else(|| {
+            checkpoint_resume_failed(CheckpointResumeFailure::MoveCounterOverflow { counter })
+        })
+    })
+}
+
+/// Rejects per-move counter states that cannot be produced by the sampler.
+fn validate_move_counter_bounds(move_stats: &MoveStatistics) -> CdtResult<()> {
+    let counters = [
+        (
+            MoveType::Move22,
+            move_stats.moves_22_attempted,
+            move_stats.moves_22_accepted,
+            move_stats.moves_22_hard_failed,
+        ),
+        (
+            MoveType::Move13Add,
+            move_stats.moves_13_attempted,
+            move_stats.moves_13_accepted,
+            move_stats.moves_13_hard_failed,
+        ),
+        (
+            MoveType::Move31Remove,
+            move_stats.moves_31_attempted,
+            move_stats.moves_31_accepted,
+            move_stats.moves_31_hard_failed,
+        ),
+        (
+            MoveType::EdgeFlip,
+            move_stats.edge_flips_attempted,
+            move_stats.edge_flips_accepted,
+            move_stats.edge_flips_hard_failed,
+        ),
+    ];
+
+    for (move_type, attempted, accepted, hard_failed) in counters {
+        if hard_failed != 0 {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::MoveHardFailures { move_type },
+            ));
+        }
+
+        if accepted > attempted {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::MoveAcceptedExceedsAttempted { move_type },
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Converts CDT move statistics into generic MCMC chain counters.
+///
+/// Accepted and rejected counts are derived from proposal accounting, with
+/// overflow and impossible accepted-above-attempted states reported as
+/// checkpoint resume errors instead of panicking.
+///
+/// # Errors
+///
+/// Returns [`CdtError::CheckpointResumeFailed`] when serialized move counters
+/// contain hard failures, accepted counts above attempted counts, arithmetic
+/// overflow, or values that cannot fit into the upstream checkpoint counter
+/// type.
+pub(crate) fn chain_counters(move_stats: &MoveStatistics) -> CdtResult<(usize, usize)> {
+    validate_move_counter_bounds(move_stats)?;
+    let attempted = checked_move_counter_sum(
+        CheckpointMoveCounter::Attempted,
+        [
+            move_stats.moves_22_attempted,
+            move_stats.moves_13_attempted,
+            move_stats.moves_31_attempted,
+            move_stats.edge_flips_attempted,
+        ],
+    )?;
+    let accepted = checked_move_counter_sum(
+        CheckpointMoveCounter::Accepted,
+        [
+            move_stats.moves_22_accepted,
+            move_stats.moves_13_accepted,
+            move_stats.moves_31_accepted,
+            move_stats.edge_flips_accepted,
+        ],
+    )?;
+    let rejected = attempted.checked_sub(accepted).ok_or_else(|| {
+        checkpoint_resume_failed(CheckpointResumeFailure::TotalAcceptedExceedsAttempted)
+    })?;
+    Ok((
+        usize::try_from(accepted).map_err(|_| {
+            checkpoint_resume_failed(CheckpointResumeFailure::CounterConversionOverflow {
+                counter: CheckpointMoveCounter::Accepted,
+            })
+        })?,
+        usize::try_from(rejected).map_err(|_| {
+            checkpoint_resume_failed(CheckpointResumeFailure::CounterConversionOverflow {
+                counter: CheckpointMoveCounter::Rejected,
+            })
+        })?,
+    ))
+}

--- a/src/cdt/metropolis/helpers.rs
+++ b/src/cdt/metropolis/helpers.rs
@@ -1,0 +1,158 @@
+//! Shared CDT-domain helpers for Metropolis sampling.
+
+use crate::cdt::action::ActionConfig;
+use crate::cdt::ergodic_moves::MoveType;
+use crate::cdt::results::Measurement;
+use crate::config::validate_schedule;
+use crate::errors::{CdtError, CdtResult, ConfigurationSetting};
+use crate::geometry::CdtTriangulation2D;
+use crate::util::saturating_usize_to_u32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SimplexCounts {
+    /// Number of vertices in the live CDT triangulation.
+    pub vertices: u32,
+    /// Number of edges in the live CDT triangulation.
+    pub edges: u32,
+    /// Number of triangular 2-simplices in the live CDT triangulation.
+    pub triangles: u32,
+}
+
+/// Adapts shared schedule validation errors to the Metropolis-specific error variant.
+///
+/// This keeps [`MetropolisConfig::validate`](super::MetropolisConfig::validate)
+/// aligned with the shared simulation schedule validator while preserving the
+/// public Metropolis error contract.
+pub const fn invalid_sim_config(
+    setting: ConfigurationSetting,
+    provided_value: String,
+    expected: String,
+) -> CdtError {
+    CdtError::InvalidSimulationConfiguration {
+        setting,
+        provided_value,
+        expected,
+    }
+}
+
+/// Validates simulation-specific configuration values.
+///
+/// This is the shared implementation behind
+/// [`MetropolisConfig::validate`](super::MetropolisConfig::validate) and the
+/// runner entry points, so all public Metropolis APIs reject the same invalid
+/// temperature, step-count, thermalization, and measurement schedules.
+///
+/// # Errors
+///
+/// Returns [`CdtError::InvalidSimulationConfiguration`] when `temperature` is
+/// not finite and positive, when `steps` or `measurement_frequency` is zero,
+/// when thermalization exceeds the step count, or when the schedule cannot
+/// produce a post-thermalization measurement.
+pub fn validate_metropolis_schedule(
+    temperature: f64,
+    steps: u32,
+    thermalization_steps: u32,
+    measurement_frequency: u32,
+) -> CdtResult<()> {
+    validate_schedule(
+        temperature,
+        steps,
+        thermalization_steps,
+        measurement_frequency,
+        invalid_sim_config,
+    )
+}
+
+/// Rejects temperatures that would make target log probabilities non-finite.
+///
+/// # Errors
+///
+/// Returns [`CdtError::InvalidSimulationConfiguration`] when `temperature` is
+/// non-finite, zero, or negative.
+pub fn validate_temperature(temperature: f64) -> CdtResult<()> {
+    if temperature.is_finite() && temperature > 0.0 {
+        Ok(())
+    } else {
+        Err(invalid_sim_config(
+            ConfigurationSetting::Temperature,
+            temperature.to_string(),
+            "finite and positive".to_string(),
+        ))
+    }
+}
+
+/// Reads simplex counts through the CDT wrapper for action and measurement code.
+///
+/// Centralizing these conversions keeps cached query paths authoritative and
+/// makes integer saturation explicit at the simulation boundary.
+pub fn simplex_counts(triangulation: &CdtTriangulation2D) -> SimplexCounts {
+    SimplexCounts {
+        vertices: saturating_usize_to_u32(triangulation.vertex_count()),
+        edges: saturating_usize_to_u32(triangulation.edge_count()),
+        triangles: saturating_usize_to_u32(triangulation.face_count()),
+    }
+}
+
+/// Computes the current action from live simplex counts.
+///
+/// The Metropolis loop calls this only after state is known to be current, which
+/// avoids trusting stale values across backend mutations or rollback.
+pub fn action_for(action_config: &ActionConfig, triangulation: &CdtTriangulation2D) -> f64 {
+    let counts = simplex_counts(triangulation);
+    action_config.calculate_action(counts.vertices, counts.edges, counts.triangles)
+}
+
+/// Captures a measurement from the live triangulation state.
+///
+/// Keeping measurement construction in one helper ensures recorded actions and
+/// simplex counts use the same query path at every measurement step.
+pub fn measurement_for(step: u32, action: f64, triangulation: &CdtTriangulation2D) -> Measurement {
+    let counts = simplex_counts(triangulation);
+    Measurement {
+        step,
+        action,
+        vertices: counts.vertices,
+        edges: counts.edges,
+        triangles: counts.triangles,
+        volume_profile: triangulation.volume_profile(),
+    }
+}
+
+/// Computes the count-level action change before mutating the triangulation.
+///
+/// This is the core proposal-before-mutation calculation: Metropolis acceptance
+/// must be based on the selected move type's known simplex-count delta, not on a
+/// speculative backend edit that may need rollback.
+pub fn proposed_delta_action(
+    action_config: &ActionConfig,
+    before: SimplexCounts,
+    move_type: MoveType,
+) -> Option<f64> {
+    let after = match move_type {
+        MoveType::Move22 | MoveType::EdgeFlip => before,
+        MoveType::Move13Add => SimplexCounts {
+            vertices: before.vertices.checked_add(1)?,
+            edges: before.edges.checked_add(3)?,
+            triangles: before.triangles.checked_add(2)?,
+        },
+        MoveType::Move31Remove => SimplexCounts {
+            vertices: before.vertices.checked_sub(1)?,
+            edges: before.edges.checked_sub(3)?,
+            triangles: before.triangles.checked_sub(2)?,
+        },
+    };
+
+    let action_before =
+        action_config.calculate_action(before.vertices, before.edges, before.triangles);
+    let action_after = action_config.calculate_action(after.vertices, after.edges, after.triangles);
+    Some(action_after - action_before)
+}
+
+/// Compares action values with a scale-aware tolerance for checkpoint validation.
+pub fn actions_match(left: f64, right: f64) -> bool {
+    if !(left.is_finite() && right.is_finite()) {
+        return false;
+    }
+    let scale = left.abs().max(right.abs()).max(1.0);
+    (left - right).abs() <= f64::EPSILON * scale * 8.0
+}

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -11,32 +11,26 @@
 //! proposal outcomes tracked in [`crate::cdt::metropolis::ProposalStatistics`].
 
 use crate::cdt::action::ActionConfig;
-use crate::cdt::ergodic_moves::{
-    ErgodicsSystem, MoveResult, MoveStatistics, MoveType, proposal_site_count,
-};
-use crate::cdt::results::{Measurement, SimulationResultsBackend, SimulationResultsParts};
+use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveStatistics, MoveType};
+use crate::cdt::results::{Measurement, SimulationResultsBackend};
 use crate::cdt::triangulation::SimulationEvent;
-use crate::config::validate_schedule;
 use crate::errors::{
-    CdtError, CdtResult, CheckpointResumeReason, ConfigurationSetting,
-    MetropolisMoveApplicationFailure,
+    CdtError, CdtResult, CheckpointResumeFailure, MetropolisMoveApplicationFailure,
 };
 use crate::geometry::CdtTriangulation2D;
-use crate::util::saturating_usize_to_u32;
-use markov_chain_monte_carlo::{Chain, ChainCheckpoint, DelayedProposal, Target};
 use rand::{Rng, RngExt, SeedableRng, rngs::Xoshiro256PlusPlus};
 use serde::{Deserialize, Serialize};
-use std::error::Error;
-use std::fmt;
-use std::hint::cold_path;
 use std::time::{Duration, Instant};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct SimplexCounts {
-    vertices: u32,
-    edges: u32,
-    triangles: u32,
-}
+use super::adapter::{
+    CdtTarget, concrete_log_q_ratio, propose_concrete_plan, restore_checkpoint_state,
+};
+use super::checkpoint::{
+    CdtMcmcCheckpoint, CdtMcmcCheckpointParts, chain_counters, checkpoint_resume_failed,
+    validate_checkpoint_counters, validate_resume_compatible,
+};
+use super::helpers::{action_for, actions_match, measurement_for, validate_metropolis_schedule};
+use super::telemetry::{MonteCarloStep, ProposalStatistics};
 
 /// Configuration for the Metropolis-Hastings algorithm.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -144,1009 +138,12 @@ impl MetropolisConfig {
     /// assert!(config.validate().is_ok());
     /// ```
     pub fn validate(&self) -> CdtResult<()> {
-        validate_schedule(
+        validate_metropolis_schedule(
             self.temperature,
             self.steps,
             self.thermalization_steps,
             self.measurement_frequency,
-            |setting, provided_value, expected| {
-                invalid_sim_config(setting, provided_value, expected)
-            },
         )
-    }
-}
-
-/// Adapts shared schedule validation errors to the Metropolis-specific error variant.
-const fn invalid_sim_config(
-    setting: ConfigurationSetting,
-    provided_value: String,
-    expected: String,
-) -> CdtError {
-    CdtError::InvalidSimulationConfiguration {
-        setting,
-        provided_value,
-        expected,
-    }
-}
-
-/// Rejects temperatures that would make target log probabilities non-finite.
-fn validate_temperature(temperature: f64) -> CdtResult<()> {
-    if temperature.is_finite() && temperature > 0.0 {
-        Ok(())
-    } else {
-        Err(invalid_sim_config(
-            ConfigurationSetting::Temperature,
-            temperature.to_string(),
-            "finite and positive".to_string(),
-        ))
-    }
-}
-
-/// Result of a Monte Carlo step.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MonteCarloStep {
-    /// Step number
-    pub step: u32,
-    /// Move type attempted
-    pub move_type: MoveType,
-    /// Whether the move was accepted
-    pub accepted: bool,
-    /// Action before the move
-    pub action_before: f64,
-    /// Action after the move (if accepted)
-    pub action_after: Option<f64>,
-    /// Change in action (ΔS)
-    pub delta_action: Option<f64>,
-}
-
-// ---------------------------------------------------------------------------
-// MCMC trait implementations for CDT
-// ---------------------------------------------------------------------------
-
-/// Target distribution for CDT: log-probability from the Regge action.
-///
-/// Computes `log_prob = -S / T` where `S` is the discrete Regge action
-/// and `T` is the temperature.
-pub struct CdtTarget {
-    action_config: ActionConfig,
-    temperature: f64,
-}
-
-impl CdtTarget {
-    /// Creates a new CDT target distribution.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`CdtError::InvalidConfiguration`] if the action couplings are
-    /// non-finite, or [`CdtError::InvalidSimulationConfiguration`] if
-    /// `temperature` is not finite and positive.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::action::ActionConfig;
-    /// use causal_triangulations::prelude::simulation::CdtTarget;
-    ///
-    /// let _target = CdtTarget::new(ActionConfig::default(), 1.0)?;
-    /// # Ok::<(), causal_triangulations::CdtError>(())
-    /// ```
-    pub fn new(action_config: ActionConfig, temperature: f64) -> CdtResult<Self> {
-        action_config.validate()?;
-        validate_temperature(temperature)?;
-        Ok(Self {
-            action_config,
-            temperature,
-        })
-    }
-}
-
-impl Target<CdtTriangulation2D> for CdtTarget {
-    fn log_prob(&self, state: &CdtTriangulation2D) -> f64 {
-        let counts = simplex_counts(state);
-        let action =
-            self.action_config
-                .calculate_action(counts.vertices, counts.edges, counts.triangles);
-        -action / self.temperature
-    }
-}
-
-/// Concrete delayed CDT move proposal selected before committing live state.
-///
-/// A plan records the selected [`MoveType`], the action before and after the
-/// move, and a cloned triangulation containing the proposed mutation. Planning
-/// may mutate that clone to realize a concrete local site, but it never mutates
-/// the live simulation state. The delayed proposal API scores this plan with
-/// the Metropolis-Hastings forward/reverse proposal-site ratio, then commits
-/// the cloned state only if the Metropolis step accepts it.
-///
-/// # Examples
-///
-/// ```
-/// use causal_triangulations::prelude::action::ActionConfig;
-/// use causal_triangulations::prelude::errors::CdtResult;
-/// use causal_triangulations::prelude::moves::MoveType;
-/// use causal_triangulations::prelude::simulation::{
-///     CdtProposal, CdtTriangulation, DelayedProposal,
-/// };
-/// use rand::{SeedableRng, rngs::StdRng};
-///
-/// # fn main() -> CdtResult<()> {
-/// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-/// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
-/// let mut rng = StdRng::seed_from_u64(11);
-///
-/// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
-///     return Ok(());
-/// };
-/// assert!(matches!(
-///     plan.move_type(),
-///     MoveType::Move22 | MoveType::Move13Add | MoveType::Move31Remove | MoveType::EdgeFlip
-/// ));
-/// assert!(plan.action_before().is_finite());
-/// if let (Some(delta), Some(action_after)) = (plan.delta_action(), plan.action_after()) {
-///     approx::assert_relative_eq!(
-///         action_after,
-///         plan.action_before() + delta,
-///         epsilon = 1e-12
-///     );
-/// }
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug, Clone)]
-pub struct CdtProposalPlan {
-    move_type: MoveType,
-    action_before: f64,
-    action_after: Option<f64>,
-    delta_action: Option<f64>,
-    forward_site_count: usize,
-    /// Reverse proposal-site denominator for the realized proposed state.
-    ///
-    /// This is the number of valid inverse-move local sites used to normalize
-    /// the reverse proposal probability in the Metropolis-Hastings site-count
-    /// ratio. It is a count of sites and must be greater than zero for a
-    /// realized proposal to have finite reverse weight.
-    reverse_site_count: usize,
-    proposed_state: CdtTriangulation2D,
-}
-
-impl CdtProposalPlan {
-    /// Returns the proposed move type.
-    #[must_use]
-    pub const fn move_type(&self) -> MoveType {
-        self.move_type
-    }
-
-    /// Returns the current action used to score this proposal.
-    #[must_use]
-    pub const fn action_before(&self) -> f64 {
-        self.action_before
-    }
-
-    /// Returns the action of the concrete proposed state, if one was realized.
-    ///
-    /// A value of `None` means the selected move could not be scored or
-    /// realized, so [`DelayedProposal::proposed_log_prob`] treats the plan as
-    /// impossible.
-    #[must_use]
-    pub const fn action_after(&self) -> Option<f64> {
-        self.action_after
-    }
-
-    /// Returns the concrete proposal action change, if it can be evaluated.
-    #[must_use]
-    pub const fn delta_action(&self) -> Option<f64> {
-        self.delta_action
-    }
-}
-
-/// Telemetry returned by delayed CDT proposal steps.
-///
-/// The sampler receives this compact record after a plan has been scored. It is
-/// intended for diagnostics and measurement backends that need to report which
-/// move family was proposed without exposing the private plan fields.
-///
-/// # Examples
-///
-/// ```
-/// use causal_triangulations::prelude::action::ActionConfig;
-/// use causal_triangulations::prelude::errors::CdtResult;
-/// use causal_triangulations::prelude::simulation::{
-///     CdtProposal, CdtTriangulation, DelayedProposal,
-/// };
-/// use rand::{SeedableRng, rngs::StdRng};
-///
-/// # fn main() -> CdtResult<()> {
-/// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-/// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
-/// let mut rng = StdRng::seed_from_u64(11);
-/// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
-///     return Ok(());
-/// };
-///
-/// let info = proposal.info(&plan);
-/// assert_eq!(info.move_type, plan.move_type());
-/// assert_eq!(info.delta_action.is_some(), plan.delta_action().is_some());
-/// if let (Some(info_delta), Some(plan_delta)) = (info.delta_action, plan.delta_action()) {
-///     approx::assert_relative_eq!(info_delta, plan_delta, epsilon = 1e-12);
-/// }
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct CdtProposalInfo {
-    /// Move type selected for the proposal.
-    pub move_type: MoveType,
-    /// Action before the proposal.
-    pub action_before: f64,
-    /// Action after the proposal if the count-level delta is valid.
-    pub action_after: Option<f64>,
-    /// Proposed action change.
-    pub delta_action: Option<f64>,
-}
-
-/// Local-site rejection observed while trying to realize an accepted CDT proposal.
-///
-/// These rejections mean the move type was selected and accepted at the
-/// count-action level, but the bounded random local-site search did not find a
-/// concrete site where the move could be applied.
-#[derive(Debug, Clone, PartialEq)]
-enum CdtProposalSiteRejection {
-    /// The selected local site would violate CDT causality.
-    CausalityViolation,
-    /// The selected local site was geometrically invalid.
-    GeometricViolation,
-    /// The selected local site was rejected by the backend mutation kernel.
-    Kernel(CdtError),
-}
-
-impl fmt::Display for CdtProposalSiteRejection {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::CausalityViolation => {
-                f.write_str("causality violation at selected application site")
-            }
-            Self::GeometricViolation => {
-                f.write_str("geometric violation at selected application site")
-            }
-            Self::Kernel(err) => err.fmt(f),
-        }
-    }
-}
-
-impl Error for CdtProposalSiteRejection {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::Kernel(err) => Some(err),
-            Self::CausalityViolation | Self::GeometricViolation => None,
-        }
-    }
-}
-
-/// Error reported by delayed CDT proposal planning or commit.
-///
-/// No-site outcomes are ordinary proposal absence and are reported from
-/// [`DelayedProposal::propose_plan`] as `Ok(None)`, matching the upstream
-/// delayed-commit contract. `ApplicationFailed` represents a hard backend or
-/// invariant failure while constructing or committing a concrete proposal, and
-/// preserves the typed [`CdtError`] that caused the failed application.
-///
-/// # Examples
-///
-/// ```
-/// use causal_triangulations::prelude::moves::MoveType;
-/// use causal_triangulations::prelude::simulation::CdtProposalError;
-/// use causal_triangulations::prelude::errors::BackendMutationOperation;
-/// use causal_triangulations::CdtError;
-///
-/// let err = CdtProposalError::ApplicationFailed {
-///     move_type: MoveType::Move13Add,
-///     attempt: 2,
-///     source: CdtError::BackendMutationFailed {
-///         operation: BackendMutationOperation::SetVertexDataByKey,
-///         target: "vertex VertexKey(7)".to_string(),
-///         detail: "backend rejected mutation".to_string(),
-///     },
-/// };
-/// assert!(err.to_string().contains("Move13Add"));
-/// ```
-#[derive(Debug, Clone, PartialEq)]
-#[non_exhaustive]
-pub enum CdtProposalError {
-    /// Constructing or applying a concrete proposal hit a hard backend or invariant failure.
-    ApplicationFailed {
-        /// Move type whose concrete application failed.
-        move_type: MoveType,
-        /// Local-site attempt that hit the hard failure.
-        attempt: usize,
-        /// Typed lower-level failure observed while committing the accepted move.
-        source: CdtError,
-    },
-}
-
-/// Telemetry for concrete Metropolis proposal outcomes.
-///
-/// These counters describe the proposal kernel observed during a run. They are
-/// diagnostic only: detailed balance is enforced by the per-step proposal
-/// probability used in the Hastings ratio, not by accumulated empirical counts.
-///
-/// The struct is non-exhaustive so future releases can add proposal telemetry
-/// without breaking downstream code. Construct empty accumulators with
-/// [`Self::new`] or [`Default::default`], and inspect fields through shared
-/// references returned by [`CdtMcmcCheckpoint::proposal_stats`] or
-/// [`SimulationResultsBackend::proposal_stats`]. Counters saturate at
-/// `u64::MAX` instead of wrapping.
-///
-/// # Examples
-///
-/// ```
-/// use causal_triangulations::prelude::simulation::ProposalStatistics;
-///
-/// let stats = ProposalStatistics::new();
-/// assert_eq!(stats.move_family_proposals, 0);
-/// assert_eq!(stats.accepted_transitions, 0);
-/// ```
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
-pub struct ProposalStatistics {
-    /// Number of selected move-family proposals, saturating at `u64::MAX`.
-    pub move_family_proposals: u64,
-    /// Sum of sampleable forward-site denominators observed during planning,
-    /// saturating at `u64::MAX`.
-    pub observed_forward_sites: u64,
-    /// Number of proposals with no sampleable local site, saturating at `u64::MAX`.
-    pub no_site_proposals: u64,
-    /// Number of sampled sites rejected by causal checks, saturating at `u64::MAX`.
-    pub site_causality_rejections: u64,
-    /// Number of sampled sites rejected by geometric checks, saturating at `u64::MAX`.
-    pub site_geometric_rejections: u64,
-    /// Number of sampled sites rejected by backend mutation errors, saturating at `u64::MAX`.
-    pub site_backend_rejections: u64,
-    /// Number of valid proposed transitions rejected by the Metropolis draw,
-    /// saturating at `u64::MAX`.
-    pub metropolis_rejections: u64,
-    /// Number of proposed transitions committed to the chain, saturating at `u64::MAX`.
-    pub accepted_transitions: u64,
-    /// Number of proposal attempts that hit a hard failure, saturating at `u64::MAX`.
-    pub hard_failures: u64,
-}
-
-impl ProposalStatistics {
-    /// Creates an empty proposal telemetry accumulator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
-    ///
-    /// let stats = ProposalStatistics::new();
-    /// assert_eq!(stats, ProposalStatistics::default());
-    /// ```
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {
-            move_family_proposals: 0,
-            observed_forward_sites: 0,
-            no_site_proposals: 0,
-            site_causality_rejections: 0,
-            site_geometric_rejections: 0,
-            site_backend_rejections: 0,
-            metropolis_rejections: 0,
-            accepted_transitions: 0,
-            hard_failures: 0,
-        }
-    }
-
-    /// Records one selected move family and the forward-site denominator observed for it.
-    ///
-    /// This is proposal-kernel telemetry only; the per-step Hastings ratio uses
-    /// the instantaneous site count directly rather than accumulated statistics.
-    fn record_move_family(&mut self, forward_sites: usize) {
-        self.move_family_proposals = self.move_family_proposals.saturating_add(1);
-        self.observed_forward_sites = self
-            .observed_forward_sites
-            .saturating_add(u64::try_from(forward_sites).unwrap_or(u64::MAX));
-    }
-
-    /// Records a move-family proposal with no concrete local site.
-    const fn record_no_site(&mut self) {
-        self.no_site_proposals = self.no_site_proposals.saturating_add(1);
-    }
-
-    /// Classifies a sampled-site rejection without changing chain state.
-    ///
-    /// These are ordinary self-loop proposal outcomes, not hard failures.
-    const fn record_site_rejection(&mut self, rejection: &CdtProposalSiteRejection) {
-        match rejection {
-            CdtProposalSiteRejection::CausalityViolation => {
-                self.site_causality_rejections = self.site_causality_rejections.saturating_add(1);
-            }
-            CdtProposalSiteRejection::GeometricViolation => {
-                self.site_geometric_rejections = self.site_geometric_rejections.saturating_add(1);
-            }
-            CdtProposalSiteRejection::Kernel(_) => {
-                self.site_backend_rejections = self.site_backend_rejections.saturating_add(1);
-            }
-        }
-    }
-
-    /// Records Metropolis rejection after a valid proposed transition was scored.
-    const fn record_metropolis_rejection(&mut self) {
-        self.metropolis_rejections = self.metropolis_rejections.saturating_add(1);
-    }
-
-    /// Records a proposed transition that was committed to the live chain.
-    const fn record_accepted_transition(&mut self) {
-        self.accepted_transitions = self.accepted_transitions.saturating_add(1);
-    }
-
-    /// Records an unexpected hard failure during proposal application.
-    const fn record_hard_failure(&mut self) {
-        self.hard_failures = self.hard_failures.saturating_add(1);
-    }
-}
-
-impl fmt::Display for CdtProposalError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::ApplicationFailed {
-                move_type,
-                attempt,
-                source,
-            } => write!(
-                f,
-                "failed to apply {move_type:?} on attempt {attempt}: {source}"
-            ),
-        }
-    }
-}
-
-impl Error for CdtProposalError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::ApplicationFailed { source, .. } => Some(source),
-        }
-    }
-}
-
-impl From<CdtProposalError> for CdtError {
-    fn from(error: CdtProposalError) -> Self {
-        match error {
-            CdtProposalError::ApplicationFailed {
-                move_type,
-                attempt,
-                source,
-            } => Self::ProposalApplicationFailed {
-                move_type,
-                attempt,
-                source: MetropolisMoveApplicationFailure::from(source),
-            },
-        }
-    }
-}
-
-/// Delayed-commit CDT proposal distribution.
-///
-/// This adapter exposes CDT's clone-plan-commit move ordering through the
-/// [`DelayedProposal`] API. It plans a concrete local move on a cloned
-/// triangulation, scores the proposed state with the same [`ActionConfig`] as
-/// the matching [`CdtTarget`] or [`MetropolisAlgorithm`], corrects for
-/// forward/reverse proposal-site counts, and commits the clone only after
-/// acceptance.
-///
-/// # Examples
-///
-/// ```
-/// use causal_triangulations::prelude::action::ActionConfig;
-/// use causal_triangulations::prelude::errors::CdtResult;
-/// use causal_triangulations::prelude::simulation::{
-///     CdtProposal, CdtTriangulation, DelayedProposal,
-/// };
-/// use rand::{SeedableRng, rngs::StdRng};
-///
-/// # fn main() -> CdtResult<()> {
-/// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-/// let mut proposal = CdtProposal::new(ActionConfig::default())?;
-/// let mut rng = StdRng::seed_from_u64(7);
-///
-/// let plan = proposal.propose_plan(&tri, &mut rng)?;
-/// if let Some(plan) = plan {
-///     assert!(plan.action_before().is_finite());
-/// }
-/// # Ok(())
-/// # }
-/// ```
-pub struct CdtProposal {
-    action_config: ActionConfig,
-    moves: ErgodicsSystem,
-}
-
-impl CdtProposal {
-    /// Creates a new unseeded delayed CDT proposal distribution.
-    ///
-    /// Delayed scoring is delegated to the target passed to
-    /// [`DelayedProposal::proposed_log_prob`].
-    ///
-    /// # Errors
-    ///
-    /// Returns [`CdtError::InvalidConfiguration`] if the action couplings are
-    /// non-finite.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::action::ActionConfig;
-    /// use causal_triangulations::prelude::simulation::CdtProposal;
-    ///
-    /// let _proposal = CdtProposal::new(ActionConfig::default())?;
-    /// # Ok::<(), causal_triangulations::CdtError>(())
-    /// ```
-    pub fn new(action_config: ActionConfig) -> CdtResult<Self> {
-        action_config.validate()?;
-        Ok(Self {
-            action_config,
-            moves: ErgodicsSystem::new(),
-        })
-    }
-
-    /// Creates a seeded delayed CDT proposal distribution.
-    ///
-    /// The seed controls the internal move-family selector. The `rng` passed to
-    /// [`DelayedProposal::propose_plan`] is still accepted for compatibility
-    /// with generic MCMC drivers.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`CdtError::InvalidConfiguration`] if the action couplings are
-    /// non-finite.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::action::ActionConfig;
-    /// use causal_triangulations::prelude::simulation::CdtProposal;
-    ///
-    /// let _proposal = CdtProposal::with_seed(ActionConfig::default(), 42)?;
-    /// # Ok::<(), causal_triangulations::CdtError>(())
-    /// ```
-    pub fn with_seed(action_config: ActionConfig, seed: u64) -> CdtResult<Self> {
-        action_config.validate()?;
-        Ok(Self {
-            action_config,
-            moves: ErgodicsSystem::with_seed(seed),
-        })
-    }
-}
-
-impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
-    type Plan = CdtProposalPlan;
-    type Info = CdtProposalInfo;
-    type Error = CdtProposalError;
-
-    fn propose_plan<R: Rng + ?Sized>(
-        &mut self,
-        state: &CdtTriangulation2D,
-        _rng: &mut R,
-    ) -> Result<Option<Self::Plan>, Self::Error> {
-        let move_type = self.moves.select_random_move();
-        let action_before = action_for(&self.action_config, state);
-        let mut proposal_stats = ProposalStatistics::new();
-        let plan = match propose_concrete_plan(
-            state,
-            &mut self.moves,
-            &mut proposal_stats,
-            &self.action_config,
-            move_type,
-            action_before,
-        ) {
-            Ok(Some(plan)) => plan,
-            Ok(None) => {
-                cold_path();
-                return Ok(None);
-            }
-            Err(err) => {
-                cold_path();
-                return Err(CdtProposalError::ApplicationFailed {
-                    move_type,
-                    attempt: err.attempt,
-                    source: err.source,
-                });
-            }
-        };
-        Ok(Some(plan))
-    }
-
-    fn proposed_log_prob<T: Target<CdtTriangulation2D>>(
-        &self,
-        _state: &CdtTriangulation2D,
-        plan: &Self::Plan,
-        target: &T,
-    ) -> Result<f64, Self::Error> {
-        Ok(plan
-            .action_after
-            .map_or(f64::NEG_INFINITY, |_| target.log_prob(&plan.proposed_state)))
-    }
-
-    fn log_q_ratio(
-        &self,
-        state: &CdtTriangulation2D,
-        plan: &Self::Plan,
-    ) -> Result<f64, Self::Error> {
-        Ok(concrete_log_q_ratio(state, plan))
-    }
-
-    fn info(&self, plan: &Self::Plan) -> Self::Info {
-        CdtProposalInfo {
-            move_type: plan.move_type,
-            action_before: plan.action_before,
-            action_after: plan.action_after,
-            delta_action: plan.delta_action,
-        }
-    }
-
-    fn commit<R: Rng + ?Sized>(
-        &mut self,
-        state: &mut CdtTriangulation2D,
-        plan: Self::Plan,
-        _rng: &mut R,
-    ) -> Result<(), Self::Error> {
-        *state = plan.proposed_state;
-        Ok(())
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Metropolis algorithm
-// ---------------------------------------------------------------------------
-
-/// Resumable checkpoint for a CDT Metropolis-Hastings run.
-///
-/// The embedded [`ChainCheckpoint`] stores the current triangulation and
-/// accepted/rejected chain counters using the shared MCMC crate's portable
-/// checkpoint type. CDT adds the domain-specific runtime state needed for
-/// scientific continuation: action/config metadata, accumulated telemetry,
-/// both RNG streams, and the ergodic move system.
-///
-/// In-memory checkpoints can be resumed directly with
-/// [`MetropolisAlgorithm::resume_from_checkpoint`] when callers want cumulative
-/// results, or [`MetropolisAlgorithm::resume_to_checkpoint`] when chunked
-/// drivers need another resumable checkpoint. Serialized checkpoints restore
-/// through the embedded [`CdtTriangulation2D`]'s checked serde path, so
-/// deserialization also requires the stored backend triangulation to satisfy
-/// the current Delaunay reconstruction invariants.
-///
-/// # Examples
-///
-/// ```
-/// use causal_triangulations::prelude::simulation::{
-///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
-/// };
-///
-/// fn main() -> CdtResult<()> {
-///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-///     let algorithm = MetropolisAlgorithm::new(
-///         MetropolisConfig::new(1.0, 2, 0, 1).with_seed(13),
-///         ActionConfig::default(),
-///     );
-///     let checkpoint = algorithm.run_to_checkpoint(tri)?;
-///
-///     assert_eq!(checkpoint.current_step(), 2);
-///     assert_eq!(checkpoint.steps().len(), 2);
-///     assert_eq!(checkpoint.chain().total_steps(), 2);
-///     assert_eq!(checkpoint.config().steps, 2);
-///     assert_eq!(checkpoint.action_config(), &ActionConfig::default());
-///     assert!(checkpoint.current_action().is_finite());
-///     assert_eq!(checkpoint.move_stats().total_attempted(), 2);
-///     assert_eq!(checkpoint.measurements().len(), 3);
-///     Ok(())
-/// }
-/// ```
-#[derive(Clone, Serialize, Deserialize)]
-pub struct CdtMcmcCheckpoint {
-    chain: ChainCheckpoint<CdtTriangulation2D>,
-    config: MetropolisConfig,
-    action_config: ActionConfig,
-    current_step: u32,
-    current_action: f64,
-    move_stats: MoveStatistics,
-    #[serde(default)]
-    proposal_stats: ProposalStatistics,
-    steps: Vec<MonteCarloStep>,
-    measurements: Vec<Measurement>,
-    elapsed_time: Duration,
-    acceptance_rng: Xoshiro256PlusPlus,
-    ergodics: ErgodicsSystem,
-}
-
-impl CdtMcmcCheckpoint {
-    /// Returns the generic MCMC chain checkpoint.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
-    /// };
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
-    ///         ActionConfig::default(),
-    ///     )
-    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
-    ///
-    ///     assert_eq!(checkpoint.chain().total_steps(), 1);
-    ///     Ok(())
-    /// }
-    /// ```
-    pub const fn chain(&self) -> &ChainCheckpoint<CdtTriangulation2D> {
-        &self.chain
-    }
-
-    /// Returns the checkpointed triangulation state.
-    ///
-    /// This accessor is intended for chunked drivers that need to inspect the
-    /// current volume before deciding how many additional Metropolis proposals
-    /// to run.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
-    ///     TriangulationQuery,
-    /// };
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
-    ///         ActionConfig::default(),
-    ///     )
-    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
-    ///
-    ///     assert_eq!(checkpoint.triangulation().vertex_count(), 12);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub const fn triangulation(&self) -> &CdtTriangulation2D {
-        self.chain.state()
-    }
-
-    /// Returns the Metropolis configuration used when the checkpoint was made.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
-    /// };
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let config = MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13);
-    ///     let checkpoint = MetropolisAlgorithm::new(config.clone(), ActionConfig::default())
-    ///         .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
-    ///
-    ///     assert_eq!(checkpoint.config(), &config);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub const fn config(&self) -> &MetropolisConfig {
-        &self.config
-    }
-
-    /// Returns the action configuration used when the checkpoint was made.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
-    /// };
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let action_config = ActionConfig::new(1.0, 0.0, 0.1);
-    ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
-    ///         action_config.clone(),
-    ///     )
-    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
-    ///
-    ///     assert_eq!(checkpoint.action_config(), &action_config);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub const fn action_config(&self) -> &ActionConfig {
-        &self.action_config
-    }
-
-    /// Returns the last completed Monte Carlo step.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
-    /// };
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
-    ///         ActionConfig::default(),
-    ///     )
-    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
-    ///
-    ///     assert_eq!(checkpoint.current_step(), 1);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub const fn current_step(&self) -> u32 {
-        self.current_step
-    }
-
-    /// Returns the action of the checkpointed triangulation.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
-    /// };
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
-    ///         ActionConfig::default(),
-    ///     )
-    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
-    ///
-    ///     assert!(checkpoint.current_action().is_finite());
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub const fn current_action(&self) -> f64 {
-        self.current_action
-    }
-
-    /// Returns accumulated move statistics through the checkpoint step.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
-    /// };
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
-    ///         ActionConfig::default(),
-    ///     )
-    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
-    ///
-    ///     assert_eq!(checkpoint.move_stats().total_attempted(), 1);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub const fn move_stats(&self) -> &MoveStatistics {
-        &self.move_stats
-    }
-
-    /// Returns accumulated proposal-kernel telemetry through the checkpoint step.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
-    /// };
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
-    ///         ActionConfig::default(),
-    ///     )
-    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
-    ///
-    ///     assert_eq!(checkpoint.proposal_stats().move_family_proposals, 1);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub const fn proposal_stats(&self) -> &ProposalStatistics {
-        &self.proposal_stats
-    }
-
-    /// Returns accumulated step telemetry through the checkpoint step.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
-    /// };
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
-    ///         ActionConfig::default(),
-    ///     )
-    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
-    ///
-    ///     assert_eq!(checkpoint.steps().len(), 1);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub fn steps(&self) -> &[MonteCarloStep] {
-        &self.steps
-    }
-
-    /// Returns accumulated measurements through the checkpoint step.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
-    /// };
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
-    ///         ActionConfig::default(),
-    ///     )
-    ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
-    ///
-    ///     assert!(!checkpoint.measurements().is_empty());
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub fn measurements(&self) -> &[Measurement] {
-        &self.measurements
-    }
-
-    /// Converts the checkpoint into a complete simulation result snapshot.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
-    /// };
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 2, 0, 1).with_seed(13),
-    ///         ActionConfig::default(),
-    ///     )
-    ///     .run_to_checkpoint(tri)?;
-    ///
-    ///     let results = checkpoint.into_results();
-    ///     assert_eq!(results.steps().len(), 2);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub fn into_results(self) -> SimulationResultsBackend {
-        let (triangulation, _, _) = self.chain.into_parts();
-        SimulationResultsBackend::from_parts(SimulationResultsParts {
-            config: self.config,
-            action_config: self.action_config,
-            move_stats: self.move_stats,
-            proposal_stats: self.proposal_stats,
-            steps: self.steps,
-            measurements: self.measurements,
-            elapsed_time: self.elapsed_time,
-            triangulation,
-        })
     }
 }
 
@@ -1192,6 +189,14 @@ impl MetropolisAlgorithm {
             config,
             action_config,
         }
+    }
+
+    pub(crate) const fn config(&self) -> &MetropolisConfig {
+        &self.config
+    }
+
+    pub(crate) const fn action_config(&self) -> &ActionConfig {
+        &self.action_config
     }
 
     /// Run the Monte Carlo simulation.
@@ -1282,8 +287,8 @@ impl MetropolisAlgorithm {
     /// Run the simulation and return a resumable checkpoint.
     ///
     /// The checkpoint embeds the current triangulation in the MCMC crate's
-    /// [`ChainCheckpoint`] and stores CDT-specific proposal state, telemetry,
-    /// and RNG streams beside it.
+    /// [`ChainCheckpoint`](markov_chain_monte_carlo::ChainCheckpoint) and stores CDT-specific
+    /// proposal state, telemetry, and RNG streams beside it.
     ///
     /// Direct in-memory resume through [`Self::resume_from_checkpoint`] or
     /// [`Self::resume_to_checkpoint`] does not reserialize the triangulation.
@@ -1438,12 +443,7 @@ impl MetropolisAlgorithm {
         result_config.steps = checkpoint
             .current_step
             .checked_add(self.config.steps)
-            .ok_or_else(|| {
-                checkpoint_resume_failed(
-                    CheckpointResumeReason::StepCountOverflow,
-                    "resumed step count exceeds u32::MAX",
-                )
-            })?;
+            .ok_or_else(|| checkpoint_resume_failed(CheckpointResumeFailure::StepCountOverflow))?;
 
         let mut state = MetropolisRunState::from_checkpoint(checkpoint)?;
         self.run_steps(&mut state, self.config.steps)?;
@@ -1478,10 +478,7 @@ impl MetropolisAlgorithm {
         let start = Instant::now();
         for _ in 0..additional_steps {
             let step = state.current_step.checked_add(1).ok_or_else(|| {
-                checkpoint_resume_failed(
-                    CheckpointResumeReason::StepCountOverflow,
-                    "resumed step count exceeds u32::MAX",
-                )
+                checkpoint_resume_failed(CheckpointResumeFailure::StepCountOverflow)
             })?;
             run_one_step(self, state, step)?;
             state.current_step = step;
@@ -1502,31 +499,16 @@ impl MetropolisRunState {
         let target = CdtTarget::new(
             checkpoint.action_config.clone(),
             checkpoint.config.temperature,
-        )
-        .map_err(|err| {
-            checkpoint_resume_failed(
-                CheckpointResumeReason::CheckpointTargetConfiguration,
-                err.to_string(),
-            )
-        })?;
-        let chain = Chain::from_checkpoint(checkpoint.chain, &target).map_err(|err| {
-            checkpoint_resume_failed(CheckpointResumeReason::McmcChainRestore, err.to_string())
-        })?;
-        let triangulation = chain.into_state();
-        triangulation.validate_evolved_cdt().map_err(|err| {
-            checkpoint_resume_failed(
-                CheckpointResumeReason::TriangulationInvariants,
-                err.to_string(),
-            )
-        })?;
+        )?;
+        let triangulation = restore_checkpoint_state(checkpoint.chain, &target)?;
+        triangulation.validate_evolved_cdt()?;
         let actual_action = action_for(&checkpoint.action_config, &triangulation);
         if !actions_match(actual_action, checkpoint.current_action) {
             return Err(checkpoint_resume_failed(
-                CheckpointResumeReason::ActionMismatch,
-                format!(
-                    "checkpoint action mismatch: stored {}, recomputed {}",
-                    checkpoint.current_action, actual_action
-                ),
+                CheckpointResumeFailure::ActionMismatch {
+                    stored: checkpoint.current_action,
+                    recomputed: actual_action,
+                },
             ));
         }
 
@@ -1556,8 +538,10 @@ impl MetropolisRunState {
     ) -> CdtResult<CdtMcmcCheckpoint> {
         self.triangulation.validate_evolved_cdt()?;
         let (accepted, rejected) = chain_counters(&self.move_stats)?;
-        Ok(CdtMcmcCheckpoint {
-            chain: ChainCheckpoint::new(self.triangulation, accepted, rejected),
+        Ok(CdtMcmcCheckpoint::from_parts(CdtMcmcCheckpointParts {
+            triangulation: self.triangulation,
+            accepted,
+            rejected,
             config,
             action_config,
             current_step: self.current_step,
@@ -1569,7 +553,7 @@ impl MetropolisRunState {
             elapsed_time: self.elapsed_time,
             acceptance_rng: self.acceptance_rng,
             ergodics: self.ergodics,
-        })
+        }))
     }
 }
 
@@ -1685,510 +669,12 @@ fn validate_evolved_cdt_if_due(state: &MetropolisRunState) -> CdtResult<()> {
     Ok(())
 }
 
-/// Builds a structured checkpoint-resume error.
-fn checkpoint_resume_failed(reason: CheckpointResumeReason, detail: impl Into<String>) -> CdtError {
-    CdtError::CheckpointResumeFailed {
-        reason,
-        detail: detail.into(),
-    }
-}
-
-/// Verifies that a checkpoint can be resumed by the requested algorithm.
-///
-/// Resume accepts a different fresh seed because serialized checkpoints carry
-/// their own RNG streams, but rejects physics and sampling schedule changes
-/// that would make the cumulative chain scientifically ambiguous.
-fn validate_resume_compatible(
-    algorithm: &MetropolisAlgorithm,
-    checkpoint: &CdtMcmcCheckpoint,
-) -> CdtResult<()> {
-    if algorithm.action_config != checkpoint.action_config {
-        return Err(checkpoint_resume_failed(
-            CheckpointResumeReason::IncompatibleActionConfiguration,
-            "action configuration differs from checkpoint",
-        ));
-    }
-    if algorithm.config.temperature.to_bits() != checkpoint.config.temperature.to_bits() {
-        return Err(checkpoint_resume_failed(
-            CheckpointResumeReason::IncompatibleTemperature,
-            "temperature differs from checkpoint",
-        ));
-    }
-    if algorithm.config.thermalization_steps != checkpoint.config.thermalization_steps {
-        return Err(checkpoint_resume_failed(
-            CheckpointResumeReason::IncompatibleThermalizationSchedule,
-            "thermalization schedule differs from checkpoint",
-        ));
-    }
-    if algorithm.config.measurement_frequency != checkpoint.config.measurement_frequency {
-        return Err(checkpoint_resume_failed(
-            CheckpointResumeReason::IncompatibleMeasurementFrequency,
-            "measurement frequency differs from checkpoint",
-        ));
-    }
-    validate_checkpoint_counters(checkpoint)
-}
-
-/// Checks that serialized chain counters and CDT telemetry agree.
-///
-/// The generic checkpoint, move statistics, current step, and step telemetry
-/// are redundant by design; this catches tampered or partially written
-/// checkpoint payloads before any resumed sampling occurs.
-fn validate_checkpoint_counters(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
-    checkpoint.config.validate().map_err(|err| {
-        checkpoint_resume_failed(
-            CheckpointResumeReason::CheckpointConfiguration,
-            err.to_string(),
-        )
-    })?;
-    checkpoint.action_config.validate().map_err(|err| {
-        checkpoint_resume_failed(
-            CheckpointResumeReason::CheckpointActionConfiguration,
-            err.to_string(),
-        )
-    })?;
-
-    let (accepted, rejected) = chain_counters(&checkpoint.move_stats)?;
-    if checkpoint.chain.accepted() != accepted || checkpoint.chain.rejected() != rejected {
-        return Err(checkpoint_resume_failed(
-            CheckpointResumeReason::ChainCounterMismatch,
-            "chain counters do not match move statistics",
-        ));
-    }
-    if checkpoint.chain.total_steps()
-        != usize::try_from(checkpoint.current_step).unwrap_or(usize::MAX)
-    {
-        return Err(checkpoint_resume_failed(
-            CheckpointResumeReason::ChainStepMismatch,
-            "chain step count does not match checkpoint step",
-        ));
-    }
-    if checkpoint.steps.len() != checkpoint.chain.total_steps() {
-        return Err(checkpoint_resume_failed(
-            CheckpointResumeReason::StepTelemetryMismatch,
-            "step telemetry length does not match chain step count",
-        ));
-    }
-    validate_checkpoint_steps(checkpoint)?;
-    validate_checkpoint_measurements(checkpoint)?;
-    Ok(())
-}
-
-/// Checks that serialized per-step telemetry forms the exact prefix being resumed.
-fn validate_checkpoint_steps(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
-    let accepted_steps = checkpoint.steps.iter().filter(|step| step.accepted).count();
-    if accepted_steps != checkpoint.chain.accepted() {
-        return Err(checkpoint_resume_failed(
-            CheckpointResumeReason::StepTelemetryMismatch,
-            format!(
-                "accepted step count mismatch: got {}, expected {}",
-                accepted_steps,
-                checkpoint.chain.accepted()
-            ),
-        ));
-    }
-
-    for (index, step) in checkpoint.steps.iter().enumerate() {
-        let expected_step = u32::try_from(index + 1).map_err(|_| {
-            checkpoint_resume_failed(
-                CheckpointResumeReason::StepTelemetryOverflow,
-                "step telemetry index exceeds u32::MAX",
-            )
-        })?;
-        if step.step != expected_step {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeReason::StepTelemetryMismatch,
-                format!(
-                    "step telemetry must be sequential: got step {}, expected {}",
-                    step.step, expected_step
-                ),
-            ));
-        }
-        if !step.action_before.is_finite() {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeReason::StepTelemetryMismatch,
-                format!("step {} has non-finite action_before", step.step),
-            ));
-        }
-        if let Some(delta_action) = step.delta_action
-            && !delta_action.is_finite()
-        {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeReason::StepTelemetryMismatch,
-                format!("step {} has non-finite delta_action", step.step),
-            ));
-        }
-        if step.accepted && step.delta_action.is_none() {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeReason::StepTelemetryMismatch,
-                format!("accepted step {} is missing delta_action", step.step),
-            ));
-        }
-        match (step.accepted, step.action_after) {
-            (true, Some(action_after)) if action_after.is_finite() => {
-                if let Some(delta_action) = step.delta_action
-                    && !actions_match(action_after, step.action_before + delta_action)
-                {
-                    return Err(checkpoint_resume_failed(
-                        CheckpointResumeReason::StepTelemetryMismatch,
-                        format!(
-                            "step {} action_after does not match delta_action",
-                            step.step
-                        ),
-                    ));
-                }
-            }
-            (true, Some(_)) => {
-                return Err(checkpoint_resume_failed(
-                    CheckpointResumeReason::StepTelemetryMismatch,
-                    format!("step {} has non-finite action_after", step.step),
-                ));
-            }
-            (true, None) => {
-                return Err(checkpoint_resume_failed(
-                    CheckpointResumeReason::StepTelemetryMismatch,
-                    format!("accepted step {} is missing action_after", step.step),
-                ));
-            }
-            (false, Some(_)) => {
-                return Err(checkpoint_resume_failed(
-                    CheckpointResumeReason::StepTelemetryMismatch,
-                    format!("rejected step {} unexpectedly has action_after", step.step),
-                ));
-            }
-            (false, None) => {}
-        }
-    }
-    Ok(())
-}
-
-/// Checks that serialized measurements match the configured sampling schedule.
-fn validate_checkpoint_measurements(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
-    let expected_measurements = usize::try_from(
-        u64::from(checkpoint.current_step) / u64::from(checkpoint.config.measurement_frequency) + 1,
-    )
-    .map_err(|_| {
-        checkpoint_resume_failed(
-            CheckpointResumeReason::MeasurementTelemetryOverflow,
-            "scheduled measurement count exceeds usize::MAX",
-        )
-    })?;
-    if checkpoint.measurements.len() != expected_measurements {
-        return Err(checkpoint_resume_failed(
-            CheckpointResumeReason::MeasurementTelemetryMismatch,
-            format!(
-                "scheduled measurement count mismatch: got {}, expected {}",
-                checkpoint.measurements.len(),
-                expected_measurements
-            ),
-        ));
-    }
-
-    for (index, measurement) in checkpoint.measurements.iter().enumerate() {
-        let expected_step = u64::try_from(index)
-            .ok()
-            .and_then(|index| index.checked_mul(u64::from(checkpoint.config.measurement_frequency)))
-            .and_then(|step| u32::try_from(step).ok())
-            .ok_or_else(|| {
-                checkpoint_resume_failed(
-                    CheckpointResumeReason::MeasurementTelemetryOverflow,
-                    "scheduled measurement step exceeds u32::MAX",
-                )
-            })?;
-        if measurement.step != expected_step {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeReason::MeasurementTelemetryMismatch,
-                format!(
-                    "measurement telemetry must follow the sampling schedule: got step {}, expected {}",
-                    measurement.step, expected_step
-                ),
-            ));
-        }
-        if !measurement.action.is_finite() {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeReason::MeasurementTelemetryMismatch,
-                format!(
-                    "measurement at step {} has non-finite action",
-                    measurement.step
-                ),
-            ));
-        }
-    }
-    Ok(())
-}
-
-/// Sums move counters without allowing invalid serialized telemetry to wrap.
-fn checked_move_counter_sum(counter_name: &str, counters: [u64; 4]) -> CdtResult<u64> {
-    counters.into_iter().try_fold(0_u64, |total, count| {
-        total.checked_add(count).ok_or_else(|| {
-            checkpoint_resume_failed(
-                CheckpointResumeReason::MoveStatisticsInvariant,
-                format!("{counter_name} move count exceeds u64::MAX"),
-            )
-        })
-    })
-}
-
-/// Rejects per-move counter states that cannot be produced by the sampler.
-fn validate_move_counter_bounds(move_stats: &MoveStatistics) -> CdtResult<()> {
-    let counters = [
-        (
-            MoveType::Move22,
-            move_stats.moves_22_attempted,
-            move_stats.moves_22_accepted,
-            move_stats.moves_22_hard_failed,
-        ),
-        (
-            MoveType::Move13Add,
-            move_stats.moves_13_attempted,
-            move_stats.moves_13_accepted,
-            move_stats.moves_13_hard_failed,
-        ),
-        (
-            MoveType::Move31Remove,
-            move_stats.moves_31_attempted,
-            move_stats.moves_31_accepted,
-            move_stats.moves_31_hard_failed,
-        ),
-        (
-            MoveType::EdgeFlip,
-            move_stats.edge_flips_attempted,
-            move_stats.edge_flips_accepted,
-            move_stats.edge_flips_hard_failed,
-        ),
-    ];
-
-    for (move_type, attempted, accepted, hard_failed) in counters {
-        if hard_failed != 0 {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeReason::MoveStatisticsInvariant,
-                format!(
-                    "{move_type:?} hard-failure move count must be zero in resumable checkpoints"
-                ),
-            ));
-        }
-
-        if accepted > attempted {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeReason::MoveStatisticsInvariant,
-                format!("{move_type:?} accepted move count exceeds attempted move count"),
-            ));
-        }
-    }
-
-    Ok(())
-}
-
-/// Converts CDT move statistics into generic MCMC chain counters.
-///
-/// Accepted and rejected counts are derived from proposal accounting, with
-/// overflow and impossible accepted-above-attempted states reported as
-/// checkpoint resume errors instead of panicking.
-fn chain_counters(move_stats: &MoveStatistics) -> CdtResult<(usize, usize)> {
-    validate_move_counter_bounds(move_stats)?;
-    let attempted = checked_move_counter_sum(
-        "attempted",
-        [
-            move_stats.moves_22_attempted,
-            move_stats.moves_13_attempted,
-            move_stats.moves_31_attempted,
-            move_stats.edge_flips_attempted,
-        ],
-    )?;
-    let accepted = checked_move_counter_sum(
-        "accepted",
-        [
-            move_stats.moves_22_accepted,
-            move_stats.moves_13_accepted,
-            move_stats.moves_31_accepted,
-            move_stats.edge_flips_accepted,
-        ],
-    )?;
-    let rejected = attempted.checked_sub(accepted).ok_or_else(|| {
-        checkpoint_resume_failed(
-            CheckpointResumeReason::MoveStatisticsInvariant,
-            "accepted move count exceeds attempted move count",
-        )
-    })?;
-    Ok((
-        usize::try_from(accepted).map_err(|_| {
-            checkpoint_resume_failed(
-                CheckpointResumeReason::CounterConversionOverflow,
-                "accepted move count exceeds usize::MAX",
-            )
-        })?,
-        usize::try_from(rejected).map_err(|_| {
-            checkpoint_resume_failed(
-                CheckpointResumeReason::CounterConversionOverflow,
-                "rejected move count exceeds usize::MAX",
-            )
-        })?,
-    ))
-}
-
 /// Builds the RNG used only for Metropolis acceptance draws.
 ///
 /// This keeps acceptance randomness separate from move-site selection, so seeded
 /// simulations are reproducible while unseeded simulations still draw fresh entropy.
 fn simulation_rng(seed: Option<u64>) -> Xoshiro256PlusPlus {
     seed.map_or_else(rand::make_rng, Xoshiro256PlusPlus::seed_from_u64)
-}
-
-/// Reads simplex counts through the CDT wrapper for action and measurement code.
-///
-/// Centralizing these conversions keeps cached query paths authoritative and
-/// makes integer saturation explicit at the simulation boundary.
-fn simplex_counts(triangulation: &CdtTriangulation2D) -> SimplexCounts {
-    SimplexCounts {
-        vertices: saturating_usize_to_u32(triangulation.vertex_count()),
-        edges: saturating_usize_to_u32(triangulation.edge_count()),
-        triangles: saturating_usize_to_u32(triangulation.face_count()),
-    }
-}
-
-/// Computes the current action from live simplex counts.
-///
-/// The Metropolis loop calls this only after state is known to be current, which
-/// avoids trusting stale values across backend mutations or rollback.
-fn action_for(action_config: &ActionConfig, triangulation: &CdtTriangulation2D) -> f64 {
-    let counts = simplex_counts(triangulation);
-    action_config.calculate_action(counts.vertices, counts.edges, counts.triangles)
-}
-
-/// Captures a measurement from the live triangulation state.
-///
-/// Keeping measurement construction in one helper ensures recorded actions and
-/// simplex counts use the same query path at every measurement step.
-fn measurement_for(step: u32, action: f64, triangulation: &CdtTriangulation2D) -> Measurement {
-    let counts = simplex_counts(triangulation);
-    Measurement {
-        step,
-        action,
-        vertices: counts.vertices,
-        edges: counts.edges,
-        triangles: counts.triangles,
-        volume_profile: triangulation.volume_profile(),
-    }
-}
-
-/// Computes the count-level action change before mutating the triangulation.
-///
-/// This is the core proposal-before-mutation calculation: Metropolis acceptance
-/// must be based on the selected move type's known simplex-count delta, not on a
-/// speculative backend edit that may need rollback.
-fn proposed_delta_action(
-    action_config: &ActionConfig,
-    before: SimplexCounts,
-    move_type: MoveType,
-) -> Option<f64> {
-    let after = match move_type {
-        MoveType::Move22 | MoveType::EdgeFlip => before,
-        MoveType::Move13Add => SimplexCounts {
-            vertices: before.vertices.checked_add(1)?,
-            edges: before.edges.checked_add(3)?,
-            triangles: before.triangles.checked_add(2)?,
-        },
-        MoveType::Move31Remove => SimplexCounts {
-            vertices: before.vertices.checked_sub(1)?,
-            edges: before.edges.checked_sub(3)?,
-            triangles: before.triangles.checked_sub(2)?,
-        },
-    };
-
-    let action_before =
-        action_config.calculate_action(before.vertices, before.edges, before.triangles);
-    let action_after = action_config.calculate_action(after.vertices, after.edges, after.triangles);
-    Some(action_after - action_before)
-}
-
-fn propose_concrete_plan(
-    state: &CdtTriangulation2D,
-    moves: &mut ErgodicsSystem,
-    proposal_stats: &mut ProposalStatistics,
-    action_config: &ActionConfig,
-    move_type: MoveType,
-    action_before: f64,
-) -> Result<Option<CdtProposalPlan>, MoveApplicationError> {
-    if proposed_delta_action(action_config, simplex_counts(state), move_type).is_none() {
-        proposal_stats.record_move_family(0);
-        proposal_stats.record_no_site();
-        return Ok(None);
-    }
-    let selection = moves.select_proposal_site(state, move_type);
-    let forward_site_count = selection.site_count;
-    proposal_stats.record_move_family(forward_site_count);
-    let Some(site) = selection.site else {
-        proposal_stats.record_no_site();
-        return Ok(None);
-    };
-
-    let mut proposed_state = state.clone();
-    let result = moves.apply_proposal_site(&mut proposed_state, move_type, site);
-    let action_after = match result {
-        MoveResult::Success => action_for(action_config, &proposed_state),
-        MoveResult::HardFailure(err) => {
-            return Err(MoveApplicationError {
-                attempt: 1,
-                source: err,
-            });
-        }
-        MoveResult::CausalityViolation => {
-            proposal_stats.record_site_rejection(&CdtProposalSiteRejection::CausalityViolation);
-            return Ok(None);
-        }
-        MoveResult::GeometricViolation => {
-            proposal_stats.record_site_rejection(&CdtProposalSiteRejection::GeometricViolation);
-            return Ok(None);
-        }
-        MoveResult::Rejected(err) => {
-            proposal_stats.record_site_rejection(&CdtProposalSiteRejection::Kernel(err));
-            return Ok(None);
-        }
-    };
-    let delta_action = action_after - action_before;
-    let reverse_site_count = proposal_site_count(&proposed_state, reverse_move_type(move_type));
-
-    Ok(Some(CdtProposalPlan {
-        move_type,
-        action_before,
-        action_after: Some(action_after),
-        delta_action: Some(delta_action),
-        forward_site_count,
-        reverse_site_count,
-        proposed_state,
-    }))
-}
-
-fn concrete_log_q_ratio(_state: &CdtTriangulation2D, plan: &CdtProposalPlan) -> f64 {
-    let forward_sites = plan.forward_site_count;
-    if forward_sites == 0 {
-        return f64::NEG_INFINITY;
-    }
-
-    let reverse_sites = plan.reverse_site_count;
-    if reverse_sites == 0 {
-        return f64::NEG_INFINITY;
-    }
-
-    site_count_to_f64(forward_sites).ln() - site_count_to_f64(reverse_sites).ln()
-}
-
-const fn reverse_move_type(move_type: MoveType) -> MoveType {
-    match move_type {
-        MoveType::Move22 => MoveType::Move22,
-        MoveType::Move13Add => MoveType::Move31Remove,
-        MoveType::Move31Remove => MoveType::Move13Add,
-        MoveType::EdgeFlip => MoveType::EdgeFlip,
-    }
-}
-
-/// Converts local-site counts to finite values for proposal-ratio accounting.
-#[expect(
-    clippy::cast_precision_loss,
-    reason = "site counts are converted only for logarithmic Metropolis-Hastings ratios"
-)]
-const fn site_count_to_f64(count: usize) -> f64 {
-    count as f64
 }
 
 /// Applies the Metropolis acceptance rule to a proposed action change.
@@ -2202,21 +688,6 @@ fn metropolis_accept<R: Rng + ?Sized>(delta_action: f64, temperature: f64, rng: 
 
 fn metropolis_accept_log_alpha<R: Rng + ?Sized>(log_alpha: f64, rng: &mut R) -> bool {
     log_alpha >= 0.0 || rng.random::<f64>() < log_alpha.exp()
-}
-
-/// Compares action values with a scale-aware tolerance for checkpoint validation.
-fn actions_match(left: f64, right: f64) -> bool {
-    if !(left.is_finite() && right.is_finite()) {
-        return false;
-    }
-    let scale = left.abs().max(right.abs()).max(1.0);
-    (left - right).abs() <= f64::EPSILON * scale * 8.0
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct MoveApplicationError {
-    attempt: usize,
-    source: CdtError,
 }
 
 /// Builds the simulation-level error for an accepted move that could not be applied.
@@ -2240,14 +711,21 @@ fn accepted_move_error(
 
 #[cfg(test)]
 mod tests {
+    use super::super::adapter::{
+        CdtProposal, CdtProposalError, CdtProposalPlan, site_count_to_f64,
+    };
+    use super::super::helpers::{SimplexCounts, proposed_delta_action, simplex_counts};
+    use super::super::telemetry::CdtProposalSiteRejection;
     use super::*;
+    use crate::cdt::ergodic_moves::proposal_site_count;
     use crate::cdt::triangulation::CdtTriangulation;
-    use crate::errors::BackendMutationOperation;
+    use crate::errors::{BackendMutationOperation, CheckpointMoveCounter, ConfigurationSetting};
     use crate::geometry::traits::TriangulationQuery;
     use approx::assert_relative_eq;
-    use markov_chain_monte_carlo::Chain;
+    use markov_chain_monte_carlo::{Chain, DelayedProposal, Target};
     use rand::rngs::StdRng;
     use serde_json::{from_str, to_string, to_value};
+    use std::error::Error;
     use std::num::NonZeroUsize;
 
     fn assert_optional_relative_eq(left: Option<f64>, right: Option<f64>) {
@@ -2402,6 +880,47 @@ mod tests {
             .expect("synthetic rejected checkpoint should validate")
     }
 
+    fn synthetic_one_step_checkpoint(accepted: bool) -> CdtMcmcCheckpoint {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let config = MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13);
+        let action_config = ActionConfig::default();
+        let current_action = action_for(&action_config, &triangulation);
+        let move_type = MoveType::Move22;
+        let mut move_stats = MoveStatistics::new();
+        move_stats.record_attempt(move_type);
+        if accepted {
+            move_stats.record_success(move_type);
+        }
+
+        CdtMcmcCheckpoint::from_parts(CdtMcmcCheckpointParts {
+            triangulation: triangulation.clone(),
+            accepted: usize::from(accepted),
+            rejected: usize::from(!accepted),
+            config,
+            action_config,
+            current_step: 1,
+            current_action,
+            move_stats,
+            proposal_stats: ProposalStatistics::new(),
+            steps: vec![MonteCarloStep {
+                step: 1,
+                move_type,
+                accepted,
+                action_before: current_action,
+                action_after: accepted.then_some(current_action),
+                delta_action: accepted.then_some(0.0),
+            }],
+            measurements: vec![
+                measurement_for(0, current_action, &triangulation),
+                measurement_for(1, current_action, &triangulation),
+            ],
+            elapsed_time: Duration::ZERO,
+            acceptance_rng: simulation_rng(Some(1)),
+            ergodics: ErgodicsSystem::with_seed(2),
+        })
+    }
+
     fn empty_run_state(triangulation: CdtTriangulation2D) -> MetropolisRunState {
         MetropolisRunState {
             triangulation,
@@ -2419,13 +938,17 @@ mod tests {
 
     fn assert_checkpoint_resume_failed<T>(
         result: CdtResult<T>,
-        expected_reason: CheckpointResumeReason,
+        matches_failure: impl FnOnce(&CheckpointResumeFailure) -> bool,
         expected_detail: &str,
     ) {
-        let Err(CdtError::CheckpointResumeFailed { reason, detail }) = result else {
+        let Err(CdtError::CheckpointResumeFailed { failure }) = result else {
             panic!("expected checkpoint resume failure");
         };
-        assert_eq!(reason, expected_reason);
+        assert!(
+            matches_failure(&failure),
+            "unexpected checkpoint resume failure: {failure:?}"
+        );
+        let detail = failure.to_string();
         assert!(
             detail.contains(expected_detail),
             "expected detail to contain {expected_detail:?}, got {detail:?}"
@@ -2615,6 +1138,48 @@ mod tests {
     }
 
     #[test]
+    fn checkpoint_accessors_report_consistent_snapshot() {
+        let checkpoint = short_checkpoint();
+        let current_step =
+            usize::try_from(checkpoint.current_step()).expect("u32 step count should fit usize");
+        let accepted_moves = usize::try_from(checkpoint.move_stats().total_accepted())
+            .expect("test accepted move count should fit usize");
+        let last_step = checkpoint
+            .steps()
+            .last()
+            .expect("checkpoint should contain step telemetry");
+        let last_measurement = checkpoint
+            .measurements()
+            .last()
+            .expect("checkpoint should contain measurements");
+
+        assert_eq!(
+            checkpoint.chain().state().vertex_count(),
+            checkpoint.triangulation().vertex_count()
+        );
+        assert_eq!(checkpoint.chain().total_steps(), current_step);
+        assert_eq!(checkpoint.chain().accepted(), accepted_moves);
+        assert_eq!(checkpoint.config().steps, checkpoint.current_step());
+        assert_eq!(checkpoint.action_config(), &ActionConfig::default());
+        assert!(checkpoint.current_action().is_finite());
+        assert_eq!(
+            checkpoint.move_stats().total_attempted(),
+            u64::from(checkpoint.current_step())
+        );
+        assert_eq!(
+            checkpoint.proposal_stats().move_family_proposals,
+            u64::from(checkpoint.current_step())
+        );
+        assert_eq!(last_step.step, checkpoint.current_step());
+        assert_eq!(last_measurement.step, checkpoint.current_step());
+        assert_relative_eq!(
+            last_measurement.action,
+            checkpoint.current_action(),
+            epsilon = 1e-12
+        );
+    }
+
+    #[test]
     fn serialized_checkpoint_resumes_from_stored_rng_state() {
         let action_config = ActionConfig::default();
         let checkpoint = serializable_rejected_checkpoint(action_config.clone());
@@ -2766,7 +1331,12 @@ mod tests {
 
         assert_checkpoint_resume_failed(
             algorithm.resume_from_checkpoint(checkpoint),
-            CheckpointResumeReason::IncompatibleActionConfiguration,
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::IncompatibleActionConfiguration
+                )
+            },
             "action configuration",
         );
     }
@@ -2781,7 +1351,12 @@ mod tests {
 
         assert_checkpoint_resume_failed(
             algorithm.resume_to_checkpoint(checkpoint),
-            CheckpointResumeReason::IncompatibleActionConfiguration,
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::IncompatibleActionConfiguration
+                )
+            },
             "action configuration",
         );
     }
@@ -2796,8 +1371,75 @@ mod tests {
 
         assert_checkpoint_resume_failed(
             algorithm.resume_from_checkpoint(checkpoint),
-            CheckpointResumeReason::IncompatibleMeasurementFrequency,
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::IncompatibleMeasurementFrequency
+                )
+            },
             "measurement frequency",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_incompatible_temperature() {
+        let checkpoint = short_checkpoint();
+        let algorithm = MetropolisAlgorithm::new(
+            MetropolisConfig::new(2.0, 2, 0, 1).with_seed(999),
+            ActionConfig::default(),
+        );
+
+        assert_checkpoint_resume_failed(
+            algorithm.resume_from_checkpoint(checkpoint),
+            |failure| matches!(failure, CheckpointResumeFailure::IncompatibleTemperature),
+            "temperature differs",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_incompatible_thermalization_schedule() {
+        let checkpoint = short_checkpoint();
+        let algorithm = MetropolisAlgorithm::new(
+            MetropolisConfig::new(1.0, 2, 1, 1).with_seed(999),
+            ActionConfig::default(),
+        );
+
+        assert_checkpoint_resume_failed(
+            algorithm.resume_from_checkpoint(checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::IncompatibleThermalizationSchedule
+                )
+            },
+            "thermalization schedule",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_chain_step_mismatch() {
+        let mut checkpoint = short_checkpoint();
+        checkpoint.current_step += 1;
+        let chain_steps = checkpoint.chain.total_steps();
+        let checkpoint_step = checkpoint.current_step;
+        let algorithm = MetropolisAlgorithm::new(
+            MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
+            ActionConfig::default(),
+        );
+
+        assert_checkpoint_resume_failed(
+            algorithm.resume_from_checkpoint(checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::ChainStepMismatch {
+                        chain_steps: actual_chain_steps,
+                        checkpoint_step: actual_checkpoint_step,
+                    } if *actual_chain_steps == chain_steps
+                        && *actual_checkpoint_step == checkpoint_step
+                )
+            },
+            "chain step count",
         );
     }
 
@@ -2812,7 +1454,12 @@ mod tests {
 
         assert_checkpoint_resume_failed(
             algorithm.resume_from_checkpoint(checkpoint),
-            CheckpointResumeReason::ChainCounterMismatch,
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::ChainCounterMismatch { .. }
+                )
+            },
             "chain counters",
         );
     }
@@ -2828,7 +1475,12 @@ mod tests {
 
         assert_checkpoint_resume_failed(
             algorithm.resume_from_checkpoint(checkpoint),
-            CheckpointResumeReason::StepTelemetryMismatch,
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::StepTelemetryLengthMismatch { .. }
+                )
+            },
             "step telemetry length",
         );
     }
@@ -2844,7 +1496,12 @@ mod tests {
 
         assert_checkpoint_resume_failed(
             algorithm.resume_from_checkpoint(checkpoint),
-            CheckpointResumeReason::StepTelemetryMismatch,
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::StepTelemetrySequenceMismatch { .. }
+                )
+            },
             "step telemetry must be sequential",
         );
     }
@@ -2868,8 +1525,132 @@ mod tests {
 
         assert_checkpoint_resume_failed(
             algorithm.resume_from_checkpoint(checkpoint),
-            CheckpointResumeReason::StepTelemetryMismatch,
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::StepTelemetryAcceptedCountMismatch { .. }
+                )
+            },
             "accepted step count mismatch",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_nonfinite_step_action_before() {
+        let mut checkpoint = synthetic_one_step_checkpoint(true);
+        checkpoint.steps[0].action_before = f64::NAN;
+
+        assert_checkpoint_resume_failed(
+            validate_checkpoint_counters(&checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::NonFiniteStepActionBefore { step: 1 }
+                )
+            },
+            "non-finite action_before",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_nonfinite_step_delta_action() {
+        let mut checkpoint = synthetic_one_step_checkpoint(true);
+        checkpoint.steps[0].delta_action = Some(f64::NAN);
+
+        assert_checkpoint_resume_failed(
+            validate_checkpoint_counters(&checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::NonFiniteStepDeltaAction { step: 1 }
+                )
+            },
+            "non-finite delta_action",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_accepted_step_missing_delta_action() {
+        let mut checkpoint = synthetic_one_step_checkpoint(true);
+        checkpoint.steps[0].delta_action = None;
+
+        assert_checkpoint_resume_failed(
+            validate_checkpoint_counters(&checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::AcceptedStepMissingDeltaAction { step: 1 }
+                )
+            },
+            "missing delta_action",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_action_after_delta_mismatch() {
+        let mut checkpoint = synthetic_one_step_checkpoint(true);
+        checkpoint.steps[0].action_after = Some(checkpoint.steps[0].action_before + 1.0);
+
+        assert_checkpoint_resume_failed(
+            validate_checkpoint_counters(&checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: 1 }
+                )
+            },
+            "action_after does not match",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_nonfinite_step_action_after() {
+        let mut checkpoint = synthetic_one_step_checkpoint(true);
+        checkpoint.steps[0].action_after = Some(f64::NAN);
+
+        assert_checkpoint_resume_failed(
+            validate_checkpoint_counters(&checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::NonFiniteStepActionAfter { step: 1 }
+                )
+            },
+            "non-finite action_after",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_accepted_step_missing_action_after() {
+        let mut checkpoint = synthetic_one_step_checkpoint(true);
+        checkpoint.steps[0].action_after = None;
+
+        assert_checkpoint_resume_failed(
+            validate_checkpoint_counters(&checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::AcceptedStepMissingActionAfter { step: 1 }
+                )
+            },
+            "missing action_after",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_rejected_step_with_action_after() {
+        let mut checkpoint = synthetic_one_step_checkpoint(false);
+        checkpoint.steps[0].action_after = Some(checkpoint.steps[0].action_before);
+
+        assert_checkpoint_resume_failed(
+            validate_checkpoint_counters(&checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::RejectedStepHasActionAfter { step: 1 }
+                )
+            },
+            "unexpectedly has action_after",
         );
     }
 
@@ -2884,8 +1665,50 @@ mod tests {
 
         assert_checkpoint_resume_failed(
             algorithm.resume_from_checkpoint(checkpoint),
-            CheckpointResumeReason::MeasurementTelemetryMismatch,
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::MeasurementCountMismatch { .. }
+                )
+            },
             "scheduled measurement count mismatch",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_measurement_step_mismatch() {
+        let mut checkpoint = synthetic_one_step_checkpoint(true);
+        checkpoint.measurements[1].step = 2;
+
+        assert_checkpoint_resume_failed(
+            validate_checkpoint_counters(&checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::MeasurementStepMismatch {
+                        actual: 2,
+                        expected: 1
+                    }
+                )
+            },
+            "measurement telemetry step mismatch",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_nonfinite_measurement_action() {
+        let mut checkpoint = synthetic_one_step_checkpoint(true);
+        checkpoint.measurements[1].action = f64::NAN;
+
+        assert_checkpoint_resume_failed(
+            validate_checkpoint_counters(&checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::NonFiniteMeasurementAction { step: 1 }
+                )
+            },
+            "non-finite action",
         );
     }
 
@@ -2900,23 +1723,27 @@ mod tests {
 
         assert_checkpoint_resume_failed(
             algorithm.resume_from_checkpoint(checkpoint),
-            CheckpointResumeReason::ActionMismatch,
+            |failure| matches!(failure, CheckpointResumeFailure::ActionMismatch { .. }),
             "checkpoint action mismatch",
         );
     }
 
     #[test]
-    fn checkpoint_restore_maps_invalid_checkpoint_config_to_resume_failure() {
+    fn checkpoint_restore_preserves_invalid_checkpoint_config_variant() {
         let mut checkpoint = short_checkpoint();
         checkpoint.config.temperature = f64::NAN;
-        let Err(CdtError::CheckpointResumeFailed { reason, detail }) =
-            MetropolisRunState::from_checkpoint(checkpoint)
+        let Err(CdtError::InvalidSimulationConfiguration {
+            setting,
+            provided_value,
+            expected,
+        }) = MetropolisRunState::from_checkpoint(checkpoint)
         else {
             panic!("expected checkpoint configuration failure");
         };
 
-        assert_eq!(reason, CheckpointResumeReason::CheckpointConfiguration);
-        assert!(detail.contains("temperature"));
+        assert_eq!(setting, ConfigurationSetting::Temperature);
+        assert_eq!(provided_value, "NaN");
+        assert_eq!(expected, "finite and positive");
     }
 
     #[test]
@@ -2925,12 +1752,17 @@ mod tests {
             moves_22_accepted: 1,
             ..MoveStatistics::new()
         };
-        let Err(CdtError::CheckpointResumeFailed { reason, detail }) = chain_counters(&stats)
-        else {
+        let Err(CdtError::CheckpointResumeFailed { failure }) = chain_counters(&stats) else {
             panic!("expected impossible move statistics to fail");
         };
 
-        assert_eq!(reason, CheckpointResumeReason::MoveStatisticsInvariant);
+        assert!(matches!(
+            failure,
+            CheckpointResumeFailure::MoveAcceptedExceedsAttempted {
+                move_type: MoveType::Move22
+            }
+        ));
+        let detail = failure.to_string();
         assert!(detail.contains("accepted move count exceeds attempted move count"));
     }
 
@@ -2941,12 +1773,17 @@ mod tests {
             moves_13_attempted: 1,
             ..MoveStatistics::new()
         };
-        let Err(CdtError::CheckpointResumeFailed { reason, detail }) = chain_counters(&stats)
-        else {
+        let Err(CdtError::CheckpointResumeFailed { failure }) = chain_counters(&stats) else {
             panic!("expected overflowing move statistics to fail");
         };
 
-        assert_eq!(reason, CheckpointResumeReason::MoveStatisticsInvariant);
+        assert!(matches!(
+            failure,
+            CheckpointResumeFailure::MoveCounterOverflow {
+                counter: CheckpointMoveCounter::Attempted
+            }
+        ));
+        let detail = failure.to_string();
         assert!(detail.contains("attempted move count exceeds u64::MAX"));
     }
 
@@ -2958,12 +1795,17 @@ mod tests {
             moves_22_hard_failed: 1,
             ..MoveStatistics::new()
         };
-        let Err(CdtError::CheckpointResumeFailed { reason, detail }) = chain_counters(&stats)
-        else {
+        let Err(CdtError::CheckpointResumeFailed { failure }) = chain_counters(&stats) else {
             panic!("expected impossible hard-failure statistics to fail");
         };
 
-        assert_eq!(reason, CheckpointResumeReason::MoveStatisticsInvariant);
+        assert!(matches!(
+            failure,
+            CheckpointResumeFailure::MoveHardFailures {
+                move_type: MoveType::Move22
+            }
+        ));
+        let detail = failure.to_string();
         assert!(detail.contains("Move22"));
         assert!(detail.contains("hard-failure move count must be zero"));
     }
@@ -3043,13 +1885,13 @@ mod tests {
         assert_relative_eq!(
             proposed_delta_action(&action_config, before, MoveType::Move13Add)
                 .expect("1,3 delta should be finite"),
-            -2.7,
+            2.0 * crate::cdt::action::CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT,
             epsilon = 1e-12
         );
         assert_relative_eq!(
             proposed_delta_action(&action_config, before, MoveType::Move31Remove)
                 .expect("3,1 delta should be finite"),
-            2.7,
+            -2.0 * crate::cdt::action::CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT,
             epsilon = 1e-12
         );
     }
@@ -3266,9 +2108,7 @@ mod tests {
     fn validate_rejects_overflow() {
         let err = MetropolisConfig::new(1.0, u32::MAX, u32::MAX, 2)
             .validate()
-            .expect_err(
-                "Configuration should reject schedules without a reachable post-thermalization measurement",
-            );
+            .expect_err("unreachable post-thermalization measurement should be rejected");
 
         match err {
             CdtError::InvalidSimulationConfiguration {
@@ -3469,6 +2309,31 @@ mod tests {
             expected,
             epsilon = 1e-12
         );
+    }
+
+    #[test]
+    fn concrete_plan_does_not_mutate_ergodics_move_stats() {
+        let action_config = ActionConfig::default();
+        let triangulation =
+            CdtTriangulation::from_toroidal_cdt(4, 3).expect("toroidal CDT should build");
+        let mut moves = ErgodicsSystem::with_seed(19);
+        let mut proposal_stats = ProposalStatistics::new();
+        let action_before = action_for(&action_config, &triangulation);
+
+        let _plan = propose_concrete_plan(
+            &triangulation,
+            &mut moves,
+            &mut proposal_stats,
+            &action_config,
+            MoveType::Move13Add,
+            action_before,
+        )
+        .expect("planning should not hard-fail")
+        .expect("toroidal triangulation should have a volume-add proposal");
+
+        assert_eq!(moves.stats.total_attempted(), 0);
+        assert_eq!(moves.stats.total_accepted(), 0);
+        assert_eq!(moves.stats.total_hard_failures(), 0);
     }
 
     #[test]

--- a/src/cdt/metropolis/telemetry.rs
+++ b/src/cdt/metropolis/telemetry.rs
@@ -1,0 +1,186 @@
+//! Proposal and step telemetry for CDT Metropolis sampling.
+
+use crate::errors::CdtError;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::fmt;
+
+use crate::cdt::ergodic_moves::MoveType;
+
+/// Result of a Monte Carlo step.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MonteCarloStep {
+    /// Step number
+    pub step: u32,
+    /// Move type attempted
+    pub move_type: MoveType,
+    /// Whether the move was accepted
+    pub accepted: bool,
+    /// Action before the move
+    pub action_before: f64,
+    /// Action after the move (if accepted)
+    pub action_after: Option<f64>,
+    /// Change in action (ΔS)
+    pub delta_action: Option<f64>,
+}
+
+/// Local-site rejection observed while trying to realize an accepted CDT proposal.
+///
+/// These rejections mean the move type was selected and accepted at the
+/// count-action level, but the bounded random local-site search did not find a
+/// concrete site where the move could be applied.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum CdtProposalSiteRejection {
+    /// The selected local site would violate CDT causality.
+    CausalityViolation,
+    /// The selected local site was geometrically invalid.
+    GeometricViolation,
+    /// The selected local site was rejected by the backend mutation kernel.
+    Kernel(CdtError),
+}
+
+impl fmt::Display for CdtProposalSiteRejection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CausalityViolation => {
+                f.write_str("causality violation at selected application site")
+            }
+            Self::GeometricViolation => {
+                f.write_str("geometric violation at selected application site")
+            }
+            Self::Kernel(err) => err.fmt(f),
+        }
+    }
+}
+
+impl Error for CdtProposalSiteRejection {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Kernel(err) => Some(err),
+            Self::CausalityViolation | Self::GeometricViolation => None,
+        }
+    }
+}
+
+/// Telemetry for concrete Metropolis proposal outcomes.
+///
+/// These counters describe the proposal kernel observed during a run. They are
+/// diagnostic only: detailed balance is enforced by the per-step proposal
+/// probability used in the Hastings ratio, not by accumulated empirical counts.
+///
+/// The struct is non-exhaustive so future releases can add proposal telemetry
+/// without breaking downstream code. Construct empty accumulators with
+/// [`Self::new`] or [`Default::default`], and inspect fields through shared
+/// references returned by
+/// [`checkpoint proposal stats`][super::CdtMcmcCheckpoint::proposal_stats] or
+/// [`result proposal stats`][crate::cdt::results::SimulationResultsBackend::proposal_stats].
+/// Counters saturate at `u64::MAX` instead of wrapping.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::simulation::ProposalStatistics;
+///
+/// let stats = ProposalStatistics::new();
+/// assert_eq!(stats.move_family_proposals, 0);
+/// assert_eq!(stats.accepted_transitions, 0);
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ProposalStatistics {
+    /// Number of selected move-family proposals, saturating at `u64::MAX`.
+    pub move_family_proposals: u64,
+    /// Sum of sampleable forward-site denominators observed during planning,
+    /// saturating at `u64::MAX`.
+    pub observed_forward_sites: u64,
+    /// Number of proposals with no sampleable local site, saturating at `u64::MAX`.
+    pub no_site_proposals: u64,
+    /// Number of sampled sites rejected by causal checks, saturating at `u64::MAX`.
+    pub site_causality_rejections: u64,
+    /// Number of sampled sites rejected by geometric checks, saturating at `u64::MAX`.
+    pub site_geometric_rejections: u64,
+    /// Number of sampled sites rejected by backend mutation errors, saturating at `u64::MAX`.
+    pub site_backend_rejections: u64,
+    /// Number of valid proposed transitions rejected by the Metropolis draw,
+    /// saturating at `u64::MAX`.
+    pub metropolis_rejections: u64,
+    /// Number of proposed transitions committed to the chain, saturating at `u64::MAX`.
+    pub accepted_transitions: u64,
+    /// Number of proposal attempts that hit a hard failure, saturating at `u64::MAX`.
+    pub hard_failures: u64,
+}
+
+impl ProposalStatistics {
+    /// Creates an empty proposal telemetry accumulator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
+    ///
+    /// let stats = ProposalStatistics::new();
+    /// assert_eq!(stats, ProposalStatistics::default());
+    /// ```
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            move_family_proposals: 0,
+            observed_forward_sites: 0,
+            no_site_proposals: 0,
+            site_causality_rejections: 0,
+            site_geometric_rejections: 0,
+            site_backend_rejections: 0,
+            metropolis_rejections: 0,
+            accepted_transitions: 0,
+            hard_failures: 0,
+        }
+    }
+
+    /// Records one selected move family and the forward-site denominator observed for it.
+    ///
+    /// This is proposal-kernel telemetry only; the per-step Hastings ratio uses
+    /// the instantaneous site count directly rather than accumulated statistics.
+    pub(crate) fn record_move_family(&mut self, forward_sites: usize) {
+        self.move_family_proposals = self.move_family_proposals.saturating_add(1);
+        self.observed_forward_sites = self
+            .observed_forward_sites
+            .saturating_add(u64::try_from(forward_sites).unwrap_or(u64::MAX));
+    }
+
+    /// Records a move-family proposal with no concrete local site.
+    pub(crate) const fn record_no_site(&mut self) {
+        self.no_site_proposals = self.no_site_proposals.saturating_add(1);
+    }
+
+    /// Classifies a sampled-site rejection without changing chain state.
+    ///
+    /// These are ordinary self-loop proposal outcomes, not hard failures.
+    pub(crate) const fn record_site_rejection(&mut self, rejection: &CdtProposalSiteRejection) {
+        match rejection {
+            CdtProposalSiteRejection::CausalityViolation => {
+                self.site_causality_rejections = self.site_causality_rejections.saturating_add(1);
+            }
+            CdtProposalSiteRejection::GeometricViolation => {
+                self.site_geometric_rejections = self.site_geometric_rejections.saturating_add(1);
+            }
+            CdtProposalSiteRejection::Kernel(_) => {
+                self.site_backend_rejections = self.site_backend_rejections.saturating_add(1);
+            }
+        }
+    }
+
+    /// Records Metropolis rejection after a valid proposed transition was scored.
+    pub(crate) const fn record_metropolis_rejection(&mut self) {
+        self.metropolis_rejections = self.metropolis_rejections.saturating_add(1);
+    }
+
+    /// Records a proposed transition that was committed to the live chain.
+    pub(crate) const fn record_accepted_transition(&mut self) {
+        self.accepted_transitions = self.accepted_transitions.saturating_add(1);
+    }
+
+    /// Records an unexpected hard failure during proposal application.
+    pub(crate) const fn record_hard_failure(&mut self) {
+        self.hard_failures = self.hard_failures.saturating_add(1);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@
 //! - Triangulation generation parameters
 //! - Runtime behavior options
 
-use crate::cdt::action::ActionConfig;
+use crate::cdt::action::{ActionConfig, DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT};
 use crate::cdt::metropolis::MetropolisConfig;
 use crate::errors::{CdtError, CdtResult, ConfigurationSetting};
 use clap::error::ErrorKind;
@@ -215,21 +215,21 @@ struct CdtCliArgs {
 
     #[arg(
         long,
-        default_value = "1.0",
+        default_value = "0.0",
         help = "Regge action vertex coupling kappa_0"
     )]
     coupling_0: f64,
 
     #[arg(
         long,
-        default_value = "1.0",
+        default_value = "0.0",
         help = "Regge action triangle coupling kappa_2"
     )]
     coupling_2: f64,
 
     #[arg(
         long,
-        default_value = "0.1",
+        default_value_t = DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
         help = "Regge action cosmological constant lambda"
     )]
     cosmological_constant: f64,
@@ -872,9 +872,9 @@ impl CdtConfig {
             steps: 1000,
             thermalization_steps: 100,
             measurement_frequency: 10,
-            coupling_0: 1.0,
-            coupling_2: 1.0,
-            cosmological_constant: 0.1,
+            coupling_0: 0.0,
+            coupling_2: 0.0,
+            cosmological_constant: DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
             simulate: false,
             seed: None,
             topology: CdtTopology::OpenBoundary,
@@ -921,7 +921,7 @@ impl CdtConfig {
     /// use causal_triangulations::CdtConfig;
     ///
     /// let action = CdtConfig::new(16, 4).to_action_config();
-    /// assert_relative_eq!(action.coupling_0, 1.0);
+    /// assert_relative_eq!(action.coupling_0, 0.0);
     /// ```
     #[must_use]
     pub const fn to_action_config(&self) -> ActionConfig {
@@ -1156,9 +1156,9 @@ impl TestConfig {
             steps: 10,
             thermalization_steps: 2,
             measurement_frequency: 2,
-            coupling_0: 1.0,
-            coupling_2: 1.0,
-            cosmological_constant: 0.1,
+            coupling_0: 0.0,
+            coupling_2: 0.0,
+            cosmological_constant: DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
             simulate: false,
             seed: None,
             topology: CdtTopology::OpenBoundary,
@@ -1188,9 +1188,9 @@ impl TestConfig {
             steps: 100,
             thermalization_steps: 20,
             measurement_frequency: 5,
-            coupling_0: 1.0,
-            coupling_2: 1.0,
-            cosmological_constant: 0.1,
+            coupling_0: 0.0,
+            coupling_2: 0.0,
+            cosmological_constant: DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
             simulate: false,
             seed: None,
             topology: CdtTopology::OpenBoundary,
@@ -1220,9 +1220,9 @@ impl TestConfig {
             steps: 1000,
             thermalization_steps: 100,
             measurement_frequency: 10,
-            coupling_0: 1.0,
-            coupling_2: 1.0,
-            cosmological_constant: 0.1,
+            coupling_0: 0.0,
+            coupling_2: 0.0,
+            cosmological_constant: DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
             simulate: false,
             seed: None,
             topology: CdtTopology::OpenBoundary,
@@ -1348,9 +1348,12 @@ mod tests {
         assert_eq!(metropolis_config.steps, 1000);
 
         let action_config = config.to_action_config();
-        assert_relative_eq!(action_config.coupling_0, 1.0);
-        assert_relative_eq!(action_config.coupling_2, 1.0);
-        assert_relative_eq!(action_config.cosmological_constant, 0.1);
+        assert_relative_eq!(action_config.coupling_0, 0.0);
+        assert_relative_eq!(action_config.coupling_2, 0.0);
+        assert_relative_eq!(
+            action_config.cosmological_constant,
+            DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT
+        );
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,7 @@
 use crate::cdt::ergodic_moves::MoveType;
 use crate::cdt::foliation::FoliationError;
 use crate::config::CdtTopology;
+use markov_chain_monte_carlo::McmcError;
 use std::fmt;
 
 /// Highest cumulative upstream Delaunay validation level being enforced.
@@ -467,88 +468,240 @@ impl fmt::Display for CdtValidationFailure {
     }
 }
 
-/// Category explaining why a checkpoint could not be resumed.
+/// Move-statistics counter category used in checkpoint resume diagnostics.
+///
+/// Use this with [`CheckpointResumeFailure::MoveCounterOverflow`] and
+/// [`CheckpointResumeFailure::CounterConversionOverflow`] to distinguish which
+/// aggregated counter could not be represented without parsing display text.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::errors::CheckpointMoveCounter;
+///
+/// assert_eq!(CheckpointMoveCounter::Attempted.to_string(), "attempted");
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
-pub enum CheckpointResumeReason {
-    /// Resumed step count would overflow.
-    StepCountOverflow,
-    /// Checkpoint target reconstruction failed.
-    CheckpointTargetConfiguration,
-    /// Generic MCMC chain restoration failed.
-    McmcChainRestore,
-    /// Restored triangulation failed invariant validation.
-    TriangulationInvariants,
-    /// Stored action disagrees with recomputed action.
-    ActionMismatch,
-    /// Action configuration differs from the checkpoint.
-    IncompatibleActionConfiguration,
-    /// Temperature differs from the checkpoint.
-    IncompatibleTemperature,
-    /// Thermalization schedule differs from the checkpoint.
-    IncompatibleThermalizationSchedule,
-    /// Measurement frequency differs from the checkpoint.
-    IncompatibleMeasurementFrequency,
-    /// Checkpoint simulation configuration failed validation.
-    CheckpointConfiguration,
-    /// Checkpoint action configuration failed validation.
-    CheckpointActionConfiguration,
-    /// Generic MCMC chain counters disagree with CDT move statistics.
-    ChainCounterMismatch,
-    /// Generic MCMC chain step count disagrees with checkpoint step.
-    ChainStepMismatch,
-    /// Step telemetry is internally inconsistent.
-    StepTelemetryMismatch,
-    /// Step telemetry index conversion overflowed.
-    StepTelemetryOverflow,
-    /// Measurement telemetry count or step conversion overflowed.
-    MeasurementTelemetryOverflow,
-    /// Measurement telemetry is internally inconsistent.
-    MeasurementTelemetryMismatch,
-    /// Move statistics violate internal accounting invariants.
-    MoveStatisticsInvariant,
-    /// Accepted or rejected counter conversion overflowed.
-    CounterConversionOverflow,
+pub enum CheckpointMoveCounter {
+    /// Attempted move counter.
+    Attempted,
+    /// Accepted move counter.
+    Accepted,
+    /// Rejected move counter.
+    Rejected,
 }
 
-impl fmt::Display for CheckpointResumeReason {
+impl fmt::Display for CheckpointMoveCounter {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::StepCountOverflow => formatter.write_str("step count overflow"),
-            Self::CheckpointTargetConfiguration => {
-                formatter.write_str("checkpoint target configuration")
-            }
-            Self::McmcChainRestore => formatter.write_str("mcmc chain restore"),
-            Self::TriangulationInvariants => formatter.write_str("triangulation invariants"),
-            Self::ActionMismatch => formatter.write_str("action mismatch"),
-            Self::IncompatibleActionConfiguration => {
-                formatter.write_str("incompatible action configuration")
-            }
-            Self::IncompatibleTemperature => formatter.write_str("incompatible temperature"),
-            Self::IncompatibleThermalizationSchedule => {
-                formatter.write_str("incompatible thermalization schedule")
-            }
-            Self::IncompatibleMeasurementFrequency => {
-                formatter.write_str("incompatible measurement frequency")
-            }
-            Self::CheckpointConfiguration => formatter.write_str("checkpoint configuration"),
-            Self::CheckpointActionConfiguration => {
-                formatter.write_str("checkpoint action configuration")
-            }
-            Self::ChainCounterMismatch => formatter.write_str("chain counter mismatch"),
-            Self::ChainStepMismatch => formatter.write_str("chain step mismatch"),
-            Self::StepTelemetryMismatch => formatter.write_str("step telemetry mismatch"),
-            Self::StepTelemetryOverflow => formatter.write_str("step telemetry overflow"),
-            Self::MeasurementTelemetryOverflow => {
-                formatter.write_str("measurement telemetry overflow")
-            }
-            Self::MeasurementTelemetryMismatch => {
-                formatter.write_str("measurement telemetry mismatch")
-            }
-            Self::MoveStatisticsInvariant => formatter.write_str("move statistics invariant"),
-            Self::CounterConversionOverflow => formatter.write_str("counter conversion overflow"),
+            Self::Attempted => formatter.write_str("attempted"),
+            Self::Accepted => formatter.write_str("accepted"),
+            Self::Rejected => formatter.write_str("rejected"),
         }
     }
+}
+
+/// Structured reason a CDT checkpoint could not be resumed.
+///
+/// [`CdtError::CheckpointResumeFailed`] wraps this enum for CDT-owned resume
+/// invariants such as incompatible schedules, inconsistent telemetry, and
+/// overflow while rebuilding upstream MCMC counters. Upstream framework,
+/// configuration, and triangulation validation failures remain separate
+/// [`CdtError`] variants so callers can keep matching the original typed error.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::errors::{
+///     CdtError, CheckpointResumeFailure,
+/// };
+///
+/// let err = CdtError::CheckpointResumeFailed {
+///     failure: CheckpointResumeFailure::IncompatibleTemperature,
+/// };
+///
+/// assert!(matches!(
+///     err,
+///     CdtError::CheckpointResumeFailed {
+///         failure: CheckpointResumeFailure::IncompatibleTemperature,
+///     }
+/// ));
+/// ```
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum CheckpointResumeFailure {
+    /// Resumed step count would overflow.
+    #[error("resumed step count exceeds u32::MAX")]
+    StepCountOverflow,
+    /// Stored action disagrees with recomputed action.
+    #[error("checkpoint action mismatch: stored {stored}, recomputed {recomputed}")]
+    ActionMismatch {
+        /// Serialized action stored in the checkpoint.
+        stored: f64,
+        /// Action recomputed from the restored triangulation.
+        recomputed: f64,
+    },
+    /// Action configuration differs from the checkpoint.
+    #[error("action configuration differs from checkpoint")]
+    IncompatibleActionConfiguration,
+    /// Temperature differs from the checkpoint.
+    #[error("temperature differs from checkpoint")]
+    IncompatibleTemperature,
+    /// Thermalization schedule differs from the checkpoint.
+    #[error("thermalization schedule differs from checkpoint")]
+    IncompatibleThermalizationSchedule,
+    /// Measurement frequency differs from the checkpoint.
+    #[error("measurement frequency differs from checkpoint")]
+    IncompatibleMeasurementFrequency,
+    /// Generic MCMC chain counters disagree with CDT move statistics.
+    #[error(
+        "chain counters do not match move statistics: chain accepted={chain_accepted}, rejected={chain_rejected}; move accepted={move_accepted}, rejected={move_rejected}"
+    )]
+    ChainCounterMismatch {
+        /// Accepted proposals recorded by the upstream MCMC chain.
+        chain_accepted: usize,
+        /// Rejected proposals recorded by the upstream MCMC chain.
+        chain_rejected: usize,
+        /// Accepted proposals reconstructed from CDT move statistics.
+        move_accepted: usize,
+        /// Rejected proposals reconstructed from CDT move statistics.
+        move_rejected: usize,
+    },
+    /// Generic MCMC chain step count disagrees with checkpoint step.
+    #[error(
+        "chain step count does not match checkpoint step: chain steps={chain_steps}, checkpoint step={checkpoint_step}"
+    )]
+    ChainStepMismatch {
+        /// Total steps recorded by the upstream MCMC chain.
+        chain_steps: usize,
+        /// Current CDT step stored in the checkpoint.
+        checkpoint_step: u32,
+    },
+    /// Step telemetry length disagrees with the chain step count.
+    #[error("step telemetry length mismatch: got {actual}, expected {expected}")]
+    StepTelemetryLengthMismatch {
+        /// Number of serialized step records.
+        actual: usize,
+        /// Expected number of step records from the chain counters.
+        expected: usize,
+    },
+    /// Accepted-step telemetry count disagrees with the chain accepted count.
+    #[error("accepted step count mismatch: got {actual}, expected {expected}")]
+    StepTelemetryAcceptedCountMismatch {
+        /// Accepted steps recorded in CDT telemetry.
+        actual: usize,
+        /// Accepted proposals recorded by the upstream MCMC chain.
+        expected: usize,
+    },
+    /// Step telemetry index conversion overflowed.
+    #[error("step telemetry index exceeds u32::MAX")]
+    StepTelemetryIndexOverflow,
+    /// Step telemetry records are not sequential.
+    #[error("step telemetry must be sequential: got step {actual}, expected {expected}")]
+    StepTelemetrySequenceMismatch {
+        /// Serialized step value.
+        actual: u32,
+        /// Expected sequential step value.
+        expected: u32,
+    },
+    /// Step telemetry contains a non-finite pre-move action.
+    #[error("step {step} has non-finite action_before")]
+    NonFiniteStepActionBefore {
+        /// Step with invalid telemetry.
+        step: u32,
+    },
+    /// Step telemetry contains a non-finite action delta.
+    #[error("step {step} has non-finite delta_action")]
+    NonFiniteStepDeltaAction {
+        /// Step with invalid telemetry.
+        step: u32,
+    },
+    /// Accepted step telemetry is missing the action delta.
+    #[error("accepted step {step} is missing delta_action")]
+    AcceptedStepMissingDeltaAction {
+        /// Step with invalid telemetry.
+        step: u32,
+    },
+    /// Accepted step telemetry has an action-after value inconsistent with the delta.
+    #[error("step {step} action_after does not match delta_action")]
+    StepActionAfterDeltaMismatch {
+        /// Step with invalid telemetry.
+        step: u32,
+    },
+    /// Accepted step telemetry contains a non-finite post-move action.
+    #[error("step {step} has non-finite action_after")]
+    NonFiniteStepActionAfter {
+        /// Step with invalid telemetry.
+        step: u32,
+    },
+    /// Accepted step telemetry is missing the post-move action.
+    #[error("accepted step {step} is missing action_after")]
+    AcceptedStepMissingActionAfter {
+        /// Step with invalid telemetry.
+        step: u32,
+    },
+    /// Rejected step telemetry unexpectedly contains a post-move action.
+    #[error("rejected step {step} unexpectedly has action_after")]
+    RejectedStepHasActionAfter {
+        /// Step with invalid telemetry.
+        step: u32,
+    },
+    /// Measurement count calculation overflowed.
+    #[error("scheduled measurement count exceeds usize::MAX")]
+    MeasurementCountOverflow,
+    /// Measurement telemetry length disagrees with the configured schedule.
+    #[error("scheduled measurement count mismatch: got {actual}, expected {expected}")]
+    MeasurementCountMismatch {
+        /// Number of serialized measurements.
+        actual: usize,
+        /// Expected measurement count from the sampling schedule.
+        expected: usize,
+    },
+    /// Measurement step calculation overflowed.
+    #[error("scheduled measurement step exceeds u32::MAX")]
+    MeasurementStepOverflow,
+    /// Measurement telemetry step disagrees with the configured schedule.
+    #[error("measurement telemetry step mismatch: got {actual}, expected {expected}")]
+    MeasurementStepMismatch {
+        /// Serialized measurement step.
+        actual: u32,
+        /// Expected measurement step from the sampling schedule.
+        expected: u32,
+    },
+    /// Measurement telemetry contains a non-finite action.
+    #[error("measurement at step {step} has non-finite action")]
+    NonFiniteMeasurementAction {
+        /// Measurement step with invalid telemetry.
+        step: u32,
+    },
+    /// A per-move counter sum overflowed.
+    #[error("{counter} move count exceeds u64::MAX")]
+    MoveCounterOverflow {
+        /// Counter category that overflowed.
+        counter: CheckpointMoveCounter,
+    },
+    /// Resumable checkpoints cannot contain hard-failure move counters.
+    #[error("{move_type:?} hard-failure move count must be zero in resumable checkpoints")]
+    MoveHardFailures {
+        /// Move type with invalid hard-failure telemetry.
+        move_type: MoveType,
+    },
+    /// Accepted move counter exceeds attempted move counter.
+    #[error("{move_type:?} accepted move count exceeds attempted move count")]
+    MoveAcceptedExceedsAttempted {
+        /// Move type with impossible move telemetry.
+        move_type: MoveType,
+    },
+    /// Total accepted move count exceeds total attempted move count.
+    #[error("accepted move count exceeds attempted move count")]
+    TotalAcceptedExceedsAttempted,
+    /// Accepted or rejected counter conversion overflowed.
+    #[error("{counter} move count exceeds usize::MAX")]
+    CounterConversionOverflow {
+        /// Counter category that could not fit in upstream chain counters.
+        counter: CheckpointMoveCounter,
+    },
 }
 
 /// Lower-level source for a Metropolis-accepted move that could not be applied.
@@ -710,8 +863,21 @@ impl From<CdtError> for MetropolisMoveApplicationFailure {
             },
             CdtError::MetropolisMoveApplicationFailed { source, .. }
             | CdtError::ProposalApplicationFailed { source, .. } => source,
-            error => Self::Unexpected {
-                detail: error.to_string(),
+            unexpected @ (CdtError::UnsupportedDimension(_)
+            | CdtError::DelaunayGenerationFailed { .. }
+            | CdtError::InvalidGenerationParameters { .. }
+            | CdtError::InvalidConfiguration { .. }
+            | CdtError::InvalidSimulationConfiguration { .. }
+            | CdtError::InvalidTriangulationMetadata { .. }
+            | CdtError::VertexBuildFailed { .. }
+            | CdtError::Mcmc(_)
+            | CdtError::OutputWriteFailed { .. }
+            | CdtError::OutputPathResolutionFailed { .. }
+            | CdtError::OutputPathConflict { .. }
+            | CdtError::OutputReadFailed { .. }
+            | CdtError::CheckpointSerializationFailed { .. }
+            | CdtError::CheckpointResumeFailed { .. }) => Self::Unexpected {
+                detail: unexpected.to_string(),
             },
         }
     }
@@ -907,9 +1073,9 @@ pub enum CdtError {
         /// quantity that triggers the violation (`step_distance > 1`).
         step_distance: u32,
     },
-    /// MCMC framework error (e.g. NaN in log-probability)
+    /// Upstream MCMC framework error, such as a non-finite log-probability.
     #[error("MCMC error: {0}")]
-    Mcmc(String),
+    Mcmc(#[from] McmcError),
     /// Writing CSV/JSON simulation output failed.
     #[error("Failed to write {format} output to {path}: {detail}")]
     OutputWriteFailed {
@@ -957,12 +1123,15 @@ pub enum CdtError {
         detail: String,
     },
     /// Restoring or continuing an MCMC checkpoint failed before sampling resumed.
-    #[error("Failed to resume MCMC checkpoint [{reason}]: {detail}")]
+    ///
+    /// The [`CheckpointResumeFailure`] source is reserved for CDT-owned
+    /// resume invariants. Upstream MCMC, configuration, and triangulation
+    /// validation errors are reported through their more specific variants.
+    #[error("Failed to resume MCMC checkpoint: {failure}")]
     CheckpointResumeFailed {
-        /// Structured reason category for the resume failure.
-        reason: CheckpointResumeReason,
-        /// Human-readable reason resume could not proceed.
-        detail: String,
+        /// Structured resume failure with typed context.
+        #[source]
+        failure: CheckpointResumeFailure,
     },
 }
 
@@ -982,12 +1151,6 @@ fn format_causality_violation(time_0: u32, time_1: u32, step_distance: u32) -> S
              (t={time_0} to t={time_1}, |Δt|={raw} on the time circle), \
              maximum allowed is 1"
         )
-    }
-}
-
-impl From<markov_chain_monte_carlo::McmcError> for CdtError {
-    fn from(err: markov_chain_monte_carlo::McmcError) -> Self {
-        Self::Mcmc(err.to_string())
     }
 }
 
@@ -1235,86 +1398,31 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_resume_reason_display_covers_all_categories() {
+    fn checkpoint_move_counter_display_covers_all_categories() {
         let cases = [
-            (
-                CheckpointResumeReason::StepCountOverflow,
-                "step count overflow",
-            ),
-            (
-                CheckpointResumeReason::CheckpointTargetConfiguration,
-                "checkpoint target configuration",
-            ),
-            (
-                CheckpointResumeReason::McmcChainRestore,
-                "mcmc chain restore",
-            ),
-            (
-                CheckpointResumeReason::TriangulationInvariants,
-                "triangulation invariants",
-            ),
-            (CheckpointResumeReason::ActionMismatch, "action mismatch"),
-            (
-                CheckpointResumeReason::IncompatibleActionConfiguration,
-                "incompatible action configuration",
-            ),
-            (
-                CheckpointResumeReason::IncompatibleTemperature,
-                "incompatible temperature",
-            ),
-            (
-                CheckpointResumeReason::IncompatibleThermalizationSchedule,
-                "incompatible thermalization schedule",
-            ),
-            (
-                CheckpointResumeReason::IncompatibleMeasurementFrequency,
-                "incompatible measurement frequency",
-            ),
-            (
-                CheckpointResumeReason::CheckpointConfiguration,
-                "checkpoint configuration",
-            ),
-            (
-                CheckpointResumeReason::CheckpointActionConfiguration,
-                "checkpoint action configuration",
-            ),
-            (
-                CheckpointResumeReason::ChainCounterMismatch,
-                "chain counter mismatch",
-            ),
-            (
-                CheckpointResumeReason::ChainStepMismatch,
-                "chain step mismatch",
-            ),
-            (
-                CheckpointResumeReason::StepTelemetryMismatch,
-                "step telemetry mismatch",
-            ),
-            (
-                CheckpointResumeReason::StepTelemetryOverflow,
-                "step telemetry overflow",
-            ),
-            (
-                CheckpointResumeReason::MeasurementTelemetryOverflow,
-                "measurement telemetry overflow",
-            ),
-            (
-                CheckpointResumeReason::MeasurementTelemetryMismatch,
-                "measurement telemetry mismatch",
-            ),
-            (
-                CheckpointResumeReason::MoveStatisticsInvariant,
-                "move statistics invariant",
-            ),
-            (
-                CheckpointResumeReason::CounterConversionOverflow,
-                "counter conversion overflow",
-            ),
+            (CheckpointMoveCounter::Attempted, "attempted"),
+            (CheckpointMoveCounter::Accepted, "accepted"),
+            (CheckpointMoveCounter::Rejected, "rejected"),
         ];
 
-        for (reason, expected) in cases {
-            assert_eq!(reason.to_string(), expected);
+        for (counter, expected) in cases {
+            assert_eq!(counter.to_string(), expected);
         }
+    }
+
+    #[test]
+    fn checkpoint_resume_failure_display_includes_structured_context() {
+        let failure = CheckpointResumeFailure::ChainCounterMismatch {
+            chain_accepted: 1,
+            chain_rejected: 2,
+            move_accepted: 3,
+            move_rejected: 4,
+        };
+
+        assert_eq!(
+            failure.to_string(),
+            "chain counters do not match move statistics: chain accepted=1, rejected=2; move accepted=3, rejected=4"
+        );
     }
 
     #[test]
@@ -1722,15 +1830,22 @@ mod tests {
 
     #[test]
     fn test_mcmc_error() {
-        let error = CdtError::Mcmc("NaN log-probability".to_string());
+        let error = CdtError::Mcmc(McmcError::NanProposedLogProb);
         let display = format!("{error}");
-        assert_eq!(display, "MCMC error: NaN log-probability");
+        assert_eq!(
+            display,
+            "MCMC error: target returned NaN log-probability for a proposed state"
+        );
     }
 
     #[test]
     fn test_mcmc_error_from_conversion() {
-        let mcmc_err = markov_chain_monte_carlo::McmcError::NanProposedLogProb;
+        let mcmc_err = McmcError::NanProposedLogProb;
         let cdt_err: CdtError = mcmc_err.into();
+        assert!(matches!(
+            cdt_err,
+            CdtError::Mcmc(McmcError::NanProposedLogProb)
+        ));
         let display = format!("{cdt_err}");
         assert!(
             display.contains("MCMC error"),
@@ -1859,17 +1974,19 @@ mod tests {
     #[test]
     fn test_checkpoint_resume_failed_error() {
         let error = CdtError::CheckpointResumeFailed {
-            reason: CheckpointResumeReason::IncompatibleTemperature,
-            detail: "temperature differs from checkpoint".to_string(),
+            failure: CheckpointResumeFailure::IncompatibleTemperature,
         };
-        let CdtError::CheckpointResumeFailed { reason, detail } = &error else {
+        let CdtError::CheckpointResumeFailed { failure } = &error else {
             panic!("expected CheckpointResumeFailed variant");
         };
-        assert_eq!(*reason, CheckpointResumeReason::IncompatibleTemperature);
-        assert_eq!(detail, "temperature differs from checkpoint");
+        assert_eq!(*failure, CheckpointResumeFailure::IncompatibleTemperature);
         assert_eq!(
             format!("{error}"),
-            "Failed to resume MCMC checkpoint [incompatible temperature]: temperature differs from checkpoint"
+            "Failed to resume MCMC checkpoint: temperature differs from checkpoint"
+        );
+        assert_eq!(
+            Error::source(&error).map(ToString::to_string),
+            Some("temperature differs from checkpoint".to_string())
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,8 +129,37 @@ pub mod cdt {
     pub mod ergodic_moves;
     /// Foliation data structures (time labels, edge classification).
     pub mod foliation;
-    /// Metropolis-Hastings algorithm implementation.
-    pub mod metropolis;
+    /// Metropolis-Hastings sampling for CDT triangulations.
+    ///
+    /// The module is split by API boundary:
+    /// [`adapter`](crate::cdt::metropolis::adapter) exposes the CDT target and
+    /// delayed proposal types used by `markov-chain-monte-carlo`,
+    /// [`runner`](crate::cdt::metropolis::runner) provides the transitional
+    /// [`MetropolisAlgorithm`](crate::cdt::metropolis::MetropolisAlgorithm)
+    /// facade, [`checkpoint`](crate::cdt::metropolis::checkpoint) owns
+    /// resumable CDT/MCMC checkpoints, and
+    /// [`telemetry`](crate::cdt::metropolis::telemetry) contains step and
+    /// proposal counters. Most callers should import these through
+    /// [`crate::prelude::simulation`] or the re-exports on this module.
+    pub mod metropolis {
+        /// Adapter boundary to the upstream MCMC crate.
+        pub mod adapter;
+        /// Checkpoint and resume validation.
+        pub mod checkpoint;
+        /// Shared CDT-domain helper functions for Metropolis modules.
+        pub(crate) mod helpers;
+        /// Transitional Metropolis runner implementation.
+        pub mod runner;
+        /// Step and proposal telemetry types.
+        pub mod telemetry;
+
+        pub use adapter::{
+            CdtProposal, CdtProposalError, CdtProposalInfo, CdtProposalPlan, CdtTarget,
+        };
+        pub use checkpoint::CdtMcmcCheckpoint;
+        pub use runner::{MetropolisAlgorithm, MetropolisConfig};
+        pub use telemetry::{MonteCarloStep, ProposalStatistics};
+    }
     /// User-facing CDT observable estimators.
     pub mod observables;
     /// Simulation result containers and measurement summaries.
@@ -152,9 +181,9 @@ pub use cdt::results::{Measurement, SimulationResultsBackend};
 pub use config::{CdtConfig, CdtConfigOverrides, CdtTopology, DimensionOverride, TestConfig};
 pub use errors::{
     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
-    CheckpointOperation, CheckpointResumeReason, ConfigurationSetting, DelaunayValidationLevel,
-    GenerationParameterIssue, MetropolisMoveApplicationFailure, OutputFormat,
-    TriangulationMetadataField,
+    CheckpointMoveCounter, CheckpointOperation, CheckpointResumeFailure, ConfigurationSetting,
+    DelaunayValidationLevel, GenerationParameterIssue, MetropolisMoveApplicationFailure,
+    OutputFormat, TriangulationMetadataField,
 };
 
 use crate::cdt::results::SimulationResultsParts;
@@ -229,9 +258,10 @@ pub mod prelude {
     pub mod errors {
         pub use crate::errors::{
             BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck,
-            CdtValidationFailure, CheckpointOperation, CheckpointResumeReason,
-            ConfigurationSetting, DelaunayValidationLevel, GenerationParameterIssue,
-            MetropolisMoveApplicationFailure, OutputFormat, TriangulationMetadataField,
+            CdtValidationFailure, CheckpointMoveCounter, CheckpointOperation,
+            CheckpointResumeFailure, ConfigurationSetting, DelaunayValidationLevel,
+            GenerationParameterIssue, MetropolisMoveApplicationFailure, OutputFormat,
+            TriangulationMetadataField,
         };
     }
 
@@ -647,9 +677,9 @@ mod tests {
             steps: 10,
             thermalization_steps: 5,
             measurement_frequency: 2,
-            coupling_0: 1.0,
-            coupling_2: 1.0,
-            cosmological_constant: 0.1,
+            coupling_0: 0.0,
+            coupling_2: 0.0,
+            cosmological_constant: crate::cdt::action::DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
             simulate: false,
             seed: Some(42),
             topology: CdtTopology::OpenBoundary,
@@ -886,9 +916,12 @@ mod tests {
         assert_eq!(metropolis_config.steps, 10);
 
         let action_config = config.to_action_config();
-        assert_relative_eq!(action_config.coupling_0, 1.0);
-        assert_relative_eq!(action_config.coupling_2, 1.0);
-        assert_relative_eq!(action_config.cosmological_constant, 0.1);
+        assert_relative_eq!(action_config.coupling_0, 0.0);
+        assert_relative_eq!(action_config.coupling_2, 0.0);
+        assert_relative_eq!(
+            action_config.cosmological_constant,
+            crate::cdt::action::DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT
+        );
     }
 
     #[test]
@@ -906,9 +939,9 @@ mod tests {
             steps: 10,
             thermalization_steps: 5,
             measurement_frequency: 2,
-            coupling_0: 1.0,
-            coupling_2: 1.0,
-            cosmological_constant: 0.1,
+            coupling_0: 0.0,
+            coupling_2: 0.0,
+            cosmological_constant: crate::cdt::action::DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
             simulate: false,
             seed: None,
             topology: CdtTopology::Toroidal,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6,6 +6,7 @@
 //! workflows, topology preservation, error handling, and consistency between components.
 
 use approx::{abs_diff_eq, assert_relative_eq};
+use causal_triangulations::cdt::action::DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT;
 use causal_triangulations::prelude::action::ActionConfig;
 use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveResult};
 use causal_triangulations::prelude::simulation::{MetropolisAlgorithm, MetropolisConfig};
@@ -260,8 +261,8 @@ mod integration_tests {
             "Action calculation must produce finite results"
         );
 
-        // For default config (κ₀=1.0, κ₂=1.0, λ=0.1): S = -V - F + 0.1*E
-        let expected = 0.1f64.mul_add(f64::from(edges), -f64::from(vertices) - f64::from(faces));
+        // Defaults map the edge-count lambda convention to the critical 1+1 CDT triangle coupling.
+        let expected = DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT * f64::from(edges);
         assert_relative_eq!(action, expected, epsilon = f64::EPSILON);
     }
 


### PR DESCRIPTION
- Move CDT Metropolis adapter, runner, checkpoint, telemetry, and shared helper logic into an explicit `src/cdt/metropolis/` module tree.
- Keep `adapter.rs` as the single boundary to `markov-chain-monte-carlo` while preserving existing public simulation re-exports.
- Calibrate the default 1+1 CDT action constants to `kappa_0 = 0`, `kappa_2 = 0`, and `lambda_edge = (2 / 3) ln 2`.
- Document the Metropolis module layout, Delaunay initialization role, and 1+1 CDT coupling calibration.

Resolves #158

BREAKING CHANGE: `ActionConfig::default()` and default CLI/config action settings now use the calibrated 1+1 CDT constants instead of `kappa_0 = 1`, `kappa_2 = 1`, and `lambda = 0.1`.