### PR TITLE
feat(config)!: require validated CDT runtime configs (#163)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,7 +11,6 @@ coverage:
         target: 50%
 
 ignore:
-  - "src/lib.rs"
   - "src/main.rs"
   - "benches/**"
   - "examples/**"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ Key principle:
 
 - **Language**: Rust
 - **Project**: {2,3,4}D Causal Dynamical Triangulations library
-- **MSRV**: 1.95.0
+- **MSRV**: 1.96.0
 - **Edition**: 2024
 - **Unsafe code**: forbidden (`#![forbid(unsafe_code)]`)
 - **Architecture**: `src/geometry/` is the backend interface layer for the `delaunay` crate; `src/cdt/` is the CDT domain layer. Direct `use delaunay::` imports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Our community is built on the principles of:
 
 Before you begin, ensure you have:
 
-1. **Rust 1.95.0** (pinned via `rust-toolchain.toml` - automatically handled by rustup)
+1. **Rust 1.96.0** (pinned via `rust-toolchain.toml` - automatically handled by rustup)
 2. **Git** for version control
 3. **Just** (command runner): `cargo install just`
 
@@ -125,7 +125,7 @@ Before you begin, ensure you have:
 
 When you enter the project directory, `rustup` will automatically:
 
-- **Install the correct Rust version** (1.95.0) if you don't have it
+- **Install the correct Rust version** (1.96.0) if you don't have it
 - **Switch to the pinned version** for this project
 - **Install required components** (clippy, rustfmt, rust-docs, rust-src, rust-analyzer)
 - **Add cross-compilation targets** for supported platforms
@@ -140,7 +140,7 @@ When you enter the project directory, `rustup` will automatically:
 **First time in the project?** You'll see:
 
 ```text
-info: syncing channel updates for '1.95.0-<your-platform>'
+info: syncing channel updates for '1.96.0-<your-platform>'
 info: downloading component 'cargo'
 info: downloading component 'clippy'
 ...
@@ -236,7 +236,7 @@ scripts/tag_release.py # Annotated release tags from root or archived changelog 
 ### Rust Code Style
 
 - **Edition**: Rust 2024
-- **MSRV**: Rust 1.95.0 (pinned in `rust-toolchain.toml`)
+- **MSRV**: Rust 1.96.0 (pinned in `rust-toolchain.toml`)
 - **Formatting**: Use `rustfmt` (configured in `rustfmt.toml`)
 - **Linting**: Strict clippy with warnings as errors
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,9 +676,9 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "markov-chain-monte-carlo"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8953e926feb16a077a9032d75603fc6d9cb00355354bca4981440177e3d7203e"
+checksum = "d00d59c60c04dd1225aa5758207755b2bc673472241c356dc52dc77f1636bed6"
 dependencies = [
  "rand 0.10.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = [
 license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/acgetchell/causal-triangulations"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 description = "Causal Dynamical Triangulations in d-dimensions"
 
 # Features removed - backend system is now internal implementation detail
@@ -37,6 +37,9 @@ harness = false
 [features]
 slow-tests = [  ]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [profile.perf]
 inherits = "release"
 lto = "thin"
@@ -48,7 +51,7 @@ debug = "line-tables-only"
 [dependencies]
 clap = { version = "4.6.1", features = [ "derive" ] }
 delaunay = "0.7.8"
-markov-chain-monte-carlo = { version = "0.3.0", features = [ "serde" ] }
+markov-chain-monte-carlo = { version = "0.4.0", features = [ "serde" ] }
 dirs = "6.0.0"
 env_logger = "0.11.10"
 log = "0.4.30"

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,7 +2,7 @@
 # This ensures consistent configuration across all developers and IDEs
 
 # Minimum Supported Rust Version
-msrv = "1.95.0"
+msrv = "1.96.0"
 
 # Allow multiple crate versions - this is common in Rust dependency trees
 # and not something we can easily control without major refactoring

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -313,5 +313,5 @@ Delaunay triangulation before CDT foliation, causality, topology, and simplex-cl
 
 - `delaunay` (v0.7.8) — geometry backend (Delaunay triangulations, vertex data for time labels, checked TDS reconstruction with topology context,
   `set_vertex_data_by_key` for O(1) label mutation)
-- `markov-chain-monte-carlo` (v0.3) — MCMC framework (`DelayedProposal`, `Chain::step_delayed`, `Target`)
+- `markov-chain-monte-carlo` (v0.4) — MCMC framework (`DelayedProposal`, `Chain::step_delayed`, `Target`)
 - `num-traits` — `ToPrimitive` and `NumCast` for checked or saturating numeric conversions

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -22,7 +22,8 @@ All design decisions should prioritize these goals.
 ## Rust Baseline
 
 The repository MSRV is Rust 1.96.0. `Cargo.toml` and `rust-toolchain.toml` must stay in sync so local `rustup` usage and CI install the same baseline.
-Tests may use `std::assert_matches` instead of `assert!(matches!(...))` when checking enum or result shapes so failures show the unexpected value directly.
+Tests and public doctests use `std::assert_matches` instead of `assert!(matches!(...))` when checking enum or result shapes so failures show the unexpected
+value directly. The `causal-triangulations.rust.prefer-assert-matches-in-doctests` Semgrep rule enforces this idiom in `src/` documentation examples.
 
 ---
 

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -19,6 +19,11 @@ Key goals:
 
 All design decisions should prioritize these goals.
 
+## Rust Baseline
+
+The repository MSRV is Rust 1.96.0. `Cargo.toml` and `rust-toolchain.toml` must stay in sync so local `rustup` usage and CI install the same baseline.
+Tests may use `std::assert_matches` instead of `assert!(matches!(...))` when checking enum or result shapes so failures show the unexpected value directly.
+
 ---
 
 ## Safety
@@ -228,6 +233,7 @@ instead of deep module paths when demonstrating public workflows. Avoid duplicat
 documented:
 
 - `prelude::geometry` for backend construction, geometry generators, and geometry traits
+- `prelude::config` for raw and validated CDT configuration types, topology selection, overrides, and presets
 - `prelude::triangulation` for CDT wrappers, foliation classification, topology metadata, and triangulation queries
 - `prelude::moves` for local ergodic move kernels, move results, move types, and move statistics
 - `prelude::action` for standalone action configuration and Regge action calculations

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -56,6 +56,7 @@ The useful updates ported from MCMC are:
 
 - explicit `rustfmt.toml` formatting configuration;
 - explicit uv package mode and pytest 9 minimum in `pyproject.toml`;
+- docs.rs package metadata with `all-features = true`, matching MCMC so rendered API documentation includes every public feature-gated surface;
 - CodeQL analysis for GitHub Actions and Rust, using `build-mode: none` for Rust;
 - the MCMC-style `cliff.toml` template and `just changelog-unreleased <version>` flow, adapted to keep CDT's changelog archive step and avoid temporary local
   release tags;

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -46,8 +46,10 @@ Some differences remain because CDT has different workflows and project invarian
   stabilization work a named path for heavier integration coverage.
 - CDT has a repository rule SARIF workflow for the local Semgrep rules. A Codacy workflow was not ported because it depends on project-specific
   `CODACY_PROJECT_TOKEN` setup and would duplicate the existing repository-rule SARIF signal until Codacy is configured for this repository.
-- CDT Semgrep rules include geometry-backend isolation, foliation/topology validation, focused prelude imports, Python support-script discipline, and typed
-  error policies. These are repository-specific and should not be weakened while porting generic rules.
+- CDT Semgrep rules include geometry-backend isolation, foliation/topology validation, focused prelude imports, doctest assertion-idiom enforcement,
+  Python support-script discipline, and typed error policies. These are repository-specific and should not be weakened while porting generic rules. The
+  `prefer-assert-matches-in-doctests` rule keeps public `///` examples on `std::assert_matches` (Rust 1.96.0) so documentation teaches the diagnostic-friendly
+  idiom rather than `assert!(matches!(...))`.
 - CDT and MCMC both require Python `>=3.12` for repository-managed support tooling.
 
 ## Ported Updates

--- a/examples/basic_cdt.rs
+++ b/examples/basic_cdt.rs
@@ -8,9 +8,8 @@
 //! - Attempt a basic CDT simulation
 //! - Run the Metropolis loop over real 2D CDT move kernels
 
-use causal_triangulations::prelude::config::CdtConfig;
 use causal_triangulations::prelude::errors::CdtResult;
-use causal_triangulations::prelude::simulation::MetropolisAlgorithm;
+use causal_triangulations::prelude::simulation::{CdtConfig, MetropolisAlgorithm};
 use causal_triangulations::prelude::triangulation::CdtTriangulation;
 use log::{LevelFilter, info};
 
@@ -44,6 +43,7 @@ fn main() -> CdtResult<()> {
     config.steps = 100;
     config.thermalization_steps = 20;
     config.measurement_frequency = 5;
+    let config = config.into_validated()?;
 
     // Extract individual configs
     let metropolis_config = config.to_metropolis_config();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Pin to MSRV as specified in Cargo.toml
-channel = "1.95.0"
+channel = "1.96.0"
 
 # Essential components for development
 components = [

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -349,6 +349,23 @@ rules:
         - "/tests/semgrep/doctests/**/*.txt"
     pattern-regex: '^\s*//[!/]\s*(?:#\s*)?.*(?:\b[\w:]+|[\]\)])\.(unwrap|expect)\s*\('
 
+  - id: causal-triangulations.rust.prefer-assert-matches-in-doctests
+    languages:
+      - generic
+    severity: WARNING
+    message: "Use assert_matches! (std::assert_matches) instead of assert!(matches!(...)) in public documentation examples."
+    metadata:
+      category: maintainability
+      rationale: >-
+        Public Rust documentation examples should teach std::assert_matches,
+        which reports the unmatched value on failure instead of the bare
+        boolean that assert!(matches!(...)) produces.
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/doctests/**/*.txt"
+    pattern-regex: '^\s*//[!/].*\bassert!\s*\(\s*matches!\s*\('
+
   - id: causal-triangulations.rust.no-unwrap-expect-in-benches-examples
     languages:
       - rust

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -553,13 +553,14 @@ impl ErgodicsSystem {
     ///
     /// ```
     /// use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveType};
+    /// use std::assert_matches;
     ///
     /// let mut system = ErgodicsSystem::new();
     /// let move_type = system.select_random_move();
-    /// assert!(matches!(
+    /// assert_matches!(
     ///     move_type,
     ///     MoveType::Move22 | MoveType::Move13Add | MoveType::Move31Remove | MoveType::EdgeFlip
-    /// ));
+    /// );
     /// ```
     #[must_use]
     pub fn select_random_move(&mut self) -> MoveType {
@@ -660,6 +661,7 @@ impl ErgodicsSystem {
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::moves::*;
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_from_simplices(
@@ -675,10 +677,10 @@ impl ErgodicsSystem {
     ///     let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)?;
     ///     let mut system = ErgodicsSystem::new();
     ///     let result = system.attempt_22_move(&mut triangulation);
-    ///     assert!(matches!(
+    ///     assert_matches!(
     ///         result,
     ///         MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
-    ///     ));
+    ///     );
     ///     assert_eq!(system.stats.moves_22_attempted, 1);
     ///     Ok(())
     /// }
@@ -709,6 +711,7 @@ impl ErgodicsSystem {
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::moves::*;
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -725,7 +728,7 @@ impl ErgodicsSystem {
     ///     let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)?;
     ///     let mut system = ErgodicsSystem::new();
     ///     let result = system.attempt_13_move(&mut triangulation);
-    ///     assert!(matches!(result, MoveResult::Success | MoveResult::GeometricViolation));
+    ///     assert_matches!(result, MoveResult::Success | MoveResult::GeometricViolation);
     ///     assert_eq!(system.stats.moves_13_attempted, 1);
     ///     Ok(())
     /// }
@@ -770,6 +773,7 @@ impl ErgodicsSystem {
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::moves::*;
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -787,10 +791,10 @@ impl ErgodicsSystem {
     ///     let mut system = ErgodicsSystem::new();
     ///     let _ = system.attempt_13_move(&mut triangulation);
     ///     let result = system.attempt_31_move(&mut triangulation);
-    ///     assert!(matches!(
+    ///     assert_matches!(
     ///         result,
     ///         MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
-    ///     ));
+    ///     );
     ///     assert_eq!(system.stats.moves_31_attempted, 1);
     ///     Ok(())
     /// }
@@ -828,6 +832,7 @@ impl ErgodicsSystem {
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::moves::*;
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_from_simplices(
@@ -843,10 +848,10 @@ impl ErgodicsSystem {
     ///     let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)?;
     ///     let mut system = ErgodicsSystem::new();
     ///     let result = system.attempt_edge_flip(&mut triangulation);
-    ///     assert!(matches!(
+    ///     assert_matches!(
     ///         result,
     ///         MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
-    ///     ));
+    ///     );
     ///     assert_eq!(system.stats.edge_flips_attempted, 1);
     ///     Ok(())
     /// }
@@ -866,6 +871,7 @@ impl ErgodicsSystem {
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::moves::*;
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -882,10 +888,10 @@ impl ErgodicsSystem {
     ///     let mut triangulation = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)?;
     ///     let mut system = ErgodicsSystem::new();
     ///     let result = system.attempt_random_move(&mut triangulation);
-    ///     assert!(matches!(
+    ///     assert_matches!(
     ///         result,
     ///         MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
-    ///     ));
+    ///     );
     ///     Ok(())
     /// }
     /// ```

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -1849,6 +1849,7 @@ mod tests {
     use crate::geometry::DelaunayBackend2D;
     use crate::geometry::generators::{build_delaunay2_from_simplices, build_delaunay2_with_data};
     use approx::assert_relative_eq;
+    use std::assert_matches;
     use std::collections::HashSet;
 
     /// Builds the minimal foliated triangle fixture used by `(1,3)` tests.
@@ -2034,7 +2035,7 @@ mod tests {
             }),
         );
 
-        assert!(matches!(result, MoveResult::HardFailure(_)));
+        assert_matches!(result, MoveResult::HardFailure(_));
         assert_eq!(system.stats.moves_13_attempted, 1);
         assert_eq!(system.stats.moves_13_accepted, 0);
         assert_eq!(system.stats.moves_13_hard_failed, 1);
@@ -2164,7 +2165,7 @@ mod tests {
             }),
         );
 
-        assert!(matches!(result, MoveResult::HardFailure(_)));
+        assert_matches!(result, MoveResult::HardFailure(_));
         assert_eq!(
             (
                 triangulation.vertex_count(),
@@ -2212,7 +2213,7 @@ mod tests {
             .expect("test Delaunay triangle should validate");
         let result = CdtTriangulation2D::with_topology(backend, 3, 2, CdtTopology::Toroidal);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::TopologyMismatch {
                 topology,
@@ -2220,7 +2221,7 @@ mod tests {
                 expected_euler_characteristics,
                 ..
             }) if topology == CdtTopology::Toroidal && expected_euler_characteristics == [0]
-        ));
+        );
     }
 
     #[test]
@@ -2620,7 +2621,7 @@ mod tests {
         let mut system = ErgodicsSystem::new();
         let mut triangulation = single_triangle();
         let result = system.attempt_13_move(&mut triangulation);
-        assert!(matches!(result, MoveResult::Success));
+        assert_matches!(result, MoveResult::Success);
         let before_vertices = triangulation.vertex_count();
 
         let result = system.attempt_31_move(&mut triangulation);
@@ -2823,9 +2824,10 @@ mod tests {
 
         let result = system.attempt_31_move(&mut triangulation);
 
-        assert!(
-            matches!(result, MoveResult::CausalityViolation),
-            "minimal periodic toroidal slices should reject volume removal causally, got {result:?}"
+        assert_matches!(
+            result,
+            MoveResult::CausalityViolation,
+            "minimal periodic toroidal slices should reject volume removal causally"
         );
         assert_eq!(system.stats.moves_31_attempted, 1);
         assert_eq!(system.stats.moves_31_accepted, 0);
@@ -2865,14 +2867,12 @@ mod tests {
 
             let result = attempt_move(&mut system, &mut triangulation);
 
-            assert!(
-                matches!(
-                    result,
-                    MoveResult::Success
-                        | MoveResult::CausalityViolation
-                        | MoveResult::GeometricViolation
-                ),
-                "periodic toroidal {move_type:?} should not fail through backend offset handling, got {result:?}"
+            assert_matches!(
+                result,
+                MoveResult::Success
+                    | MoveResult::CausalityViolation
+                    | MoveResult::GeometricViolation,
+                "periodic toroidal {move_type:?} should not fail through backend offset handling"
             );
             triangulation.validate().expect(
                 "periodic toroidal k=2 move attempt should preserve evolved CDT invariants",

--- a/src/cdt/metropolis/adapter.rs
+++ b/src/cdt/metropolis/adapter.rs
@@ -75,6 +75,7 @@ impl Target<CdtTriangulation2D> for CdtTarget {
 ///     ActionConfig, CdtProposal, CdtResult, CdtTriangulation, DelayedProposal, MoveType,
 /// };
 /// use rand::{SeedableRng, rngs::StdRng};
+/// use std::assert_matches;
 ///
 /// # fn main() -> CdtResult<()> {
 /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
@@ -84,10 +85,10 @@ impl Target<CdtTriangulation2D> for CdtTarget {
 /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
 ///     return Ok(());
 /// };
-/// assert!(matches!(
+/// assert_matches!(
 ///     plan.move_type(),
 ///     MoveType::Move22 | MoveType::Move13Add | MoveType::Move31Remove | MoveType::EdgeFlip
-/// ));
+/// );
 /// assert!(plan.action_before().is_finite());
 /// if let (Some(delta), Some(action_after)) = (plan.delta_action(), plan.action_after()) {
 ///     approx::assert_relative_eq!(
@@ -126,6 +127,7 @@ impl CdtProposalPlan {
     ///     ActionConfig, CdtProposal, CdtResult, CdtTriangulation, DelayedProposal, MoveType,
     /// };
     /// use rand::{SeedableRng, rngs::StdRng};
+    /// use std::assert_matches;
     ///
     /// # fn main() -> CdtResult<()> {
     /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
@@ -134,10 +136,10 @@ impl CdtProposalPlan {
     /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
     ///     return Ok(());
     /// };
-    /// assert!(matches!(
+    /// assert_matches!(
     ///     plan.move_type(),
     ///     MoveType::Move22 | MoveType::Move13Add | MoveType::Move31Remove | MoveType::EdgeFlip
-    /// ));
+    /// );
     /// # Ok(())
     /// # }
     /// ```

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -725,6 +725,7 @@ mod tests {
     use markov_chain_monte_carlo::{Chain, DelayedProposal, Target};
     use rand::rngs::StdRng;
     use serde_json::{from_str, to_string, to_value};
+    use std::assert_matches;
     use std::error::Error;
     use std::num::NonZeroUsize;
 
@@ -1756,12 +1757,12 @@ mod tests {
             panic!("expected impossible move statistics to fail");
         };
 
-        assert!(matches!(
+        assert_matches!(
             failure,
             CheckpointResumeFailure::MoveAcceptedExceedsAttempted {
                 move_type: MoveType::Move22
             }
-        ));
+        );
         let detail = failure.to_string();
         assert!(detail.contains("accepted move count exceeds attempted move count"));
     }
@@ -1777,12 +1778,12 @@ mod tests {
             panic!("expected overflowing move statistics to fail");
         };
 
-        assert!(matches!(
+        assert_matches!(
             failure,
             CheckpointResumeFailure::MoveCounterOverflow {
                 counter: CheckpointMoveCounter::Attempted
             }
-        ));
+        );
         let detail = failure.to_string();
         assert!(detail.contains("attempted move count exceeds u64::MAX"));
     }
@@ -1799,12 +1800,12 @@ mod tests {
             panic!("expected impossible hard-failure statistics to fail");
         };
 
-        assert!(matches!(
+        assert_matches!(
             failure,
             CheckpointResumeFailure::MoveHardFailures {
                 move_type: MoveType::Move22
             }
-        ));
+        );
         let detail = failure.to_string();
         assert!(detail.contains("Move22"));
         assert!(detail.contains("hard-failure move count must be zero"));
@@ -2377,8 +2378,8 @@ mod tests {
             .step_delayed(&target, &mut proposal, &mut rng)
             .expect("ordinary no-site outcomes must be delayed-step rejections, not errors");
 
-        assert_eq!(step.proposed, step.info.is_some());
-        assert!(!step.accepted || step.log_prob_after.is_some());
+        assert_eq!(step.outcome.has_proposal(), step.info.is_some());
+        assert!(!step.outcome.is_accepted() || step.log_prob_after.is_some());
     }
 
     #[test]
@@ -2433,7 +2434,7 @@ mod tests {
         assert!(err.to_string().contains("attempt 2"));
 
         let cdt_error = CdtError::from(err);
-        assert!(matches!(
+        assert_matches!(
             cdt_error,
             CdtError::ProposalApplicationFailed {
                 move_type: MoveType::Move13Add,
@@ -2443,7 +2444,7 @@ mod tests {
                     ..
                 },
             }
-        ));
+        );
 
         let site_rejection = CdtProposalSiteRejection::Kernel(source.clone());
         assert_eq!(

--- a/src/cdt/results.rs
+++ b/src/cdt/results.rs
@@ -1099,6 +1099,7 @@ mod tests {
     use crate::geometry::traits::TriangulationQuery;
     use approx::assert_relative_eq;
     use serde_json::{Value, from_str, to_value};
+    use std::assert_matches;
     use std::env;
     use std::fs;
     use std::path::PathBuf;
@@ -1239,7 +1240,7 @@ mod tests {
         )
         .expect_err("zero temperature should be rejected");
 
-        assert!(matches!(
+        assert_matches!(
             error,
             CdtError::InvalidSimulationConfiguration {
                 ref setting,
@@ -1248,7 +1249,7 @@ mod tests {
             } if *setting == ConfigurationSetting::Temperature
                 && provided_value == "0"
                 && expected == "finite and positive"
-        ));
+        );
     }
 
     #[test]
@@ -1268,14 +1269,14 @@ mod tests {
         )
         .expect_err("non-finite action coupling should be rejected");
 
-        assert!(matches!(
+        assert_matches!(
             error,
             CdtError::InvalidConfiguration {
                 ref setting,
                 ref provided_value,
                 ref expected,
             } if *setting == ConfigurationSetting::Coupling0 && provided_value == "NaN" && expected == "finite"
-        ));
+        );
     }
 
     #[test]
@@ -1307,10 +1308,10 @@ mod tests {
         )
         .expect_err("stale foliation should be rejected");
 
-        assert!(matches!(
+        assert_matches!(
             error,
             CdtError::Foliation(FoliationError::StaleBookkeeping { .. })
-        ));
+        );
     }
 
     #[test]
@@ -1392,14 +1393,14 @@ mod tests {
         })
         .expect_err("invalid wire Metropolis config should be rejected");
 
-        assert!(matches!(
+        assert_matches!(
             error,
             CdtError::InvalidSimulationConfiguration {
                 ref setting,
                 ref provided_value,
                 ref expected,
             } if *setting == ConfigurationSetting::Temperature && provided_value == "0" && expected == "finite and positive"
-        ));
+        );
     }
 
     #[test]
@@ -1418,14 +1419,14 @@ mod tests {
         })
         .expect_err("invalid wire action config should be rejected");
 
-        assert!(matches!(
+        assert_matches!(
             error,
             CdtError::InvalidConfiguration {
                 ref setting,
                 ref provided_value,
                 ref expected,
             } if *setting == ConfigurationSetting::Coupling0 && provided_value == "NaN" && expected == "finite"
-        ));
+        );
     }
 
     #[test]

--- a/src/cdt/triangulation.rs
+++ b/src/cdt/triangulation.rs
@@ -848,6 +848,7 @@ mod tests {
     use crate::geometry::generators::build_delaunay2_with_data;
     use serde_json::error::Category;
     use serde_json::{from_str, from_value, json, to_string, to_value};
+    use std::assert_matches;
     use std::num::NonZeroUsize;
     use std::thread;
     use std::time::{Duration, Instant};
@@ -896,7 +897,7 @@ mod tests {
         let backend = labeled_triangle_backend([0, 0, 1]);
         let result = CdtTriangulation::try_new(backend, 0, 2);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidTriangulationMetadata {
                 ref field,
@@ -907,7 +908,7 @@ mod tests {
                 && topology == CdtTopology::OpenBoundary
                 && provided_value == "0"
                 && expected == "≥ 1"
-        ));
+        );
     }
 
     #[test]
@@ -915,7 +916,7 @@ mod tests {
         let backend = labeled_triangle_backend([0, 0, 1]);
         let result = CdtTriangulation::try_new(backend, 2, 3);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidTriangulationMetadata {
                 ref field,
@@ -926,7 +927,7 @@ mod tests {
                 && topology == CdtTopology::OpenBoundary
                 && provided_value == "3"
                 && expected == "backend dimension (2)"
-        ));
+        );
     }
 
     #[test]
@@ -935,7 +936,7 @@ mod tests {
         let tri = unchecked_open_boundary(backend, 2, 3);
         let result = tri.validate_topology();
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidTriangulationMetadata {
                 ref field,
@@ -945,7 +946,7 @@ mod tests {
             }) if *field == TriangulationMetadataField::Dimension
                 && provided_value == "3"
                 && expected == "backend dimension (2)"
-        ));
+        );
     }
 
     #[test]
@@ -1281,7 +1282,7 @@ mod tests {
     #[test]
     fn test_zero_time_slices_rejected() {
         let result = CdtTriangulation::from_random_points(5, 0, 2);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidTriangulationMetadata {
                 ref field,
@@ -1289,7 +1290,7 @@ mod tests {
                 ref expected,
                 ..
             }) if *field == TriangulationMetadataField::Timeslices && provided_value == "0" && expected == "≥ 1"
-        ));
+        );
     }
 
     #[test]
@@ -1513,7 +1514,7 @@ mod tests {
 
         let result = tri.validate_topology();
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::TopologyMismatch {
                 topology,
@@ -1521,7 +1522,7 @@ mod tests {
                 ref expected_euler_characteristics,
                 ..
             }) if topology == CdtTopology::OpenBoundary && expected_euler_characteristics == &[1, 2]
-        ));
+        );
     }
 
     #[test]
@@ -1534,7 +1535,7 @@ mod tests {
             .expect("test Delaunay triangle should validate");
 
         let result = CdtTriangulation::with_topology(backend, 3, 2, CdtTopology::Toroidal);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::TopologyMismatch {
                 topology,
@@ -1542,7 +1543,7 @@ mod tests {
                 ref expected_euler_characteristics,
                 ..
             }) if topology == CdtTopology::Toroidal && expected_euler_characteristics == &[0]
-        ));
+        );
     }
 
     #[test]
@@ -1550,7 +1551,7 @@ mod tests {
         let mut tri = CdtTriangulation::from_toroidal_cdt(4, 3).expect("build toroidal CDT");
 
         let result = tri.set_time_slices(2);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidTriangulationMetadata {
                 ref field,
@@ -1561,7 +1562,7 @@ mod tests {
                 && topology == CdtTopology::Toroidal
                 && provided_value == "2"
                 && expected == "≥ 3"
-        ));
+        );
         assert_eq!(tri.time_slices(), 3);
         assert!(tri.validate_topology().is_ok());
     }
@@ -1574,7 +1575,7 @@ mod tests {
             .expect("test Delaunay triangle should validate");
 
         let result = CdtTriangulation::with_topology(backend, 2, 3, CdtTopology::Toroidal);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidTriangulationMetadata {
                 ref field,
@@ -1585,7 +1586,7 @@ mod tests {
                 && topology == CdtTopology::Toroidal
                 && provided_value == "2"
                 && expected == "≥ 3"
-        ));
+        );
     }
 
     #[test]

--- a/src/cdt/triangulation.rs
+++ b/src/cdt/triangulation.rs
@@ -122,19 +122,20 @@ struct CachedValue<T> {
 /// ```
 /// use causal_triangulations::prelude::moves::MoveType;
 /// use causal_triangulations::prelude::triangulation::SimulationEvent;
+/// use std::assert_matches;
 ///
 /// let event = SimulationEvent::MoveAttempted {
 ///     move_type: MoveType::Move13Add,
 ///     step: 7,
 /// };
 ///
-/// assert!(matches!(
+/// assert_matches!(
 ///     event,
 ///     SimulationEvent::MoveAttempted {
 ///         move_type: MoveType::Move13Add,
 ///         step: 7,
 ///     }
-/// ));
+/// );
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SimulationEvent {
@@ -320,6 +321,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -335,7 +337,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///     })?;
     ///
     ///     let tri = CdtTriangulation::with_topology(backend, 2, 2, CdtTopology::OpenBoundary)?;
-    ///     assert!(matches!(tri.metadata().topology, CdtTopology::OpenBoundary));
+    ///     assert_matches!(tri.metadata().topology, CdtTopology::OpenBoundary);
     ///     assert_eq!(tri.time_slices(), 2);
     ///     assert_eq!(tri.dimension(), 2);
     ///     Ok(())
@@ -347,6 +349,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// use causal_triangulations::prelude::errors::TriangulationMetadataField;
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -363,7 +366,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///
     ///     let err = CdtTriangulation::with_topology(backend, 2, 3, CdtTopology::Toroidal)
     ///         .expect_err("toroidal metadata requires at least three time slices");
-    ///     assert!(matches!(
+    ///     assert_matches!(
     ///         err,
     ///         CdtError::InvalidTriangulationMetadata {
     ///             field,
@@ -374,7 +377,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///             && topology == CdtTopology::Toroidal
     ///             && provided_value == "2"
     ///             && expected == "≥ 3"
-    ///     ));
+    ///     );
     ///     Ok(())
     /// }
     /// ```
@@ -384,6 +387,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// use causal_triangulations::prelude::errors::TriangulationMetadataField;
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -400,7 +404,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///
     ///     let err = CdtTriangulation::with_topology(backend, 3, 2, CdtTopology::Toroidal)
     ///         .expect_err("a planar triangle cannot be published as toroidal");
-    ///     assert!(matches!(
+    ///     assert_matches!(
     ///         err,
     ///         CdtError::TopologyMismatch {
     ///             topology,
@@ -408,7 +412,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///             expected_euler_characteristics,
     ///             ..
     ///         } if topology == CdtTopology::Toroidal && expected_euler_characteristics.as_slice() == [0]
-    ///     ));
+    ///     );
     ///     Ok(())
     /// }
     /// ```
@@ -790,12 +794,13 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// ```
     /// use causal_triangulations::prelude::errors::{CdtError, TriangulationMetadataField};
     /// use causal_triangulations::prelude::triangulation::{CdtTopology, CdtTriangulation};
+    /// use std::assert_matches;
     ///
     /// fn main() -> causal_triangulations::CdtResult<()> {
     /// let mut tri = CdtTriangulation::from_toroidal_cdt(4, 3)?;
     ///
     /// let err = tri.set_time_slices(2).expect_err("T < 3 is invalid");
-    /// assert!(matches!(
+    /// assert_matches!(
     ///     err,
     ///     CdtError::InvalidTriangulationMetadata {
     ///         field,
@@ -806,7 +811,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///         && topology == CdtTopology::Toroidal
     ///         && provided_value == "2"
     ///         && expected == "≥ 3"
-    /// ));
+    /// );
     /// # Ok(())
     /// # }
     /// ```

--- a/src/cdt/triangulation/builders.rs
+++ b/src/cdt/triangulation/builders.rs
@@ -1083,6 +1083,7 @@ mod tests {
     use crate::cdt::foliation::{EdgeType, FoliationError, SimplexType};
     use crate::errors::{CdtValidationCheck, CdtValidationFailure, TriangulationMetadataField};
     use crate::geometry::generators::{build_delaunay2_from_simplices, build_delaunay2_with_data};
+    use std::assert_matches;
 
     /// Builds a minimal labeled Delaunay backend for constructor tests.
     fn labeled_triangle_backend(labels: [u32; 3]) -> DelaunayBackend2D {
@@ -1144,7 +1145,7 @@ mod tests {
             12,
         );
 
-        assert!(matches!(
+        assert_matches!(
             remapped,
             CdtError::DelaunayGenerationFailed {
                 vertex_count: 12,
@@ -1152,7 +1153,7 @@ mod tests {
                 attempt: 1,
                 ref underlying_error,
             } if underlying_error == "builder failed"
-        ));
+        );
     }
 
     #[test]
@@ -1283,14 +1284,14 @@ mod tests {
     fn test_from_seeded_points_rejects_invalid_dimension() {
         let result = CdtTriangulation::from_seeded_points(10, 3, 3, 42);
 
-        assert!(matches!(result, Err(CdtError::UnsupportedDimension(3))));
+        assert_matches!(result, Err(CdtError::UnsupportedDimension(3)));
     }
 
     #[test]
     fn test_from_seeded_points_rejects_zero_time_slices() {
         let result = CdtTriangulation::from_seeded_points(5, 0, 2, 53);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidTriangulationMetadata {
                 ref field,
@@ -1298,7 +1299,7 @@ mod tests {
                 ref expected,
                 ..
             }) if *field == TriangulationMetadataField::Timeslices && provided_value == "0" && expected == "≥ 1"
-        ));
+        );
     }
 
     #[test]
@@ -1365,7 +1366,7 @@ mod tests {
 
         let result = CdtTriangulation::from_labeled_delaunay(backend, 2, 3);
 
-        assert!(matches!(result, Err(CdtError::UnsupportedDimension(3))));
+        assert_matches!(result, Err(CdtError::UnsupportedDimension(3)));
     }
 
     #[test]
@@ -1374,7 +1375,7 @@ mod tests {
 
         let result = CdtTriangulation::from_labeled_delaunay(backend, 0, 2);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidTriangulationMetadata {
                 ref field,
@@ -1382,7 +1383,7 @@ mod tests {
                 ref expected,
                 ..
             }) if *field == TriangulationMetadataField::Timeslices && provided_value == "0" && expected == "≥ 1"
-        ));
+        );
     }
 
     #[test]
@@ -1393,14 +1394,14 @@ mod tests {
             .expect("test Delaunay triangle should validate");
 
         let result = CdtTriangulation::from_labeled_delaunay(backend, 2, 2);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::Foliation(FoliationError::OutOfRangeVertexLabel {
                 label: 5,
                 expected_range_end: 2,
                 ..
             }))
-        ));
+        );
     }
 
     #[test]
@@ -1411,10 +1412,10 @@ mod tests {
             .expect("test Delaunay triangle should validate");
 
         let result = CdtTriangulation::from_labeled_delaunay(backend, 3, 2);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::Foliation(FoliationError::EmptySlice { slice: 1 }))
-        ));
+        );
     }
 
     #[test]
@@ -1434,13 +1435,13 @@ mod tests {
 
         let result = CdtTriangulation::from_labeled_delaunay(backend, 2, 2);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::ValidationFailed {
                 ref check,
                 failure: CdtValidationFailure::InvalidCdtTriangle { .. },
             }) if *check == CdtValidationCheck::Causality
-        ));
+        );
     }
 
     #[test]
@@ -1455,14 +1456,14 @@ mod tests {
             &[vec![0, 1, 2], vec![1, 3, 2]],
         );
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::DelaunayGenerationFailed {
                 vertex_count: 4,
                 attempt: 1,
                 ..
             })
-        ));
+        );
     }
 
     #[test]
@@ -1477,17 +1478,17 @@ mod tests {
     fn test_from_cdt_strip_edge_classification() {
         let tri = strict_strip(5, 3);
         for edge in tri.geometry().edges() {
-            assert!(matches!(
+            assert_matches!(
                 tri.edge_type(&edge),
                 Some(EdgeType::Spacelike | EdgeType::Timelike)
-            ));
+            );
         }
     }
 
     #[test]
     fn test_from_cdt_strip_rejects_invalid_params() {
         let few_vertices = CdtTriangulation::from_cdt_strip(3, 3);
-        assert!(matches!(
+        assert_matches!(
             few_vertices,
             Err(CdtError::InvalidGenerationParameters {
                 ref issue,
@@ -1496,10 +1497,10 @@ mod tests {
             }) if *issue == GenerationParameterIssue::InsufficientVerticesPerSlice
                 && provided_value == "3"
                 && expected_range == "≥ 4"
-        ));
+        );
 
         let few_slices = CdtTriangulation::from_cdt_strip(4, 1);
-        assert!(matches!(
+        assert_matches!(
             few_slices,
             Err(CdtError::InvalidGenerationParameters {
                 ref issue,
@@ -1508,14 +1509,14 @@ mod tests {
             }) if *issue == GenerationParameterIssue::InsufficientNumberOfTimeSlices
                 && provided_value == "1"
                 && expected_range == "≥ 2"
-        ));
+        );
     }
 
     #[test]
     fn test_from_cdt_strip_rejects_simplex_count_overflow() {
         let result = CdtTriangulation::from_cdt_strip(65_535, 65_537);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidGenerationParameters {
                 ref issue,
@@ -1524,7 +1525,7 @@ mod tests {
             }) if *issue == GenerationParameterIssue::SimplexCountOverflow
                 && provided_value == "2 × 4294836224"
                 && expected_range == "product ≤ u32::MAX"
-        ));
+        );
     }
 
     #[test]
@@ -1573,7 +1574,7 @@ mod tests {
     fn test_open_profile_face_count_rejects_empty_profile() {
         let result = open_profile_face_count(&[]);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidGenerationParameters {
                 ref issue,
@@ -1582,7 +1583,7 @@ mod tests {
             }) if *issue == GenerationParameterIssue::EmptyVolumeProfile
                 && provided_value == "[]"
                 && expected_range == "at least one time slice"
-        ));
+        );
     }
 
     #[test]
@@ -1591,7 +1592,7 @@ mod tests {
             .expect("nonuniform Delaunay strip should build");
         let result = validate_profile_strip_counts(tri.geometry(), 15, 16, 18, 3.0);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::DelaunayGenerationFailed {
                 vertex_count: 15,
@@ -1602,14 +1603,14 @@ mod tests {
                 .contains("build_delaunay2_with_data()/from_cdt_strip_profile()")
                 && underlying_error.contains("produced 15 vertices and 17 faces")
                 && underlying_error.contains("expected 16 vertices and 18 faces")
-        ));
+        );
     }
 
     #[test]
     fn test_from_cdt_strip_profile_rejects_invalid_profile() {
         let result = CdtTriangulation::from_cdt_strip_profile(&[4, 3, 5]);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidGenerationParameters {
                 ref issue,
@@ -1618,14 +1619,14 @@ mod tests {
             }) if *issue == GenerationParameterIssue::InsufficientVerticesInVolumeProfileSlice
                 && provided_value == "slice 1 has 3"
                 && expected_range == "each slice ≥ 4 for open-boundary topology"
-        ));
+        );
     }
 
     #[test]
     fn test_from_cdt_strip_profile_rejects_too_few_slices() {
         let result = CdtTriangulation::from_cdt_strip_profile(&[4]);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidGenerationParameters {
                 ref issue,
@@ -1634,7 +1635,7 @@ mod tests {
             }) if *issue == GenerationParameterIssue::InsufficientNumberOfTimeSlices
                 && provided_value == "1"
                 && expected_range == "≥ 2 for open-boundary topology"
-        ));
+        );
     }
 
     #[test]
@@ -1642,7 +1643,7 @@ mod tests {
         let tri = CdtTriangulation::from_cdt_strip(4, 2).expect("Delaunay strip should build");
         let result = validate_strip_counts(tri.geometry(), 8, 7, 8, 7, 4, 2, 1.0);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::DelaunayGenerationFailed {
                 vertex_count: 8,
@@ -1653,17 +1654,17 @@ mod tests {
                 && underlying_error.contains("produced 6 faces, expected 7")
                 && underlying_error.contains("vertices_per_slice=4")
                 && underlying_error.contains("num_slices=2")
-        ));
+        );
     }
 
     #[test]
     fn test_simplex_type_returns_up_or_down() {
         let tri = strict_strip(5, 3);
         for face in tri.geometry().faces() {
-            assert!(matches!(
+            assert_matches!(
                 tri.simplex_type(&face),
                 Some(SimplexType::Up | SimplexType::Down)
-            ));
+            );
         }
     }
 
@@ -1679,7 +1680,7 @@ mod tests {
         assert_eq!(tri.geometry().euler_characteristic(), 0);
         assert_eq!(tri.dimension(), 2);
         assert_eq!(tri.time_slices(), 3);
-        assert!(matches!(tri.metadata().topology, CdtTopology::Toroidal));
+        assert_matches!(tri.metadata().topology, CdtTopology::Toroidal);
     }
 
     #[test]
@@ -1719,7 +1720,7 @@ mod tests {
         assert_eq!(tri.edge_count(), 48);
         assert_eq!(tri.slice_sizes(), &[3, 4, 5, 4]);
         assert_eq!(tri.geometry().euler_characteristic(), 0);
-        assert!(matches!(tri.metadata().topology, CdtTopology::Toroidal));
+        assert_matches!(tri.metadata().topology, CdtTopology::Toroidal);
         assert!(tri.geometry().validate_delaunay().is_ok());
         assert!(tri.validate_topology().is_ok());
         assert!(tri.validate_foliation().is_ok());
@@ -1730,7 +1731,7 @@ mod tests {
     #[test]
     fn test_from_toroidal_cdt_profile_rejects_invalid_profile() {
         let few_slices = CdtTriangulation::from_toroidal_cdt_profile(&[3, 4]);
-        assert!(matches!(
+        assert_matches!(
             few_slices,
             Err(CdtError::InvalidGenerationParameters {
                 ref issue,
@@ -1739,10 +1740,10 @@ mod tests {
             }) if *issue == GenerationParameterIssue::InsufficientNumberOfTimeSlices
                 && provided_value == "2"
                 && expected_range == "≥ 3 for toroidal topology"
-        ));
+        );
 
         let small_slice = CdtTriangulation::from_toroidal_cdt_profile(&[3, 2, 3]);
-        assert!(matches!(
+        assert_matches!(
             small_slice,
             Err(CdtError::InvalidGenerationParameters {
                 ref issue,
@@ -1751,7 +1752,7 @@ mod tests {
             }) if *issue == GenerationParameterIssue::InsufficientVerticesInVolumeProfileSlice
                 && provided_value == "slice 1 has 2"
                 && expected_range == "each slice ≥ 3 for toroidal topology"
-        ));
+        );
     }
 
     #[test]
@@ -1783,7 +1784,7 @@ mod tests {
     #[test]
     fn test_from_toroidal_cdt_invalid_params() {
         let few_vertices = CdtTriangulation::from_toroidal_cdt(2, 3);
-        assert!(matches!(
+        assert_matches!(
             few_vertices,
             Err(CdtError::InvalidGenerationParameters {
                 ref issue,
@@ -1792,11 +1793,11 @@ mod tests {
             }) if *issue == GenerationParameterIssue::InsufficientVerticesPerSlice
                 && provided_value == "2"
                 && expected_range == "≥ 3"
-        ));
+        );
 
         for slices in [1, 2] {
             let few_slices = CdtTriangulation::from_toroidal_cdt(4, slices);
-            assert!(matches!(
+            assert_matches!(
                 few_slices,
                 Err(CdtError::InvalidGenerationParameters {
                     ref issue,
@@ -1805,7 +1806,7 @@ mod tests {
                 }) if *issue == GenerationParameterIssue::InsufficientNumberOfTimeSlices
                     && provided_value == &slices.to_string()
                     && expected_range == "≥ 3"
-            ));
+            );
         }
     }
 
@@ -1813,7 +1814,7 @@ mod tests {
     fn test_from_toroidal_cdt_rejects_vertex_count_overflow() {
         let result = CdtTriangulation::from_toroidal_cdt(u32::MAX, 3);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidGenerationParameters {
                 ref issue,
@@ -1822,7 +1823,7 @@ mod tests {
             }) if *issue == GenerationParameterIssue::VertexCountOverflow
                 && provided_value == "4294967295 × 3"
                 && expected_range == "product ≤ u32::MAX"
-        ));
+        );
     }
 
     #[test]
@@ -1830,7 +1831,7 @@ mod tests {
         let tri = CdtTriangulation::from_toroidal_cdt(4, 3).expect("build toroidal CDT");
         let result = validate_toroidal_counts(tri.geometry(), 12, 12, 23, (0.0, 3.0));
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::DelaunayGenerationFailed {
                 vertex_count: 12,
@@ -1840,7 +1841,7 @@ mod tests {
             }) if underlying_error.contains("periodic toroidal builder")
                 && underlying_error.contains("produced 12 vertices and 24 faces")
                 && underlying_error.contains("expected 12 vertices and 23 faces")
-        ));
+        );
     }
 
     #[test]

--- a/src/cdt/triangulation/foliation.rs
+++ b/src/cdt/triangulation/foliation.rs
@@ -1027,6 +1027,7 @@ mod tests {
     use super::*;
     use crate::errors::TriangulationMetadataField;
     use crate::geometry::generators::build_delaunay2_with_data;
+    use std::assert_matches;
     use std::thread;
     use std::time::Duration;
 
@@ -1092,10 +1093,10 @@ mod tests {
 
         tri.set_vertex_data(&first_vertex, None)
             .expect("Expected valid vertex handle while clearing label");
-        assert!(matches!(
+        assert_matches!(
             tri.validate_foliation(),
             Err(CdtError::Foliation(FoliationError::StaleBookkeeping { .. }))
-        ));
+        );
     }
 
     #[test]
@@ -1111,12 +1112,12 @@ mod tests {
 
         tri.set_vertex_data(&first_vertex, None)
             .expect("Expected valid vertex handle while clearing label");
-        assert!(matches!(
+        assert_matches!(
             tri.synchronize_foliation_from_live_labels(),
             Err(CdtError::Foliation(FoliationError::MissingVertexLabel {
                 vertex: 0
             }))
-        ));
+        );
 
         let backend = labeled_triangle_backend([0, 0, 1]);
         let mut tri = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)
@@ -1129,14 +1130,14 @@ mod tests {
 
         tri.set_vertex_data(&first_vertex, Some(7))
             .expect("Expected valid vertex handle while mutating label");
-        assert!(matches!(
+        assert_matches!(
             tri.synchronize_foliation_from_live_labels(),
             Err(CdtError::Foliation(FoliationError::OutOfRangeVertexLabel {
                 vertex: 0,
                 label: 7,
                 expected_range_end: 2,
             }))
-        ));
+        );
     }
 
     #[test]
@@ -1149,13 +1150,13 @@ mod tests {
                 .expect("non-empty mismatched bookkeeping is constructible"),
         );
 
-        assert!(matches!(
+        assert_matches!(
             tri.validate_foliation(),
             Err(CdtError::Foliation(FoliationError::LabelCountMismatch {
                 labeled: 2,
                 expected: 3,
             }))
-        ));
+        );
     }
 
     #[test]
@@ -1211,10 +1212,10 @@ mod tests {
             .saturating_add(1);
         let result = tri.assign_foliation_by_y(requested_slices);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::Foliation(FoliationError::EmptySlice { .. }))
-        ));
+        );
         assert_eq!(tri.time_slices(), initial_time_slices);
         assert_eq!(
             tri.metadata().modification_count,
@@ -1233,7 +1234,7 @@ mod tests {
 
         let result = tri.assign_foliation_by_y(2);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::InvalidTriangulationMetadata {
                 ref field,
@@ -1244,7 +1245,7 @@ mod tests {
                 && topology == CdtTopology::Toroidal
                 && provided_value == "2"
                 && expected == "≥ 3"
-        ));
+        );
         assert_eq!(tri.time_slices(), 3);
         assert_eq!(tri.slice_sizes(), initial_slice_sizes.as_slice());
         assert!(tri.has_foliation());
@@ -1311,10 +1312,10 @@ mod tests {
             tri.validate_causality(),
             tri.validate_simplex_classification(),
         ] {
-            assert!(matches!(
+            assert_matches!(
                 result,
                 Err(CdtError::Foliation(FoliationError::StaleBookkeeping { .. }))
-            ));
+            );
         }
     }
 
@@ -1371,7 +1372,7 @@ mod tests {
         let live_ct = tri
             .simplex_type(&face)
             .expect("Single face should be classifiable");
-        assert!(matches!(live_ct, SimplexType::Up | SimplexType::Down));
+        assert_matches!(live_ct, SimplexType::Up | SimplexType::Down);
 
         tri.classify_all_simplices()
             .expect("Should classify simplices with foliation")
@@ -1393,7 +1394,7 @@ mod tests {
     fn classification_rejects_same_slice_triangle() {
         let backend = labeled_triangle_backend([0, 0, 0]);
 
-        assert!(matches!(
+        assert_matches!(
             CdtTriangulation::from_labeled_delaunay(backend, 1, 2),
             Err(CdtError::ValidationFailed {
                 ref check,
@@ -1404,7 +1405,7 @@ mod tests {
                 },
             })
                 if *check == CdtValidationCheck::Causality
-        ));
+        );
     }
 
     #[test]

--- a/src/cdt/triangulation/validation.rs
+++ b/src/cdt/triangulation/validation.rs
@@ -330,6 +330,7 @@ mod tests {
     use crate::cdt::foliation::{EdgeType, FoliationError};
     use crate::config::CdtTopology;
     use crate::geometry::generators::build_delaunay2_with_data;
+    use std::assert_matches;
 
     /// Builds a minimal labeled Delaunay backend for validation tests.
     fn labeled_triangle_backend(labels: [u32; 3]) -> DelaunayBackend2D {
@@ -460,10 +461,10 @@ mod tests {
         tri.set_vertex_data(&vertex_to_mutate, Some(3))
             .expect("Expected valid vertex handle while mutating deterministic triangle");
 
-        assert!(matches!(
+        assert_matches!(
             tri.validate_causality_delaunay(),
             Err(CdtError::Foliation(FoliationError::StaleBookkeeping { .. }))
-        ));
+        );
     }
 
     #[test]
@@ -480,10 +481,10 @@ mod tests {
         tri.set_vertex_data(&vertex_to_clear, None)
             .expect("Expected valid vertex handle while clearing label");
 
-        assert!(matches!(
+        assert_matches!(
             tri.validate_causality_delaunay(),
             Err(CdtError::Foliation(FoliationError::StaleBookkeeping { .. }))
-        ));
+        );
     }
 
     #[test]
@@ -491,7 +492,7 @@ mod tests {
         let backend = labeled_triangle_backend([0, 0, 0]);
         let result = CdtTriangulation::from_labeled_delaunay(backend, 1, 2);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CdtError::ValidationFailed {
                 ref check,
@@ -502,7 +503,7 @@ mod tests {
                 },
             })
                 if *check == CdtValidationCheck::Causality
-        ));
+        );
     }
 
     #[test]
@@ -518,9 +519,9 @@ mod tests {
         tri.set_vertex_data(&slice0_vertex, Some(8))
             .expect("Expected valid vertex handle while mutating label");
 
-        assert!(matches!(
+        assert_matches!(
             tri.validate_causality_delaunay(),
             Err(CdtError::Foliation(FoliationError::StaleBookkeeping { .. }))
-        ));
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -170,15 +170,16 @@ pub struct ValidatedCdtConfig {
 /// ```
 /// use causal_triangulations::prelude::config::{CdtConfig, ValidatedInitialVolume};
 /// use causal_triangulations::prelude::errors::CdtResult;
+/// use std::assert_matches;
 ///
 /// fn main() -> CdtResult<()> {
 ///     let config = CdtConfig::new(16, 4).into_validated()?;
-///     assert!(matches!(
+///     assert_matches!(
 ///         config.initial_volume(),
 ///         ValidatedInitialVolume::Regular {
 ///             vertices_per_slice: 4
 ///         }
-///     ));
+///     );
 ///     Ok(())
 /// }
 /// ```
@@ -378,6 +379,7 @@ impl ValidatedCdtConfig {
     /// ```
     /// use causal_triangulations::prelude::config::{CdtConfig, ValidatedInitialVolume};
     /// use causal_triangulations::prelude::errors::CdtResult;
+    /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let config = CdtConfig {
@@ -388,10 +390,10 @@ impl ValidatedCdtConfig {
     ///     }
     ///     .into_validated()?;
     ///
-    ///     assert!(matches!(
+    ///     assert_matches!(
     ///         config.initial_volume(),
     ///         ValidatedInitialVolume::ExplicitProfile([4, 6, 5])
-    ///     ));
+    ///     );
     ///     Ok(())
     /// }
     /// ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,424 @@ pub struct CdtConfig {
     pub output_json: Option<PathBuf>,
 }
 
+/// Runtime configuration that has passed all CDT validation rules.
+///
+/// [`CdtConfig`] remains the raw DTO for CLI, file, and test construction. Convert it
+/// into [`ValidatedCdtConfig`] before running algorithms that rely on topology,
+/// schedule, dimensionality, and finite-coupling invariants.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::config::{CdtConfig, ValidatedCdtConfig};
+/// use causal_triangulations::prelude::errors::CdtResult;
+///
+/// fn main() -> CdtResult<()> {
+///     let validated = ValidatedCdtConfig::new(CdtConfig::new(16, 4))?;
+///     assert_eq!(validated.regular_vertices_per_slice(), Some(4));
+///     Ok(())
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct ValidatedCdtConfig {
+    config: CdtConfig,
+}
+
+/// Validated initial spatial-volume input for CDT construction.
+///
+/// This lets callers branch on regular equal-slice data versus an explicit
+/// nonuniform profile without rechecking divisibility, slice-count, or per-slice
+/// minimum invariants.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::config::{CdtConfig, ValidatedInitialVolume};
+/// use causal_triangulations::prelude::errors::CdtResult;
+///
+/// fn main() -> CdtResult<()> {
+///     let config = CdtConfig::new(16, 4).into_validated()?;
+///     assert!(matches!(
+///         config.initial_volume(),
+///         ValidatedInitialVolume::Regular {
+///             vertices_per_slice: 4
+///         }
+///     ));
+///     Ok(())
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidatedInitialVolume<'a> {
+    /// Regular equal-size spatial slices.
+    Regular {
+        /// Number of vertices in each slice.
+        vertices_per_slice: u32,
+    },
+    /// Explicit nonuniform spatial slice volumes.
+    ExplicitProfile(&'a [u32]),
+}
+
+impl ValidatedCdtConfig {
+    /// Validates a raw configuration and stores only the accepted value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidConfiguration`] when a geometry, topology, or
+    /// action invariant is violated, or [`CdtError::InvalidSimulationConfiguration`]
+    /// when the Metropolis temperature or schedule is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::{CdtConfig, ValidatedCdtConfig};
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let validated = ValidatedCdtConfig::new(CdtConfig::new(16, 4))?;
+    ///     assert_eq!(validated.timeslices(), 4);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn new(config: CdtConfig) -> CdtResult<Self> {
+        config.ensure_valid()?;
+        Ok(Self { config })
+    }
+
+    /// Returns the validated configuration for serialization/reporting APIs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let validated = CdtConfig::new(16, 4).into_validated()?;
+    ///     assert_eq!(validated.config().vertices, 16);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn config(&self) -> &CdtConfig {
+        &self.config
+    }
+
+    /// Converts the validated wrapper back into the inner configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig::new(16, 4).into_validated()?.into_config();
+    ///     assert_eq!(config.timeslices, 4);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub fn into_config(self) -> CdtConfig {
+        self.config
+    }
+
+    /// Gets the effective dimension.
+    ///
+    /// This is always `2` for accepted configurations.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig::new(16, 4).into_validated()?;
+    ///     assert_eq!(config.dimension(), 2);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn dimension(&self) -> u8 {
+        match self.config.dimension {
+            Some(dimension) => dimension,
+            None => 2,
+        }
+    }
+
+    /// Total number of vertices in the initial triangulation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig::new(16, 4).into_validated()?;
+    ///     assert_eq!(config.vertices(), 16);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn vertices(&self) -> u32 {
+        self.config.vertices
+    }
+
+    /// Number of initial time slices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig::new(16, 4).into_validated()?;
+    ///     assert_eq!(config.timeslices(), 4);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn timeslices(&self) -> u32 {
+        self.config.timeslices
+    }
+
+    /// Optional explicit initial spatial volume profile.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig {
+    ///         vertices: 15,
+    ///         timeslices: 3,
+    ///         volume_profile: Some(vec![4, 6, 5]),
+    ///         ..CdtConfig::new(15, 3)
+    ///     }
+    ///     .into_validated()?;
+    ///     assert_eq!(config.volume_profile(), Some([4, 6, 5].as_slice()));
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub fn volume_profile(&self) -> Option<&[u32]> {
+        self.config.volume_profile.as_deref()
+    }
+
+    /// Vertices per slice for validated regular equal-slice initial data.
+    ///
+    /// Returns `None` when the configuration uses an explicit volume profile.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let regular = CdtConfig::new(16, 4).into_validated()?;
+    ///     assert_eq!(regular.regular_vertices_per_slice(), Some(4));
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub fn regular_vertices_per_slice(&self) -> Option<u32> {
+        self.config
+            .volume_profile
+            .is_none()
+            .then_some(self.config.vertices / self.config.timeslices)
+    }
+
+    /// Initial spatial-volume input with validation proof attached.
+    ///
+    /// The returned value is safe to feed directly into CDT constructors because
+    /// [`Self::new`] has already checked topology-specific slice constraints.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::{CdtConfig, ValidatedInitialVolume};
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig {
+    ///         vertices: 15,
+    ///         timeslices: 3,
+    ///         volume_profile: Some(vec![4, 6, 5]),
+    ///         ..CdtConfig::new(15, 3)
+    ///     }
+    ///     .into_validated()?;
+    ///
+    ///     assert!(matches!(
+    ///         config.initial_volume(),
+    ///         ValidatedInitialVolume::ExplicitProfile([4, 6, 5])
+    ///     ));
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub fn initial_volume(&self) -> ValidatedInitialVolume<'_> {
+        self.config.volume_profile.as_ref().map_or_else(
+            || ValidatedInitialVolume::Regular {
+                vertices_per_slice: self.config.vertices / self.config.timeslices,
+            },
+            |profile| ValidatedInitialVolume::ExplicitProfile(profile),
+        )
+    }
+
+    /// Selected initial topology.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::{CdtConfig, CdtTopology};
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig {
+    ///         topology: CdtTopology::Toroidal,
+    ///         ..CdtConfig::new(12, 3)
+    ///     }
+    ///     .into_validated()?;
+    ///     assert_eq!(config.topology(), CdtTopology::Toroidal);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn topology(&self) -> CdtTopology {
+        self.config.topology
+    }
+
+    /// Whether to run Metropolis simulation after constructing the initial triangulation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig {
+    ///         simulate: false,
+    ///         ..CdtConfig::new(16, 4)
+    ///     }
+    ///     .into_validated()?;
+    ///     assert!(!config.simulate());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn simulate(&self) -> bool {
+        self.config.simulate
+    }
+
+    /// Configured CSV output path, if any.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    /// use std::path::Path;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig {
+    ///         output_csv: Some("measurements.csv".into()),
+    ///         ..CdtConfig::new(16, 4)
+    ///     }
+    ///     .into_validated()?;
+    ///     assert_eq!(config.output_csv(), Some(Path::new("measurements.csv")));
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub fn output_csv(&self) -> Option<&Path> {
+        self.config.output_csv.as_deref()
+    }
+
+    /// Configured JSON output path, if any.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    /// use std::path::Path;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig {
+    ///         output_json: Some("summary.json".into()),
+    ///         ..CdtConfig::new(16, 4)
+    ///     }
+    ///     .into_validated()?;
+    ///     assert_eq!(config.output_json(), Some(Path::new("summary.json")));
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub fn output_json(&self) -> Option<&Path> {
+        self.config.output_json.as_deref()
+    }
+
+    /// Creates a validated [`MetropolisConfig`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig {
+    ///         seed: Some(42),
+    ///         ..CdtConfig::new(16, 4)
+    ///     }
+    ///     .into_validated()?;
+    ///     let metropolis = config.to_metropolis_config();
+    ///     assert_eq!(metropolis.seed, Some(42));
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn to_metropolis_config(&self) -> MetropolisConfig {
+        to_metropolis_config(&self.config)
+    }
+
+    /// Creates a validated [`ActionConfig`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let action = CdtConfig::new(16, 4)
+    ///         .into_validated()?
+    ///         .to_action_config();
+    ///     assert_relative_eq!(action.coupling_0, 0.0);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn to_action_config(&self) -> ActionConfig {
+        to_action_config(&self.config)
+    }
+}
+
+impl TryFrom<CdtConfig> for ValidatedCdtConfig {
+    type Error = CdtError;
+
+    fn try_from(config: CdtConfig) -> Result<Self, Self::Error> {
+        Self::new(config)
+    }
+}
+
 /// Command-line arguments accepted by the `cdt` binary.
 #[derive(Parser)]
 #[command(
@@ -417,6 +835,30 @@ pub struct CdtConfigOverrides {
 }
 
 impl CdtConfig {
+    /// Converts this raw configuration DTO into a validated runtime configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidConfiguration`] when a geometry, topology, or
+    /// action invariant is violated, or [`CdtError::InvalidSimulationConfiguration`]
+    /// when the Metropolis temperature or schedule is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::config::CdtConfig;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig::new(16, 4).into_validated()?;
+    ///     assert_eq!(config.vertices(), 16);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn into_validated(self) -> CdtResult<ValidatedCdtConfig> {
+        ValidatedCdtConfig::new(self)
+    }
+
     /// Merges this configuration with a set of override values, returning a new configuration.
     ///
     /// Override fields that are `None` are ignored, leaving the original configuration values
@@ -674,6 +1116,19 @@ const fn invalid_config_parts(
     }
 }
 
+/// Builds a typed simulation-configuration error for Metropolis schedule settings.
+const fn invalid_sim_config_parts(
+    setting: ConfigurationSetting,
+    provided_value: String,
+    expected: String,
+) -> CdtError {
+    CdtError::InvalidSimulationConfiguration {
+        setting,
+        provided_value,
+        expected,
+    }
+}
+
 /// Rejects non-finite action couplings before they can poison action/log-probability math.
 fn validate_coupling(setting: ConfigurationSetting, value: f64) -> CdtResult<()> {
     if value.is_finite() {
@@ -783,6 +1238,29 @@ pub(crate) fn validate_schedule(
     Ok(())
 }
 
+/// Builds the MCMC runtime configuration from an already validated raw config.
+const fn to_metropolis_config(config: &CdtConfig) -> MetropolisConfig {
+    let metropolis = MetropolisConfig::new(
+        config.temperature,
+        config.steps,
+        config.thermalization_steps,
+        config.measurement_frequency,
+    );
+    MetropolisConfig {
+        seed: config.seed,
+        ..metropolis
+    }
+}
+
+/// Builds the action runtime configuration from an already validated raw config.
+const fn to_action_config(config: &CdtConfig) -> ActionConfig {
+    ActionConfig::new(
+        config.coupling_0,
+        config.coupling_2,
+        config.cosmological_constant,
+    )
+}
+
 impl CdtConfig {
     /// Builds a new instance of `CdtConfig` from command-line arguments.
     ///
@@ -848,8 +1326,8 @@ impl CdtConfig {
     /// Creates a new configuration from total vertices and time slices.
     ///
     /// The `vertices` argument is the total initial vertex count, not a
-    /// per-slice count. Call [`Self::validate`] before running a simulation to
-    /// check topology-specific divisibility and per-slice minimums.
+    /// per-slice count. Call [`Self::into_validated`] before deriving runtime
+    /// action or Metropolis configuration.
     ///
     /// # Examples
     ///
@@ -883,51 +1361,6 @@ impl CdtConfig {
         }
     }
 
-    /// Creates a `MetropolisConfig` from this configuration.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::CdtConfig;
-    ///
-    /// let config = CdtConfig {
-    ///     seed: Some(42),
-    ///     ..CdtConfig::new(16, 4)
-    /// };
-    /// let metropolis = config.to_metropolis_config();
-    /// assert_eq!(metropolis.seed, Some(42));
-    /// ```
-    #[must_use]
-    pub const fn to_metropolis_config(&self) -> MetropolisConfig {
-        let config = MetropolisConfig::new(
-            self.temperature,
-            self.steps,
-            self.thermalization_steps,
-            self.measurement_frequency,
-        );
-        // Wire seed through if present
-        MetropolisConfig {
-            seed: self.seed,
-            ..config
-        }
-    }
-
-    /// Creates an `ActionConfig` from this configuration.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use approx::assert_relative_eq;
-    /// use causal_triangulations::CdtConfig;
-    ///
-    /// let action = CdtConfig::new(16, 4).to_action_config();
-    /// assert_relative_eq!(action.coupling_0, 0.0);
-    /// ```
-    #[must_use]
-    pub const fn to_action_config(&self) -> ActionConfig {
-        ActionConfig::new(self.coupling_0, self.coupling_2, self.cosmological_constant)
-    }
-
     /// Gets the effective dimension (defaults to 2 if not specified).
     ///
     /// # Examples
@@ -949,27 +1382,29 @@ impl CdtConfig {
         }
     }
 
-    /// Validates the configuration parameters.
+    /// Checks the configuration parameters without returning a validated wrapper.
     ///
     /// # Errors
     ///
     /// Returns [`CdtError::InvalidConfiguration`] if the dimension is not 2, if
-    /// action couplings or temperature are non-finite, if the measurement
-    /// schedule cannot produce a post-thermalization measurement, or if topology
-    /// constraints on time slices, total vertices, or per-slice vertices are not
-    /// satisfied. Regular equal-slice initialization requires `vertices` to be
-    /// divisible by `timeslices`; explicit [`Self::volume_profile`] initialization
-    /// instead requires the profile length and sum to match the configured counts.
+    /// action couplings are non-finite, or if topology constraints on time
+    /// slices, total vertices, or per-slice vertices are not satisfied. Regular
+    /// equal-slice initialization requires `vertices` to be divisible by
+    /// `timeslices`; explicit [`Self::volume_profile`] initialization instead
+    /// requires the profile length and sum to match the configured counts.
+    /// Returns [`CdtError::InvalidSimulationConfiguration`] if the Metropolis
+    /// temperature or measurement schedule is invalid.
     ///
     /// # Examples
     ///
     /// ```
     /// use causal_triangulations::CdtConfig;
     ///
-    /// let config = CdtConfig::new(16, 4);
-    /// assert!(config.validate().is_ok());
+    /// let config = CdtConfig::new(16, 4).into_validated()?;
+    /// assert_eq!(config.timeslices(), 4);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
-    pub fn validate(&self) -> CdtResult<()> {
+    fn ensure_valid(&self) -> CdtResult<()> {
         if self.vertices < 3 {
             return Err(invalid_config(
                 ConfigurationSetting::Vertices,
@@ -1006,9 +1441,7 @@ impl CdtConfig {
             self.steps,
             self.thermalization_steps,
             self.measurement_frequency,
-            |setting, provided_value, expected| {
-                invalid_config_parts(setting, provided_value, expected)
-            },
+            invalid_sim_config_parts,
         )
     }
 
@@ -1237,6 +1670,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use dirs::home_dir;
+    use std::assert_matches;
     use std::path::PathBuf;
 
     #[test]
@@ -1322,10 +1756,10 @@ mod tests {
         ])
         .expect_err("unsupported dimension should be reported as a parse error");
 
-        assert!(matches!(
+        assert_matches!(
             error.kind(),
             clap::error::ErrorKind::ValueValidation | clap::error::ErrorKind::InvalidValue
-        ));
+        );
     }
 
     #[test]
@@ -1341,7 +1775,9 @@ mod tests {
 
     #[test]
     fn test_config_conversions() {
-        let config = CdtConfig::new(64, 4);
+        let config = CdtConfig::new(64, 4)
+            .into_validated()
+            .expect("test config should validate");
 
         let metropolis_config = config.to_metropolis_config();
         assert_relative_eq!(metropolis_config.temperature, 1.0);
@@ -1357,95 +1793,155 @@ mod tests {
     }
 
     #[test]
+    fn validated_config_carries_initial_volume_proof() {
+        let regular = CdtConfig::new(64, 4)
+            .into_validated()
+            .expect("regular config should validate");
+        assert_eq!(regular.dimension(), 2);
+        assert_eq!(regular.vertices(), 64);
+        assert_eq!(regular.timeslices(), 4);
+        assert_eq!(regular.regular_vertices_per_slice(), Some(16));
+        assert_matches!(
+            regular.initial_volume(),
+            ValidatedInitialVolume::Regular {
+                vertices_per_slice: 16
+            }
+        );
+
+        let profiled = CdtConfig {
+            vertices: 15,
+            timeslices: 3,
+            volume_profile: Some(vec![4, 6, 5]),
+            ..CdtConfig::new(15, 3)
+        }
+        .into_validated()
+        .expect("profile config should validate");
+
+        assert_eq!(profiled.regular_vertices_per_slice(), None);
+        assert_matches!(
+            profiled.initial_volume(),
+            ValidatedInitialVolume::ExplicitProfile([4, 6, 5])
+        );
+    }
+
+    #[test]
+    fn validated_config_exposes_raw_runtime_fields() {
+        let raw = CdtConfig {
+            topology: CdtTopology::Toroidal,
+            simulate: false,
+            output_csv: Some(PathBuf::from("measurements.csv")),
+            output_json: Some(PathBuf::from("summary.json")),
+            ..CdtConfig::new(12, 3)
+        };
+
+        let validated =
+            ValidatedCdtConfig::try_from(raw.clone()).expect("toroidal config should validate");
+
+        assert_eq!(validated.config().vertices, 12);
+        assert_eq!(validated.volume_profile(), None);
+        assert_eq!(validated.topology(), CdtTopology::Toroidal);
+        assert!(!validated.simulate());
+        assert_eq!(
+            validated.output_csv(),
+            Some(PathBuf::from("measurements.csv").as_path())
+        );
+        assert_eq!(
+            validated.output_json(),
+            Some(PathBuf::from("summary.json").as_path())
+        );
+        assert_eq!(validated.into_config().output_json, raw.output_json);
+    }
+
+    #[test]
     #[expect(
         clippy::too_many_lines,
         reason = "validation test exercises the full structured configuration error matrix"
     )]
     fn test_config_validation() {
         let valid_config = CdtConfig::new(36, 3);
-        assert!(valid_config.validate().is_ok());
+        assert!(valid_config.into_validated().is_ok());
 
         let invalid_vertices = CdtConfig {
             vertices: 2,
             ..CdtConfig::new(36, 3)
         };
-        assert!(matches!(
-            invalid_vertices.validate(),
+        assert_matches!(
+            invalid_vertices.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
                 expected,
             }) if setting == ConfigurationSetting::Vertices && provided_value == "2" && expected == "≥ 3"
-        ));
+        );
 
         let invalid_timeslices = CdtConfig {
             timeslices: 0,
             ..CdtConfig::new(36, 3)
         };
-        assert!(matches!(
-            invalid_timeslices.validate(),
+        assert_matches!(
+            invalid_timeslices.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
                 expected,
             }) if setting == ConfigurationSetting::Timeslices && provided_value == "0" && expected == "≥ 1"
-        ));
+        );
 
         let invalid_temperature = CdtConfig {
             temperature: -1.0,
             ..CdtConfig::new(36, 3)
         };
-        assert!(matches!(
-            invalid_temperature.validate(),
-            Err(CdtError::InvalidConfiguration {
+        assert_matches!(
+            invalid_temperature.into_validated(),
+            Err(CdtError::InvalidSimulationConfiguration {
                 setting,
                 provided_value,
                 expected,
             }) if setting == ConfigurationSetting::Temperature
                 && provided_value == "-1"
                 && expected == "finite and positive"
-        ));
+        );
 
         let invalid_measurement_frequency = CdtConfig {
             measurement_frequency: 0,
             ..CdtConfig::new(36, 3)
         };
-        assert!(matches!(
-            invalid_measurement_frequency.validate(),
-            Err(CdtError::InvalidConfiguration {
+        assert_matches!(
+            invalid_measurement_frequency.into_validated(),
+            Err(CdtError::InvalidSimulationConfiguration {
                 setting,
                 provided_value,
                 expected,
             }) if setting == ConfigurationSetting::MeasurementFrequency
                 && provided_value == "0"
                 && expected == "≥ 1"
-        ));
+        );
 
         let invalid_steps = CdtConfig {
             steps: 0,
             ..CdtConfig::new(36, 3)
         };
-        assert!(matches!(
-            invalid_steps.validate(),
-            Err(CdtError::InvalidConfiguration {
+        assert_matches!(
+            invalid_steps.into_validated(),
+            Err(CdtError::InvalidSimulationConfiguration {
                 setting,
                 provided_value,
                 expected,
             }) if setting == ConfigurationSetting::Steps && provided_value == "0" && expected == "≥ 1"
-        ));
+        );
 
         let invalid_dimension = CdtConfig {
             dimension: Some(4),
             ..CdtConfig::new(36, 3)
         };
-        assert!(matches!(
-            invalid_dimension.validate(),
+        assert_matches!(
+            invalid_dimension.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
                 expected,
             }) if setting == ConfigurationSetting::Dimension && provided_value == "4" && expected == "2"
-        ));
+        );
 
         for (setting, value) in [
             (ConfigurationSetting::Coupling0, f64::NAN),
@@ -1464,14 +1960,14 @@ mod tests {
                 }
                 _ => unreachable!("test case should name a known action coupling"),
             }
-            assert!(matches!(
-                invalid_action_coupling.validate(),
+            assert_matches!(
+                invalid_action_coupling.into_validated(),
                 Err(CdtError::InvalidConfiguration {
                     setting: invalid_setting,
                     expected,
                     ..
                 }) if invalid_setting == setting && expected == "finite"
-            ));
+            );
         }
 
         let finite_action_couplings = CdtConfig {
@@ -1481,7 +1977,7 @@ mod tests {
             ..CdtConfig::new(36, 3)
         };
         assert!(
-            finite_action_couplings.validate().is_ok(),
+            finite_action_couplings.into_validated().is_ok(),
             "finite signed action couplings should be accepted"
         );
 
@@ -1489,16 +1985,16 @@ mod tests {
             measurement_frequency: 2_000,
             ..CdtConfig::new(36, 3)
         };
-        assert!(matches!(
-            measurement_frequency_exceeds_steps.validate(),
-            Err(CdtError::InvalidConfiguration {
+        assert_matches!(
+            measurement_frequency_exceeds_steps.into_validated(),
+            Err(CdtError::InvalidSimulationConfiguration {
                 setting,
                 provided_value,
                 expected,
             }) if setting == ConfigurationSetting::MeasurementFrequency
                 && provided_value == "2000"
                 && expected == "≤ steps (1000)"
-        ));
+        );
 
         let boundary_aligned_measurement = CdtConfig {
             steps: 11,
@@ -1507,7 +2003,7 @@ mod tests {
             ..CdtConfig::new(36, 3)
         };
         assert!(
-            boundary_aligned_measurement.validate().is_ok(),
+            boundary_aligned_measurement.into_validated().is_ok(),
             "Configurations where thermalization ends on a measurement boundary should pass validation"
         );
 
@@ -1518,7 +2014,7 @@ mod tests {
             ..CdtConfig::new(36, 3)
         };
         assert!(
-            boundary_aligned_final_measurement.validate().is_ok(),
+            boundary_aligned_final_measurement.into_validated().is_ok(),
             "Configurations with a final-step post-thermalization measurement should pass validation"
         );
 
@@ -1529,7 +2025,7 @@ mod tests {
             ..CdtConfig::new(36, 3)
         };
         assert!(
-            final_step_measurement.validate().is_ok(),
+            final_step_measurement.into_validated().is_ok(),
             "A measurement taken exactly at the final completed step should satisfy the schedule"
         );
 
@@ -1539,8 +2035,8 @@ mod tests {
             measurement_frequency: 10,
             ..CdtConfig::new(36, 3)
         };
-        match insufficient_measurements.validate() {
-            Err(CdtError::InvalidConfiguration {
+        match insufficient_measurements.into_validated() {
+            Err(CdtError::InvalidSimulationConfiguration {
                 setting,
                 provided_value,
                 expected,
@@ -1563,16 +2059,16 @@ mod tests {
             measurement_frequency: 1,
             ..CdtConfig::new(36, 3)
         };
-        assert!(matches!(
-            thermalization_exceeds_steps.validate(),
-            Err(CdtError::InvalidConfiguration {
+        assert_matches!(
+            thermalization_exceeds_steps.into_validated(),
+            Err(CdtError::InvalidSimulationConfiguration {
                 setting,
                 provided_value,
                 expected,
             }) if setting == ConfigurationSetting::ThermalizationSteps
                 && provided_value == "11"
                 && expected == "≤ steps (10)"
-        ));
+        );
 
         let overflowed_post_thermalization_boundary = CdtConfig {
             steps: u32::MAX,
@@ -1580,8 +2076,8 @@ mod tests {
             measurement_frequency: 2,
             ..CdtConfig::new(36, 3)
         };
-        match overflowed_post_thermalization_boundary.validate() {
-            Err(CdtError::InvalidConfiguration {
+        match overflowed_post_thermalization_boundary.into_validated() {
+            Err(CdtError::InvalidSimulationConfiguration {
                 setting,
                 provided_value,
                 expected,
@@ -1609,7 +2105,7 @@ mod tests {
             ..CdtConfig::new(12, 3)
         };
         assert!(
-            valid_toroidal.validate().is_ok(),
+            valid_toroidal.into_validated().is_ok(),
             "Valid toroidal config (T=3, V=12) should validate"
         );
 
@@ -1620,8 +2116,8 @@ mod tests {
             timeslices: 2,
             ..CdtConfig::new(6, 2)
         };
-        assert!(matches!(
-            toroidal_t_too_small.validate(),
+        assert_matches!(
+            toroidal_t_too_small.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
@@ -1629,7 +2125,7 @@ mod tests {
             }) if setting == ConfigurationSetting::Timeslices
                 && provided_value == "2"
                 && expected == "≥ 3 for toroidal topology"
-        ));
+        );
 
         // Vertices not divisible by timeslices must be rejected.
         let toroidal_indivisible = CdtConfig {
@@ -1638,8 +2134,8 @@ mod tests {
             timeslices: 3,
             ..CdtConfig::new(11, 3)
         };
-        assert!(matches!(
-            toroidal_indivisible.validate(),
+        assert_matches!(
+            toroidal_indivisible.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
@@ -1647,7 +2143,7 @@ mod tests {
             }) if setting == ConfigurationSetting::Vertices
                 && provided_value == "11"
                 && expected == "divisible by timeslices (3) for toroidal topology"
-        ));
+        );
 
         // Fewer than 3 vertices per slice must be rejected (e.g. T=3, N=2).
         let toroidal_too_few_per_slice = CdtConfig {
@@ -1656,8 +2152,8 @@ mod tests {
             timeslices: 3,
             ..CdtConfig::new(6, 3)
         };
-        assert!(matches!(
-            toroidal_too_few_per_slice.validate(),
+        assert_matches!(
+            toroidal_too_few_per_slice.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
@@ -1665,7 +2161,7 @@ mod tests {
             }) if setting == ConfigurationSetting::Vertices
                 && provided_value == "6"
                 && expected == "≥ 3 · timeslices (9) for toroidal topology"
-        ));
+        );
 
         let toroidal_min_total_overflow = CdtConfig {
             topology: CdtTopology::Toroidal,
@@ -1673,8 +2169,8 @@ mod tests {
             timeslices: u32::MAX,
             ..CdtConfig::new(u32::MAX, u32::MAX)
         };
-        assert!(matches!(
-            toroidal_min_total_overflow.validate(),
+        assert_matches!(
+            toroidal_min_total_overflow.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
@@ -1682,7 +2178,7 @@ mod tests {
             }) if setting == ConfigurationSetting::Timeslices
                 && provided_value == u32::MAX.to_string()
                 && expected == "3 · timeslices must fit in u32 for toroidal topology"
-        ));
+        );
     }
 
     #[test]
@@ -1694,7 +2190,7 @@ mod tests {
             ..CdtConfig::new(12, 3)
         };
         assert!(
-            valid_open_boundary.validate().is_ok(),
+            valid_open_boundary.into_validated().is_ok(),
             "valid open-boundary config should validate"
         );
 
@@ -1704,8 +2200,8 @@ mod tests {
             timeslices: 1,
             ..CdtConfig::new(4, 1)
         };
-        assert!(matches!(
-            open_boundary_too_few_slices.validate(),
+        assert_matches!(
+            open_boundary_too_few_slices.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
@@ -1713,7 +2209,7 @@ mod tests {
             }) if setting == ConfigurationSetting::Timeslices
                 && provided_value == "1"
                 && expected == "≥ 2 for open-boundary topology"
-        ));
+        );
 
         let open_boundary_indivisible = CdtConfig {
             topology: CdtTopology::OpenBoundary,
@@ -1721,8 +2217,8 @@ mod tests {
             timeslices: 3,
             ..CdtConfig::new(11, 3)
         };
-        assert!(matches!(
-            open_boundary_indivisible.validate(),
+        assert_matches!(
+            open_boundary_indivisible.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
@@ -1730,7 +2226,7 @@ mod tests {
             }) if setting == ConfigurationSetting::Vertices
                 && provided_value == "11"
                 && expected == "divisible by timeslices (3) for open-boundary topology"
-        ));
+        );
 
         let open_boundary_too_few_per_slice = CdtConfig {
             topology: CdtTopology::OpenBoundary,
@@ -1738,8 +2234,8 @@ mod tests {
             timeslices: 3,
             ..CdtConfig::new(9, 3)
         };
-        assert!(matches!(
-            open_boundary_too_few_per_slice.validate(),
+        assert_matches!(
+            open_boundary_too_few_per_slice.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
@@ -1747,7 +2243,7 @@ mod tests {
             }) if setting == ConfigurationSetting::Vertices
                 && provided_value == "9"
                 && expected == "≥ 4 · timeslices (12) for open-boundary topology"
-        ));
+        );
     }
 
     #[test]
@@ -1759,7 +2255,7 @@ mod tests {
             ..CdtConfig::new(12, 3)
         };
         assert!(
-            valid_profile.validate().is_ok(),
+            valid_profile.into_validated().is_ok(),
             "nonuniform open-boundary profiles should not require divisible vertex counts"
         );
 
@@ -1769,8 +2265,8 @@ mod tests {
             volume_profile: Some(vec![4, 6, 5]),
             ..CdtConfig::new(12, 3)
         };
-        assert!(matches!(
-            mismatched_sum.validate(),
+        assert_matches!(
+            mismatched_sum.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
@@ -1778,7 +2274,7 @@ mod tests {
             }) if setting == ConfigurationSetting::Vertices
                 && provided_value == "14"
                 && expected == "sum of volume_profile (15)"
-        ));
+        );
 
         let mismatched_len = CdtConfig {
             vertices: 15,
@@ -1786,8 +2282,8 @@ mod tests {
             volume_profile: Some(vec![4, 6, 5]),
             ..CdtConfig::new(16, 4)
         };
-        assert!(matches!(
-            mismatched_len.validate(),
+        assert_matches!(
+            mismatched_len.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
@@ -1795,7 +2291,7 @@ mod tests {
             }) if setting == ConfigurationSetting::VolumeProfile
                 && provided_value == "3 entries"
                 && expected == "4 entries for configured timeslices"
-        ));
+        );
     }
 
     #[test]
@@ -1807,7 +2303,7 @@ mod tests {
             volume_profile: Some(vec![3, 4, 5, 4]),
             ..CdtConfig::new(16, 4)
         };
-        assert!(valid_profile.validate().is_ok());
+        assert!(valid_profile.into_validated().is_ok());
 
         let too_small = CdtConfig {
             vertices: 11,
@@ -1816,8 +2312,8 @@ mod tests {
             volume_profile: Some(vec![3, 2, 3, 3]),
             ..CdtConfig::new(12, 4)
         };
-        assert!(matches!(
-            too_small.validate(),
+        assert_matches!(
+            too_small.into_validated(),
             Err(CdtError::InvalidConfiguration {
                 setting,
                 provided_value,
@@ -1825,7 +2321,7 @@ mod tests {
             }) if setting == ConfigurationSetting::VolumeProfile
                 && provided_value == "slice 1 has 2"
                 && expected == "each slice ≥ 3 for toroidal topology"
-        ));
+        );
     }
 
     #[test]
@@ -1863,17 +2359,17 @@ mod tests {
     #[test]
     fn test_preset_configs() {
         let small = TestConfig::small();
-        assert!(small.validate().is_ok());
+        assert!(small.clone().into_validated().is_ok());
         assert_eq!(small.vertices, 16);
         assert_eq!(small.steps, 10);
 
         let medium = TestConfig::medium();
-        assert!(medium.validate().is_ok());
+        assert!(medium.clone().into_validated().is_ok());
         assert_eq!(medium.vertices, 64);
         assert_eq!(medium.steps, 100);
 
         let large = TestConfig::large();
-        assert!(large.validate().is_ok());
+        assert!(large.clone().into_validated().is_ok());
         assert_eq!(large.vertices, 256);
         assert_eq!(large.steps, 1000);
     }
@@ -2007,17 +2503,14 @@ mod tests {
 
         let result = base.merge_with_override(&overrides);
 
-        assert!(
-            matches!(
-                result,
-                Err(CdtError::InvalidConfiguration {
-                    setting: ConfigurationSetting::Vertices,
-                    ref provided_value,
-                    ref expected,
-                }) if provided_value == "[4294967295, 1]"
-                    && expected == "volume profile sum <= u32::MAX"
-            ),
-            "{result:?}"
+        assert_matches!(
+            result,
+            Err(CdtError::InvalidConfiguration {
+                setting: ConfigurationSetting::Vertices,
+                ref provided_value,
+                ref expected,
+            }) if provided_value == "[4294967295, 1]"
+                && expected == "volume profile sum <= u32::MAX"
         );
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -49,14 +49,12 @@ impl fmt::Display for DelaunayValidationLevel {
 ///     vertices: 2,
 ///     ..CdtConfig::new(36, 3)
 /// };
-/// let err = config.validate().expect_err("vertices below the minimum are invalid");
-///
 /// assert!(matches!(
-///     err,
-///     CdtError::InvalidConfiguration {
+///     config.into_validated(),
+///     Err(CdtError::InvalidConfiguration {
 ///         setting: ConfigurationSetting::Vertices,
 ///         ..
-///     }
+///     })
 /// ));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1160,6 +1158,7 @@ pub type CdtResult<T> = Result<T, CdtError>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
     use std::error::Error;
 
     #[test]
@@ -1842,10 +1841,7 @@ mod tests {
     fn test_mcmc_error_from_conversion() {
         let mcmc_err = McmcError::NanProposedLogProb;
         let cdt_err: CdtError = mcmc_err.into();
-        assert!(matches!(
-            cdt_err,
-            CdtError::Mcmc(McmcError::NanProposedLogProb)
-        ));
+        assert_matches!(cdt_err, CdtError::Mcmc(McmcError::NanProposedLogProb));
         let display = format!("{cdt_err}");
         assert!(
             display.contains("MCMC error"),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -44,18 +44,19 @@ impl fmt::Display for DelaunayValidationLevel {
 /// ```
 /// use causal_triangulations::prelude::errors::{CdtError, ConfigurationSetting};
 /// use causal_triangulations::prelude::CdtConfig;
+/// use std::assert_matches;
 ///
 /// let config = CdtConfig {
 ///     vertices: 2,
 ///     ..CdtConfig::new(36, 3)
 /// };
-/// assert!(matches!(
+/// assert_matches!(
 ///     config.into_validated(),
 ///     Err(CdtError::InvalidConfiguration {
 ///         setting: ConfigurationSetting::Vertices,
 ///         ..
 ///     })
-/// ));
+/// );
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -115,17 +116,18 @@ impl fmt::Display for ConfigurationSetting {
 /// ```
 /// use causal_triangulations::prelude::errors::{CdtError, GenerationParameterIssue};
 /// use causal_triangulations::prelude::triangulation::CdtTriangulation;
+/// use std::assert_matches;
 ///
 /// let err = CdtTriangulation::from_random_points(2, 2, 2)
 ///     .expect_err("fewer than three vertices cannot form a triangulation");
 ///
-/// assert!(matches!(
+/// assert_matches!(
 ///     err,
 ///     CdtError::InvalidGenerationParameters {
 ///         issue: GenerationParameterIssue::InsufficientVertexCount,
 ///         ..
 ///     }
-/// ));
+/// );
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -193,6 +195,7 @@ impl fmt::Display for GenerationParameterIssue {
 /// ```
 /// use causal_triangulations::prelude::errors::{CdtError, TriangulationMetadataField};
 /// use causal_triangulations::prelude::triangulation::CdtTopology;
+/// use std::assert_matches;
 ///
 /// let metadata_error = CdtError::InvalidTriangulationMetadata {
 ///     field: TriangulationMetadataField::Timeslices,
@@ -201,13 +204,13 @@ impl fmt::Display for GenerationParameterIssue {
 ///     expected: "at least three time slices".to_string(),
 /// };
 ///
-/// assert!(matches!(
+/// assert_matches!(
 ///     metadata_error,
 ///     CdtError::InvalidTriangulationMetadata {
 ///         field: TriangulationMetadataField::Timeslices,
 ///         ..
 ///     }
-/// ));
+/// );
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -514,17 +517,18 @@ impl fmt::Display for CheckpointMoveCounter {
 /// use causal_triangulations::prelude::errors::{
 ///     CdtError, CheckpointResumeFailure,
 /// };
+/// use std::assert_matches;
 ///
 /// let err = CdtError::CheckpointResumeFailed {
 ///     failure: CheckpointResumeFailure::IncompatibleTemperature,
 /// };
 ///
-/// assert!(matches!(
+/// assert_matches!(
 ///     err,
 ///     CdtError::CheckpointResumeFailed {
 ///         failure: CheckpointResumeFailure::IncompatibleTemperature,
 ///     }
-/// ));
+/// );
 /// ```
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 #[non_exhaustive]

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -1647,6 +1647,7 @@ mod tests {
     };
     use serde_json::{Value, error::Category};
     use slotmap::KeyData;
+    use std::assert_matches;
     use std::collections::HashSet;
 
     /// Wraps generated test fixtures through the public checked constructor.
@@ -2025,10 +2026,7 @@ mod tests {
         let bogus_key = VertexKey::from(KeyData::from_ffi(u64::MAX));
         let invalid_handle = DelaunayVertexHandle { key: bogus_key };
         let err = backend.vertex_coordinates(&invalid_handle).unwrap_err();
-        assert!(
-            matches!(err, DelaunayError::InvalidVertex { key } if key == bogus_key),
-            "Expected InvalidVertex with matching key, got: {err}"
-        );
+        assert_matches!(err, DelaunayError::InvalidVertex { key } if key == bogus_key);
     }
 
     #[test]
@@ -2063,10 +2061,7 @@ mod tests {
         let bogus_key = SimplexKey::from(KeyData::from_ffi(u64::MAX));
         let invalid_handle = DelaunayFaceHandle { key: bogus_key };
         let err = backend.face_vertices(&invalid_handle).unwrap_err();
-        assert!(
-            matches!(err, DelaunayError::InvalidFace { key } if key == bogus_key),
-            "Expected InvalidFace with matching key, got: {err}"
-        );
+        assert_matches!(err, DelaunayError::InvalidFace { key } if key == bogus_key);
     }
 
     #[test]
@@ -2282,10 +2277,7 @@ mod tests {
         let bogus_key = SimplexKey::from(KeyData::from_ffi(u64::MAX));
         let invalid_handle = DelaunayFaceHandle { key: bogus_key };
         let err = backend.face_neighbors(&invalid_handle).unwrap_err();
-        assert!(
-            matches!(err, DelaunayError::InvalidFace { key } if key == bogus_key),
-            "Expected InvalidFace with matching key, got: {err}"
-        );
+        assert_matches!(err, DelaunayError::InvalidFace { key } if key == bogus_key);
     }
 
     #[test]
@@ -2296,10 +2288,7 @@ mod tests {
         let bogus_key = VertexKey::from(KeyData::from_ffi(u64::MAX));
         let invalid_handle = DelaunayVertexHandle { key: bogus_key };
         let err = backend.adjacent_faces(&invalid_handle).unwrap_err();
-        assert!(
-            matches!(err, DelaunayError::InvalidVertex { key } if key == bogus_key),
-            "Expected InvalidVertex with matching key, got: {err}"
-        );
+        assert_matches!(err, DelaunayError::InvalidVertex { key } if key == bogus_key);
     }
 
     #[test]
@@ -2310,10 +2299,7 @@ mod tests {
         let bogus_key = VertexKey::from(KeyData::from_ffi(u64::MAX));
         let invalid_handle = DelaunayVertexHandle { key: bogus_key };
         let err = backend.incident_edges(&invalid_handle).unwrap_err();
-        assert!(
-            matches!(err, DelaunayError::InvalidVertex { key } if key == bogus_key),
-            "Expected InvalidVertex with matching key, got: {err}"
-        );
+        assert_matches!(err, DelaunayError::InvalidVertex { key } if key == bogus_key);
     }
 
     #[test]
@@ -2505,39 +2491,39 @@ mod tests {
 
         let vertex = backend.vertices().next().expect("valid vertex handle");
 
-        assert!(matches!(
+        assert_matches!(
             backend.move_vertex(vertex, &[1.0, 1.0]),
             Err(DelaunayError::NotImplemented {
                 operation: DelaunayOperation::MoveVertex,
             })
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             backend.insert_vertex(&[0.0]),
             Err(DelaunayError::CoordinateDimensionMismatch {
                 actual: 1,
                 expected: 2,
             })
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             backend.insert_vertex(&[f64::NAN, 0.0]),
             Err(DelaunayError::NonFiniteCoordinate {
                 operation: DelaunayOperation::InsertVertex,
                 axis: 0,
                 value,
             }) if value.is_nan()
-        ));
+        );
 
         let bogus_vertex = VertexKey::from(KeyData::from_ffi(u64::MAX));
-        assert!(matches!(
+        assert_matches!(
             backend.remove_vertex(DelaunayVertexHandle { key: bogus_vertex }),
             Err(DelaunayError::InvalidVertex { key }) if key == bogus_vertex,
-        ));
+        );
 
         let bogus_face = SimplexKey::from(KeyData::from_ffi(u64::MAX));
-        assert!(matches!(
+        assert_matches!(
             backend.subdivide_face(DelaunayFaceHandle { key: bogus_face }, &[0.25, 0.25]),
             Err(DelaunayError::InvalidFace { key }) if key == bogus_face,
-        ));
+        );
 
         let dt = build_delaunay2_with_data(&[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.5, 1.0], 1)])
             .expect("labeled triangle should build");
@@ -2546,11 +2532,11 @@ mod tests {
             .edges()
             .next()
             .expect("single triangle has boundary edges");
-        assert!(matches!(
+        assert_matches!(
             boundary_backend.flip_edge(boundary_edge),
             Err(DelaunayError::NonFlippableEdge { reason, .. })
                 if reason == NonFlippableEdgeReason::NotInteriorFacet,
-        ));
+        );
     }
 
     #[test]
@@ -2587,18 +2573,18 @@ mod tests {
             backend.face_count(),
         );
 
-        assert!(matches!(
+        assert_matches!(
             backend.clear(),
             Err(DelaunayError::NotImplemented {
                 operation: DelaunayOperation::Clear,
             })
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             backend.reserve_capacity(32, 64),
             Err(DelaunayError::NotImplemented {
                 operation: DelaunayOperation::ReserveCapacity,
             })
-        ));
+        );
         assert_eq!(
             (
                 backend.vertex_count(),

--- a/src/geometry/backends/mock.rs
+++ b/src/geometry/backends/mock.rs
@@ -670,6 +670,7 @@ impl TriangulationMut for MockBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     #[test]
     fn mock_operation_display_covers_all_operations() {
@@ -788,73 +789,70 @@ mod tests {
         let missing_edge = MockEdgeHandle(99);
         let missing_face = MockFaceHandle(99);
 
-        assert!(matches!(
+        assert_matches!(
             backend.vertex_coordinates(&missing_vertex),
             Err(MockError::Vertex(99))
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             backend.face_vertices(&missing_face),
             Err(MockError::Face(99))
-        ));
+        );
         assert!(backend.edge_endpoints(&missing_edge).is_none());
-        assert!(matches!(
+        assert_matches!(
             backend.adjacent_faces(&missing_vertex),
             Err(MockError::Vertex(99))
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             backend.incident_edges(&missing_vertex),
             Err(MockError::Vertex(99))
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             backend.face_neighbors(&missing_face),
             Err(MockError::Face(99))
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             backend.remove_vertex(missing_vertex.clone()),
             Err(MockError::Vertex(99))
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             backend.move_vertex(missing_vertex, &[1.0, 2.0]),
             Err(MockError::Vertex(99))
-        ));
-        assert!(matches!(
-            backend.flip_edge(missing_edge),
-            Err(MockError::Edge(99))
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(backend.flip_edge(missing_edge), Err(MockError::Edge(99)));
+        assert_matches!(
             backend.subdivide_face(missing_face, &[0.25, 0.25]),
             Err(MockError::Face(99))
-        ));
+        );
     }
 
     #[test]
     fn test_mock_backend_rejects_invalid_coordinate_dimensions() {
         let mut backend = MockBackend::create_triangle();
 
-        assert!(matches!(
+        assert_matches!(
             backend.insert_vertex(&[1.0]),
             Err(MockError::InvalidCoordinateDimension {
                 operation: MockOperation::InsertVertex,
                 expected: 2,
                 actual: 1,
             })
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             backend.move_vertex(MockVertexHandle(0), &[1.0, 2.0, 3.0]),
             Err(MockError::InvalidCoordinateDimension {
                 operation: MockOperation::MoveVertex,
                 expected: 2,
                 actual: 3,
             })
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             backend.subdivide_face(MockFaceHandle(0), &[0.25]),
             Err(MockError::InvalidCoordinateDimension {
                 operation: MockOperation::SubdivideFace,
                 expected: 2,
                 actual: 1,
             })
-        ));
+        );
     }
 
     #[test]
@@ -888,14 +886,14 @@ mod tests {
             .edges()
             .next()
             .expect("triangle should contain edges");
-        assert!(matches!(
+        assert_matches!(
             backend.flip_edge(edge.clone()),
             Err(MockError::NonFlippableEdge {
                 edge: _,
                 adjacent_faces: 1,
                 reason: MockNonFlippableReason::EdgeSharedByTwoFaces,
             })
-        ));
+        );
         assert!(!backend.can_flip_edge(&edge));
         assert!(!backend.can_flip_edge(&MockEdgeHandle(99)));
 
@@ -938,14 +936,14 @@ mod tests {
 
         let result = backend.reserve_capacity(usize::MAX, 0);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(MockError::ReservationFailed {
                 operation: MockStorageTarget::Vertices,
                 requested_capacity: usize::MAX,
                 detail,
             }) if !detail.is_empty()
-        ));
+        );
     }
 
     #[test]
@@ -1039,36 +1037,36 @@ mod tests {
         backend.edges.insert(0, (0, 1));
         backend.faces.insert(0, vec![0, 1, 2, 3]);
         backend.faces.insert(1, vec![0, 1, 2]);
-        assert!(matches!(
+        assert_matches!(
             backend.flip_edge(MockEdgeHandle(0)),
             Err(MockError::NonFlippableEdge {
                 edge: 0,
                 adjacent_faces: 2,
                 reason: MockNonFlippableReason::AdjacentFacesMustBeTriangles,
             })
-        ));
+        );
 
         backend.faces.insert(0, vec![0, 1, 2]);
         backend.faces.insert(1, vec![1, 0, 2]);
-        assert!(matches!(
+        assert_matches!(
             backend.flip_edge(MockEdgeHandle(0)),
             Err(MockError::NonFlippableEdge {
                 edge: 0,
                 adjacent_faces: 2,
                 reason: MockNonFlippableReason::OppositeVerticesMustBeDistinct,
             })
-        ));
+        );
 
         backend.faces.insert(1, vec![1, 0, 3]);
         backend.edges.insert(1, (2, 3));
-        assert!(matches!(
+        assert_matches!(
             backend.flip_edge(MockEdgeHandle(0)),
             Err(MockError::NonFlippableEdge {
                 edge: 0,
                 adjacent_faces: 2,
                 reason: MockNonFlippableReason::ReplacementEdgeAlreadyExists,
             })
-        ));
+        );
     }
 
     #[test]
@@ -1082,14 +1080,14 @@ mod tests {
         backend.faces.insert(0, vec![0, 1, 2, 3]);
         backend.next_face_id = 1;
 
-        assert!(matches!(
+        assert_matches!(
             backend.subdivide_face(MockFaceHandle(0), &[0.5, 0.5]),
             Err(MockError::NonSubdividableFace {
                 face: 0,
                 vertex_count: 4,
                 expected: "3 vertices",
             })
-        ));
+        );
         assert_eq!(backend.vertex_count(), 4);
         assert_eq!(backend.face_count(), 1);
     }

--- a/src/geometry/generators.rs
+++ b/src/geometry/generators.rs
@@ -403,6 +403,7 @@ pub fn build_delaunay2_with_topology(
 /// ```
 /// use causal_triangulations::{CdtError, CdtResult};
 /// use causal_triangulations::prelude::geometry::*;
+/// use std::assert_matches;
 ///
 /// fn main() -> CdtResult<()> {
 ///     const N: usize = 3;
@@ -431,11 +432,11 @@ pub fn build_delaunay2_with_topology(
 ///     }
 ///
 ///     let result = build_toroidal_delaunay2(&vertices, &simplices, [1.0, 1.0]);
-///     assert!(matches!(
+///     assert_matches!(
 ///         result,
 ///         Err(CdtError::DelaunayGenerationFailed { ref underlying_error, .. })
 ///             if underlying_error.contains("Explicit non-Euclidean connectivity")
-///     ));
+///     );
 ///     Ok(())
 /// }
 /// ```

--- a/src/geometry/generators.rs
+++ b/src/geometry/generators.rs
@@ -597,6 +597,7 @@ mod tests {
     use super::*;
     use crate::errors::CdtError;
     use crate::geometry::DelaunayBackend2D;
+    use std::assert_matches;
     use std::collections::HashMap;
 
     /// Produces an order-independent snapshot of vertices and simplex connectivity for seeded tests.
@@ -638,14 +639,14 @@ mod tests {
     fn test_generate_delaunay2_vertex_build_error_context() {
         let error = generate_delaunay2_vertex_build_error(5, "missing point".to_string());
 
-        assert!(matches!(
+        assert_matches!(
             error,
             CdtError::VertexBuildFailed {
                 ref context,
                 ref underlying_error,
             } if context == "generate_delaunay2(5 vertices)"
                 && underlying_error == "missing point"
-        ));
+        );
     }
 
     #[test]
@@ -668,9 +669,10 @@ mod tests {
         let simplices = vec![vec![0, 1, 3]];
 
         let result = build_delaunay2_from_simplices(&vertices, &simplices);
-        assert!(
-            matches!(result, Err(CdtError::DelaunayGenerationFailed { .. })),
-            "explicit builder must reject out-of-bounds vertex indices, got {result:?}"
+        assert_matches!(
+            result,
+            Err(CdtError::DelaunayGenerationFailed { .. }),
+            "explicit builder must reject out-of-bounds vertex indices"
         );
     }
 
@@ -720,18 +722,16 @@ mod tests {
 
         let error = build_toroidal_delaunay2(&vertices, &simplices, [1.0, 1.0])
             .expect_err("explicit toroidal topology should report upstream limitation");
-        assert!(
-            matches!(
-                error,
-                CdtError::DelaunayGenerationFailed {
-                    vertex_count: 9,
-                    ref underlying_error,
-                    ..
-                } if underlying_error.contains(
-                    "Explicit non-Euclidean connectivity is not supported for Toroidal"
-                )
+        assert_matches!(
+            error,
+            CdtError::DelaunayGenerationFailed {
+                vertex_count: 9,
+                ref underlying_error,
+                ..
+            } if underlying_error.contains(
+                "Explicit non-Euclidean connectivity is not supported for Toroidal"
             ),
-            "explicit toroidal mesh should fail with the upstream topology limitation, got {error:?}"
+            "explicit toroidal mesh should fail with the upstream topology limitation"
         );
     }
 
@@ -776,18 +776,16 @@ mod tests {
             ([f64::INFINITY, 3.0], "axis 0 period inf"),
         ] {
             let result = build_periodic_toroidal_delaunay2(&vertices, domain);
-            assert!(
-                matches!(
-                    result,
-                    Err(CdtError::InvalidGenerationParameters {
-                        ref issue,
-                        ref provided_value,
-                        ref expected_range,
-                    }) if *issue == GenerationParameterIssue::InvalidToroidalDomain
-                        && provided_value == expected_value
-                        && expected_range == "finite and positive periods"
-                ),
-                "invalid periodic toroidal domain {domain:?} should be rejected, got {result:?}"
+            assert_matches!(
+                result,
+                Err(CdtError::InvalidGenerationParameters {
+                    ref issue,
+                    ref provided_value,
+                    ref expected_range,
+                }) if *issue == GenerationParameterIssue::InvalidToroidalDomain
+                    && provided_value == expected_value
+                    && expected_range == "finite and positive periods",
+                "invalid periodic toroidal domain {domain:?} should be rejected"
             );
         }
     }
@@ -801,18 +799,16 @@ mod tests {
         ];
 
         let result = build_periodic_toroidal_delaunay2(&vertices, [3.0, 3.0]);
-        assert!(
-            matches!(
-                result,
-                Err(CdtError::InvalidGenerationParameters {
-                    ref issue,
-                    ref provided_value,
-                    ref expected_range,
-                }) if *issue == GenerationParameterIssue::NonFiniteVertexCoordinate
-                    && provided_value == "vertex 1 axis 1 = -inf"
-                    && expected_range == "finite coordinate values"
-            ),
-            "periodic toroidal non-finite coordinate should be rejected, got {result:?}"
+        assert_matches!(
+            result,
+            Err(CdtError::InvalidGenerationParameters {
+                ref issue,
+                ref provided_value,
+                ref expected_range,
+            }) if *issue == GenerationParameterIssue::NonFiniteVertexCoordinate
+                && provided_value == "vertex 1 axis 1 = -inf"
+                && expected_range == "finite coordinate values",
+            "periodic toroidal non-finite coordinate should be rejected"
         );
     }
 
@@ -917,17 +913,15 @@ mod tests {
     fn test_generate_delaunay2_rejects_non_finite_range() {
         for range in [(f64::NAN, 1.0), (0.0, f64::INFINITY)] {
             let result = generate_delaunay2(4, range, None);
-            assert!(
-                matches!(
-                    result,
-                    Err(CdtError::InvalidGenerationParameters {
-                        ref issue,
-                        ref expected_range,
-                        ..
-                    }) if *issue == GenerationParameterIssue::InvalidCoordinateRange
-                        && expected_range == "finite min < max"
-                ),
-                "non-finite range {range:?} should be rejected, got {result:?}"
+            assert_matches!(
+                result,
+                Err(CdtError::InvalidGenerationParameters {
+                    ref issue,
+                    ref expected_range,
+                    ..
+                }) if *issue == GenerationParameterIssue::InvalidCoordinateRange
+                    && expected_range == "finite min < max",
+                "non-finite range {range:?} should be rejected"
             );
         }
     }
@@ -937,18 +931,16 @@ mod tests {
         let vertices = [([0.0, 0.0], 0u32), ([1.0, f64::NAN], 0), ([0.5, 1.0], 1)];
 
         let result = build_delaunay2_with_data(&vertices);
-        assert!(
-            matches!(
-                result,
-                Err(CdtError::InvalidGenerationParameters {
-                    ref issue,
-                    ref provided_value,
-                    ref expected_range,
-                }) if *issue == GenerationParameterIssue::NonFiniteVertexCoordinate
-                    && provided_value == "vertex 1 axis 1 = NaN"
-                    && expected_range == "finite coordinate values"
-            ),
-            "explicit non-finite coordinate should be rejected, got {result:?}"
+        assert_matches!(
+            result,
+            Err(CdtError::InvalidGenerationParameters {
+                ref issue,
+                ref provided_value,
+                ref expected_range,
+            }) if *issue == GenerationParameterIssue::NonFiniteVertexCoordinate
+                && provided_value == "vertex 1 axis 1 = NaN"
+                && expected_range == "finite coordinate values",
+            "explicit non-finite coordinate should be rejected"
         );
     }
 
@@ -962,18 +954,16 @@ mod tests {
         let simplices = vec![vec![0, 1, 2]];
 
         let result = build_delaunay2_from_simplices(&vertices, &simplices);
-        assert!(
-            matches!(
-                result,
-                Err(CdtError::InvalidGenerationParameters {
-                    ref issue,
-                    ref provided_value,
-                    ref expected_range,
-                }) if *issue == GenerationParameterIssue::NonFiniteVertexCoordinate
-                    && provided_value == "vertex 2 axis 1 = -inf"
-                    && expected_range == "finite coordinate values"
-            ),
-            "delegating explicit-simplex builder should reject non-finite coordinates, got {result:?}"
+        assert_matches!(
+            result,
+            Err(CdtError::InvalidGenerationParameters {
+                ref issue,
+                ref provided_value,
+                ref expected_range,
+            }) if *issue == GenerationParameterIssue::NonFiniteVertexCoordinate
+                && provided_value == "vertex 2 axis 1 = -inf"
+                && expected_range == "finite coordinate values",
+            "delegating explicit-simplex builder should reject non-finite coordinates"
         );
     }
 
@@ -992,18 +982,16 @@ mod tests {
             TopologyGuarantee::DEFAULT,
             GlobalTopology::Euclidean,
         );
-        assert!(
-            matches!(
-                result,
-                Err(CdtError::InvalidGenerationParameters {
-                    ref issue,
-                    ref provided_value,
-                    ref expected_range,
-                }) if *issue == GenerationParameterIssue::NonFiniteVertexCoordinate
-                    && provided_value == "vertex 1 axis 0 = inf"
-                    && expected_range == "finite coordinate values"
-            ),
-            "explicit non-finite topology coordinate should be rejected, got {result:?}"
+        assert_matches!(
+            result,
+            Err(CdtError::InvalidGenerationParameters {
+                ref issue,
+                ref provided_value,
+                ref expected_range,
+            }) if *issue == GenerationParameterIssue::NonFiniteVertexCoordinate
+                && provided_value == "vertex 1 axis 0 = inf"
+                && expected_range == "finite coordinate values",
+            "explicit non-finite topology coordinate should be rejected"
         );
     }
 
@@ -1019,18 +1007,16 @@ mod tests {
             ([f64::INFINITY, 1.0], "axis 0 period inf"),
         ] {
             let result = build_toroidal_delaunay2(&vertices, &simplices, domain);
-            assert!(
-                matches!(
-                    result,
-                    Err(CdtError::InvalidGenerationParameters {
-                        ref issue,
-                        ref provided_value,
-                        ref expected_range,
-                    }) if *issue == GenerationParameterIssue::InvalidToroidalDomain
-                        && provided_value == expected_value
-                        && expected_range == "finite and positive periods"
-                ),
-                "invalid domain {domain:?} should be rejected, got {result:?}"
+            assert_matches!(
+                result,
+                Err(CdtError::InvalidGenerationParameters {
+                    ref issue,
+                    ref provided_value,
+                    ref expected_range,
+                }) if *issue == GenerationParameterIssue::InvalidToroidalDomain
+                    && provided_value == expected_value
+                    && expected_range == "finite and positive periods",
+                "invalid domain {domain:?} should be rejected"
             );
         }
     }

--- a/src/geometry/operations.rs
+++ b/src/geometry/operations.rs
@@ -239,6 +239,7 @@ mod tests {
     use super::*;
     use crate::geometry::backends::mock::MockBackend;
     use crate::geometry::traits::{EdgeAdjacentFacesResult, GeometryBackend, TriangulationQuery};
+    use std::assert_matches;
     use std::collections::HashSet;
 
     #[derive(Debug, Clone)]
@@ -412,25 +413,13 @@ mod tests {
         assert_eq!(backend.dimension(), 1);
         assert_eq!(backend.vertices().collect::<Vec<_>>(), vec![0, 1, 2]);
         assert_eq!(backend.vertex_coordinates(&0), Ok(vec![0.0]));
-        assert!(matches!(
-            backend.vertex_coordinates(&99),
-            Err(FixtureError::Vertex)
-        ));
+        assert_matches!(backend.vertex_coordinates(&99), Err(FixtureError::Vertex));
         assert_eq!(backend.adjacent_faces(&0), Ok(Vec::new()));
-        assert!(matches!(
-            backend.adjacent_faces(&99),
-            Err(FixtureError::Vertex)
-        ));
+        assert_matches!(backend.adjacent_faces(&99), Err(FixtureError::Vertex));
         assert_eq!(backend.incident_edges(&0), Ok(Vec::new()));
-        assert!(matches!(
-            backend.incident_edges(&99),
-            Err(FixtureError::Vertex)
-        ));
+        assert_matches!(backend.incident_edges(&99), Err(FixtureError::Vertex));
         assert_eq!(backend.face_neighbors(&0), Ok(Vec::new()));
-        assert!(matches!(
-            backend.face_neighbors(&99),
-            Err(FixtureError::Face)
-        ));
+        assert_matches!(backend.face_neighbors(&99), Err(FixtureError::Face));
 
         let hull: HashSet<_> = backend.convex_hull().into_iter().collect();
         assert_eq!(hull, HashSet::from([0, 1]));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,10 @@ pub use cdt::metropolis::{
 };
 pub use cdt::observables::{estimate_hausdorff_dimension, estimate_spectral_dimension};
 pub use cdt::results::{Measurement, SimulationResultsBackend};
-pub use config::{CdtConfig, CdtConfigOverrides, CdtTopology, DimensionOverride, TestConfig};
+pub use config::{
+    CdtConfig, CdtConfigOverrides, CdtTopology, DimensionOverride, TestConfig, ValidatedCdtConfig,
+    ValidatedInitialVolume,
+};
 pub use errors::{
     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
     CheckpointMoveCounter, CheckpointOperation, CheckpointResumeFailure, ConfigurationSetting,
@@ -225,13 +228,14 @@ pub mod prelude {
     pub use crate::run_simulation;
 
     // Configuration and errors
-    pub use crate::config::{CdtConfig, CdtTopology};
+    pub use crate::config::{CdtConfig, CdtTopology, ValidatedCdtConfig};
     pub use crate::errors::{CdtError, CdtResult};
 
     /// Focused exports for configuration parsing and presets.
     pub mod config {
         pub use crate::config::{
             CdtConfig, CdtConfigOverrides, CdtTopology, DimensionOverride, TestConfig,
+            ValidatedCdtConfig, ValidatedInitialVolume,
         };
     }
 
@@ -321,15 +325,39 @@ pub mod prelude {
 
     /// Focused exports for running CDT simulations.
     ///
-    /// This prelude includes [`run_simulation`], the Metropolis runner, delayed
-    /// proposal adapter, telemetry structs, result containers, and typed
-    /// proposal errors needed by MCMC workflows. It also includes the
-    /// triangulation query trait so callers can inspect final or checkpointed
-    /// states returned by simulation APIs. The upstream MCMC traits are
-    /// re-exported here because [`CdtProposal`](crate::cdt::metropolis::CdtProposal)
-    /// and [`CdtTarget`](crate::cdt::metropolis::CdtTarget) expose their primary
+    /// This prelude includes [`run_simulation`], validated simulation
+    /// configuration, the Metropolis runner, delayed proposal adapter, telemetry
+    /// structs, result containers, and typed proposal errors needed by MCMC
+    /// workflows. It also includes the triangulation query trait so callers can
+    /// inspect final or checkpointed states returned by simulation APIs. The
+    /// upstream MCMC traits are re-exported here because
+    /// [`CdtProposal`](crate::cdt::metropolis::CdtProposal) and
+    /// [`CdtTarget`](crate::cdt::metropolis::CdtTarget) expose their primary
     /// behavior through those trait implementations.
     /// Observable estimators live in [`crate::prelude::observables`].
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtConfig, CdtResult, ValidatedCdtConfig,
+    /// };
+    ///
+    /// fn configured_steps(config: ValidatedCdtConfig) -> u32 {
+    ///     config.to_metropolis_config().steps
+    /// }
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let config = CdtConfig {
+    ///         steps: 5,
+    ///         thermalization_steps: 0,
+    ///         measurement_frequency: 1,
+    ///         ..CdtConfig::new(16, 4)
+    ///     }
+    ///     .into_validated()?;
+    ///
+    ///     assert_eq!(configured_steps(config), 5);
+    ///     Ok(())
+    /// }
+    /// ```
     pub mod simulation {
         pub use crate::cdt::action::{ActionConfig, compute_regge_action};
         pub use crate::cdt::ergodic_moves::MoveType;
@@ -339,7 +367,7 @@ pub mod prelude {
         };
         pub use crate::cdt::results::{Measurement, SimulationResultsBackend};
         pub use crate::cdt::triangulation::SimulationEvent;
-        pub use crate::config::{CdtConfig, CdtTopology};
+        pub use crate::config::{CdtConfig, CdtTopology, ValidatedCdtConfig};
         pub use crate::errors::{CdtError, CdtResult};
         pub use crate::geometry::CdtTriangulation2D;
         pub use crate::geometry::traits::TriangulationQuery;
@@ -474,12 +502,12 @@ pub mod prelude {
 ///
 /// # Errors
 ///
-/// Returns [`CdtError::InvalidConfiguration`] if the configuration fails validation,
-/// including invalid measurement schedules, unsupported open-boundary or
-/// toroidal slice counts, invalid regular slice counts, or inconsistent
-/// explicit spatial volume profiles.
-/// Returns [`CdtError::UnsupportedDimension`] if a validated configuration requests
-/// a simulation dimension other than 2.
+/// Returns [`CdtError::InvalidConfiguration`] if geometry, topology, action, or
+/// initial-volume configuration fails validation, including unsupported
+/// dimensions, unsupported open-boundary or toroidal slice counts, invalid
+/// regular slice counts, or inconsistent explicit spatial volume profiles.
+/// Returns [`CdtError::InvalidSimulationConfiguration`] if the Metropolis
+/// temperature or measurement schedule is invalid.
 /// Returns triangulation generation, topology, foliation, or Metropolis errors
 /// from the selected construction and simulation path.
 /// If [`CdtConfig::output_csv`] or [`CdtConfig::output_json`] is set, returns
@@ -509,50 +537,37 @@ pub mod prelude {
 /// }
 /// ```
 pub fn run_simulation(config: &CdtConfig) -> CdtResult<SimulationResultsBackend> {
-    // Validate configuration early to fail fast with clear error messages
-    config.validate()?;
+    let config = config.clone().into_validated()?;
 
-    let vertices = config.vertices;
-    let timeslices = config.timeslices;
+    let vertices = config.vertices();
+    let timeslices = config.timeslices();
 
-    if let Some(dim) = config.dimension
-        && dim != 2
-    {
-        return Err(CdtError::UnsupportedDimension(dim.into()));
-    }
-
-    log::info!("Dimensionality: {}", config.dimension.unwrap_or(2));
+    log::info!("Dimensionality: {}", config.dimension());
     log::info!("Number of vertices: {vertices}");
     log::info!("Number of timeslices: {timeslices}");
-    if let Some(profile) = &config.volume_profile {
+    if let Some(profile) = config.volume_profile() {
         log::info!("Initial spatial volume profile: {profile:?}");
     }
-    log::info!("Topology: {:?}", config.topology);
+    log::info!("Topology: {:?}", config.topology());
     log::info!("Using trait-based backend system");
 
-    // Create initial triangulation based on topology.
-    //
-    // `config.vertices` is always the *total* vertex count. With no explicit
-    // profile, `validate()` has checked topology-specific divisibility so we can
-    // divide to recover N = vertices/T per slice.
-    let triangulation = match config.topology {
-        CdtTopology::Toroidal => {
+    // Create initial triangulation from the validated topology/profile matrix.
+    let triangulation = match (config.topology(), config.initial_volume()) {
+        (CdtTopology::Toroidal, ValidatedInitialVolume::ExplicitProfile(profile)) => {
             log::info!("Constructing toroidal CDT (S¹×S¹)");
-            if let Some(profile) = &config.volume_profile {
-                CdtTriangulation::from_toroidal_cdt_profile(profile)?
-            } else {
-                let vertices_per_slice = vertices / timeslices;
-                CdtTriangulation::from_toroidal_cdt(vertices_per_slice, timeslices)?
-            }
+            CdtTriangulation::from_toroidal_cdt_profile(profile)?
         }
-        CdtTopology::OpenBoundary => {
+        (CdtTopology::Toroidal, ValidatedInitialVolume::Regular { vertices_per_slice }) => {
+            log::info!("Constructing toroidal CDT (S¹×S¹)");
+            CdtTriangulation::from_toroidal_cdt(vertices_per_slice, timeslices)?
+        }
+        (CdtTopology::OpenBoundary, ValidatedInitialVolume::ExplicitProfile(profile)) => {
             log::info!("Constructing open-boundary CDT strip");
-            if let Some(profile) = &config.volume_profile {
-                CdtTriangulation::from_cdt_strip_profile(profile)?
-            } else {
-                let vertices_per_slice = vertices / timeslices;
-                CdtTriangulation::from_cdt_strip(vertices_per_slice, timeslices)?
-            }
+            CdtTriangulation::from_cdt_strip_profile(profile)?
+        }
+        (CdtTopology::OpenBoundary, ValidatedInitialVolume::Regular { vertices_per_slice }) => {
+            log::info!("Constructing open-boundary CDT strip");
+            CdtTriangulation::from_cdt_strip(vertices_per_slice, timeslices)?
         }
     };
 
@@ -563,7 +578,7 @@ pub fn run_simulation(config: &CdtConfig) -> CdtResult<SimulationResultsBackend>
         triangulation.face_count()
     );
 
-    let results = if config.simulate {
+    let results = if config.simulate() {
         // Run full CDT simulation with MCMC backend
         let metropolis_config = config.to_metropolis_config();
         let action_config = config.to_action_config();
@@ -584,13 +599,12 @@ pub fn run_simulation(config: &CdtConfig) -> CdtResult<SimulationResultsBackend>
         let vertices = saturating_usize_to_u32(triangulation.vertex_count());
         let edges = saturating_usize_to_u32(triangulation.edge_count());
         let triangles = saturating_usize_to_u32(triangulation.face_count());
-        let initial_action = config
-            .to_action_config()
-            .calculate_action(vertices, edges, triangles);
+        let action_config = config.to_action_config();
+        let initial_action = action_config.calculate_action(vertices, edges, triangles);
 
         SimulationResultsBackend::from_parts(SimulationResultsParts {
             config: config.to_metropolis_config(),
-            action_config: config.to_action_config(),
+            action_config,
             move_stats: MoveStatistics::new(),
             proposal_stats: ProposalStatistics::new(),
             steps: vec![],
@@ -607,16 +621,16 @@ pub fn run_simulation(config: &CdtConfig) -> CdtResult<SimulationResultsBackend>
         })
     };
 
-    write_configured_outputs(config, &results)?;
+    write_configured_outputs(&config, &results)?;
     Ok(results)
 }
 
 /// Writes configured result outputs after a run completes.
 fn write_configured_outputs(
-    config: &CdtConfig,
+    validated_config: &ValidatedCdtConfig,
     results: &SimulationResultsBackend,
 ) -> CdtResult<()> {
-    if config.output_csv.is_none() && config.output_json.is_none() {
+    if validated_config.output_csv().is_none() && validated_config.output_json().is_none() {
         return Ok(());
     }
 
@@ -625,13 +639,11 @@ fn write_configured_outputs(
         detail: err.to_string(),
     })?;
 
-    let resolved_csv = config
-        .output_csv
-        .as_ref()
+    let resolved_csv = validated_config
+        .output_csv()
         .map(|path| CdtConfig::resolve_path(&base_dir, path));
-    let resolved_json = config
-        .output_json
-        .as_ref()
+    let resolved_json = validated_config
+        .output_json()
         .map(|path| CdtConfig::resolve_path(&base_dir, path));
 
     if let (Some(csv_path), Some(json_path)) = (&resolved_csv, &resolved_json)
@@ -649,7 +661,7 @@ fn write_configured_outputs(
     }
 
     if let Some(resolved) = resolved_json {
-        results.write_summary_json(config, &resolved)?;
+        results.write_summary_json(validated_config.config(), &resolved)?;
         log::info!("Wrote simulation JSON summary to {}", resolved.display());
     }
 
@@ -661,6 +673,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use serde_json::{Value, from_str};
+    use std::assert_matches;
     use std::env;
     use std::fs;
     use std::path::PathBuf;
@@ -797,7 +810,7 @@ mod tests {
         let result = run_simulation(&config);
         assert!(result.is_err(), "Should reject zero measurement frequency");
 
-        if let Err(CdtError::InvalidConfiguration {
+        if let Err(CdtError::InvalidSimulationConfiguration {
             setting,
             provided_value,
             expected,
@@ -807,7 +820,7 @@ mod tests {
             assert_eq!(provided_value, "0");
             assert_eq!(expected, "≥ 1");
         } else {
-            panic!("Expected InvalidConfiguration error");
+            panic!("Expected InvalidSimulationConfiguration error");
         }
     }
 
@@ -823,7 +836,7 @@ mod tests {
             "Should reject measurement frequency greater than steps"
         );
 
-        if let Err(CdtError::InvalidConfiguration {
+        if let Err(CdtError::InvalidSimulationConfiguration {
             setting,
             provided_value,
             expected,
@@ -833,7 +846,7 @@ mod tests {
             assert_eq!(provided_value, "200");
             assert_eq!(expected, "≤ steps (100)");
         } else {
-            panic!("Expected InvalidConfiguration error");
+            panic!("Expected InvalidSimulationConfiguration error");
         }
     }
 
@@ -867,7 +880,7 @@ mod tests {
         let result = run_simulation(&config);
         assert!(result.is_err(), "Should reject negative temperature");
 
-        if let Err(CdtError::InvalidConfiguration {
+        if let Err(CdtError::InvalidSimulationConfiguration {
             setting,
             provided_value,
             expected,
@@ -877,7 +890,7 @@ mod tests {
             assert_eq!(provided_value, "-1");
             assert_eq!(expected, "finite and positive");
         } else {
-            panic!("Expected InvalidConfiguration error");
+            panic!("Expected InvalidSimulationConfiguration error");
         }
     }
 
@@ -909,7 +922,9 @@ mod tests {
 
     #[test]
     fn test_config_conversions() {
-        let config = create_test_config();
+        let config = create_test_config()
+            .into_validated()
+            .expect("test config should validate");
 
         let metropolis_config = config.to_metropolis_config();
         assert_relative_eq!(metropolis_config.temperature, 1.0);
@@ -960,10 +975,10 @@ mod tests {
             3,
             "Toroidal run_simulation must preserve the configured timeslice count"
         );
-        assert!(matches!(
+        assert_matches!(
             results.triangulation().metadata().topology,
             CdtTopology::Toroidal
-        ));
+        );
     }
 
     #[test]
@@ -1007,10 +1022,10 @@ mod tests {
 
         assert_eq!(results.triangulation().vertex_count(), 16);
         assert_eq!(results.triangulation().slice_sizes(), &[3, 4, 5, 4]);
-        assert!(matches!(
+        assert_matches!(
             results.triangulation().metadata().topology,
             CdtTopology::Toroidal
-        ));
+        );
         results
             .triangulation()
             .validate()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,6 +415,7 @@ pub mod prelude {
     /// ```
     /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
+    /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -435,10 +436,10 @@ pub mod prelude {
     ///         domain: [1.0, 1.0],
     ///         mode: ToroidalConstructionMode::Explicit,
     ///     };
-    ///     assert!(matches!(topology, GlobalTopology::Toroidal { .. }));
+    ///     assert_matches!(topology, GlobalTopology::Toroidal { .. });
     ///
     ///     let error = backend.insert_vertex(&[0.0]).expect_err("coordinate dimension is invalid");
-    ///     assert!(matches!(error, DelaunayError::CoordinateDimensionMismatch { .. }));
+    ///     assert_matches!(error, DelaunayError::CoordinateDimensionMismatch { .. });
     ///     Ok(())
     /// }
     /// ```

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -170,7 +170,7 @@ fn cdt_cli_invalid_measurement_frequency_too_large() {
     cmd.arg("--simulate");
 
     cmd.assert().failure().stderr(predicate::str::contains(
-        "Invalid configuration: measurement_frequency (got: 200, expected: ≤ steps (100))",
+        "Invalid simulation configuration: measurement_frequency (got: 200, expected: ≤ steps (100))",
     ));
 }
 
@@ -316,7 +316,7 @@ fn cdt_cli_rejects_missing_post_thermalization_measurement() {
     cmd.arg("--simulate");
 
     cmd.assert().failure().stderr(predicate::str::contains(
-        "Invalid configuration: measurement schedule",
+        "Invalid simulation configuration: measurement schedule",
     ));
 }
 

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -6,6 +6,7 @@ use causal_triangulations::{
     ActionConfig, CdtTriangulation, ErgodicsSystem, MetropolisAlgorithm, MetropolisConfig,
     MoveResult,
 };
+use std::assert_matches;
 
 #[test]
 fn toroidal_observables_run_accepts_periodic_moves_after_offset_support() {
@@ -60,12 +61,10 @@ fn proposal_site_cache_does_not_reuse_sites_for_replaced_triangulation_instances
     assert_eq!(triangulation.metadata().modification_count, 0);
 
     let first_result = system.attempt_13_move(&mut triangulation);
-    assert!(
-        !matches!(
-            first_result,
-            MoveResult::Rejected(_) | MoveResult::HardFailure(_)
-        ),
-        "initial toroidal move should not hit a hard proposal failure: {first_result:?}"
+    assert_matches!(
+        first_result,
+        MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation,
+        "initial toroidal move should not hit a hard proposal failure"
     );
     triangulation
         .validate()

--- a/tests/semgrep/doctests/assert_matches.txt
+++ b/tests/semgrep/doctests/assert_matches.txt
@@ -1,0 +1,14 @@
+// ruleid: causal-triangulations.rust.prefer-assert-matches-in-doctests
+/// assert!(matches!(value, Some(_)));
+
+// ruleid: causal-triangulations.rust.prefer-assert-matches-in-doctests
+//! assert!(matches!(plan.move_type(), MoveType::Move22 | MoveType::EdgeFlip));
+
+// ok: causal-triangulations.rust.prefer-assert-matches-in-doctests
+/// assert_matches!(value, Some(_));
+
+// ok: causal-triangulations.rust.prefer-assert-matches-in-doctests
+/// assert!(value.is_some());
+
+// ok: causal-triangulations.rust.prefer-assert-matches-in-doctests
+/// Prefer assert_matches! to nested matches! checks in public examples.


### PR DESCRIPTION
- Add `ValidatedCdtConfig` and `ValidatedInitialVolume` so runtime construction consumes topology, volume, schedule, dimensionality, and coupling invariants after validation.
- Move Metropolis/action runtime conversion behind validated configs and route `run_simulation` and examples through the proof-bearing API.
- Report invalid Metropolis schedules and temperatures with `InvalidSimulationConfiguration` while keeping geometry, topology, and action failures on `InvalidConfiguration`.
- Bump the Rust baseline to 1.96.0, update the MCMC backend to 0.4.0, and align docs.rs metadata, API docs, and test assertions with the new baseline.

BREAKING CHANGE: `CdtConfig::validate`, `CdtConfig::to_metropolis_config`, and `CdtConfig::to_action_config` are removed from the raw DTO API. Call `CdtConfig::into_validated()` or `ValidatedCdtConfig::new(...)` before deriving runtime configs.