### PR TITLE
refactor(cdt)!: validate runtime invariants at parse boundaries

### DIFF
--- a/benches/cdt_benchmarks.rs
+++ b/benches/cdt_benchmarks.rs
@@ -10,16 +10,12 @@
 //! - Ergodic move operations
 
 use causal_triangulations::prelude::action::ActionConfig;
-use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveStatistics, MoveType};
-use causal_triangulations::prelude::simulation::{
-    Measurement, MetropolisAlgorithm, MetropolisConfig, MonteCarloStep, ProposalStatistics,
-    SimulationResultsBackend,
-};
+use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveType};
+use causal_triangulations::prelude::simulation::{MetropolisAlgorithm, MetropolisConfig};
 use causal_triangulations::prelude::triangulation::{CdtTriangulation2D, TriangulationQuery};
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hint::black_box;
-use std::time::Duration;
 
 #[derive(Clone, Copy)]
 enum SetupOperation {
@@ -305,7 +301,11 @@ fn bench_metropolis_simulation(c: &mut Criterion) {
                         SetupOperation::CreateCdtStrip,
                     );
 
-                    let config = MetropolisConfig::new(1.0, steps, 5, 5).with_seed(42);
+                    let config = require_result(
+                        MetropolisConfig::new(1.0, steps, 5, 5),
+                        SetupOperation::RunSimulation,
+                    )
+                    .with_seed(42);
                     let action_config = ActionConfig::default();
                     let algorithm = MetropolisAlgorithm::new(config, action_config);
 
@@ -332,48 +332,15 @@ fn bench_simulation_analysis(c: &mut Criterion) {
         SetupOperation::CreateCdtStrip,
     );
 
-    let config = MetropolisConfig::new(1.0, 100, 10, 5);
-    let action_config = ActionConfig::default();
-    let results = SimulationResultsBackend::new(
-        config,
-        action_config,
-        MoveStatistics::new(),
-        ProposalStatistics::new(),
-        vec![
-            MonteCarloStep {
-                step: 1,
-                move_type: MoveType::Move22,
-                accepted: true,
-                action_before: 12.5,
-                action_after: Some(11.8),
-                delta_action: Some(-0.7),
-            },
-            MonteCarloStep {
-                step: 2,
-                move_type: MoveType::Move13Add,
-                accepted: false,
-                action_before: 11.8,
-                action_after: None,
-                delta_action: Some(1.4),
-            },
-            MonteCarloStep {
-                step: 3,
-                move_type: MoveType::Move31Remove,
-                accepted: true,
-                action_before: 11.8,
-                action_after: Some(12.1),
-                delta_action: Some(0.3),
-            },
-        ],
-        vec![
-            Measurement::new(0, 12.5, 15, 32, 18).with_volume_profile(vec![9, 9, 0]),
-            Measurement::new(10, 11.8, 16, 34, 19).with_volume_profile(vec![9, 10, 0]),
-            Measurement::new(20, 12.1, 15, 31, 17).with_volume_profile(vec![8, 9, 0]),
-        ],
-        Duration::from_millis(37),
-        triangulation,
+    let config = require_result(
+        MetropolisConfig::new(1.0, 100, 10, 5),
+        SetupOperation::BuildSimulationResults,
+    )
+    .with_seed(42);
+    let results = require_result(
+        MetropolisAlgorithm::new(config, ActionConfig::default()).run(triangulation),
+        SetupOperation::BuildSimulationResults,
     );
-    let results = require_result(results, SetupOperation::BuildSimulationResults);
 
     group.bench_function("acceptance_rate", |b| {
         b.iter(|| {

--- a/benches/ci_performance_suite.rs
+++ b/benches/ci_performance_suite.rs
@@ -219,7 +219,11 @@ fn prepare_fixture(fixture: CdtFixture) -> PreparedFixture {
 
 /// Runs one Metropolis proposal step through the public simulation driver.
 fn run_single_metropolis_proposal(triangulation: CdtTriangulation2D) {
-    let config = MetropolisConfig::new(1.0, 1, 0, 1).with_seed(BENCH_SEED);
+    let config = require_result(
+        MetropolisConfig::new(1.0, 1, 0, 1),
+        SetupOperation::RunSingleMetropolisProposal,
+    )
+    .with_seed(BENCH_SEED);
     let results = require_result(
         MetropolisAlgorithm::new(config, ActionConfig::default()).run(triangulation),
         SetupOperation::RunSingleMetropolisProposal,
@@ -269,13 +273,17 @@ fn run_random_move_sweeps(mut triangulation: CdtTriangulation2D, seed: u64) -> M
         SetupOperation::ValidateRandomSweepWorkload,
     );
     black_box(triangulation.face_count());
-    ergodics.stats
+    ergodics.stats().clone()
 }
 
 /// Runs a short Metropolis simulation sized to match the ten-sweep workload.
 fn run_metropolis_ten_sweeps(triangulation: CdtTriangulation2D, simplices: usize) -> usize {
     let steps = ten_sweep_step_count(simplices);
-    let config = MetropolisConfig::new(1.0, steps, 0, steps).with_seed(BENCH_SEED);
+    let config = require_result(
+        MetropolisConfig::new(1.0, steps, 0, steps),
+        SetupOperation::RunTenSweepMetropolis,
+    )
+    .with_seed(BENCH_SEED);
     let results = require_result(
         MetropolisAlgorithm::new(config, ActionConfig::default()).run(triangulation),
         SetupOperation::RunTenSweepMetropolis,

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -99,11 +99,11 @@ causal-triangulations/
 │   │   │   └── telemetry.rs
 │   │   ├── observables.rs
 │   │   ├── results.rs
-│   │   ├── triangulation.rs
 │   │   └── triangulation/
 │   │       ├── builders.rs
 │   │       ├── foliation.rs
 │   │       ├── moves.rs
+│   │       ├── state.rs
 │   │       └── validation.rs
 │   ├── geometry/
 │   │   ├── backends/
@@ -201,13 +201,13 @@ design details.
 - `SimplexType` — `Up` (2,1) or `Down` (1,2) triangle classification, encoded as `i32` simplex data
 - Time labels are stored directly as vertex data (`Vertex.data: Option<u32>`), mirroring CDT-plusplus’s `vertex->info()`
 
-### `cdt/triangulation.rs` — Foliation integration
+### `cdt/triangulation/` — Foliation integration
 
 This is CDT domain logic layered over the geometry backend interface. It may use `DelaunayBackend2D` and crate-owned Delaunay handles, but it does not reach
 through to upstream `delaunay::` APIs directly.
 
-- Owns the `CdtTriangulation` wrapper, `CdtMetadata`, `SimulationEvent`, metadata validation, cached simplex-count accessors, and common backend-agnostic
-  wrapper methods
+- Owns the `CdtTriangulation` state, `CdtMetadata`, `SimulationEvent`, metadata validation, cached simplex-count accessors, and common backend-agnostic state
+  methods
 - `from_cdt_strip(vertices_per_slice, num_slices)` — Delaunay-built open-boundary 1+1 CDT strip with strict Up/Down simplex classification and upstream Level
   1–4 Delaunay validation before wrapping
 - `from_cdt_strip_profile(volume_profile)` — open-boundary 1+1 CDT strip from explicit nonuniform per-slice vertex counts; builds labeled point data and
@@ -223,11 +223,13 @@ through to upstream `delaunay::` APIs directly.
 - Mutable backend access is not exposed. CDT code mutates Delaunay state only through narrow crate-internal operations (`flip_edge`, `subdivide_face`,
   `remove_vertex`, `set_vertex_data`) that invalidate cached counts and foliation synchronization bookkeeping on success.
 
-The implementation is split into child modules under `src/cdt/triangulation/`:
+The implementation lives under `src/cdt/triangulation/` and is wired from `src/lib.rs` to avoid `mod.rs` files:
 
 - `builders.rs` — Delaunay-backed random/seeded/labeled builders plus strip and periodic toroidal CDT builders
 - `foliation.rs` — foliation assignment, slice and label queries, volume profiles, simplex/edge classification, and foliation synchronization
 - `moves.rs` — narrow crate-internal Delaunay mutation hooks used by ergodic moves
+- `state.rs` — module entry point, `CdtTriangulation`, `CdtMetadata`, `SimulationEvent`, serialization, cached geometry accessors, and backend-agnostic
+  state methods
 - `validation.rs` — full CDT validation and Delaunay-backed causality checks
 
 ### `config.rs` — `CdtTopology` enum
@@ -235,8 +237,8 @@ The implementation is split into child modules under `src/cdt/triangulation/`:
 - `OpenBoundary` (default) — finite strip with boundary, χ ∈ {1, 2}
 - `Toroidal` — periodic in space and time, S¹×S¹, χ = 0
 - Wired through `CdtConfig.topology`, `CdtConfigOverrides.topology`, the CLI `--topology` flag, and `CdtMetadata.topology`
-- `run_simulation()` dispatches on topology and profile mode: regular `Toroidal` → `from_toroidal_cdt`, regular `OpenBoundary` → `from_cdt_strip`, and
-  explicit `CdtConfig.volume_profile` → the matching profile constructor; `vertices` is always the total vertex count
+- `run_simulation()` accepts `ValidatedCdtConfig` and dispatches on topology and profile mode: regular `Toroidal` → `from_toroidal_cdt`, regular
+  `OpenBoundary` → `from_cdt_strip`, and explicit `CdtConfig.volume_profile` → the matching profile constructor; `vertices` is always the total vertex count
 
 ### `cdt/metropolis/` — Metropolis move ordering
 
@@ -277,7 +279,7 @@ detailed ordering and
 
 - `GeometryBackend` defines associated coordinate, handle, and error types for a geometry implementation
 - `TriangulationQuery` is the read-only surface used by CDT logic for counts, handles, adjacency, coordinates, face vertices, and validation
-- `TriangulationMut` is the narrow mutation surface used by CDT-owned move kernels through wrapper methods, not broad mutable backend exposure
+- `TriangulationMut` is the narrow mutation surface used by CDT-owned move kernels through CDT state mutation methods, not broad mutable backend exposure
 - Result structs such as `FlipResult`, `EdgeAdjacentFaces`, and `SubdivisionResult` keep local topology operations backend-neutral
 - Use `prelude::geometry` for real backend construction and geometry traits; use `prelude::testing` for mock-backend doctests or downstream fixture code
 

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -201,7 +201,7 @@ design details.
 - `SimplexType` — `Up` (2,1) or `Down` (1,2) triangle classification, encoded as `i32` simplex data
 - Time labels are stored directly as vertex data (`Vertex.data: Option<u32>`), mirroring CDT-plusplus’s `vertex->info()`
 
-### `cdt/triangulation/` — Foliation integration
+### `cdt/triangulation/` — CDT Triangulation State and Builders
 
 This is CDT domain logic layered over the geometry backend interface. It may use `DelaunayBackend2D` and crate-owned Delaunay handles, but it does not reach
 through to upstream `delaunay::` APIs directly.

--- a/examples/observables.rs
+++ b/examples/observables.rs
@@ -30,7 +30,7 @@ fn main() -> CdtResult<()> {
     );
     println!("Initial spectral-dimension estimate: {spectral}");
 
-    let metropolis_config = MetropolisConfig::new(1.0, 80, 20, 10).with_seed(7);
+    let metropolis_config = MetropolisConfig::new(1.0, 80, 20, 10)?.with_seed(7);
     let action_config = ActionConfig::default();
     let results = MetropolisAlgorithm::new(metropolis_config, action_config).run(triangulation)?;
 

--- a/examples/output_and_checkpoint.rs
+++ b/examples/output_and_checkpoint.rs
@@ -29,7 +29,8 @@ fn main() -> CdtResult<()> {
         output_csv: Some(csv_path.clone()),
         output_json: Some(json_path.clone()),
         ..CdtConfig::new(12, 3)
-    };
+    }
+    .into_validated()?;
 
     let results = run_simulation(&config)?;
 
@@ -41,10 +42,10 @@ fn main() -> CdtResult<()> {
         detail: err.to_string(),
     })?;
     assert!(csv.starts_with("step,action,vertices,edges,triangles,accepted,delta_action\n"));
-    assert_eq!(summary["config"]["vertices"], config.vertices);
+    assert_eq!(summary["config"]["vertices"], config.vertices());
     assert_eq!(
         summary["final_triangulation"]["time_slices"],
-        config.timeslices
+        config.timeslices()
     );
     assert_eq!(
         summary["measurements"].as_array().map_or(0, Vec::len),
@@ -70,12 +71,12 @@ fn main() -> CdtResult<()> {
     restored.validate_simplex_classification()?;
 
     let mcmc_checkpoint = MetropolisAlgorithm::new(
-        MetropolisConfig::new(1.0, 2, 0, 1).with_seed(13),
+        MetropolisConfig::new(1.0, 2, 0, 1)?.with_seed(13),
         ActionConfig::default(),
     )
     .run_to_checkpoint(CdtTriangulation2D::from_cdt_strip(4, 3)?)?;
     let resumed = MetropolisAlgorithm::new(
-        MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
+        MetropolisConfig::new(1.0, 2, 0, 1)?.with_seed(999),
         ActionConfig::default(),
     )
     .resume_from_checkpoint(mcmc_checkpoint)?;

--- a/src/cdt/action.rs
+++ b/src/cdt/action.rs
@@ -6,7 +6,7 @@
 //! which is based on the Regge calculus formulation of general relativity.
 
 use crate::errors::{CdtError, CdtResult, ConfigurationSetting};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Critical cosmological coupling for pure 1+1 CDT in the triangle-volume convention.
 ///
@@ -73,15 +73,37 @@ pub fn compute_regge_action(
     cosmological_constant.mul_add(n_1, (-coupling_0).mul_add(n_0, -(coupling_2 * n_2)))
 }
 
-/// Configuration for CDT action parameters.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// Validated configuration for CDT action parameters.
+///
+/// The stored couplings are always finite. Raw action parameters enter through
+/// [`Self::new`] or deserialization, both of which reject NaN and infinite values
+/// before the configuration can be used by action or Metropolis code.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ActionConfig {
     /// Coupling constant for vertices (κ₀)
-    pub coupling_0: f64,
+    coupling_0: f64,
     /// Coupling constant for triangles (κ₂)
-    pub coupling_2: f64,
+    coupling_2: f64,
     /// Cosmological constant (λ)
-    pub cosmological_constant: f64,
+    cosmological_constant: f64,
+}
+
+#[derive(Deserialize)]
+struct ActionConfigWire {
+    coupling_0: f64,
+    coupling_2: f64,
+    cosmological_constant: f64,
+}
+
+impl<'de> Deserialize<'de> for ActionConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = ActionConfigWire::deserialize(deserializer)?;
+        Self::new(wire.coupling_0, wire.coupling_2, wire.cosmological_constant)
+            .map_err(serde::de::Error::custom)
+    }
 }
 
 impl Default for ActionConfig {
@@ -92,36 +114,12 @@ impl Default for ActionConfig {
     /// at zero and use the edge-count cosmological coupling that maps to the
     /// standard 2D CDT critical value `λ_c = ln 2` for toroidal triangulations.
     fn default() -> Self {
-        Self {
-            coupling_0: 0.0,
-            coupling_2: 0.0,
-            cosmological_constant: DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
-        }
+        Self::from_validated_parts(0.0, 0.0, DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT)
     }
 }
 
 impl ActionConfig {
-    /// Creates a new action configuration.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use approx::assert_relative_eq;
-    /// use causal_triangulations::prelude::action::ActionConfig;
-    ///
-    /// let config = ActionConfig::new(2.0, 1.5, 0.2);
-    /// assert_relative_eq!(config.coupling_0, 2.0);
-    /// ```
-    #[must_use]
-    pub const fn new(coupling_0: f64, coupling_2: f64, cosmological_constant: f64) -> Self {
-        Self {
-            coupling_0,
-            coupling_2,
-            cosmological_constant,
-        }
-    }
-
-    /// Validates that action couplings are finite.
+    /// Creates a new validated action configuration.
     ///
     /// # Errors
     ///
@@ -131,18 +129,112 @@ impl ActionConfig {
     /// # Examples
     ///
     /// ```
+    /// use approx::assert_relative_eq;
     /// use causal_triangulations::prelude::action::ActionConfig;
     ///
-    /// assert!(ActionConfig::default().validate().is_ok());
-    /// assert!(ActionConfig::new(f64::NAN, 1.0, 0.1).validate().is_err());
+    /// let config = ActionConfig::new(2.0, 1.5, 0.2)?;
+    /// assert_relative_eq!(config.coupling_0(), 2.0);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
-    pub fn validate(&self) -> CdtResult<()> {
-        validate_coupling(ConfigurationSetting::Coupling0, self.coupling_0)?;
-        validate_coupling(ConfigurationSetting::Coupling2, self.coupling_2)?;
+    pub fn new(coupling_0: f64, coupling_2: f64, cosmological_constant: f64) -> CdtResult<Self> {
+        validate_coupling(ConfigurationSetting::Coupling0, coupling_0)?;
+        validate_coupling(ConfigurationSetting::Coupling2, coupling_2)?;
         validate_coupling(
             ConfigurationSetting::CosmologicalConstant,
-            self.cosmological_constant,
-        )
+            cosmological_constant,
+        )?;
+        Ok(Self::from_validated_parts(
+            coupling_0,
+            coupling_2,
+            cosmological_constant,
+        ))
+    }
+
+    /// Builds an action configuration after the caller has already checked coupling finiteness.
+    ///
+    /// This keeps validated higher-level configuration conversion infallible
+    /// without opening a second public path that could store invalid couplings.
+    pub(crate) const fn from_validated_parts(
+        coupling_0: f64,
+        coupling_2: f64,
+        cosmological_constant: f64,
+    ) -> Self {
+        Self {
+            coupling_0,
+            coupling_2,
+            cosmological_constant,
+        }
+    }
+
+    /// Returns the vertex coupling (κ₀).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use causal_triangulations::prelude::action::ActionConfig;
+    ///
+    /// let config = ActionConfig::new(2.0, 1.5, 0.2)?;
+    /// assert_relative_eq!(config.coupling_0(), 2.0);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn coupling_0(&self) -> f64 {
+        self.coupling_0
+    }
+
+    /// Returns the triangle coupling (κ₂).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use causal_triangulations::prelude::action::ActionConfig;
+    ///
+    /// let config = ActionConfig::new(2.0, 1.5, 0.2)?;
+    /// assert_relative_eq!(config.coupling_2(), 1.5);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn coupling_2(&self) -> f64 {
+        self.coupling_2
+    }
+
+    /// Returns the cosmological coupling (λ).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use causal_triangulations::prelude::action::ActionConfig;
+    ///
+    /// let config = ActionConfig::new(2.0, 1.5, 0.2)?;
+    /// assert_relative_eq!(config.cosmological_constant(), 0.2);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn cosmological_constant(&self) -> f64 {
+        self.cosmological_constant
+    }
+
+    /// Confirms that stored action couplings are finite.
+    ///
+    /// This method is kept for code that wants a common validation hook across
+    /// configuration-like types. Because [`ActionConfig`] validates before
+    /// storage, it is an infallible debug assertion of the stored invariant.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::action::ActionConfig;
+    ///
+    /// ActionConfig::default().validate();
+    /// assert!(ActionConfig::new(f64::NAN, 1.0, 0.1).is_err());
+    /// ```
+    pub fn validate(&self) {
+        debug_assert!(self.coupling_0.is_finite());
+        debug_assert!(self.coupling_2.is_finite());
+        debug_assert!(self.cosmological_constant.is_finite());
     }
 
     /// Calculates the action for given simplex counts.
@@ -153,9 +245,10 @@ impl ActionConfig {
     /// use approx::assert_relative_eq;
     /// use causal_triangulations::prelude::action::ActionConfig;
     ///
-    /// let config = ActionConfig::new(2.0, 1.5, 0.2);
+    /// let config = ActionConfig::new(2.0, 1.5, 0.2)?;
     /// let action = config.calculate_action(5, 10, 8);
     /// assert_relative_eq!(action, -20.0, epsilon = 1e-12);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     #[must_use]
     pub fn calculate_action(&self, vertices: u32, edges: u32, triangles: u32) -> f64 {
@@ -214,22 +307,44 @@ mod tests {
     #[test]
     fn test_action_config_default() {
         let config = ActionConfig::default();
-        assert_relative_eq!(config.coupling_0, 0.0);
-        assert_relative_eq!(config.coupling_2, 0.0);
+        assert_relative_eq!(config.coupling_0(), 0.0);
+        assert_relative_eq!(config.coupling_2(), 0.0);
         assert_relative_eq!(
-            config.cosmological_constant,
+            config.cosmological_constant(),
             DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT
         );
     }
 
     #[test]
     fn test_action_config_calculate() {
-        let config = ActionConfig::new(2.0, 1.5, 0.2);
+        let config = ActionConfig::new(2.0, 1.5, 0.2).expect("finite couplings are valid");
         let action = config.calculate_action(5, 10, 8);
 
         // Expected: -2.0 * 5 - 1.5 * 8 + 0.2 * 10 = -10 - 12 + 2 = -20
         let expected = -20.0;
         assert_relative_eq!(action, expected);
+    }
+
+    #[test]
+    fn action_config_deserialization_rejects_non_finite_couplings() {
+        let payload = r#"{"coupling_0":null,"coupling_2":0.0,"cosmological_constant":0.0}"#;
+        let error = serde_json::from_str::<ActionConfig>(payload)
+            .expect_err("non-finite action coupling should be rejected");
+
+        assert!(
+            error.to_string().contains("invalid type"),
+            "serde error should reject non-number coupling before storage, got {error}"
+        );
+
+        let payload = r#"{"coupling_0":1e999,"coupling_2":0.0,"cosmological_constant":0.0}"#;
+        let error = serde_json::from_str::<ActionConfig>(payload)
+            .expect_err("infinite action coupling should be rejected");
+
+        assert!(
+            error.to_string().contains("number out of range"),
+            "serde error should reject out-of-range JSON numbers before storage, got {error}"
+        );
+        assert!(ActionConfig::new(f64::INFINITY, 0.0, 0.0).is_err());
     }
 }
 
@@ -267,21 +382,22 @@ mod prop_tests {
             coupling_2 in -5.0f64..5.0,
             cosmological_constant in -2.0f64..2.0
         ) {
-            let config = ActionConfig::new(coupling_0, coupling_2, cosmological_constant);
+            let config = ActionConfig::new(coupling_0, coupling_2, cosmological_constant)
+                .expect("proptest finite ranges are valid action couplings");
 
             // Config should preserve values
             prop_assert!(relative_eq!(
-                config.coupling_0,
+                config.coupling_0(),
                 coupling_0,
                 epsilon = f64::EPSILON
             ));
             prop_assert!(relative_eq!(
-                config.coupling_2,
+                config.coupling_2(),
                 coupling_2,
                 epsilon = f64::EPSILON
             ));
             prop_assert!(relative_eq!(
-                config.cosmological_constant,
+                config.cosmological_constant(),
                 cosmological_constant,
                 epsilon = f64::EPSILON
             ));

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -1441,8 +1441,8 @@ fn reject_backend(
 fn time_dist(triangulation: &CdtTriangulation2D, t0: u32, t1: u32) -> u32 {
     let raw = t0.abs_diff(t1);
     if matches!(triangulation.metadata().topology(), CdtTopology::Toroidal) {
-        let total = triangulation.time_slices();
-        if total > 0 && t0 < total && t1 < total {
+        let total = triangulation.time_slices().get();
+        if t0 < total && t1 < total {
             return raw.min(total - raw);
         }
     }
@@ -1569,7 +1569,7 @@ const fn toroidal_neighbor_labels(
     triangulation: &CdtTriangulation2D,
     label: u32,
 ) -> Option<(u32, u32)> {
-    let total = triangulation.time_slices();
+    let total = triangulation.time_slices().get();
     if total < 3 || label >= total {
         return None;
     }

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -16,7 +16,7 @@ use crate::geometry::backends::delaunay::{
 };
 use crate::geometry::traits::{EdgeAdjacentFaces, TriangulationMut, TriangulationQuery};
 use rand::{RngExt, SeedableRng, rngs::Xoshiro256PlusPlus};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::array;
 use std::fmt::Display;
 
@@ -59,36 +59,66 @@ pub enum MoveResult {
 /// those failures remain in the attempt denominator but are not counted as
 /// accepted moves. Individual counters and aggregate totals saturate at
 /// `u64::MAX` so long-running or restored simulations cannot wrap telemetry.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct MoveStatistics {
     /// Number of (2,2) moves attempted
-    pub moves_22_attempted: u64,
+    moves_22_attempted: u64,
     /// Number of (2,2) moves accepted
-    pub moves_22_accepted: u64,
+    moves_22_accepted: u64,
     /// Number of (2,2) moves that mutated state but failed post-mutation invariants.
     #[serde(default)]
-    pub moves_22_hard_failed: u64,
+    moves_22_hard_failed: u64,
     /// Number of (1,3) moves attempted
-    pub moves_13_attempted: u64,
+    moves_13_attempted: u64,
     /// Number of (1,3) moves accepted
-    pub moves_13_accepted: u64,
+    moves_13_accepted: u64,
     /// Number of (1,3) moves that mutated state but failed post-mutation invariants.
     #[serde(default)]
-    pub moves_13_hard_failed: u64,
+    moves_13_hard_failed: u64,
     /// Number of (3,1) moves attempted
-    pub moves_31_attempted: u64,
+    moves_31_attempted: u64,
     /// Number of (3,1) moves accepted
-    pub moves_31_accepted: u64,
+    moves_31_accepted: u64,
     /// Number of (3,1) moves that mutated state but failed post-mutation invariants.
     #[serde(default)]
-    pub moves_31_hard_failed: u64,
+    moves_31_hard_failed: u64,
     /// Number of edge flips attempted
-    pub edge_flips_attempted: u64,
+    edge_flips_attempted: u64,
     /// Number of edge flips accepted
-    pub edge_flips_accepted: u64,
+    edge_flips_accepted: u64,
     /// Number of edge flips that mutated state but failed post-mutation invariants.
     #[serde(default)]
-    pub edge_flips_hard_failed: u64,
+    edge_flips_hard_failed: u64,
+}
+
+#[derive(Deserialize)]
+struct MoveStatisticsWire {
+    moves_22_attempted: u64,
+    moves_22_accepted: u64,
+    #[serde(default)]
+    moves_22_hard_failed: u64,
+    moves_13_attempted: u64,
+    moves_13_accepted: u64,
+    #[serde(default)]
+    moves_13_hard_failed: u64,
+    moves_31_attempted: u64,
+    moves_31_accepted: u64,
+    #[serde(default)]
+    moves_31_hard_failed: u64,
+    edge_flips_attempted: u64,
+    edge_flips_accepted: u64,
+    #[serde(default)]
+    edge_flips_hard_failed: u64,
+}
+
+impl<'de> Deserialize<'de> for MoveStatistics {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = MoveStatisticsWire::deserialize(deserializer)?;
+        Self::from_wire(&wire).map_err(serde::de::Error::custom)
+    }
 }
 
 impl MoveStatistics {
@@ -97,14 +127,95 @@ impl MoveStatistics {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::prelude::moves::MoveStatistics;
+    /// use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
     ///
     /// let stats = MoveStatistics::new();
-    /// assert_eq!(stats.moves_22_attempted, 0);
+    /// assert_eq!(stats.attempted(MoveType::Move22), 0);
     /// ```
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    #[cfg(test)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "test and serde helpers need to preserve the flat move-statistics wire shape"
+    )]
+    pub(crate) const fn from_validated_parts(
+        moves_22_attempted: u64,
+        moves_22_accepted: u64,
+        moves_22_hard_failed: u64,
+        moves_13_attempted: u64,
+        moves_13_accepted: u64,
+        moves_13_hard_failed: u64,
+        moves_31_attempted: u64,
+        moves_31_accepted: u64,
+        moves_31_hard_failed: u64,
+        edge_flips_attempted: u64,
+        edge_flips_accepted: u64,
+        edge_flips_hard_failed: u64,
+    ) -> Self {
+        Self {
+            moves_22_attempted,
+            moves_22_accepted,
+            moves_22_hard_failed,
+            moves_13_attempted,
+            moves_13_accepted,
+            moves_13_hard_failed,
+            moves_31_attempted,
+            moves_31_accepted,
+            moves_31_hard_failed,
+            edge_flips_attempted,
+            edge_flips_accepted,
+            edge_flips_hard_failed,
+        }
+    }
+
+    /// Rebuilds move statistics from the serialized wire shape while preserving counter invariants.
+    ///
+    /// Deserialization rejects impossible counters such as accepted moves plus
+    /// hard failures exceeding attempts, so public accessors can treat stored
+    /// move-family counters as coherent telemetry.
+    fn from_wire(wire: &MoveStatisticsWire) -> Result<Self, String> {
+        validate_move_counter(
+            MoveType::Move22,
+            wire.moves_22_attempted,
+            wire.moves_22_accepted,
+            wire.moves_22_hard_failed,
+        )?;
+        validate_move_counter(
+            MoveType::Move13Add,
+            wire.moves_13_attempted,
+            wire.moves_13_accepted,
+            wire.moves_13_hard_failed,
+        )?;
+        validate_move_counter(
+            MoveType::Move31Remove,
+            wire.moves_31_attempted,
+            wire.moves_31_accepted,
+            wire.moves_31_hard_failed,
+        )?;
+        validate_move_counter(
+            MoveType::EdgeFlip,
+            wire.edge_flips_attempted,
+            wire.edge_flips_accepted,
+            wire.edge_flips_hard_failed,
+        )?;
+        Ok(Self {
+            moves_22_attempted: wire.moves_22_attempted,
+            moves_22_accepted: wire.moves_22_accepted,
+            moves_22_hard_failed: wire.moves_22_hard_failed,
+            moves_13_attempted: wire.moves_13_attempted,
+            moves_13_accepted: wire.moves_13_accepted,
+            moves_13_hard_failed: wire.moves_13_hard_failed,
+            moves_31_attempted: wire.moves_31_attempted,
+            moves_31_accepted: wire.moves_31_accepted,
+            moves_31_hard_failed: wire.moves_31_hard_failed,
+            edge_flips_attempted: wire.edge_flips_attempted,
+            edge_flips_accepted: wire.edge_flips_accepted,
+            edge_flips_hard_failed: wire.edge_flips_hard_failed,
+        })
     }
 
     /// Records an attempted move, saturating the matching counter at `u64::MAX`.
@@ -116,7 +227,7 @@ impl MoveStatistics {
     ///
     /// let mut stats = MoveStatistics::new();
     /// stats.record_attempt(MoveType::Move22);
-    /// assert_eq!(stats.moves_22_attempted, 1);
+    /// assert_eq!(stats.attempted(MoveType::Move22), 1);
     /// ```
     pub const fn record_attempt(&mut self, move_type: MoveType) {
         match move_type {
@@ -146,20 +257,48 @@ impl MoveStatistics {
     ///
     /// let mut stats = MoveStatistics::new();
     /// stats.record_success(MoveType::EdgeFlip);
-    /// assert_eq!(stats.edge_flips_accepted, 1);
+    /// assert_eq!(stats.accepted(MoveType::EdgeFlip), 1);
     /// ```
     pub const fn record_success(&mut self, move_type: MoveType) {
         match move_type {
             MoveType::Move22 => {
+                if self
+                    .moves_22_accepted
+                    .saturating_add(self.moves_22_hard_failed)
+                    >= self.moves_22_attempted
+                {
+                    self.moves_22_attempted = self.moves_22_attempted.saturating_add(1);
+                }
                 self.moves_22_accepted = self.moves_22_accepted.saturating_add(1);
             }
             MoveType::Move13Add => {
+                if self
+                    .moves_13_accepted
+                    .saturating_add(self.moves_13_hard_failed)
+                    >= self.moves_13_attempted
+                {
+                    self.moves_13_attempted = self.moves_13_attempted.saturating_add(1);
+                }
                 self.moves_13_accepted = self.moves_13_accepted.saturating_add(1);
             }
             MoveType::Move31Remove => {
+                if self
+                    .moves_31_accepted
+                    .saturating_add(self.moves_31_hard_failed)
+                    >= self.moves_31_attempted
+                {
+                    self.moves_31_attempted = self.moves_31_attempted.saturating_add(1);
+                }
                 self.moves_31_accepted = self.moves_31_accepted.saturating_add(1);
             }
             MoveType::EdgeFlip => {
+                if self
+                    .edge_flips_accepted
+                    .saturating_add(self.edge_flips_hard_failed)
+                    >= self.edge_flips_attempted
+                {
+                    self.edge_flips_attempted = self.edge_flips_attempted.saturating_add(1);
+                }
                 self.edge_flips_accepted = self.edge_flips_accepted.saturating_add(1);
             }
         }
@@ -181,21 +320,49 @@ impl MoveStatistics {
     /// let mut stats = MoveStatistics::new();
     /// stats.record_attempt(MoveType::Move31Remove);
     /// stats.record_hard_failure(MoveType::Move31Remove);
-    /// assert_eq!(stats.moves_31_accepted, 0);
-    /// assert_eq!(stats.moves_31_hard_failed, 1);
+    /// assert_eq!(stats.accepted(MoveType::Move31Remove), 0);
+    /// assert_eq!(stats.hard_failed(MoveType::Move31Remove), 1);
     /// ```
     pub const fn record_hard_failure(&mut self, move_type: MoveType) {
         match move_type {
             MoveType::Move22 => {
+                if self
+                    .moves_22_accepted
+                    .saturating_add(self.moves_22_hard_failed)
+                    >= self.moves_22_attempted
+                {
+                    self.moves_22_attempted = self.moves_22_attempted.saturating_add(1);
+                }
                 self.moves_22_hard_failed = self.moves_22_hard_failed.saturating_add(1);
             }
             MoveType::Move13Add => {
+                if self
+                    .moves_13_accepted
+                    .saturating_add(self.moves_13_hard_failed)
+                    >= self.moves_13_attempted
+                {
+                    self.moves_13_attempted = self.moves_13_attempted.saturating_add(1);
+                }
                 self.moves_13_hard_failed = self.moves_13_hard_failed.saturating_add(1);
             }
             MoveType::Move31Remove => {
+                if self
+                    .moves_31_accepted
+                    .saturating_add(self.moves_31_hard_failed)
+                    >= self.moves_31_attempted
+                {
+                    self.moves_31_attempted = self.moves_31_attempted.saturating_add(1);
+                }
                 self.moves_31_hard_failed = self.moves_31_hard_failed.saturating_add(1);
             }
             MoveType::EdgeFlip => {
+                if self
+                    .edge_flips_accepted
+                    .saturating_add(self.edge_flips_hard_failed)
+                    >= self.edge_flips_attempted
+                {
+                    self.edge_flips_attempted = self.edge_flips_attempted.saturating_add(1);
+                }
                 self.edge_flips_hard_failed = self.edge_flips_hard_failed.saturating_add(1);
             }
         }
@@ -340,6 +507,88 @@ impl MoveStatistics {
             .saturating_add(self.moves_31_hard_failed)
             .saturating_add(self.edge_flips_hard_failed)
     }
+
+    /// Returns the attempted counter for one move family.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
+    ///
+    /// let mut stats = MoveStatistics::new();
+    /// stats.record_attempt(MoveType::Move22);
+    /// assert_eq!(stats.attempted(MoveType::Move22), 1);
+    /// ```
+    #[must_use]
+    pub const fn attempted(&self, move_type: MoveType) -> u64 {
+        match move_type {
+            MoveType::Move22 => self.moves_22_attempted,
+            MoveType::Move13Add => self.moves_13_attempted,
+            MoveType::Move31Remove => self.moves_31_attempted,
+            MoveType::EdgeFlip => self.edge_flips_attempted,
+        }
+    }
+
+    /// Returns the accepted counter for one move family.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
+    ///
+    /// let mut stats = MoveStatistics::new();
+    /// stats.record_success(MoveType::Move13Add);
+    /// assert_eq!(stats.accepted(MoveType::Move13Add), 1);
+    /// ```
+    #[must_use]
+    pub const fn accepted(&self, move_type: MoveType) -> u64 {
+        match move_type {
+            MoveType::Move22 => self.moves_22_accepted,
+            MoveType::Move13Add => self.moves_13_accepted,
+            MoveType::Move31Remove => self.moves_31_accepted,
+            MoveType::EdgeFlip => self.edge_flips_accepted,
+        }
+    }
+
+    /// Returns the hard-failure counter for one move family.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::{MoveStatistics, MoveType};
+    ///
+    /// let mut stats = MoveStatistics::new();
+    /// stats.record_hard_failure(MoveType::EdgeFlip);
+    /// assert_eq!(stats.hard_failed(MoveType::EdgeFlip), 1);
+    /// ```
+    #[must_use]
+    pub const fn hard_failed(&self, move_type: MoveType) -> u64 {
+        match move_type {
+            MoveType::Move22 => self.moves_22_hard_failed,
+            MoveType::Move13Add => self.moves_13_hard_failed,
+            MoveType::Move31Remove => self.moves_31_hard_failed,
+            MoveType::EdgeFlip => self.edge_flips_hard_failed,
+        }
+    }
+}
+
+/// Checks one move family's serialized counters before they become invariant-bearing telemetry.
+fn validate_move_counter(
+    move_type: MoveType,
+    attempted: u64,
+    accepted: u64,
+    hard_failed: u64,
+) -> Result<(), String> {
+    let terminal = accepted.checked_add(hard_failed).ok_or_else(|| {
+        format!("{move_type:?} accepted plus hard-failure counters exceed u64::MAX")
+    })?;
+    if terminal > attempted {
+        Err(format!(
+            "{move_type:?} accepted plus hard-failure counters ({terminal}) exceed attempted counter ({attempted})"
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 /// Converts an accumulated move counter to a finite value for rate reporting.
@@ -355,7 +604,7 @@ const fn count_to_f64(count: u64) -> f64 {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ErgodicsSystem {
     /// Move statistics
-    pub stats: MoveStatistics,
+    stats: MoveStatistics,
     /// Random number generator
     rng: Xoshiro256PlusPlus,
     /// Authoritative cached local-site universes for proposal sampling.
@@ -389,7 +638,7 @@ impl MoveSiteCache {
     /// Rebuilds the selected move-family cache for a new triangulation version.
     fn ensure_current(&mut self, triangulation: &CdtTriangulation2D, move_type: MoveType) {
         let instance_id = triangulation.instance_id();
-        let modification_count = triangulation.metadata().modification_count;
+        let modification_count = triangulation.metadata().modification_count();
         let family = self.family(move_type);
         if family.instance_id == Some(instance_id)
             && family.modification_count == Some(modification_count)
@@ -513,10 +762,10 @@ impl ErgodicsSystem {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::prelude::moves::ErgodicsSystem;
+    /// use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveType};
     ///
     /// let system = ErgodicsSystem::new();
-    /// assert_eq!(system.stats.moves_22_attempted, 0);
+    /// assert_eq!(system.stats().attempted(MoveType::Move22), 0);
     /// ```
     #[must_use]
     pub fn new() -> Self {
@@ -545,6 +794,30 @@ impl ErgodicsSystem {
             rng: Xoshiro256PlusPlus::seed_from_u64(seed),
             site_cache: MoveSiteCache::default(),
         }
+    }
+
+    /// Returns accumulated move statistics.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveType};
+    ///
+    /// let system = ErgodicsSystem::new();
+    /// assert_eq!(system.stats().attempted(MoveType::Move22), 0);
+    /// ```
+    #[must_use]
+    pub const fn stats(&self) -> &MoveStatistics {
+        &self.stats
+    }
+
+    /// Replaces move statistics after an internal speculative operation.
+    ///
+    /// This keeps public callers from mutating sampler accounting independently
+    /// of actual move execution while allowing proposal planning to roll back
+    /// temporary counters after applying a candidate to a cloned state.
+    pub(crate) const fn replace_stats(&mut self, stats: MoveStatistics) -> MoveStatistics {
+        std::mem::replace(&mut self.stats, stats)
     }
 
     /// Selects a random move type.
@@ -681,7 +954,7 @@ impl ErgodicsSystem {
     ///         result,
     ///         MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
     ///     );
-    ///     assert_eq!(system.stats.moves_22_attempted, 1);
+    ///     assert_eq!(system.stats().attempted(MoveType::Move22), 1);
     ///     Ok(())
     /// }
     /// ```
@@ -729,7 +1002,7 @@ impl ErgodicsSystem {
     ///     let mut system = ErgodicsSystem::new();
     ///     let result = system.attempt_13_move(&mut triangulation);
     ///     assert_matches!(result, MoveResult::Success | MoveResult::GeometricViolation);
-    ///     assert_eq!(system.stats.moves_13_attempted, 1);
+    ///     assert_eq!(system.stats().attempted(MoveType::Move13Add), 1);
     ///     Ok(())
     /// }
     /// ```
@@ -795,7 +1068,7 @@ impl ErgodicsSystem {
     ///         result,
     ///         MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
     ///     );
-    ///     assert_eq!(system.stats.moves_31_attempted, 1);
+    ///     assert_eq!(system.stats().attempted(MoveType::Move31Remove), 1);
     ///     Ok(())
     /// }
     /// ```
@@ -852,7 +1125,7 @@ impl ErgodicsSystem {
     ///         result,
     ///         MoveResult::Success | MoveResult::CausalityViolation | MoveResult::GeometricViolation
     ///     );
-    ///     assert_eq!(system.stats.edge_flips_attempted, 1);
+    ///     assert_eq!(system.stats().attempted(MoveType::EdgeFlip), 1);
     ///     Ok(())
     /// }
     /// ```
@@ -1167,7 +1440,7 @@ fn reject_backend(
 /// difference.
 fn time_dist(triangulation: &CdtTriangulation2D, t0: u32, t1: u32) -> u32 {
     let raw = t0.abs_diff(t1);
-    if matches!(triangulation.metadata().topology, CdtTopology::Toroidal) {
+    if matches!(triangulation.metadata().topology(), CdtTopology::Toroidal) {
         let total = triangulation.time_slices();
         if total > 0 && t0 < total && t1 < total {
             return raw.min(total - raw);
@@ -1435,7 +1708,7 @@ fn centroid(triangulation: &CdtTriangulation2D, face: &DelaunayFaceHandle) -> Op
         vertex_point_2d(triangulation, v2)?,
     ];
 
-    if matches!(triangulation.metadata().topology, CdtTopology::Toroidal) {
+    if matches!(triangulation.metadata().topology(), CdtTopology::Toroidal) {
         return toroidal_centroid(&coords, triangulation.geometry().periodic_domain()?);
     }
 
@@ -1844,7 +2117,7 @@ fn removal_sites(triangulation: &CdtTriangulation2D, visit: &mut impl FnMut(Prop
 
 /// Checks whether toroidal move kernels must preserve periodic foliation structure.
 fn is_toroidal_foliated(triangulation: &CdtTriangulation2D) -> bool {
-    matches!(triangulation.metadata().topology, CdtTopology::Toroidal)
+    matches!(triangulation.metadata().topology(), CdtTopology::Toroidal)
         && triangulation.has_foliation()
 }
 
@@ -2070,6 +2343,31 @@ mod tests {
     }
 
     #[test]
+    fn move_statistics_deserialization_rejects_impossible_counters() {
+        let error = serde_json::from_str::<MoveStatistics>(
+            r#"{
+                "moves_22_attempted": 1,
+                "moves_22_accepted": 1,
+                "moves_22_hard_failed": 1,
+                "moves_13_attempted": 0,
+                "moves_13_accepted": 0,
+                "moves_31_attempted": 0,
+                "moves_31_accepted": 0,
+                "edge_flips_attempted": 0,
+                "edge_flips_accepted": 0
+            }"#,
+        )
+        .expect_err("accepted plus hard failures above attempts should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("accepted plus hard-failure counters"),
+            "serde error should explain move-counter invariant, got {error}"
+        );
+    }
+
+    #[test]
     fn move_22_uses_real_tri() {
         let mut system = ErgodicsSystem::new();
         let mut triangulation = square_two_triangles();
@@ -2146,7 +2444,7 @@ mod tests {
             triangulation.vertex_count(),
             triangulation.edge_count(),
             triangulation.face_count(),
-            triangulation.metadata().modification_count,
+            triangulation.metadata().modification_count(),
         );
 
         let face = triangulation
@@ -2177,7 +2475,7 @@ mod tests {
                 triangulation.vertex_count(),
                 triangulation.edge_count(),
                 triangulation.face_count(),
-                triangulation.metadata().modification_count,
+                triangulation.metadata().modification_count(),
             ),
             counts_before
         );
@@ -2298,7 +2596,7 @@ mod tests {
             triangulation.vertex_count(),
             triangulation.edge_count(),
             triangulation.face_count(),
-            triangulation.metadata().modification_count,
+            triangulation.metadata().modification_count(),
         );
 
         let empty_selection = system.select_proposal_site(&triangulation, MoveType::Move31Remove);
@@ -2308,7 +2606,7 @@ mod tests {
         assert_eq!(cached_family.instance_id, Some(triangulation.instance_id()));
         assert_eq!(
             cached_family.modification_count,
-            Some(triangulation.metadata().modification_count)
+            Some(triangulation.metadata().modification_count())
         );
 
         let retry_selection = system.select_proposal_site(&triangulation, MoveType::Move31Remove);
@@ -2319,7 +2617,7 @@ mod tests {
                 triangulation.vertex_count(),
                 triangulation.edge_count(),
                 triangulation.face_count(),
-                triangulation.metadata().modification_count,
+                triangulation.metadata().modification_count(),
             ),
             counts_before
         );
@@ -2336,7 +2634,7 @@ mod tests {
     fn proposal_site_cache_refreshes_after_accepted_mutation() {
         let mut system = ErgodicsSystem::with_seed(11);
         let mut triangulation = single_triangle();
-        let initial_modification_count = triangulation.metadata().modification_count;
+        let initial_modification_count = triangulation.metadata().modification_count();
 
         let insertion_selection = system.select_proposal_site(&triangulation, MoveType::Move13Add);
         assert_eq!(
@@ -2354,7 +2652,7 @@ mod tests {
         let result =
             system.apply_proposal_site(&mut triangulation, MoveType::Move13Add, insertion_site);
         assert_eq!(result, MoveResult::Success);
-        let mutated_modification_count = triangulation.metadata().modification_count;
+        let mutated_modification_count = triangulation.metadata().modification_count();
         assert!(mutated_modification_count > initial_modification_count);
         assert_eq!(
             system
@@ -2388,7 +2686,7 @@ mod tests {
             triangulation.vertex_count(),
             triangulation.edge_count(),
             triangulation.face_count(),
-            triangulation.metadata().modification_count,
+            triangulation.metadata().modification_count(),
         );
 
         let insertion_selection = system.select_proposal_site(&triangulation, MoveType::Move13Add);
@@ -2408,7 +2706,7 @@ mod tests {
                 triangulation.vertex_count(),
                 triangulation.edge_count(),
                 triangulation.face_count(),
-                triangulation.metadata().modification_count,
+                triangulation.metadata().modification_count(),
             ),
             counts_before
         );
@@ -2436,7 +2734,7 @@ mod tests {
                 .site_cache
                 .family(MoveType::Move13Add)
                 .modification_count,
-            Some(original.metadata().modification_count)
+            Some(original.metadata().modification_count())
         );
         let Some(insertion_site) = insertion_selection.site else {
             panic!("single triangle should expose one insertion site");
@@ -2447,8 +2745,8 @@ mod tests {
             system.apply_proposal_site(&mut proposed_state, MoveType::Move13Add, insertion_site);
         assert_eq!(result, MoveResult::Success);
         assert_ne!(
-            proposed_state.metadata().modification_count,
-            original.metadata().modification_count
+            proposed_state.metadata().modification_count(),
+            original.metadata().modification_count()
         );
 
         let proposed_selection =
@@ -2458,7 +2756,7 @@ mod tests {
                 .site_cache
                 .family(MoveType::Move31Remove)
                 .modification_count,
-            Some(proposed_state.metadata().modification_count)
+            Some(proposed_state.metadata().modification_count())
         );
         assert!(proposed_selection.site.is_some());
 
@@ -2468,7 +2766,7 @@ mod tests {
                 .site_cache
                 .family(MoveType::Move13Add)
                 .modification_count,
-            Some(original.metadata().modification_count)
+            Some(original.metadata().modification_count())
         );
         assert_eq!(
             original_selection.site_count,
@@ -2482,8 +2780,8 @@ mod tests {
         let first = single_triangle();
         let second = single_triangle();
         assert_eq!(
-            first.metadata().modification_count,
-            second.metadata().modification_count
+            first.metadata().modification_count(),
+            second.metadata().modification_count()
         );
 
         let first_selection = system.select_proposal_site(&first, MoveType::Move13Add);
@@ -2516,8 +2814,8 @@ mod tests {
         let original = single_triangle();
         let cloned = original.clone();
         assert_eq!(
-            original.metadata().modification_count,
-            cloned.metadata().modification_count
+            original.metadata().modification_count(),
+            cloned.metadata().modification_count()
         );
         assert_ne!(original.instance_id(), cloned.instance_id());
 
@@ -2544,7 +2842,7 @@ mod tests {
             triangulation.vertex_count(),
             triangulation.edge_count(),
             triangulation.face_count(),
-            triangulation.metadata().modification_count,
+            triangulation.metadata().modification_count(),
         );
 
         let insertion_selection = system.select_proposal_site(&triangulation, MoveType::Move13Add);
@@ -2561,7 +2859,7 @@ mod tests {
                 triangulation.vertex_count(),
                 triangulation.edge_count(),
                 triangulation.face_count(),
-                triangulation.metadata().modification_count,
+                triangulation.metadata().modification_count(),
             ),
             counts_before
         );

--- a/src/cdt/foliation.rs
+++ b/src/cdt/foliation.rs
@@ -14,6 +14,7 @@
 
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize};
+use std::num::NonZeroU32;
 use std::{error::Error, fmt};
 
 /// Classification of an edge
@@ -361,8 +362,8 @@ impl Error for FoliationError {}
 pub struct Foliation {
     /// Number of vertices per time slice (`slice_sizes[t]`).
     slice_sizes: Vec<usize>,
-    /// Total number of time slices.
-    num_slices: u32,
+    /// Nonzero total number of time slices.
+    num_slices: NonZeroU32,
 }
 
 #[derive(Deserialize)]
@@ -397,7 +398,7 @@ impl Foliation {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let foliation = Foliation::from_slice_sizes(vec![3, 4], 2)?;
-    ///     assert_eq!(foliation.num_slices(), 2);
+    ///     assert_eq!(foliation.num_slices().get(), 2);
     ///     assert_eq!(foliation.labeled_vertex_count(), 7);
     ///
     ///     let err = Foliation::from_slice_sizes(vec![], 0).expect_err("zero slices are invalid");
@@ -418,6 +419,9 @@ impl Foliation {
                 num_slices,
             });
         }
+        let Some(num_slices) = NonZeroU32::new(num_slices) else {
+            return Err(FoliationError::EmptyFoliation);
+        };
         if let Some(slice) = slice_sizes.iter().position(|&slice_size| slice_size == 0) {
             return Err(FoliationError::EmptySlice { slice });
         }
@@ -454,12 +458,12 @@ impl Foliation {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let foliation = Foliation::from_slice_sizes(vec![3, 4], 2)?;
-    ///     assert_eq!(foliation.num_slices(), 2);
+    ///     assert_eq!(foliation.num_slices().get(), 2);
     ///     Ok(())
     /// }
     /// ```
     #[must_use]
-    pub const fn num_slices(&self) -> u32 {
+    pub const fn num_slices(&self) -> NonZeroU32 {
         self.num_slices
     }
 
@@ -511,7 +515,7 @@ mod tests {
     #[test]
     fn test_foliation_populated() {
         let fol = Foliation::from_slice_sizes(vec![3, 3], 2).expect("valid foliation");
-        assert_eq!(fol.num_slices(), 2);
+        assert_eq!(fol.num_slices().get(), 2);
         assert_eq!(fol.labeled_vertex_count(), 6);
         assert_eq!(fol.slice_sizes()[0], 3);
         assert_eq!(fol.slice_sizes()[1], 3);

--- a/src/cdt/metropolis/adapter.rs
+++ b/src/cdt/metropolis/adapter.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 //! Adapter boundary between CDT state and `markov-chain-monte-carlo`.
 
 use crate::cdt::action::ActionConfig;
@@ -40,7 +42,7 @@ impl CdtTarget {
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     pub fn new(action_config: ActionConfig, temperature: f64) -> CdtResult<Self> {
-        action_config.validate()?;
+        action_config.validate();
         validate_temperature(temperature)?;
         Ok(Self {
             action_config,
@@ -79,7 +81,7 @@ impl Target<CdtTriangulation2D> for CdtTarget {
 ///
 /// # fn main() -> CdtResult<()> {
 /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-/// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
+/// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7);
 /// let mut rng = StdRng::seed_from_u64(11);
 ///
 /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
@@ -131,7 +133,7 @@ impl CdtProposalPlan {
     ///
     /// # fn main() -> CdtResult<()> {
     /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
+    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7);
     /// let mut rng = StdRng::seed_from_u64(11);
     /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
     ///     return Ok(());
@@ -160,7 +162,7 @@ impl CdtProposalPlan {
     ///
     /// # fn main() -> CdtResult<()> {
     /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
+    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7);
     /// let mut rng = StdRng::seed_from_u64(11);
     /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
     ///     return Ok(());
@@ -190,7 +192,7 @@ impl CdtProposalPlan {
     ///
     /// # fn main() -> CdtResult<()> {
     /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
+    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7);
     /// let mut rng = StdRng::seed_from_u64(11);
     /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
     ///     return Ok(());
@@ -216,7 +218,7 @@ impl CdtProposalPlan {
     ///
     /// # fn main() -> CdtResult<()> {
     /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
+    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7);
     /// let mut rng = StdRng::seed_from_u64(11);
     /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
     ///     return Ok(());
@@ -253,7 +255,7 @@ impl CdtProposalPlan {
 ///
 /// # fn main() -> CdtResult<()> {
 /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-/// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7)?;
+/// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7);
 /// let mut rng = StdRng::seed_from_u64(11);
 /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
 ///     return Ok(());
@@ -377,7 +379,7 @@ impl From<CdtProposalError> for CdtError {
 ///
 /// # fn main() -> CdtResult<()> {
 /// let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-/// let mut proposal = CdtProposal::new(ActionConfig::default())?;
+/// let mut proposal = CdtProposal::new(ActionConfig::default());
 /// let mut rng = StdRng::seed_from_u64(7);
 ///
 /// let plan = proposal.propose_plan(&tri, &mut rng)?;
@@ -398,25 +400,20 @@ impl CdtProposal {
     /// Delayed scoring is delegated to the target passed to
     /// [`DelayedProposal::proposed_log_prob`].
     ///
-    /// # Errors
-    ///
-    /// Returns [`CdtError::InvalidConfiguration`] if the action couplings are
-    /// non-finite.
-    ///
     /// # Examples
     ///
     /// ```
     /// use causal_triangulations::prelude::simulation::{ActionConfig, CdtProposal};
     ///
-    /// let _proposal = CdtProposal::new(ActionConfig::default())?;
-    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// let _proposal = CdtProposal::new(ActionConfig::default());
     /// ```
-    pub fn new(action_config: ActionConfig) -> CdtResult<Self> {
-        action_config.validate()?;
-        Ok(Self {
+    #[must_use]
+    pub fn new(action_config: ActionConfig) -> Self {
+        action_config.validate();
+        Self {
             action_config,
             moves: ErgodicsSystem::new(),
-        })
+        }
     }
 
     /// Creates a seeded delayed CDT proposal distribution.
@@ -425,25 +422,20 @@ impl CdtProposal {
     /// [`DelayedProposal::propose_plan`] is still accepted for compatibility
     /// with generic MCMC drivers.
     ///
-    /// # Errors
-    ///
-    /// Returns [`CdtError::InvalidConfiguration`] if the action couplings are
-    /// non-finite.
-    ///
     /// # Examples
     ///
     /// ```
     /// use causal_triangulations::prelude::simulation::{ActionConfig, CdtProposal};
     ///
-    /// let _proposal = CdtProposal::with_seed(ActionConfig::default(), 42)?;
-    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// let _proposal = CdtProposal::with_seed(ActionConfig::default(), 42);
     /// ```
-    pub fn with_seed(action_config: ActionConfig, seed: u64) -> CdtResult<Self> {
-        action_config.validate()?;
-        Ok(Self {
+    #[must_use]
+    pub fn with_seed(action_config: ActionConfig, seed: u64) -> Self {
+        action_config.validate();
+        Self {
             action_config,
             moves: ErgodicsSystem::with_seed(seed),
-        })
+        }
     }
 }
 
@@ -564,9 +556,9 @@ pub(crate) fn propose_concrete_plan(
     };
 
     let mut proposed_state = state.clone();
-    let move_stats_before = moves.stats.clone();
+    let move_stats_before = moves.stats().clone();
     let result = moves.apply_proposal_site(&mut proposed_state, move_type, site);
-    moves.stats = move_stats_before;
+    moves.replace_stats(move_stats_before);
     let action_after = match result {
         MoveResult::Success => action_for(action_config, &proposed_state),
         MoveResult::HardFailure(err) => {

--- a/src/cdt/metropolis/checkpoint.rs
+++ b/src/cdt/metropolis/checkpoint.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 //! Checkpoint and resume validation for CDT Metropolis sampling.
 
 use crate::cdt::action::ActionConfig;
@@ -7,7 +9,8 @@ use crate::errors::{CdtError, CdtResult, CheckpointMoveCounter, CheckpointResume
 use crate::geometry::CdtTriangulation2D;
 use markov_chain_monte_carlo::ChainCheckpoint;
 use rand::rngs::Xoshiro256PlusPlus;
-use serde::{Deserialize, Serialize};
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer, Serialize};
 use std::time::Duration;
 
 use super::helpers::actions_match;
@@ -49,7 +52,7 @@ pub(crate) struct CdtMcmcCheckpointParts {
 /// fn main() -> CdtResult<()> {
 ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
 ///     let checkpoint = MetropolisAlgorithm::new(
-///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
 ///         ActionConfig::default(),
 ///     )
 ///     .run_to_checkpoint(tri)?;
@@ -59,7 +62,7 @@ pub(crate) struct CdtMcmcCheckpointParts {
 ///     Ok(())
 /// }
 /// ```
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize)]
 pub struct CdtMcmcCheckpoint {
     pub(crate) chain: ChainCheckpoint<CdtTriangulation2D>,
     pub(crate) config: MetropolisConfig,
@@ -76,9 +79,51 @@ pub struct CdtMcmcCheckpoint {
     pub(crate) ergodics: ErgodicsSystem,
 }
 
+#[derive(Deserialize)]
+struct CdtMcmcCheckpointWire {
+    chain: ChainCheckpoint<CdtTriangulation2D>,
+    config: MetropolisConfig,
+    action_config: ActionConfig,
+    current_step: u32,
+    current_action: f64,
+    move_stats: MoveStatistics,
+    #[serde(default)]
+    proposal_stats: ProposalStatistics,
+    steps: Vec<MonteCarloStep>,
+    measurements: Vec<Measurement>,
+    elapsed_time: Duration,
+    acceptance_rng: Xoshiro256PlusPlus,
+    ergodics: ErgodicsSystem,
+}
+
+impl<'de> Deserialize<'de> for CdtMcmcCheckpoint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = CdtMcmcCheckpointWire::deserialize(deserializer)?;
+        let checkpoint = Self {
+            chain: wire.chain,
+            config: wire.config,
+            action_config: wire.action_config,
+            current_step: wire.current_step,
+            current_action: wire.current_action,
+            move_stats: wire.move_stats,
+            proposal_stats: wire.proposal_stats,
+            steps: wire.steps,
+            measurements: wire.measurements,
+            elapsed_time: wire.elapsed_time,
+            acceptance_rng: wire.acceptance_rng,
+            ergodics: wire.ergodics,
+        };
+        validate_checkpoint_counters(&checkpoint).map_err(DeError::custom)?;
+        Ok(checkpoint)
+    }
+}
+
 impl CdtMcmcCheckpoint {
-    pub(crate) fn from_parts(parts: CdtMcmcCheckpointParts) -> Self {
-        Self {
+    pub(crate) fn from_parts(parts: CdtMcmcCheckpointParts) -> CdtResult<Self> {
+        let checkpoint = Self {
             chain: ChainCheckpoint::new(parts.triangulation, parts.accepted, parts.rejected),
             config: parts.config,
             action_config: parts.action_config,
@@ -91,7 +136,9 @@ impl CdtMcmcCheckpoint {
             elapsed_time: parts.elapsed_time,
             acceptance_rng: parts.acceptance_rng,
             ergodics: parts.ergodics,
-        }
+        };
+        validate_checkpoint_counters(&checkpoint)?;
+        Ok(checkpoint)
     }
 
     /// Returns the generic MCMC chain checkpoint for upstream interop.
@@ -106,7 +153,7 @@ impl CdtMcmcCheckpoint {
     ///
     /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
     /// MetropolisAlgorithm::new(
-    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
     ///     ActionConfig::default(),
     /// )
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
@@ -131,7 +178,7 @@ impl CdtMcmcCheckpoint {
     ///
     /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
     /// MetropolisAlgorithm::new(
-    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
     ///     ActionConfig::default(),
     /// )
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
@@ -157,13 +204,13 @@ impl CdtMcmcCheckpoint {
     ///
     /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
     /// MetropolisAlgorithm::new(
-    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
     ///     ActionConfig::default(),
     /// )
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
     /// # }
     /// # let checkpoint = checkpoint()?;
-    /// assert_eq!(checkpoint.config().steps, 1);
+    /// assert_eq!(checkpoint.config().steps(), 1);
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     #[must_use]
@@ -183,7 +230,7 @@ impl CdtMcmcCheckpoint {
     ///
     /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
     /// MetropolisAlgorithm::new(
-    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
     ///     ActionConfig::default(),
     /// )
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
@@ -209,7 +256,7 @@ impl CdtMcmcCheckpoint {
     ///
     /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
     /// MetropolisAlgorithm::new(
-    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
     ///     ActionConfig::default(),
     /// )
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
@@ -235,7 +282,7 @@ impl CdtMcmcCheckpoint {
     ///
     /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
     /// MetropolisAlgorithm::new(
-    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
     ///     ActionConfig::default(),
     /// )
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
@@ -261,7 +308,7 @@ impl CdtMcmcCheckpoint {
     ///
     /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
     /// MetropolisAlgorithm::new(
-    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
     ///     ActionConfig::default(),
     /// )
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
@@ -287,13 +334,13 @@ impl CdtMcmcCheckpoint {
     ///
     /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
     /// MetropolisAlgorithm::new(
-    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
     ///     ActionConfig::default(),
     /// )
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
     /// # }
     /// # let checkpoint = checkpoint()?;
-    /// assert_eq!(checkpoint.proposal_stats().move_family_proposals, 1);
+    /// assert_eq!(checkpoint.proposal_stats().move_family_proposals(), 1);
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     #[must_use]
@@ -313,7 +360,7 @@ impl CdtMcmcCheckpoint {
     ///
     /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
     /// MetropolisAlgorithm::new(
-    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
     ///     ActionConfig::default(),
     /// )
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
@@ -339,7 +386,7 @@ impl CdtMcmcCheckpoint {
     ///
     /// # fn checkpoint() -> CdtResult<CdtMcmcCheckpoint> {
     /// MetropolisAlgorithm::new(
-    ///     MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///     MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
     ///     ActionConfig::default(),
     /// )
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
@@ -368,7 +415,7 @@ impl CdtMcmcCheckpoint {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
     ///         ActionConfig::default(),
     ///     )
     ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
@@ -419,17 +466,17 @@ pub(crate) fn validate_resume_compatible(
             CheckpointResumeFailure::IncompatibleActionConfiguration,
         ));
     }
-    if algorithm.config().temperature.to_bits() != checkpoint.config.temperature.to_bits() {
+    if algorithm.config().temperature().to_bits() != checkpoint.config.temperature().to_bits() {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::IncompatibleTemperature,
         ));
     }
-    if algorithm.config().thermalization_steps != checkpoint.config.thermalization_steps {
+    if algorithm.config().thermalization_steps() != checkpoint.config.thermalization_steps() {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::IncompatibleThermalizationSchedule,
         ));
     }
-    if algorithm.config().measurement_frequency != checkpoint.config.measurement_frequency {
+    if algorithm.config().measurement_frequency() != checkpoint.config.measurement_frequency() {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::IncompatibleMeasurementFrequency,
         ));
@@ -439,9 +486,9 @@ pub(crate) fn validate_resume_compatible(
 
 /// Compares action couplings with the same tolerance used for persisted action values.
 fn action_configs_match(left: &ActionConfig, right: &ActionConfig) -> bool {
-    actions_match(left.coupling_0, right.coupling_0)
-        && actions_match(left.coupling_2, right.coupling_2)
-        && actions_match(left.cosmological_constant, right.cosmological_constant)
+    actions_match(left.coupling_0(), right.coupling_0())
+        && actions_match(left.coupling_2(), right.coupling_2())
+        && actions_match(left.cosmological_constant(), right.cosmological_constant())
 }
 
 /// Checks that serialized chain counters and CDT telemetry agree.
@@ -458,8 +505,8 @@ fn action_configs_match(left: &ActionConfig, right: &ActionConfig) -> bool {
 /// counters, step telemetry, or measurements do not match the configured
 /// sampling schedule.
 pub(crate) fn validate_checkpoint_counters(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
-    checkpoint.config.validate()?;
-    checkpoint.action_config.validate()?;
+    checkpoint.config.validate();
+    checkpoint.action_config.validate();
 
     let (accepted, rejected) = chain_counters(&checkpoint.move_stats)?;
     if checkpoint.chain.accepted() != accepted || checkpoint.chain.rejected() != rejected {
@@ -569,7 +616,8 @@ fn validate_checkpoint_steps(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
 /// Checks that serialized measurements match the configured sampling schedule.
 fn validate_checkpoint_measurements(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
     let expected_measurements = usize::try_from(
-        u64::from(checkpoint.current_step) / u64::from(checkpoint.config.measurement_frequency) + 1,
+        u64::from(checkpoint.current_step) / u64::from(checkpoint.config.measurement_frequency())
+            + 1,
     )
     .map_err(|_| checkpoint_resume_failed(CheckpointResumeFailure::MeasurementCountOverflow))?;
     if checkpoint.measurements.len() != expected_measurements {
@@ -584,7 +632,9 @@ fn validate_checkpoint_measurements(checkpoint: &CdtMcmcCheckpoint) -> CdtResult
     for (index, measurement) in checkpoint.measurements.iter().enumerate() {
         let expected_step = u64::try_from(index)
             .ok()
-            .and_then(|index| index.checked_mul(u64::from(checkpoint.config.measurement_frequency)))
+            .and_then(|index| {
+                index.checked_mul(u64::from(checkpoint.config.measurement_frequency()))
+            })
             .and_then(|step| u32::try_from(step).ok())
             .ok_or_else(|| {
                 checkpoint_resume_failed(CheckpointResumeFailure::MeasurementStepOverflow)
@@ -622,27 +672,27 @@ fn validate_move_counter_bounds(move_stats: &MoveStatistics) -> CdtResult<()> {
     let counters = [
         (
             MoveType::Move22,
-            move_stats.moves_22_attempted,
-            move_stats.moves_22_accepted,
-            move_stats.moves_22_hard_failed,
+            move_stats.attempted(MoveType::Move22),
+            move_stats.accepted(MoveType::Move22),
+            move_stats.hard_failed(MoveType::Move22),
         ),
         (
             MoveType::Move13Add,
-            move_stats.moves_13_attempted,
-            move_stats.moves_13_accepted,
-            move_stats.moves_13_hard_failed,
+            move_stats.attempted(MoveType::Move13Add),
+            move_stats.accepted(MoveType::Move13Add),
+            move_stats.hard_failed(MoveType::Move13Add),
         ),
         (
             MoveType::Move31Remove,
-            move_stats.moves_31_attempted,
-            move_stats.moves_31_accepted,
-            move_stats.moves_31_hard_failed,
+            move_stats.attempted(MoveType::Move31Remove),
+            move_stats.accepted(MoveType::Move31Remove),
+            move_stats.hard_failed(MoveType::Move31Remove),
         ),
         (
             MoveType::EdgeFlip,
-            move_stats.edge_flips_attempted,
-            move_stats.edge_flips_accepted,
-            move_stats.edge_flips_hard_failed,
+            move_stats.attempted(MoveType::EdgeFlip),
+            move_stats.accepted(MoveType::EdgeFlip),
+            move_stats.hard_failed(MoveType::EdgeFlip),
         ),
     ];
 
@@ -680,19 +730,19 @@ pub(crate) fn chain_counters(move_stats: &MoveStatistics) -> CdtResult<(usize, u
     let attempted = checked_move_counter_sum(
         CheckpointMoveCounter::Attempted,
         [
-            move_stats.moves_22_attempted,
-            move_stats.moves_13_attempted,
-            move_stats.moves_31_attempted,
-            move_stats.edge_flips_attempted,
+            move_stats.attempted(MoveType::Move22),
+            move_stats.attempted(MoveType::Move13Add),
+            move_stats.attempted(MoveType::Move31Remove),
+            move_stats.attempted(MoveType::EdgeFlip),
         ],
     )?;
     let accepted = checked_move_counter_sum(
         CheckpointMoveCounter::Accepted,
         [
-            move_stats.moves_22_accepted,
-            move_stats.moves_13_accepted,
-            move_stats.moves_31_accepted,
-            move_stats.edge_flips_accepted,
+            move_stats.accepted(MoveType::Move22),
+            move_stats.accepted(MoveType::Move13Add),
+            move_stats.accepted(MoveType::Move31Remove),
+            move_stats.accepted(MoveType::EdgeFlip),
         ],
     )?;
     let rejected = attempted.checked_sub(accepted).ok_or_else(|| {

--- a/src/cdt/metropolis/checkpoint.rs
+++ b/src/cdt/metropolis/checkpoint.rs
@@ -5,7 +5,9 @@
 use crate::cdt::action::ActionConfig;
 use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveStatistics, MoveType};
 use crate::cdt::results::{Measurement, SimulationResultsBackend, SimulationResultsParts};
-use crate::errors::{CdtError, CdtResult, CheckpointMoveCounter, CheckpointResumeFailure};
+use crate::errors::{
+    CdtError, CdtResult, CheckpointMoveCounter, CheckpointResumeFailure, ProposalTelemetryCounter,
+};
 use crate::geometry::CdtTriangulation2D;
 use markov_chain_monte_carlo::ChainCheckpoint;
 use rand::rngs::Xoshiro256PlusPlus;
@@ -13,7 +15,7 @@ use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::time::Duration;
 
-use super::helpers::actions_match;
+use super::helpers::{actions_match, expected_measurement_count, expected_measurement_step};
 use super::runner::{MetropolisAlgorithm, MetropolisConfig};
 use super::telemetry::{MonteCarloStep, ProposalStatistics};
 
@@ -324,6 +326,10 @@ impl CdtMcmcCheckpoint {
 
     /// Returns accumulated proposal-kernel telemetry through the checkpoint step.
     ///
+    /// Checkpoint validation requires these counters to account for exactly the
+    /// same move-family proposals and accepted/rejected transitions as the
+    /// stored chain and step telemetry.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -375,6 +381,10 @@ impl CdtMcmcCheckpoint {
     }
 
     /// Returns accumulated measurements through the checkpoint step.
+    ///
+    /// Measurements follow the configured post-thermalization cadence. The
+    /// initial step `0` appears only when the checkpoint schedule has zero
+    /// thermalization.
     ///
     /// # Examples
     ///
@@ -536,8 +546,73 @@ pub(crate) fn validate_checkpoint_counters(checkpoint: &CdtMcmcCheckpoint) -> Cd
             },
         ));
     }
+    validate_checkpoint_proposal_stats(checkpoint, accepted, rejected)?;
     validate_checkpoint_steps(checkpoint)?;
     validate_checkpoint_measurements(checkpoint)?;
+    Ok(())
+}
+
+/// Checks proposal telemetry against checkpoint step and chain counters.
+///
+/// This preserves the public resume contract: a deserialized checkpoint must not
+/// silently default, drop, or double-count proposal outcomes relative to the
+/// MCMC chain prefix it claims to resume.
+fn validate_checkpoint_proposal_stats(
+    checkpoint: &CdtMcmcCheckpoint,
+    accepted: usize,
+    rejected: usize,
+) -> CdtResult<()> {
+    if checkpoint.proposal_stats.hard_failures() != 0 {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ProposalHardFailures {
+                actual: checkpoint.proposal_stats.hard_failures(),
+            },
+        ));
+    }
+
+    let steps = u64::try_from(checkpoint.steps.len()).map_err(|_| {
+        checkpoint_resume_failed(CheckpointResumeFailure::ProposalCounterOverflow {
+            counter: ProposalTelemetryCounter::MoveFamilyProposals,
+        })
+    })?;
+    if checkpoint.proposal_stats.move_family_proposals() != steps {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ProposalMoveFamilyCountMismatch {
+                actual: checkpoint.proposal_stats.move_family_proposals(),
+                expected: steps,
+            },
+        ));
+    }
+
+    let accepted = u64::try_from(accepted).map_err(|_| {
+        checkpoint_resume_failed(CheckpointResumeFailure::ProposalCounterOverflow {
+            counter: ProposalTelemetryCounter::AcceptedTransitions,
+        })
+    })?;
+    if checkpoint.proposal_stats.accepted_transitions() != accepted {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ProposalAcceptedCountMismatch {
+                actual: checkpoint.proposal_stats.accepted_transitions(),
+                expected: accepted,
+            },
+        ));
+    }
+
+    let rejected = u64::try_from(rejected).map_err(|_| {
+        checkpoint_resume_failed(CheckpointResumeFailure::ProposalCounterOverflow {
+            counter: ProposalTelemetryCounter::RejectedTransitions,
+        })
+    })?;
+    let actual_rejected = checkpoint.proposal_stats.rejected_transitions();
+    if actual_rejected != rejected {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ProposalRejectedCountMismatch {
+                actual: actual_rejected,
+                expected: rejected,
+            },
+        ));
+    }
+
     Ok(())
 }
 
@@ -613,13 +688,14 @@ fn validate_checkpoint_steps(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
     Ok(())
 }
 
-/// Checks that serialized measurements match the configured sampling schedule.
+/// Checks that serialized measurements match the configured post-thermalization schedule.
 fn validate_checkpoint_measurements(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
-    let expected_measurements = usize::try_from(
-        u64::from(checkpoint.current_step) / u64::from(checkpoint.config.measurement_frequency())
-            + 1,
+    let expected_measurements = expected_measurement_count(
+        checkpoint.current_step,
+        checkpoint.config.thermalization_steps(),
+        checkpoint.config.measurement_frequency(),
     )
-    .map_err(|_| checkpoint_resume_failed(CheckpointResumeFailure::MeasurementCountOverflow))?;
+    .ok_or_else(|| checkpoint_resume_failed(CheckpointResumeFailure::MeasurementCountOverflow))?;
     if checkpoint.measurements.len() != expected_measurements {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::MeasurementCountMismatch {
@@ -630,15 +706,14 @@ fn validate_checkpoint_measurements(checkpoint: &CdtMcmcCheckpoint) -> CdtResult
     }
 
     for (index, measurement) in checkpoint.measurements.iter().enumerate() {
-        let expected_step = u64::try_from(index)
-            .ok()
-            .and_then(|index| {
-                index.checked_mul(u64::from(checkpoint.config.measurement_frequency()))
-            })
-            .and_then(|step| u32::try_from(step).ok())
-            .ok_or_else(|| {
-                checkpoint_resume_failed(CheckpointResumeFailure::MeasurementStepOverflow)
-            })?;
+        let expected_step = expected_measurement_step(
+            index,
+            checkpoint.config.thermalization_steps(),
+            checkpoint.config.measurement_frequency(),
+        )
+        .ok_or_else(|| {
+            checkpoint_resume_failed(CheckpointResumeFailure::MeasurementStepOverflow)
+        })?;
         if measurement.step != expected_step {
             return Err(checkpoint_resume_failed(
                 CheckpointResumeFailure::MeasurementStepMismatch {

--- a/src/cdt/metropolis/checkpoint.rs
+++ b/src/cdt/metropolis/checkpoint.rs
@@ -186,7 +186,7 @@ impl CdtMcmcCheckpoint {
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
     /// # }
     /// # let checkpoint = checkpoint()?;
-    /// assert_eq!(checkpoint.triangulation().time_slices(), 3);
+    /// assert_eq!(checkpoint.triangulation().time_slices().get(), 3);
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     #[must_use]
@@ -212,7 +212,7 @@ impl CdtMcmcCheckpoint {
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
     /// # }
     /// # let checkpoint = checkpoint()?;
-    /// assert_eq!(checkpoint.config().steps(), 1);
+    /// assert_eq!(checkpoint.config().steps().get(), 1);
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     #[must_use]

--- a/src/cdt/metropolis/helpers.rs
+++ b/src/cdt/metropolis/helpers.rs
@@ -9,6 +9,7 @@ use crate::config::validate_schedule;
 use crate::errors::{CdtError, CdtResult, ConfigurationSetting};
 use crate::geometry::CdtTriangulation2D;
 use crate::util::saturating_usize_to_u32;
+use std::num::NonZeroU32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SimplexCounts {
@@ -128,9 +129,9 @@ pub fn measurement_for(step: u32, action: f64, triangulation: &CdtTriangulation2
 pub const fn measurement_is_due(
     step: u32,
     thermalization_steps: u32,
-    measurement_frequency: u32,
+    measurement_frequency: NonZeroU32,
 ) -> bool {
-    step >= thermalization_steps && step.is_multiple_of(measurement_frequency)
+    step >= thermalization_steps && step.is_multiple_of(measurement_frequency.get())
 }
 
 /// Counts scheduled post-thermalization measurements through `current_step`.
@@ -142,13 +143,17 @@ pub const fn measurement_is_due(
 pub fn expected_measurement_count(
     current_step: u32,
     thermalization_steps: u32,
-    measurement_frequency: u32,
+    measurement_frequency: NonZeroU32,
 ) -> Option<usize> {
     let first = first_measurement_step(thermalization_steps, measurement_frequency)?;
     if first > current_step {
         return Some(0);
     }
-    usize::try_from((current_step - first) / measurement_frequency + 1).ok()
+    let current_step = u64::from(current_step);
+    let first = u64::from(first);
+    let measurement_frequency = u64::from(measurement_frequency.get());
+    let count = (current_step - first) / measurement_frequency + 1;
+    usize::try_from(count).ok()
 }
 
 /// Returns the scheduled post-thermalization step at a zero-based measurement index.
@@ -160,22 +165,23 @@ pub fn expected_measurement_count(
 pub fn expected_measurement_step(
     index: usize,
     thermalization_steps: u32,
-    measurement_frequency: u32,
+    measurement_frequency: NonZeroU32,
 ) -> Option<u32> {
     let first = first_measurement_step(thermalization_steps, measurement_frequency)?;
     let offset = u32::try_from(index)
         .ok()?
-        .checked_mul(measurement_frequency)?;
+        .checked_mul(measurement_frequency.get())?;
     first.checked_add(offset)
 }
 
 /// Finds the first measurement cadence at or after thermalization.
-fn first_measurement_step(thermalization_steps: u32, measurement_frequency: u32) -> Option<u32> {
-    if measurement_frequency == 0 {
-        return None;
-    }
-    let first = u64::from(thermalization_steps).div_ceil(u64::from(measurement_frequency))
-        * u64::from(measurement_frequency);
+fn first_measurement_step(
+    thermalization_steps: u32,
+    measurement_frequency: NonZeroU32,
+) -> Option<u32> {
+    let measurement_frequency = u64::from(measurement_frequency.get());
+    let first =
+        u64::from(thermalization_steps).div_ceil(measurement_frequency) * measurement_frequency;
     u32::try_from(first).ok()
 }
 
@@ -222,23 +228,31 @@ pub fn actions_match(left: f64, right: f64) -> bool {
 mod tests {
     use super::*;
 
+    fn frequency(value: u32) -> NonZeroU32 {
+        NonZeroU32::new(value).expect("test measurement frequency should be nonzero")
+    }
+
     #[test]
     fn measurement_count_ignores_steps_before_first_post_thermalization_cadence() {
-        assert_eq!(expected_measurement_count(1, 2, 2), Some(0));
-        assert_eq!(expected_measurement_count(2, 2, 2), Some(1));
-        assert_eq!(expected_measurement_count(4, 2, 2), Some(2));
+        assert_eq!(expected_measurement_count(1, 2, frequency(2)), Some(0));
+        assert_eq!(expected_measurement_count(2, 2, frequency(2)), Some(1));
+        assert_eq!(expected_measurement_count(4, 2, frequency(2)), Some(2));
     }
 
     #[test]
     fn measurement_step_rounds_thermalization_up_to_cadence() {
-        assert_eq!(expected_measurement_step(0, 3, 2), Some(4));
-        assert_eq!(expected_measurement_step(1, 3, 2), Some(6));
+        assert_eq!(expected_measurement_step(0, 3, frequency(2)), Some(4));
+        assert_eq!(expected_measurement_step(1, 3, frequency(2)), Some(6));
     }
 
     #[test]
-    fn measurement_helpers_reject_zero_frequency() {
-        assert_eq!(expected_measurement_count(4, 0, 0), None);
-        assert_eq!(expected_measurement_step(0, 0, 0), None);
+    fn measurement_count_widens_before_including_current_step() {
+        let expected = usize::try_from(u64::from(u32::MAX) + 1).ok();
+
+        assert_eq!(
+            expected_measurement_count(u32::MAX, 0, frequency(1)),
+            expected
+        );
     }
 
     #[test]

--- a/src/cdt/metropolis/helpers.rs
+++ b/src/cdt/metropolis/helpers.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 //! Shared CDT-domain helpers for Metropolis sampling.
 
 use crate::cdt::action::ActionConfig;

--- a/src/cdt/metropolis/helpers.rs
+++ b/src/cdt/metropolis/helpers.rs
@@ -120,6 +120,65 @@ pub fn measurement_for(step: u32, action: f64, triangulation: &CdtTriangulation2
     }
 }
 
+/// Returns true when a completed step is on the post-thermalization measurement cadence.
+///
+/// Measurements are emitted only at steps greater than or equal to
+/// `thermalization_steps`. Step `0` is therefore recorded only for schedules with
+/// zero thermalization.
+pub const fn measurement_is_due(
+    step: u32,
+    thermalization_steps: u32,
+    measurement_frequency: u32,
+) -> bool {
+    step >= thermalization_steps && step.is_multiple_of(measurement_frequency)
+}
+
+/// Counts scheduled post-thermalization measurements through `current_step`.
+///
+/// This is the shared cadence calculation used by checkpoint and result
+/// validation, keeping deserialized telemetry aligned with the runner's public
+/// measurement schedule. Returns `None` if the schedule cannot be represented in
+/// `usize`.
+pub fn expected_measurement_count(
+    current_step: u32,
+    thermalization_steps: u32,
+    measurement_frequency: u32,
+) -> Option<usize> {
+    let first = first_measurement_step(thermalization_steps, measurement_frequency)?;
+    if first > current_step {
+        return Some(0);
+    }
+    usize::try_from((current_step - first) / measurement_frequency + 1).ok()
+}
+
+/// Returns the scheduled post-thermalization step at a zero-based measurement index.
+///
+/// This mirrors [`expected_measurement_count`] so checkpoint and result
+/// validation reject pre-thermalization samples instead of accepting a shifted
+/// measurement stream. Returns `None` if the requested index cannot be expressed
+/// as a `u32` step.
+pub fn expected_measurement_step(
+    index: usize,
+    thermalization_steps: u32,
+    measurement_frequency: u32,
+) -> Option<u32> {
+    let first = first_measurement_step(thermalization_steps, measurement_frequency)?;
+    let offset = u32::try_from(index)
+        .ok()?
+        .checked_mul(measurement_frequency)?;
+    first.checked_add(offset)
+}
+
+/// Finds the first measurement cadence at or after thermalization.
+fn first_measurement_step(thermalization_steps: u32, measurement_frequency: u32) -> Option<u32> {
+    if measurement_frequency == 0 {
+        return None;
+    }
+    let first = u64::from(thermalization_steps).div_ceil(u64::from(measurement_frequency))
+        * u64::from(measurement_frequency);
+    u32::try_from(first).ok()
+}
+
 /// Computes the count-level action change before mutating the triangulation.
 ///
 /// This is the core proposal-before-mutation calculation: Metropolis acceptance
@@ -157,4 +216,34 @@ pub fn actions_match(left: f64, right: f64) -> bool {
     }
     let scale = left.abs().max(right.abs()).max(1.0);
     (left - right).abs() <= f64::EPSILON * scale * 8.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn measurement_count_ignores_steps_before_first_post_thermalization_cadence() {
+        assert_eq!(expected_measurement_count(1, 2, 2), Some(0));
+        assert_eq!(expected_measurement_count(2, 2, 2), Some(1));
+        assert_eq!(expected_measurement_count(4, 2, 2), Some(2));
+    }
+
+    #[test]
+    fn measurement_step_rounds_thermalization_up_to_cadence() {
+        assert_eq!(expected_measurement_step(0, 3, 2), Some(4));
+        assert_eq!(expected_measurement_step(1, 3, 2), Some(6));
+    }
+
+    #[test]
+    fn measurement_helpers_reject_zero_frequency() {
+        assert_eq!(expected_measurement_count(4, 0, 0), None);
+        assert_eq!(expected_measurement_step(0, 0, 0), None);
+    }
+
+    #[test]
+    fn actions_match_rejects_nonfinite_values() {
+        assert!(!actions_match(f64::NAN, 1.0));
+        assert!(!actions_match(1.0, f64::INFINITY));
+    }
 }

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -15,7 +15,8 @@ use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveStatistics, MoveType};
 use crate::cdt::results::{Measurement, SimulationResultsBackend};
 use crate::cdt::triangulation::SimulationEvent;
 use crate::errors::{
-    CdtError, CdtResult, CheckpointResumeFailure, MetropolisMoveApplicationFailure,
+    CdtError, CdtResult, CheckpointResumeFailure, ConfigurationSetting,
+    MetropolisMoveApplicationFailure,
 };
 use crate::geometry::CdtTriangulation2D;
 use rand::{Rng, RngExt, SeedableRng, rngs::Xoshiro256PlusPlus};
@@ -33,6 +34,7 @@ use super::helpers::{
     action_for, actions_match, measurement_for, measurement_is_due, validate_metropolis_schedule,
 };
 use super::telemetry::{MonteCarloStep, ProposalStatistics};
+use std::num::NonZeroU32;
 
 /// Validated configuration for the Metropolis-Hastings algorithm.
 ///
@@ -43,12 +45,12 @@ use super::telemetry::{MonteCarloStep, ProposalStatistics};
 pub struct MetropolisConfig {
     /// Temperature parameter (1/β)
     temperature: f64,
-    /// Number of Monte Carlo steps to perform
-    steps: u32,
+    /// Nonzero number of Monte Carlo steps to perform
+    steps: NonZeroU32,
     /// Number of thermalization steps before measurements
     thermalization_steps: u32,
-    /// Frequency of measurements (take measurement every N steps)
-    measurement_frequency: u32,
+    /// Nonzero frequency of measurements (take measurement every N steps)
+    measurement_frequency: NonZeroU32,
     /// Optional RNG seed for reproducible simulations (default: None = random)
     seed: Option<u64>,
 }
@@ -82,7 +84,13 @@ impl<'de> Deserialize<'de> for MetropolisConfig {
 impl Default for MetropolisConfig {
     /// Default Metropolis configuration for 2D CDT.
     fn default() -> Self {
-        Self::from_validated_parts(1.0, 1000, 100, 10, None)
+        Self::from_validated_parts(
+            1.0,
+            default_step_count(),
+            100,
+            default_measurement_frequency(),
+            None,
+        )
     }
 }
 
@@ -102,7 +110,7 @@ impl MetropolisConfig {
     /// use causal_triangulations::MetropolisConfig;
     ///
     /// let config = MetropolisConfig::new(2.0, 500, 50, 5)?;
-    /// assert_eq!(config.steps(), 500);
+    /// assert_eq!(config.steps().get(), 500);
     /// assert!(config.seed().is_none());
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
@@ -150,6 +158,20 @@ impl MetropolisConfig {
             thermalization_steps,
             measurement_frequency,
         )?;
+        let Some(steps) = NonZeroU32::new(steps) else {
+            return Err(CdtError::InvalidSimulationConfiguration {
+                setting: ConfigurationSetting::Steps,
+                provided_value: steps.to_string(),
+                expected: "≥ 1".to_string(),
+            });
+        };
+        let Some(measurement_frequency) = NonZeroU32::new(measurement_frequency) else {
+            return Err(CdtError::InvalidSimulationConfiguration {
+                setting: ConfigurationSetting::MeasurementFrequency,
+                provided_value: measurement_frequency.to_string(),
+                expected: "≥ 1".to_string(),
+            });
+        };
         Ok(Self::from_validated_parts(
             temperature,
             steps,
@@ -166,9 +188,9 @@ impl MetropolisConfig {
     /// second fallible branch.
     pub(crate) const fn from_validated_parts(
         temperature: f64,
-        steps: u32,
+        steps: NonZeroU32,
         thermalization_steps: u32,
-        measurement_frequency: u32,
+        measurement_frequency: NonZeroU32,
         seed: Option<u64>,
     ) -> Self {
         Self {
@@ -214,7 +236,7 @@ impl MetropolisConfig {
         self.temperature
     }
 
-    /// Returns the configured number of Monte Carlo steps.
+    /// Returns the nonzero configured number of Monte Carlo steps.
     ///
     /// # Examples
     ///
@@ -222,11 +244,11 @@ impl MetropolisConfig {
     /// use causal_triangulations::MetropolisConfig;
     ///
     /// let config = MetropolisConfig::new(2.0, 100, 10, 5)?;
-    /// assert_eq!(config.steps(), 100);
+    /// assert_eq!(config.steps().get(), 100);
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     #[must_use]
-    pub const fn steps(&self) -> u32 {
+    pub const fn steps(&self) -> NonZeroU32 {
         self.steps
     }
 
@@ -246,7 +268,7 @@ impl MetropolisConfig {
         self.thermalization_steps
     }
 
-    /// Returns the measurement cadence.
+    /// Returns the nonzero measurement cadence.
     ///
     /// # Examples
     ///
@@ -254,11 +276,11 @@ impl MetropolisConfig {
     /// use causal_triangulations::MetropolisConfig;
     ///
     /// let config = MetropolisConfig::new(2.0, 100, 10, 5)?;
-    /// assert_eq!(config.measurement_frequency(), 5);
+    /// assert_eq!(config.measurement_frequency().get(), 5);
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     #[must_use]
-    pub const fn measurement_frequency(&self) -> u32 {
+    pub const fn measurement_frequency(&self) -> NonZeroU32 {
         self.measurement_frequency
     }
 
@@ -312,9 +334,23 @@ impl MetropolisConfig {
     /// ```
     pub fn validate(&self) {
         debug_assert!(self.temperature.is_finite() && self.temperature > 0.0);
-        debug_assert_ne!(self.steps, 0);
-        debug_assert_ne!(self.measurement_frequency, 0);
-        debug_assert!(self.thermalization_steps <= self.steps);
+        debug_assert!(self.thermalization_steps <= self.steps.get());
+    }
+}
+
+/// Returns the built-in nonzero Metropolis step count.
+const fn default_step_count() -> NonZeroU32 {
+    match NonZeroU32::new(1000) {
+        Some(steps) => steps,
+        None => NonZeroU32::MIN,
+    }
+}
+
+/// Returns the built-in nonzero measurement cadence.
+const fn default_measurement_frequency() -> NonZeroU32 {
+    match NonZeroU32::new(10) {
+        Some(measurement_frequency) => measurement_frequency,
+        None => NonZeroU32::MIN,
     }
 }
 
@@ -547,7 +583,7 @@ impl MetropolisAlgorithm {
     ///     .resume_from_checkpoint(checkpoint)?;
     ///
     ///     assert_eq!(resumed.steps().len(), 4);
-    ///     assert_eq!(resumed.config().steps(), 4);
+    ///     assert_eq!(resumed.config().steps().get(), 4);
     ///     Ok(())
     /// }
     /// ```
@@ -599,7 +635,7 @@ impl MetropolisAlgorithm {
     ///     .resume_to_checkpoint(checkpoint)?;
     ///
     ///     assert_eq!(checkpoint.current_step(), 5);
-    ///     assert_eq!(checkpoint.config().steps(), 5);
+    ///     assert_eq!(checkpoint.config().steps().get(), 5);
     ///     Ok(())
     /// }
     /// ```
@@ -612,9 +648,11 @@ impl MetropolisAlgorithm {
         validate_resume_compatible(self, &checkpoint)?;
 
         let mut result_config = checkpoint.config.clone();
-        result_config.steps = checkpoint
+        let steps = checkpoint
             .current_step
-            .checked_add(self.config.steps)
+            .checked_add(self.config.steps.get())
+            .ok_or_else(|| checkpoint_resume_failed(CheckpointResumeFailure::StepCountOverflow))?;
+        result_config.steps = NonZeroU32::new(steps)
             .ok_or_else(|| checkpoint_resume_failed(CheckpointResumeFailure::StepCountOverflow))?;
 
         let mut state = MetropolisRunState::from_checkpoint(checkpoint)?;
@@ -653,9 +691,13 @@ impl MetropolisAlgorithm {
         }
     }
 
-    fn run_steps(&self, state: &mut MetropolisRunState, additional_steps: u32) -> CdtResult<()> {
+    fn run_steps(
+        &self,
+        state: &mut MetropolisRunState,
+        additional_steps: NonZeroU32,
+    ) -> CdtResult<()> {
         let start = Instant::now();
-        for _ in 0..additional_steps {
+        for _ in 0..additional_steps.get() {
             let step = state.current_step.checked_add(1).ok_or_else(|| {
                 checkpoint_resume_failed(CheckpointResumeFailure::StepCountOverflow)
             })?;
@@ -1242,7 +1284,7 @@ mod tests {
         let config = metropolis_config(2.0, 500, 50, 5);
         assert_relative_eq!(config.temperature(), 2.0);
         assert_relative_eq!(config.beta(), 0.5);
-        assert_eq!(config.steps(), 500);
+        assert_eq!(config.steps().get(), 500);
         assert!(config.seed().is_none());
 
         let seeded = config.with_seed(123);
@@ -1416,7 +1458,7 @@ mod tests {
         );
         assert_eq!(checkpoint.chain().total_steps(), current_step);
         assert_eq!(checkpoint.chain().accepted(), accepted_moves);
-        assert_eq!(checkpoint.config().steps(), checkpoint.current_step());
+        assert_eq!(checkpoint.config().steps().get(), checkpoint.current_step());
         assert_eq!(checkpoint.action_config(), &ActionConfig::default());
         assert!(checkpoint.current_action().is_finite());
         assert_eq!(
@@ -1458,7 +1500,7 @@ mod tests {
             .resume_from_checkpoint(alternate_checkpoint)
             .expect("resume should ignore fresh seed and use checkpoint RNG state");
 
-        assert_eq!(first_resumed.config().steps(), 7);
+        assert_eq!(first_resumed.config().steps().get(), 7);
         assert_eq!(first_resumed.steps().len(), 7);
         assert_eq!(first_resumed.steps()[1].step, 2);
         first_resumed
@@ -1532,7 +1574,7 @@ mod tests {
                 .expect("chunked checkpoint resume should complete");
         let chunked = chunked_checkpoint.into_results();
 
-        assert_eq!(chunked.config().steps(), 10);
+        assert_eq!(chunked.config().steps().get(), 10);
         assert_eq!(
             to_value(one_shot.steps()).expect("steps should serialize"),
             to_value(chunked.steps()).expect("steps should serialize")
@@ -2343,7 +2385,7 @@ mod tests {
 
         assert_eq!(
             proposal_stats.move_family_proposals(),
-            u64::from(config.steps())
+            u64::from(config.steps().get())
         );
         assert_eq!(
             proposal_stats.move_family_proposals(),

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -29,7 +29,9 @@ use super::checkpoint::{
     CdtMcmcCheckpoint, CdtMcmcCheckpointParts, chain_counters, checkpoint_resume_failed,
     validate_checkpoint_counters, validate_resume_compatible,
 };
-use super::helpers::{action_for, actions_match, measurement_for, validate_metropolis_schedule};
+use super::helpers::{
+    action_for, actions_match, measurement_for, measurement_is_due, validate_metropolis_schedule,
+};
 use super::telemetry::{MonteCarloStep, ProposalStatistics};
 
 /// Validated configuration for the Metropolis-Hastings algorithm.
@@ -622,11 +624,18 @@ impl MetropolisAlgorithm {
 
     fn initial_state(&self, mut triangulation: CdtTriangulation2D) -> MetropolisRunState {
         let current_action = action_for(&self.action_config, &triangulation);
-        let measurements = vec![measurement_for(0, current_action, &triangulation)];
-        triangulation.record_event(SimulationEvent::MeasurementTaken {
-            step: 0,
-            action: current_action,
-        });
+        let mut measurements = Vec::new();
+        if measurement_is_due(
+            0,
+            self.config.thermalization_steps(),
+            self.config.measurement_frequency(),
+        ) {
+            measurements.push(measurement_for(0, current_action, &triangulation));
+            triangulation.record_event(SimulationEvent::MeasurementTaken {
+                step: 0,
+                action: current_action,
+            });
+        }
 
         MetropolisRunState {
             triangulation,
@@ -810,7 +819,11 @@ fn run_one_step(
         delta_action,
     });
 
-    if step.is_multiple_of(algorithm.config.measurement_frequency()) {
+    if measurement_is_due(
+        step,
+        algorithm.config.thermalization_steps(),
+        algorithm.config.measurement_frequency(),
+    ) {
         state.measurements.push(measurement_for(
             step,
             state.current_action,
@@ -1075,6 +1088,8 @@ mod tests {
             ),
         });
         state.current_step = 1;
+        state.proposal_stats.record_move_family(1);
+        state.proposal_stats.record_metropolis_rejection();
         state.measurements.push(measurement_for(
             1,
             state.current_action,
@@ -1114,7 +1129,11 @@ mod tests {
             current_step: 1,
             current_action,
             move_stats,
-            proposal_stats: ProposalStatistics::new(),
+            proposal_stats: if accepted {
+                ProposalStatistics::from_validated_parts(1, 1, 0, 0, 0, 0, 0, 1, 0)
+            } else {
+                ProposalStatistics::from_validated_parts(1, 1, 0, 0, 0, 0, 1, 0, 0)
+            },
             steps: vec![MonteCarloStep {
                 step: 1,
                 move_type,
@@ -1324,6 +1343,31 @@ mod tests {
     }
 
     #[test]
+    fn run_skips_pre_thermalization_measurements() {
+        let config = seeded_metropolis_config(1.0, 4, 2, 2, 42);
+        let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+
+        let results = algorithm
+            .run(triangulation)
+            .expect("simulation should run with post-thermalization measurements");
+        let measurement_steps = results
+            .measurements()
+            .iter()
+            .map(|measurement| measurement.step)
+            .collect::<Vec<_>>();
+
+        assert_eq!(measurement_steps, vec![2, 4]);
+        assert!(
+            results
+                .measurements()
+                .iter()
+                .all(|measurement| measurement.step >= results.config().thermalization_steps())
+        );
+    }
+
+    #[test]
     fn run_with_checkpoint_returns_matching_results_and_checkpoint() {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
@@ -1513,7 +1557,7 @@ mod tests {
     }
 
     #[test]
-    fn serialized_checkpoint_missing_proposal_stats_defaults_on_restore() {
+    fn serialized_checkpoint_missing_proposal_stats_rejects_nonempty_checkpoint() {
         let checkpoint = serializable_rejected_checkpoint(ActionConfig::default());
         let mut payload = to_value(&checkpoint).expect("checkpoint should serialize");
         payload
@@ -1521,13 +1565,16 @@ mod tests {
             .expect("checkpoint payload should be an object")
             .remove("proposal_stats");
 
-        let restored: CdtMcmcCheckpoint =
-            from_str(&payload.to_string()).expect("legacy checkpoint should deserialize");
+        let Err(error) = from_str::<CdtMcmcCheckpoint>(&payload.to_string()) else {
+            panic!("nonempty checkpoint missing proposal stats should be rejected");
+        };
 
-        assert_eq!(restored.proposal_stats(), &ProposalStatistics::new());
-        MetropolisAlgorithm::new(metropolis_config(1.0, 2, 0, 1), ActionConfig::default())
-            .resume_from_checkpoint(restored)
-            .expect("legacy checkpoint with default proposal stats should resume");
+        assert!(
+            error
+                .to_string()
+                .contains("proposal move-family count mismatch"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]
@@ -1764,6 +1811,66 @@ mod tests {
                 )
             },
             "accepted step count mismatch",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_checkpoint_proposal_hard_failures() {
+        let mut checkpoint = synthetic_one_step_checkpoint(false);
+        checkpoint.proposal_stats =
+            ProposalStatistics::from_validated_parts(1, 1, 0, 0, 0, 0, 0, 0, 1);
+
+        assert_checkpoint_resume_failed(
+            validate_checkpoint_counters(&checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::ProposalHardFailures { actual: 1 }
+                )
+            },
+            "hard failures",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_checkpoint_proposal_accepted_count_mismatch() {
+        let mut checkpoint = synthetic_one_step_checkpoint(true);
+        checkpoint.proposal_stats =
+            ProposalStatistics::from_validated_parts(1, 1, 1, 0, 0, 0, 0, 0, 0);
+
+        assert_checkpoint_resume_failed(
+            validate_checkpoint_counters(&checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::ProposalAcceptedCountMismatch {
+                        actual: 0,
+                        expected: 1
+                    }
+                )
+            },
+            "accepted-transition count mismatch",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_checkpoint_proposal_rejected_count_mismatch() {
+        let mut checkpoint = synthetic_one_step_checkpoint(false);
+        checkpoint.proposal_stats =
+            ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 0);
+
+        assert_checkpoint_resume_failed(
+            validate_checkpoint_counters(&checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::ProposalRejectedCountMismatch {
+                        actual: 0,
+                        expected: 1
+                    }
+                )
+            },
+            "rejected-transition count mismatch",
         );
     }
 

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -32,95 +32,60 @@ use super::checkpoint::{
 use super::helpers::{action_for, actions_match, measurement_for, validate_metropolis_schedule};
 use super::telemetry::{MonteCarloStep, ProposalStatistics};
 
-/// Configuration for the Metropolis-Hastings algorithm.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// Validated configuration for the Metropolis-Hastings algorithm.
+///
+/// Temperature and schedule invariants are checked before storage. The sampler
+/// can therefore compute beta values, measurement cadence, and continuation step
+/// counts without revalidating raw fields at every use.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct MetropolisConfig {
     /// Temperature parameter (1/β)
-    pub temperature: f64,
+    temperature: f64,
     /// Number of Monte Carlo steps to perform
-    pub steps: u32,
+    steps: u32,
     /// Number of thermalization steps before measurements
-    pub thermalization_steps: u32,
+    thermalization_steps: u32,
     /// Frequency of measurements (take measurement every N steps)
-    pub measurement_frequency: u32,
+    measurement_frequency: u32,
     /// Optional RNG seed for reproducible simulations (default: None = random)
-    pub seed: Option<u64>,
+    seed: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct MetropolisConfigWire {
+    temperature: f64,
+    steps: u32,
+    thermalization_steps: u32,
+    measurement_frequency: u32,
+    seed: Option<u64>,
+}
+
+impl<'de> Deserialize<'de> for MetropolisConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = MetropolisConfigWire::deserialize(deserializer)?;
+        Self::new_with_seed(
+            wire.temperature,
+            wire.steps,
+            wire.thermalization_steps,
+            wire.measurement_frequency,
+            wire.seed,
+        )
+        .map_err(serde::de::Error::custom)
+    }
 }
 
 impl Default for MetropolisConfig {
     /// Default Metropolis configuration for 2D CDT.
     fn default() -> Self {
-        Self {
-            temperature: 1.0,
-            steps: 1000,
-            thermalization_steps: 100,
-            measurement_frequency: 10,
-            seed: None,
-        }
+        Self::from_validated_parts(1.0, 1000, 100, 10, None)
     }
 }
 
 impl MetropolisConfig {
-    /// Creates a new Metropolis configuration.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::MetropolisConfig;
-    ///
-    /// let config = MetropolisConfig::new(2.0, 500, 50, 5);
-    /// assert_eq!(config.steps, 500);
-    /// assert!(config.seed.is_none());
-    /// ```
-    #[must_use]
-    pub const fn new(
-        temperature: f64,
-        steps: u32,
-        thermalization_steps: u32,
-        measurement_frequency: u32,
-    ) -> Self {
-        Self {
-            temperature,
-            steps,
-            thermalization_steps,
-            measurement_frequency,
-            seed: None,
-        }
-    }
-
-    /// Sets the RNG seed for reproducible simulations.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::MetropolisConfig;
-    ///
-    /// let config = MetropolisConfig::new(1.0, 100, 10, 5).with_seed(42);
-    /// assert_eq!(config.seed, Some(42));
-    /// ```
-    #[must_use]
-    pub const fn with_seed(mut self, seed: u64) -> Self {
-        self.seed = Some(seed);
-        self
-    }
-
-    /// Returns the inverse temperature (β = 1/T).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use approx::assert_relative_eq;
-    /// use causal_triangulations::MetropolisConfig;
-    ///
-    /// let config = MetropolisConfig::new(2.0, 100, 10, 5);
-    /// assert_relative_eq!(config.beta(), 0.5);
-    /// ```
-    #[must_use]
-    pub fn beta(&self) -> f64 {
-        1.0 / self.temperature
-    }
-
-    /// Validates simulation-specific configuration values.
+    /// Creates a new validated Metropolis configuration.
     ///
     /// # Errors
     ///
@@ -134,16 +99,220 @@ impl MetropolisConfig {
     /// ```
     /// use causal_triangulations::MetropolisConfig;
     ///
-    /// let config = MetropolisConfig::new(1.0, 100, 10, 5);
-    /// assert!(config.validate().is_ok());
+    /// let config = MetropolisConfig::new(2.0, 500, 50, 5)?;
+    /// assert_eq!(config.steps(), 500);
+    /// assert!(config.seed().is_none());
+    /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
-    pub fn validate(&self) -> CdtResult<()> {
-        validate_metropolis_schedule(
-            self.temperature,
-            self.steps,
-            self.thermalization_steps,
-            self.measurement_frequency,
+    pub fn new(
+        temperature: f64,
+        steps: u32,
+        thermalization_steps: u32,
+        measurement_frequency: u32,
+    ) -> CdtResult<Self> {
+        Self::new_with_seed(
+            temperature,
+            steps,
+            thermalization_steps,
+            measurement_frequency,
+            None,
         )
+    }
+
+    /// Creates a new validated Metropolis configuration with an explicit RNG seed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidSimulationConfiguration`] for the same invalid
+    /// temperature or schedule values as [`Self::new`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::MetropolisConfig;
+    ///
+    /// let config = MetropolisConfig::new_with_seed(1.0, 100, 10, 5, Some(42))?;
+    /// assert_eq!(config.seed(), Some(42));
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    pub fn new_with_seed(
+        temperature: f64,
+        steps: u32,
+        thermalization_steps: u32,
+        measurement_frequency: u32,
+        seed: Option<u64>,
+    ) -> CdtResult<Self> {
+        validate_metropolis_schedule(
+            temperature,
+            steps,
+            thermalization_steps,
+            measurement_frequency,
+        )?;
+        Ok(Self::from_validated_parts(
+            temperature,
+            steps,
+            thermalization_steps,
+            measurement_frequency,
+            seed,
+        ))
+    }
+
+    /// Builds a Metropolis configuration after raw schedule validation.
+    ///
+    /// This helper is used when a higher-level validated config already proved
+    /// the temperature and schedule invariants, allowing conversion without a
+    /// second fallible branch.
+    pub(crate) const fn from_validated_parts(
+        temperature: f64,
+        steps: u32,
+        thermalization_steps: u32,
+        measurement_frequency: u32,
+        seed: Option<u64>,
+    ) -> Self {
+        Self {
+            temperature,
+            steps,
+            thermalization_steps,
+            measurement_frequency,
+            seed,
+        }
+    }
+
+    /// Sets the RNG seed for reproducible simulations.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::MetropolisConfig;
+    ///
+    /// let config = MetropolisConfig::new(1.0, 100, 10, 5)?.with_seed(42);
+    /// assert_eq!(config.seed(), Some(42));
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
+    /// Returns the temperature parameter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use causal_triangulations::MetropolisConfig;
+    ///
+    /// let config = MetropolisConfig::new(2.0, 100, 10, 5)?;
+    /// assert_relative_eq!(config.temperature(), 2.0);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn temperature(&self) -> f64 {
+        self.temperature
+    }
+
+    /// Returns the configured number of Monte Carlo steps.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::MetropolisConfig;
+    ///
+    /// let config = MetropolisConfig::new(2.0, 100, 10, 5)?;
+    /// assert_eq!(config.steps(), 100);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn steps(&self) -> u32 {
+        self.steps
+    }
+
+    /// Returns the number of thermalization steps.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::MetropolisConfig;
+    ///
+    /// let config = MetropolisConfig::new(2.0, 100, 10, 5)?;
+    /// assert_eq!(config.thermalization_steps(), 10);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn thermalization_steps(&self) -> u32 {
+        self.thermalization_steps
+    }
+
+    /// Returns the measurement cadence.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::MetropolisConfig;
+    ///
+    /// let config = MetropolisConfig::new(2.0, 100, 10, 5)?;
+    /// assert_eq!(config.measurement_frequency(), 5);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn measurement_frequency(&self) -> u32 {
+        self.measurement_frequency
+    }
+
+    /// Returns the optional reproducibility seed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::MetropolisConfig;
+    ///
+    /// let config = MetropolisConfig::new(2.0, 100, 10, 5)?.with_seed(13);
+    /// assert_eq!(config.seed(), Some(13));
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub const fn seed(&self) -> Option<u64> {
+        self.seed
+    }
+
+    /// Returns the inverse temperature (β = 1/T).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use causal_triangulations::MetropolisConfig;
+    ///
+    /// let config = MetropolisConfig::new(2.0, 100, 10, 5)?;
+    /// assert_relative_eq!(config.beta(), 0.5);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    #[must_use]
+    pub fn beta(&self) -> f64 {
+        1.0 / self.temperature
+    }
+
+    /// Confirms that stored simulation-specific configuration values are valid.
+    ///
+    /// This method is kept for code that wants a common validation hook across
+    /// configuration-like types. Because [`MetropolisConfig`] validates before
+    /// storage, it is an infallible debug assertion of the stored invariant.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::MetropolisConfig;
+    ///
+    /// let config = MetropolisConfig::new(1.0, 100, 10, 5)?;
+    /// config.validate();
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    pub fn validate(&self) {
+        debug_assert!(self.temperature.is_finite() && self.temperature > 0.0);
+        debug_assert_ne!(self.steps, 0);
+        debug_assert_ne!(self.measurement_frequency, 0);
+        debug_assert!(self.thermalization_steps <= self.steps);
     }
 }
 
@@ -180,8 +349,9 @@ impl MetropolisAlgorithm {
     ///     ActionConfig, MetropolisAlgorithm, MetropolisConfig,
     /// };
     ///
-    /// let config = MetropolisConfig::new(1.0, 10, 2, 1);
+    /// let config = MetropolisConfig::new(1.0, 10, 2, 1)?;
     /// let _algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
+    /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     #[must_use]
     pub const fn new(config: MetropolisConfig, action_config: ActionConfig) -> Self {
@@ -227,7 +397,7 @@ impl MetropolisAlgorithm {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::from_seeded_points(5, 2, 2, 53)?;
-    ///     let config = MetropolisConfig::new(1.0, 2, 1, 1).with_seed(7);
+    ///     let config = MetropolisConfig::new(1.0, 2, 1, 1)?.with_seed(7);
     ///     let results = MetropolisAlgorithm::new(config, ActionConfig::default()).run(tri)?;
     ///     assert_eq!(results.steps().len(), 2);
     ///     Ok(())
@@ -265,7 +435,7 @@ impl MetropolisAlgorithm {
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
     ///     let algorithm = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 2, 0, 1).with_seed(13),
+    ///         MetropolisConfig::new(1.0, 2, 0, 1)?.with_seed(13),
     ///         ActionConfig::default(),
     ///     );
     ///     let (results, checkpoint) = algorithm.run_with_checkpoint(tri)?;
@@ -315,7 +485,7 @@ impl MetropolisAlgorithm {
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
     ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 2, 0, 1).with_seed(13),
+    ///         MetropolisConfig::new(1.0, 2, 0, 1)?.with_seed(13),
     ///         ActionConfig::default(),
     ///     )
     ///     .run_to_checkpoint(tri)?;
@@ -328,8 +498,8 @@ impl MetropolisAlgorithm {
         &self,
         triangulation: CdtTriangulation2D,
     ) -> CdtResult<CdtMcmcCheckpoint> {
-        self.config.validate()?;
-        self.action_config.validate()?;
+        self.config.validate();
+        self.action_config.validate();
 
         let mut state = self.initial_state(triangulation);
         self.run_steps(&mut state, self.config.steps)?;
@@ -363,19 +533,19 @@ impl MetropolisAlgorithm {
     ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
     ///     let action = ActionConfig::default();
     ///     let prefix = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 2, 0, 1).with_seed(13),
+    ///         MetropolisConfig::new(1.0, 2, 0, 1)?.with_seed(13),
     ///         action.clone(),
     ///     );
     ///     let checkpoint = prefix.run_to_checkpoint(tri)?;
     ///
     ///     let resumed = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
+    ///         MetropolisConfig::new(1.0, 2, 0, 1)?.with_seed(999),
     ///         action,
     ///     )
     ///     .resume_from_checkpoint(checkpoint)?;
     ///
     ///     assert_eq!(resumed.steps().len(), 4);
-    ///     assert_eq!(resumed.config().steps, 4);
+    ///     assert_eq!(resumed.config().steps(), 4);
     ///     Ok(())
     /// }
     /// ```
@@ -415,19 +585,19 @@ impl MetropolisAlgorithm {
     /// fn main() -> CdtResult<()> {
     ///     let action = ActionConfig::default();
     ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 2, 0, 1).with_seed(13),
+    ///         MetropolisConfig::new(1.0, 2, 0, 1)?.with_seed(13),
     ///         action.clone(),
     ///     )
     ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
     ///
     ///     let checkpoint = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 3, 0, 1).with_seed(999),
+    ///         MetropolisConfig::new(1.0, 3, 0, 1)?.with_seed(999),
     ///         action,
     ///     )
     ///     .resume_to_checkpoint(checkpoint)?;
     ///
     ///     assert_eq!(checkpoint.current_step(), 5);
-    ///     assert_eq!(checkpoint.config().steps, 5);
+    ///     assert_eq!(checkpoint.config().steps(), 5);
     ///     Ok(())
     /// }
     /// ```
@@ -435,8 +605,8 @@ impl MetropolisAlgorithm {
         &self,
         checkpoint: CdtMcmcCheckpoint,
     ) -> CdtResult<CdtMcmcCheckpoint> {
-        self.config.validate()?;
-        self.action_config.validate()?;
+        self.config.validate();
+        self.action_config.validate();
         validate_resume_compatible(self, &checkpoint)?;
 
         let mut result_config = checkpoint.config.clone();
@@ -498,7 +668,7 @@ impl MetropolisRunState {
         validate_checkpoint_counters(&checkpoint)?;
         let target = CdtTarget::new(
             checkpoint.action_config.clone(),
-            checkpoint.config.temperature,
+            checkpoint.config.temperature(),
         )?;
         let triangulation = restore_checkpoint_state(checkpoint.chain, &target)?;
         triangulation.validate_evolved_cdt()?;
@@ -538,7 +708,7 @@ impl MetropolisRunState {
     ) -> CdtResult<CdtMcmcCheckpoint> {
         self.triangulation.validate_evolved_cdt()?;
         let (accepted, rejected) = chain_counters(&self.move_stats)?;
-        Ok(CdtMcmcCheckpoint::from_parts(CdtMcmcCheckpointParts {
+        CdtMcmcCheckpoint::from_parts(CdtMcmcCheckpointParts {
             triangulation: self.triangulation,
             accepted,
             rejected,
@@ -553,7 +723,7 @@ impl MetropolisRunState {
             elapsed_time: self.elapsed_time,
             acceptance_rng: self.acceptance_rng,
             ergodics: self.ergodics,
-        }))
+        })
     }
 }
 
@@ -607,7 +777,7 @@ fn run_one_step(
     if let Some(plan) = plan {
         delta_action = plan.delta_action;
         let log_alpha = -(plan.action_after.expect("planned moves have actions") - action_before)
-            / algorithm.config.temperature
+            / algorithm.config.temperature()
             + concrete_log_q_ratio(&state.triangulation, &plan);
 
         if metropolis_accept_log_alpha(log_alpha, &mut state.acceptance_rng) {
@@ -640,7 +810,7 @@ fn run_one_step(
         delta_action,
     });
 
-    if step.is_multiple_of(algorithm.config.measurement_frequency) {
+    if step.is_multiple_of(algorithm.config.measurement_frequency()) {
         state.measurements.push(measurement_for(
             step,
             state.current_action,
@@ -717,6 +887,7 @@ mod tests {
     use super::super::helpers::{SimplexCounts, proposed_delta_action, simplex_counts};
     use super::super::telemetry::CdtProposalSiteRejection;
     use super::*;
+    use crate::cdt::action::CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT;
     use crate::cdt::ergodic_moves::proposal_site_count;
     use crate::cdt::triangulation::CdtTriangulation;
     use crate::errors::{BackendMutationOperation, CheckpointMoveCounter, ConfigurationSetting};
@@ -804,17 +975,20 @@ mod tests {
         assert_eq!(left.face_count(), right.face_count());
         assert_eq!(left.slice_sizes(), right.slice_sizes());
         assert_eq!(left.volume_profile(), right.volume_profile());
-        assert_eq!(left.metadata().time_slices, right.metadata().time_slices);
-        assert_eq!(left.metadata().dimension, right.metadata().dimension);
-        assert_eq!(left.metadata().topology, right.metadata().topology);
         assert_eq!(
-            left.metadata().modification_count,
-            right.metadata().modification_count
+            left.metadata().time_slices(),
+            right.metadata().time_slices()
+        );
+        assert_eq!(left.metadata().dimension(), right.metadata().dimension());
+        assert_eq!(left.metadata().topology(), right.metadata().topology());
+        assert_eq!(
+            left.metadata().modification_count(),
+            right.metadata().modification_count()
         );
         assert_eq!(
-            to_value(&left.metadata().simulation_history)
+            to_value(left.metadata().simulation_history())
                 .expect("left simulation history should serialize"),
-            to_value(&right.metadata().simulation_history)
+            to_value(right.metadata().simulation_history())
                 .expect("right simulation history should serialize")
         );
         assert_eq!(
@@ -827,11 +1001,48 @@ mod tests {
         );
     }
 
+    fn metropolis_config(
+        temperature: f64,
+        steps: u32,
+        thermalization_steps: u32,
+        measurement_frequency: u32,
+    ) -> MetropolisConfig {
+        MetropolisConfig::new(
+            temperature,
+            steps,
+            thermalization_steps,
+            measurement_frequency,
+        )
+        .expect("test Metropolis config should be valid")
+    }
+
+    fn seeded_metropolis_config(
+        temperature: f64,
+        steps: u32,
+        thermalization_steps: u32,
+        measurement_frequency: u32,
+        seed: u64,
+    ) -> MetropolisConfig {
+        MetropolisConfig::new_with_seed(
+            temperature,
+            steps,
+            thermalization_steps,
+            measurement_frequency,
+            Some(seed),
+        )
+        .expect("test Metropolis config should be valid")
+    }
+
+    fn action_config(coupling_0: f64, coupling_2: f64, cosmological_constant: f64) -> ActionConfig {
+        ActionConfig::new(coupling_0, coupling_2, cosmological_constant)
+            .expect("test action config should be valid")
+    }
+
     fn short_checkpoint() -> CdtMcmcCheckpoint {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 2, 0, 1).with_seed(13),
+            seeded_metropolis_config(1.0, 2, 0, 1, 13),
             ActionConfig::default(),
         )
         .run_to_checkpoint(triangulation)
@@ -841,7 +1052,7 @@ mod tests {
     fn serializable_rejected_checkpoint(action_config: ActionConfig) -> CdtMcmcCheckpoint {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
-        let config = MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13);
+        let config = seeded_metropolis_config(1.0, 1, 0, 1, 13);
         let algorithm = MetropolisAlgorithm::new(config.clone(), action_config.clone());
         let mut state = algorithm.initial_state(triangulation);
         let move_type = state.ergodics.select_random_move();
@@ -884,7 +1095,7 @@ mod tests {
     fn synthetic_one_step_checkpoint(accepted: bool) -> CdtMcmcCheckpoint {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
-        let config = MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13);
+        let config = seeded_metropolis_config(1.0, 1, 0, 1, 13);
         let action_config = ActionConfig::default();
         let current_action = action_for(&action_config, &triangulation);
         let move_type = MoveType::Move22;
@@ -920,6 +1131,7 @@ mod tests {
             acceptance_rng: simulation_rng(Some(1)),
             ergodics: ErgodicsSystem::with_seed(2),
         })
+        .expect("synthetic checkpoint should validate")
     }
 
     fn empty_run_state(triangulation: CdtTriangulation2D) -> MetropolisRunState {
@@ -1008,14 +1220,14 @@ mod tests {
 
     #[test]
     fn test_metropolis_config() {
-        let config = MetropolisConfig::new(2.0, 500, 50, 5);
-        assert_relative_eq!(config.temperature, 2.0);
+        let config = metropolis_config(2.0, 500, 50, 5);
+        assert_relative_eq!(config.temperature(), 2.0);
         assert_relative_eq!(config.beta(), 0.5);
-        assert_eq!(config.steps, 500);
-        assert!(config.seed.is_none());
+        assert_eq!(config.steps(), 500);
+        assert!(config.seed().is_none());
 
         let seeded = config.with_seed(123);
-        assert_eq!(seeded.seed, Some(123));
+        assert_eq!(seeded.seed(), Some(123));
     }
 
     #[test]
@@ -1088,7 +1300,7 @@ mod tests {
 
     #[test]
     fn seeded_simulation_runs_moves() {
-        let config = MetropolisConfig::new(1.0, 10, 2, 2).with_seed(42);
+        let config = seeded_metropolis_config(1.0, 10, 2, 2, 42);
         let action_config = ActionConfig::default();
         let algorithm = MetropolisAlgorithm::new(config, action_config);
 
@@ -1116,7 +1328,7 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 3, 0, 1).with_seed(13),
+            seeded_metropolis_config(1.0, 3, 0, 1, 13),
             ActionConfig::default(),
         );
 
@@ -1160,7 +1372,7 @@ mod tests {
         );
         assert_eq!(checkpoint.chain().total_steps(), current_step);
         assert_eq!(checkpoint.chain().accepted(), accepted_moves);
-        assert_eq!(checkpoint.config().steps, checkpoint.current_step());
+        assert_eq!(checkpoint.config().steps(), checkpoint.current_step());
         assert_eq!(checkpoint.action_config(), &ActionConfig::default());
         assert!(checkpoint.current_action().is_finite());
         assert_eq!(
@@ -1168,7 +1380,7 @@ mod tests {
             u64::from(checkpoint.current_step())
         );
         assert_eq!(
-            checkpoint.proposal_stats().move_family_proposals,
+            checkpoint.proposal_stats().move_family_proposals(),
             u64::from(checkpoint.current_step())
         );
         assert_eq!(last_step.step, checkpoint.current_step());
@@ -1190,21 +1402,19 @@ mod tests {
         let alternate_checkpoint: CdtMcmcCheckpoint =
             from_str(&checkpoint_json).expect("checkpoint should deserialize again");
         let first_resume_algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 6, 0, 1).with_seed(999),
+            seeded_metropolis_config(1.0, 6, 0, 1, 999),
             action_config.clone(),
         );
         let first_resumed = first_resume_algorithm
             .resume_from_checkpoint(checkpoint)
             .expect("resume should complete");
-        let second_resume_algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 6, 0, 1).with_seed(123),
-            action_config,
-        );
+        let second_resume_algorithm =
+            MetropolisAlgorithm::new(seeded_metropolis_config(1.0, 6, 0, 1, 123), action_config);
         let second_resumed = second_resume_algorithm
             .resume_from_checkpoint(alternate_checkpoint)
             .expect("resume should ignore fresh seed and use checkpoint RNG state");
 
-        assert_eq!(first_resumed.config().steps, 7);
+        assert_eq!(first_resumed.config().steps(), 7);
         assert_eq!(first_resumed.steps().len(), 7);
         assert_eq!(first_resumed.steps()[1].step, 2);
         first_resumed
@@ -1257,14 +1467,14 @@ mod tests {
     fn chunked_checkpoint_resume_matches_one_shot_seeded_run() {
         let action_config = ActionConfig::default();
         let one_shot = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 10, 0, 1).with_seed(19),
+            seeded_metropolis_config(1.0, 10, 0, 1, 19),
             action_config.clone(),
         )
         .run(CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build"))
         .expect("one-shot run should complete");
 
         let prefix = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 4, 0, 1).with_seed(19),
+            seeded_metropolis_config(1.0, 4, 0, 1, 19),
             action_config.clone(),
         )
         .run_to_checkpoint(
@@ -1272,15 +1482,13 @@ mod tests {
         )
         .expect("prefix run should checkpoint");
 
-        let chunked_checkpoint = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 6, 0, 1).with_seed(999),
-            action_config,
-        )
-        .resume_to_checkpoint(prefix)
-        .expect("chunked checkpoint resume should complete");
+        let chunked_checkpoint =
+            MetropolisAlgorithm::new(seeded_metropolis_config(1.0, 6, 0, 1, 999), action_config)
+                .resume_to_checkpoint(prefix)
+                .expect("chunked checkpoint resume should complete");
         let chunked = chunked_checkpoint.into_results();
 
-        assert_eq!(chunked.config().steps, 10);
+        assert_eq!(chunked.config().steps(), 10);
         assert_eq!(
             to_value(one_shot.steps()).expect("steps should serialize"),
             to_value(chunked.steps()).expect("steps should serialize")
@@ -1317,17 +1525,40 @@ mod tests {
             from_str(&payload.to_string()).expect("legacy checkpoint should deserialize");
 
         assert_eq!(restored.proposal_stats(), &ProposalStatistics::new());
-        MetropolisAlgorithm::new(MetropolisConfig::new(1.0, 2, 0, 1), ActionConfig::default())
+        MetropolisAlgorithm::new(metropolis_config(1.0, 2, 0, 1), ActionConfig::default())
             .resume_from_checkpoint(restored)
             .expect("legacy checkpoint with default proposal stats should resume");
+    }
+
+    #[test]
+    fn serialized_checkpoint_rejects_counter_mismatch_on_restore() {
+        let checkpoint = serializable_rejected_checkpoint(ActionConfig::default());
+        let mut payload = to_value(&checkpoint).expect("checkpoint should serialize");
+        payload
+            .as_object_mut()
+            .expect("checkpoint payload should be an object")
+            .insert(
+                "current_step".to_string(),
+                to_value(2_u32).expect("step should serialize"),
+            );
+
+        let Err(error) = from_str::<CdtMcmcCheckpoint>(&payload.to_string()) else {
+            panic!("checkpoint counter mismatch should be rejected during deserialization");
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("chain step count does not match checkpoint step"),
+            "unexpected serde error: {error}"
+        );
     }
 
     #[test]
     fn resume_rejects_incompatible_action_config() {
         let checkpoint = short_checkpoint();
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
-            ActionConfig::new(2.0, 1.0, 0.1),
+            seeded_metropolis_config(1.0, 2, 0, 1, 999),
+            action_config(2.0, 1.0, 0.1),
         );
 
         assert_checkpoint_resume_failed(
@@ -1346,8 +1577,8 @@ mod tests {
     fn resume_to_checkpoint_rejects_incompatible_action_config() {
         let checkpoint = short_checkpoint();
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
-            ActionConfig::new(2.0, 1.0, 0.1),
+            seeded_metropolis_config(1.0, 2, 0, 1, 999),
+            action_config(2.0, 1.0, 0.1),
         );
 
         assert_checkpoint_resume_failed(
@@ -1366,7 +1597,7 @@ mod tests {
     fn resume_rejects_incompatible_sampling_schedule() {
         let checkpoint = short_checkpoint();
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 2, 0, 2).with_seed(999),
+            seeded_metropolis_config(1.0, 2, 0, 2, 999),
             ActionConfig::default(),
         );
 
@@ -1386,7 +1617,7 @@ mod tests {
     fn resume_rejects_incompatible_temperature() {
         let checkpoint = short_checkpoint();
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(2.0, 2, 0, 1).with_seed(999),
+            seeded_metropolis_config(2.0, 2, 0, 1, 999),
             ActionConfig::default(),
         );
 
@@ -1401,7 +1632,7 @@ mod tests {
     fn resume_rejects_incompatible_thermalization_schedule() {
         let checkpoint = short_checkpoint();
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 2, 1, 1).with_seed(999),
+            seeded_metropolis_config(1.0, 2, 1, 1, 999),
             ActionConfig::default(),
         );
 
@@ -1424,7 +1655,7 @@ mod tests {
         let chain_steps = checkpoint.chain.total_steps();
         let checkpoint_step = checkpoint.current_step;
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
+            seeded_metropolis_config(1.0, 2, 0, 1, 999),
             ActionConfig::default(),
         );
 
@@ -1449,7 +1680,7 @@ mod tests {
         let mut checkpoint = short_checkpoint();
         checkpoint.move_stats.record_attempt(MoveType::Move22);
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
+            seeded_metropolis_config(1.0, 2, 0, 1, 999),
             ActionConfig::default(),
         );
 
@@ -1470,7 +1701,7 @@ mod tests {
         let mut checkpoint = short_checkpoint();
         checkpoint.steps.pop();
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
+            seeded_metropolis_config(1.0, 2, 0, 1, 999),
             ActionConfig::default(),
         );
 
@@ -1491,7 +1722,7 @@ mod tests {
         let mut checkpoint = short_checkpoint();
         checkpoint.steps[0].step = 2;
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
+            seeded_metropolis_config(1.0, 2, 0, 1, 999),
             ActionConfig::default(),
         );
 
@@ -1520,7 +1751,7 @@ mod tests {
             step.action_after = Some(step.action_before);
         }
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
+            seeded_metropolis_config(1.0, 2, 0, 1, 999),
             ActionConfig::default(),
         );
 
@@ -1660,7 +1891,7 @@ mod tests {
         let mut checkpoint = short_checkpoint();
         checkpoint.measurements.pop();
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
+            seeded_metropolis_config(1.0, 2, 0, 1, 999),
             ActionConfig::default(),
         );
 
@@ -1718,7 +1949,7 @@ mod tests {
         let mut checkpoint = short_checkpoint();
         checkpoint.current_action += 1.0;
         let algorithm = MetropolisAlgorithm::new(
-            MetropolisConfig::new(1.0, 2, 0, 1).with_seed(999),
+            seeded_metropolis_config(1.0, 2, 0, 1, 999),
             ActionConfig::default(),
         );
 
@@ -1730,29 +1961,21 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_restore_preserves_invalid_checkpoint_config_variant() {
-        let mut checkpoint = short_checkpoint();
-        checkpoint.config.temperature = f64::NAN;
-        let Err(CdtError::InvalidSimulationConfiguration {
-            setting,
-            provided_value,
-            expected,
-        }) = MetropolisRunState::from_checkpoint(checkpoint)
-        else {
-            panic!("expected checkpoint configuration failure");
+    fn checkpoint_config_deserialization_rejects_invalid_metropolis_config() {
+        let payload = r#"{"temperature":0.0,"steps":2,"thermalization_steps":0,"measurement_frequency":1,"seed":13}"#;
+        let Err(error) = from_str::<MetropolisConfig>(payload) else {
+            panic!("expected Metropolis configuration failure");
         };
-
-        assert_eq!(setting, ConfigurationSetting::Temperature);
-        assert_eq!(provided_value, "NaN");
-        assert_eq!(expected, "finite and positive");
+        let message = error.to_string();
+        assert!(
+            message.contains("temperature") && message.contains("finite and positive"),
+            "unexpected serde error: {message}"
+        );
     }
 
     #[test]
     fn chain_counters_rejects_accepted_above_attempted() {
-        let stats = MoveStatistics {
-            moves_22_accepted: 1,
-            ..MoveStatistics::new()
-        };
+        let stats = MoveStatistics::from_validated_parts(0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         let Err(CdtError::CheckpointResumeFailed { failure }) = chain_counters(&stats) else {
             panic!("expected impossible move statistics to fail");
         };
@@ -1769,11 +1992,7 @@ mod tests {
 
     #[test]
     fn chain_counters_rejects_counter_sum_overflow() {
-        let stats = MoveStatistics {
-            moves_22_attempted: u64::MAX,
-            moves_13_attempted: 1,
-            ..MoveStatistics::new()
-        };
+        let stats = MoveStatistics::from_validated_parts(u64::MAX, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0);
         let Err(CdtError::CheckpointResumeFailed { failure }) = chain_counters(&stats) else {
             panic!("expected overflowing move statistics to fail");
         };
@@ -1790,12 +2009,7 @@ mod tests {
 
     #[test]
     fn chain_counters_rejects_nonzero_hard_failures() {
-        let stats = MoveStatistics {
-            moves_22_attempted: 3,
-            moves_22_accepted: 1,
-            moves_22_hard_failed: 1,
-            ..MoveStatistics::new()
-        };
+        let stats = MoveStatistics::from_validated_parts(3, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         let Err(CdtError::CheckpointResumeFailed { failure }) = chain_counters(&stats) else {
             panic!("expected impossible hard-failure statistics to fail");
         };
@@ -1846,7 +2060,7 @@ mod tests {
     #[test]
     fn seeded_simulation_deterministic() {
         let run = |seed: u64| {
-            let config = MetropolisConfig::new(1.0, 20, 5, 5).with_seed(seed);
+            let config = seeded_metropolis_config(1.0, 20, 5, 5, seed);
             let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
             let tri = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
             algorithm.run(tri).expect("seeded simulation should run")
@@ -1886,13 +2100,13 @@ mod tests {
         assert_relative_eq!(
             proposed_delta_action(&action_config, before, MoveType::Move13Add)
                 .expect("1,3 delta should be finite"),
-            2.0 * crate::cdt::action::CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT,
+            2.0 * CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT,
             epsilon = 1e-12
         );
         assert_relative_eq!(
             proposed_delta_action(&action_config, before, MoveType::Move31Remove)
                 .expect("3,1 delta should be finite"),
-            -2.0 * crate::cdt::action::CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT,
+            -2.0 * CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT,
             epsilon = 1e-12
         );
     }
@@ -1955,25 +2169,25 @@ mod tests {
         .expect("site rejection is an ordinary proposal outcome");
 
         assert!(result.is_none());
-        assert_eq!(proposal_stats.move_family_proposals, 1);
-        assert_eq!(proposal_stats.no_site_proposals, 1);
+        assert_eq!(proposal_stats.move_family_proposals(), 1);
+        assert_eq!(proposal_stats.no_site_proposals(), 1);
         assert_eq!(simplex_counts(&triangulation), counts_before);
         assert_relative_eq!(action_for(&action_config, &triangulation), action_before);
     }
 
     #[test]
     fn proposal_statistics_saturate_extreme_counters() {
-        let mut stats = ProposalStatistics {
-            move_family_proposals: u64::MAX,
-            observed_forward_sites: u64::MAX - 1,
-            no_site_proposals: u64::MAX,
-            site_causality_rejections: u64::MAX,
-            site_geometric_rejections: u64::MAX,
-            site_backend_rejections: u64::MAX,
-            metropolis_rejections: u64::MAX,
-            accepted_transitions: u64::MAX,
-            hard_failures: u64::MAX,
-        };
+        let mut stats = ProposalStatistics::from_validated_parts(
+            u64::MAX,
+            u64::MAX - 1,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+        );
 
         stats.record_move_family(2);
         stats.record_no_site();
@@ -1990,20 +2204,20 @@ mod tests {
         stats.record_accepted_transition();
         stats.record_hard_failure();
 
-        assert_eq!(stats.move_family_proposals, u64::MAX);
-        assert_eq!(stats.observed_forward_sites, u64::MAX);
-        assert_eq!(stats.no_site_proposals, u64::MAX);
-        assert_eq!(stats.site_causality_rejections, u64::MAX);
-        assert_eq!(stats.site_geometric_rejections, u64::MAX);
-        assert_eq!(stats.site_backend_rejections, u64::MAX);
-        assert_eq!(stats.metropolis_rejections, u64::MAX);
-        assert_eq!(stats.accepted_transitions, u64::MAX);
-        assert_eq!(stats.hard_failures, u64::MAX);
+        assert_eq!(stats.move_family_proposals(), u64::MAX);
+        assert_eq!(stats.observed_forward_sites(), u64::MAX);
+        assert_eq!(stats.no_site_proposals(), u64::MAX);
+        assert_eq!(stats.site_causality_rejections(), u64::MAX);
+        assert_eq!(stats.site_geometric_rejections(), u64::MAX);
+        assert_eq!(stats.site_backend_rejections(), u64::MAX);
+        assert_eq!(stats.metropolis_rejections(), u64::MAX);
+        assert_eq!(stats.accepted_transitions(), u64::MAX);
+        assert_eq!(stats.hard_failures(), u64::MAX);
     }
 
     #[test]
     fn run_records_proposal_statistics_for_each_selected_move_family() {
-        let config = MetropolisConfig::new(1.0, 12, 0, 1).with_seed(2);
+        let config = seeded_metropolis_config(1.0, 12, 0, 1, 2);
         let algorithm = MetropolisAlgorithm::new(config.clone(), ActionConfig::default());
         let triangulation =
             CdtTriangulation::from_seeded_points(3, 1, 2, 53).expect("Failed to create");
@@ -2012,36 +2226,32 @@ mod tests {
             .run(triangulation)
             .expect("short run should finish");
         let proposal_stats = results.proposal_stats();
-        let classified_proposals = proposal_stats.no_site_proposals
-            + proposal_stats.site_causality_rejections
-            + proposal_stats.site_geometric_rejections
-            + proposal_stats.site_backend_rejections
-            + proposal_stats.metropolis_rejections
-            + proposal_stats.accepted_transitions
-            + proposal_stats.hard_failures;
+        let classified_proposals = proposal_stats.no_site_proposals()
+            + proposal_stats.site_causality_rejections()
+            + proposal_stats.site_geometric_rejections()
+            + proposal_stats.site_backend_rejections()
+            + proposal_stats.metropolis_rejections()
+            + proposal_stats.accepted_transitions()
+            + proposal_stats.hard_failures();
 
         assert_eq!(
-            proposal_stats.move_family_proposals,
-            u64::from(config.steps)
+            proposal_stats.move_family_proposals(),
+            u64::from(config.steps())
         );
         assert_eq!(
-            proposal_stats.move_family_proposals,
+            proposal_stats.move_family_proposals(),
             results.move_stats().total_attempted()
         );
         assert_eq!(
-            proposal_stats.accepted_transitions,
+            proposal_stats.accepted_transitions(),
             results.move_stats().total_accepted()
         );
-        assert_eq!(classified_proposals, proposal_stats.move_family_proposals);
+        assert_eq!(classified_proposals, proposal_stats.move_family_proposals());
     }
 
     #[test]
     fn run_rejects_zero_frequency() {
-        let config = MetropolisConfig::new(1.0, 10, 2, 0);
-        let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
-        let tri = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
-
-        let err = algorithm.run(tri).unwrap_err();
+        let err = MetropolisConfig::new(1.0, 10, 2, 0).expect_err("zero cadence is invalid");
         match err {
             CdtError::InvalidSimulationConfiguration {
                 setting,
@@ -2059,11 +2269,8 @@ mod tests {
     #[test]
     fn run_rejects_bad_temperature() {
         for bad_temp in [0.0, -1.0, f64::NAN, f64::INFINITY] {
-            let config = MetropolisConfig::new(bad_temp, 10, 2, 2);
-            let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
-            let tri = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
-
-            let err = algorithm.run(tri).unwrap_err();
+            let err =
+                MetropolisConfig::new(bad_temp, 10, 2, 2).expect_err("bad temperature is invalid");
             match err {
                 CdtError::InvalidSimulationConfiguration {
                     setting, expected, ..
@@ -2080,11 +2287,9 @@ mod tests {
 
     #[test]
     fn validate_requires_measurement() {
-        let err = MetropolisConfig::new(1.0, 19, 15, 10)
-            .validate()
-            .expect_err(
-                "Configuration should require at least one post-thermalization measurement",
-            );
+        let err = MetropolisConfig::new(1.0, 19, 15, 10).expect_err(
+            "Configuration should require at least one post-thermalization measurement",
+        );
 
         match err {
             CdtError::InvalidSimulationConfiguration {
@@ -2108,7 +2313,6 @@ mod tests {
     #[test]
     fn validate_rejects_overflow() {
         let err = MetropolisConfig::new(1.0, u32::MAX, u32::MAX, 2)
-            .validate()
             .expect_err("unreachable post-thermalization measurement should be rejected");
 
         match err {
@@ -2132,7 +2336,7 @@ mod tests {
 
     #[test]
     fn run_accepts_boundary_schedule() {
-        let config = MetropolisConfig::new(1.0, 20, 15, 10).with_seed(42);
+        let config = seeded_metropolis_config(1.0, 20, 15, 10, 42);
         let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
         let tri = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
 
@@ -2148,14 +2352,8 @@ mod tests {
 
     #[test]
     fn run_validates_action_config() {
-        let config = MetropolisConfig::new(1.0, 20, 15, 10).with_seed(42);
-        let action_config = ActionConfig::new(f64::INFINITY, 1.0, 0.1);
-        let algorithm = MetropolisAlgorithm::new(config, action_config);
-        let tri = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
-
-        let err = algorithm
-            .run(tri)
-            .expect_err("invalid action config should be reported before simulation");
+        let err = ActionConfig::new(f64::INFINITY, 1.0, 0.1)
+            .expect_err("invalid action config should be rejected before simulation");
         match err {
             CdtError::InvalidConfiguration {
                 setting,
@@ -2193,9 +2391,8 @@ mod tests {
 
     #[test]
     fn cdt_target_rejects_invalid_action_config() {
-        let Err(err) = CdtTarget::new(ActionConfig::new(f64::NAN, 1.0, 0.0), 1.0) else {
-            panic!("invalid action config should be rejected");
-        };
+        let err = ActionConfig::new(f64::NAN, 1.0, 0.0)
+            .expect_err("invalid action config should be rejected");
 
         match err {
             CdtError::InvalidConfiguration {
@@ -2212,10 +2409,8 @@ mod tests {
 
     #[test]
     fn cdt_proposal_rejects_invalid_action_config() {
-        let action_config = ActionConfig::new(1.0, f64::NEG_INFINITY, 0.0);
-        let Err(err) = CdtProposal::new(action_config.clone()) else {
-            panic!("invalid action config should be rejected");
-        };
+        let err = ActionConfig::new(1.0, f64::NEG_INFINITY, 0.0)
+            .expect_err("invalid action config should be rejected");
 
         match err {
             CdtError::InvalidConfiguration {
@@ -2228,16 +2423,15 @@ mod tests {
             }
             other => panic!("Expected InvalidConfiguration, got {other:?}"),
         }
-
-        assert!(CdtProposal::with_seed(action_config, 7).is_err());
+        assert!(ActionConfig::new(1.0, f64::NEG_INFINITY, 0.0).is_err());
     }
 
     #[test]
     fn unseeded_config_uses_random_rng() {
-        let config = MetropolisConfig::new(1.0, 5, 1, 1); // no seed
-        assert!(config.seed.is_none());
+        let config = metropolis_config(1.0, 5, 1, 1); // no seed
+        assert!(config.seed().is_none());
 
-        let mut rng = simulation_rng(config.seed);
+        let mut rng = simulation_rng(config.seed());
         let draw = rng.random::<f64>();
         assert!((0.0..1.0).contains(&draw));
     }
@@ -2247,8 +2441,7 @@ mod tests {
         let action_config = ActionConfig::default();
         let target =
             CdtTarget::new(action_config.clone(), 1.0).expect("valid target configuration");
-        let mut proposal =
-            CdtProposal::with_seed(action_config, 7).expect("valid proposal configuration");
+        let mut proposal = CdtProposal::with_seed(action_config, 7);
         let triangulation = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
         let mut rng = StdRng::seed_from_u64(7);
 
@@ -2302,7 +2495,7 @@ mod tests {
             epsilon = 1e-12
         );
 
-        let proposal = CdtProposal::new(action_config).expect("valid proposal configuration");
+        let proposal = CdtProposal::new(action_config);
         assert_relative_eq!(
             proposal
                 .log_q_ratio(&triangulation, &plan)
@@ -2332,9 +2525,9 @@ mod tests {
         .expect("planning should not hard-fail")
         .expect("toroidal triangulation should have a volume-add proposal");
 
-        assert_eq!(moves.stats.total_attempted(), 0);
-        assert_eq!(moves.stats.total_accepted(), 0);
-        assert_eq!(moves.stats.total_hard_failures(), 0);
+        assert_eq!(moves.stats().total_attempted(), 0);
+        assert_eq!(moves.stats().total_accepted(), 0);
+        assert_eq!(moves.stats().total_hard_failures(), 0);
     }
 
     #[test]
@@ -2342,8 +2535,7 @@ mod tests {
         let action_config = ActionConfig::default();
         let target =
             CdtTarget::new(action_config.clone(), 1.0).expect("valid target configuration");
-        let proposal =
-            CdtProposal::with_seed(action_config, 7).expect("valid proposal configuration");
+        let proposal = CdtProposal::with_seed(action_config, 7);
         let triangulation = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
         let plan = CdtProposalPlan {
             move_type: MoveType::Move31Remove,
@@ -2370,8 +2562,7 @@ mod tests {
         let triangulation = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
         let mut chain = Chain::new(triangulation, &target)
             .expect("initial state should have finite log probability");
-        let mut proposal =
-            CdtProposal::with_seed(action_config, 7).expect("valid proposal configuration");
+        let mut proposal = CdtProposal::with_seed(action_config, 7);
         let mut rng = StdRng::seed_from_u64(11);
 
         let step = chain
@@ -2385,8 +2576,7 @@ mod tests {
     #[test]
     fn cdt_proposal_commit_applies_concrete_planned_state() {
         let action_config = ActionConfig::default();
-        let mut proposal = CdtProposal::with_seed(action_config.clone(), 11)
-            .expect("valid proposal configuration");
+        let mut proposal = CdtProposal::with_seed(action_config.clone(), 11);
         let mut triangulation =
             CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed to create");
         let proposed_state =

--- a/src/cdt/metropolis/telemetry.rs
+++ b/src/cdt/metropolis/telemetry.rs
@@ -75,7 +75,9 @@ impl Error for CdtProposalSiteRejection {
 /// references returned by
 /// [`checkpoint proposal stats`][super::CdtMcmcCheckpoint::proposal_stats] or
 /// [`result proposal stats`][crate::cdt::results::SimulationResultsBackend::proposal_stats].
-/// Counters saturate at `u64::MAX` instead of wrapping.
+/// Deserialization requires exactly one terminal outcome for every selected
+/// move-family proposal, and counters saturate at `u64::MAX` instead of
+/// wrapping.
 ///
 /// # Examples
 ///
@@ -191,10 +193,10 @@ impl ProposalStatistics {
 
     /// Rebuilds proposal telemetry from the serialized wire shape.
     ///
-    /// The wire form is rejected when terminal outcomes exceed selected move
-    /// families, or when forward-site observations exist without any selected
-    /// move family. That keeps deserialized result and checkpoint telemetry
-    /// coherent before public accessors expose the counters.
+    /// The wire form is rejected when terminal outcomes do not exactly account
+    /// for selected move families, or when forward-site observations exist
+    /// without any selected move family. That keeps deserialized result and
+    /// checkpoint telemetry coherent before public accessors expose the counters.
     fn from_wire(wire: &ProposalStatisticsWire) -> Result<Self, String> {
         let terminal_outcomes = [
             wire.no_site_proposals,
@@ -208,9 +210,9 @@ impl ProposalStatistics {
         .into_iter()
         .try_fold(0_u64, u64::checked_add)
         .ok_or_else(|| "proposal terminal-outcome counters exceed u64::MAX".to_string())?;
-        if terminal_outcomes > wire.move_family_proposals {
+        if terminal_outcomes != wire.move_family_proposals {
             return Err(format!(
-                "proposal terminal outcomes ({terminal_outcomes}) exceed move-family proposals ({})",
+                "proposal terminal outcomes ({terminal_outcomes}) do not match move-family proposals ({})",
                 wire.move_family_proposals
             ));
         }
@@ -464,6 +466,29 @@ mod tests {
         assert!(
             error.to_string().contains("terminal outcomes"),
             "serde error should explain proposal telemetry invariant, got {error}"
+        );
+    }
+
+    #[test]
+    fn proposal_statistics_deserialization_rejects_under_classified_proposals() {
+        let payload = r#"{
+            "move_family_proposals": 2,
+            "observed_forward_sites": 1,
+            "no_site_proposals": 1,
+            "site_causality_rejections": 0,
+            "site_geometric_rejections": 0,
+            "site_backend_rejections": 0,
+            "metropolis_rejections": 0,
+            "accepted_transitions": 0,
+            "hard_failures": 0
+        }"#;
+
+        let error = serde_json::from_str::<ProposalStatistics>(payload)
+            .expect_err("under-classified move-family proposals should be rejected");
+
+        assert!(
+            error.to_string().contains("do not match"),
+            "serde error should explain exact proposal telemetry invariant, got {error}"
         );
     }
 

--- a/src/cdt/metropolis/telemetry.rs
+++ b/src/cdt/metropolis/telemetry.rs
@@ -1,11 +1,12 @@
+#![forbid(unsafe_code)]
+
 //! Proposal and step telemetry for CDT Metropolis sampling.
 
+use crate::cdt::ergodic_moves::MoveType;
 use crate::errors::CdtError;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::error::Error;
 use std::fmt;
-
-use crate::cdt::ergodic_moves::MoveType;
 
 /// Result of a Monte Carlo step.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -82,32 +83,55 @@ impl Error for CdtProposalSiteRejection {
 /// use causal_triangulations::prelude::simulation::ProposalStatistics;
 ///
 /// let stats = ProposalStatistics::new();
-/// assert_eq!(stats.move_family_proposals, 0);
-/// assert_eq!(stats.accepted_transitions, 0);
+/// assert_eq!(stats.move_family_proposals(), 0);
+/// assert_eq!(stats.accepted_transitions(), 0);
 /// ```
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
 pub struct ProposalStatistics {
     /// Number of selected move-family proposals, saturating at `u64::MAX`.
-    pub move_family_proposals: u64,
+    move_family_proposals: u64,
     /// Sum of sampleable forward-site denominators observed during planning,
     /// saturating at `u64::MAX`.
-    pub observed_forward_sites: u64,
+    observed_forward_sites: u64,
     /// Number of proposals with no sampleable local site, saturating at `u64::MAX`.
-    pub no_site_proposals: u64,
+    no_site_proposals: u64,
     /// Number of sampled sites rejected by causal checks, saturating at `u64::MAX`.
-    pub site_causality_rejections: u64,
+    site_causality_rejections: u64,
     /// Number of sampled sites rejected by geometric checks, saturating at `u64::MAX`.
-    pub site_geometric_rejections: u64,
+    site_geometric_rejections: u64,
     /// Number of sampled sites rejected by backend mutation errors, saturating at `u64::MAX`.
-    pub site_backend_rejections: u64,
+    site_backend_rejections: u64,
     /// Number of valid proposed transitions rejected by the Metropolis draw,
     /// saturating at `u64::MAX`.
-    pub metropolis_rejections: u64,
+    metropolis_rejections: u64,
     /// Number of proposed transitions committed to the chain, saturating at `u64::MAX`.
-    pub accepted_transitions: u64,
+    accepted_transitions: u64,
     /// Number of proposal attempts that hit a hard failure, saturating at `u64::MAX`.
-    pub hard_failures: u64,
+    hard_failures: u64,
+}
+
+#[derive(Deserialize)]
+struct ProposalStatisticsWire {
+    move_family_proposals: u64,
+    observed_forward_sites: u64,
+    no_site_proposals: u64,
+    site_causality_rejections: u64,
+    site_geometric_rejections: u64,
+    site_backend_rejections: u64,
+    metropolis_rejections: u64,
+    accepted_transitions: u64,
+    hard_failures: u64,
+}
+
+impl<'de> Deserialize<'de> for ProposalStatistics {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = ProposalStatisticsWire::deserialize(deserializer)?;
+        Self::from_wire(&wire).map_err(serde::de::Error::custom)
+    }
 }
 
 impl ProposalStatistics {
@@ -134,6 +158,237 @@ impl ProposalStatistics {
             accepted_transitions: 0,
             hard_failures: 0,
         }
+    }
+
+    #[cfg(test)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "test and serde helpers need to preserve the flat telemetry wire shape"
+    )]
+    pub(crate) const fn from_validated_parts(
+        move_family_proposals: u64,
+        observed_forward_sites: u64,
+        no_site_proposals: u64,
+        site_causality_rejections: u64,
+        site_geometric_rejections: u64,
+        site_backend_rejections: u64,
+        metropolis_rejections: u64,
+        accepted_transitions: u64,
+        hard_failures: u64,
+    ) -> Self {
+        Self {
+            move_family_proposals,
+            observed_forward_sites,
+            no_site_proposals,
+            site_causality_rejections,
+            site_geometric_rejections,
+            site_backend_rejections,
+            metropolis_rejections,
+            accepted_transitions,
+            hard_failures,
+        }
+    }
+
+    /// Rebuilds proposal telemetry from the serialized wire shape.
+    ///
+    /// The wire form is rejected when terminal outcomes exceed selected move
+    /// families, or when forward-site observations exist without any selected
+    /// move family. That keeps deserialized result and checkpoint telemetry
+    /// coherent before public accessors expose the counters.
+    fn from_wire(wire: &ProposalStatisticsWire) -> Result<Self, String> {
+        let terminal_outcomes = [
+            wire.no_site_proposals,
+            wire.site_causality_rejections,
+            wire.site_geometric_rejections,
+            wire.site_backend_rejections,
+            wire.metropolis_rejections,
+            wire.accepted_transitions,
+            wire.hard_failures,
+        ]
+        .into_iter()
+        .try_fold(0_u64, u64::checked_add)
+        .ok_or_else(|| "proposal terminal-outcome counters exceed u64::MAX".to_string())?;
+        if terminal_outcomes > wire.move_family_proposals {
+            return Err(format!(
+                "proposal terminal outcomes ({terminal_outcomes}) exceed move-family proposals ({})",
+                wire.move_family_proposals
+            ));
+        }
+        if wire.move_family_proposals == 0 && wire.observed_forward_sites != 0 {
+            return Err(
+                "observed forward-site count must be zero when no move families were proposed"
+                    .to_string(),
+            );
+        }
+        Ok(Self {
+            move_family_proposals: wire.move_family_proposals,
+            observed_forward_sites: wire.observed_forward_sites,
+            no_site_proposals: wire.no_site_proposals,
+            site_causality_rejections: wire.site_causality_rejections,
+            site_geometric_rejections: wire.site_geometric_rejections,
+            site_backend_rejections: wire.site_backend_rejections,
+            metropolis_rejections: wire.metropolis_rejections,
+            accepted_transitions: wire.accepted_transitions,
+            hard_failures: wire.hard_failures,
+        })
+    }
+
+    /// Returns the number of selected move families.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
+    ///
+    /// let stats = ProposalStatistics::new();
+    /// assert_eq!(stats.move_family_proposals(), 0);
+    /// ```
+    #[must_use]
+    pub const fn move_family_proposals(&self) -> u64 {
+        self.move_family_proposals
+    }
+
+    /// Returns the accumulated sampleable forward-site denominators.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
+    ///
+    /// let stats = ProposalStatistics::new();
+    /// assert_eq!(stats.observed_forward_sites(), 0);
+    /// ```
+    #[must_use]
+    pub const fn observed_forward_sites(&self) -> u64 {
+        self.observed_forward_sites
+    }
+
+    /// Returns the number of proposals with no local site.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
+    ///
+    /// let stats = ProposalStatistics::new();
+    /// assert_eq!(stats.no_site_proposals(), 0);
+    /// ```
+    #[must_use]
+    pub const fn no_site_proposals(&self) -> u64 {
+        self.no_site_proposals
+    }
+
+    /// Returns the number of sampled sites rejected by causality checks.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
+    ///
+    /// let stats = ProposalStatistics::new();
+    /// assert_eq!(stats.site_causality_rejections(), 0);
+    /// ```
+    #[must_use]
+    pub const fn site_causality_rejections(&self) -> u64 {
+        self.site_causality_rejections
+    }
+
+    /// Returns the number of sampled sites rejected by geometric checks.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
+    ///
+    /// let stats = ProposalStatistics::new();
+    /// assert_eq!(stats.site_geometric_rejections(), 0);
+    /// ```
+    #[must_use]
+    pub const fn site_geometric_rejections(&self) -> u64 {
+        self.site_geometric_rejections
+    }
+
+    /// Returns the number of sampled sites rejected by backend mutation errors.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
+    ///
+    /// let stats = ProposalStatistics::new();
+    /// assert_eq!(stats.site_backend_rejections(), 0);
+    /// ```
+    #[must_use]
+    pub const fn site_backend_rejections(&self) -> u64 {
+        self.site_backend_rejections
+    }
+
+    /// Returns the number of valid transitions rejected by Metropolis.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
+    ///
+    /// let stats = ProposalStatistics::new();
+    /// assert_eq!(stats.metropolis_rejections(), 0);
+    /// ```
+    #[must_use]
+    pub const fn metropolis_rejections(&self) -> u64 {
+        self.metropolis_rejections
+    }
+
+    /// Returns the number of committed transitions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
+    ///
+    /// let stats = ProposalStatistics::new();
+    /// assert_eq!(stats.accepted_transitions(), 0);
+    /// ```
+    #[must_use]
+    pub const fn accepted_transitions(&self) -> u64 {
+        self.accepted_transitions
+    }
+
+    /// Returns the number of hard proposal failures.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
+    ///
+    /// let stats = ProposalStatistics::new();
+    /// assert_eq!(stats.hard_failures(), 0);
+    /// ```
+    #[must_use]
+    pub const fn hard_failures(&self) -> u64 {
+        self.hard_failures
+    }
+
+    /// Returns proposal outcomes that rejected a selected move family.
+    ///
+    /// This includes no-site, causality, geometric, backend, and Metropolis
+    /// rejections. Accepted transitions and hard failures are intentionally
+    /// reported by separate counters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::ProposalStatistics;
+    ///
+    /// let stats = ProposalStatistics::new();
+    /// assert_eq!(stats.rejected_transitions(), 0);
+    /// ```
+    #[must_use]
+    pub const fn rejected_transitions(&self) -> u64 {
+        self.no_site_proposals
+            .saturating_add(self.site_causality_rejections)
+            .saturating_add(self.site_geometric_rejections)
+            .saturating_add(self.site_backend_rejections)
+            .saturating_add(self.metropolis_rejections)
     }
 
     /// Records one selected move family and the forward-site denominator observed for it.
@@ -182,5 +437,56 @@ impl ProposalStatistics {
     /// Records an unexpected hard failure during proposal application.
     pub(crate) const fn record_hard_failure(&mut self) {
         self.hard_failures = self.hard_failures.saturating_add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proposal_statistics_deserialization_rejects_terminal_outcomes_above_proposals() {
+        let payload = r#"{
+            "move_family_proposals": 1,
+            "observed_forward_sites": 1,
+            "no_site_proposals": 1,
+            "site_causality_rejections": 0,
+            "site_geometric_rejections": 0,
+            "site_backend_rejections": 0,
+            "metropolis_rejections": 0,
+            "accepted_transitions": 1,
+            "hard_failures": 0
+        }"#;
+
+        let error = serde_json::from_str::<ProposalStatistics>(payload)
+            .expect_err("terminal outcomes above move-family proposals should be rejected");
+
+        assert!(
+            error.to_string().contains("terminal outcomes"),
+            "serde error should explain proposal telemetry invariant, got {error}"
+        );
+    }
+
+    #[test]
+    fn proposal_statistics_deserialization_rejects_forward_sites_without_proposals() {
+        let payload = r#"{
+            "move_family_proposals": 0,
+            "observed_forward_sites": 1,
+            "no_site_proposals": 0,
+            "site_causality_rejections": 0,
+            "site_geometric_rejections": 0,
+            "site_backend_rejections": 0,
+            "metropolis_rejections": 0,
+            "accepted_transitions": 0,
+            "hard_failures": 0
+        }"#;
+
+        let error = serde_json::from_str::<ProposalStatistics>(payload)
+            .expect_err("forward sites without proposals should be rejected");
+
+        assert!(
+            error.to_string().contains("forward-site"),
+            "serde error should explain forward-site invariant, got {error}"
+        );
     }
 }

--- a/src/cdt/results.rs
+++ b/src/cdt/results.rs
@@ -8,10 +8,17 @@
 
 use crate::cdt::action::ActionConfig;
 use crate::cdt::ergodic_moves::MoveStatistics;
-use crate::cdt::metropolis::{MetropolisConfig, MonteCarloStep, ProposalStatistics};
+use crate::cdt::metropolis::{
+    MetropolisConfig, MonteCarloStep, ProposalStatistics,
+    checkpoint::{chain_counters, checkpoint_resume_failed},
+    helpers::actions_match,
+};
 use crate::cdt::observables::{estimate_hausdorff_dimension, estimate_spectral_dimension};
-use crate::config::{CdtConfig, CdtTopology};
-use crate::errors::{CdtError, CdtResult, OutputFormat};
+use crate::config::{CdtConfig, CdtTopology, ValidatedCdtConfig};
+use crate::errors::{
+    CdtError, CdtResult, CheckpointMoveCounter, CheckpointResumeFailure, OutputFormat,
+    ProposalTelemetryCounter,
+};
 use crate::geometry::CdtTriangulation2D;
 use crate::util::usize_to_f64;
 use serde::de::Error as DeError;
@@ -162,19 +169,19 @@ impl TryFrom<SimulationResultsBackendWire> for SimulationResultsBackend {
     type Error = CdtError;
 
     fn try_from(wire: SimulationResultsBackendWire) -> Result<Self, Self::Error> {
-        wire.config.validate()?;
-        wire.action_config.validate()?;
+        wire.config.validate();
+        wire.action_config.validate();
         wire.triangulation.validate_evolved_cdt()?;
-        Ok(Self::from_parts(SimulationResultsParts {
-            config: wire.config,
-            action_config: wire.action_config,
-            move_stats: wire.move_stats,
-            proposal_stats: wire.proposal_stats,
-            steps: wire.steps,
-            measurements: wire.measurements,
-            elapsed_time: wire.elapsed_time,
-            triangulation: wire.triangulation,
-        }))
+        Self::new(
+            wire.config,
+            wire.action_config,
+            wire.move_stats,
+            wire.proposal_stats,
+            wire.steps,
+            wire.measurements,
+            wire.elapsed_time,
+            wire.triangulation,
+        )
     }
 }
 
@@ -187,6 +194,254 @@ impl<'de> Deserialize<'de> for SimulationResultsBackend {
             .try_into()
             .map_err(DeError::custom)
     }
+}
+
+/// Validates that public result snapshots contain coherent chain telemetry.
+///
+/// This protects the [`SimulationResultsBackend`] contract when data crosses a
+/// serialization boundary or is assembled by crate-internal tests: step records,
+/// measurements, move counters, and proposal counters must describe the same
+/// completed chain, or the initial construction snapshot produced when callers
+/// build a triangulation without running Metropolis sampling.
+fn validate_result_telemetry(
+    config: &MetropolisConfig,
+    move_stats: &MoveStatistics,
+    proposal_stats: &ProposalStatistics,
+    steps: &[MonteCarloStep],
+    measurements: &[Measurement],
+) -> CdtResult<()> {
+    if is_initial_construction_snapshot(move_stats, proposal_stats, steps, measurements) {
+        return Ok(());
+    }
+
+    let expected_steps = usize::try_from(config.steps()).unwrap_or(usize::MAX);
+    if steps.len() != expected_steps {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::StepTelemetryLengthMismatch {
+                actual: steps.len(),
+                expected: expected_steps,
+            },
+        ));
+    }
+
+    let (accepted, rejected) = chain_counters(move_stats)?;
+    let total_moves = accepted.checked_add(rejected).ok_or_else(|| {
+        checkpoint_resume_failed(CheckpointResumeFailure::CounterConversionOverflow {
+            counter: CheckpointMoveCounter::Attempted,
+        })
+    })?;
+    if total_moves != steps.len() {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::StepTelemetryLengthMismatch {
+                actual: steps.len(),
+                expected: total_moves,
+            },
+        ));
+    }
+
+    validate_result_steps(steps, accepted)?;
+    validate_result_measurements(config, steps, measurements)?;
+    validate_result_proposal_stats(proposal_stats, steps.len(), accepted, rejected)
+}
+
+/// Recognizes a construction-only result before Metropolis steps have run.
+fn is_initial_construction_snapshot(
+    move_stats: &MoveStatistics,
+    proposal_stats: &ProposalStatistics,
+    steps: &[MonteCarloStep],
+    measurements: &[Measurement],
+) -> bool {
+    steps.is_empty()
+        && move_stats.total_attempted() == 0
+        && move_stats.total_accepted() == 0
+        && move_stats.total_hard_failures() == 0
+        && proposal_stats.move_family_proposals() == 0
+        && proposal_stats.observed_forward_sites() == 0
+        && proposal_stats.rejected_transitions() == 0
+        && proposal_stats.accepted_transitions() == 0
+        && proposal_stats.hard_failures() == 0
+        && matches!(measurements, [measurement] if measurement.step == 0 && measurement.action.is_finite())
+}
+
+/// Checks per-step records against accepted-count and action-delta invariants.
+fn validate_result_steps(steps: &[MonteCarloStep], accepted: usize) -> CdtResult<()> {
+    let accepted_steps = steps.iter().filter(|step| step.accepted).count();
+    if accepted_steps != accepted {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::StepTelemetryAcceptedCountMismatch {
+                actual: accepted_steps,
+                expected: accepted,
+            },
+        ));
+    }
+
+    for (index, step) in steps.iter().enumerate() {
+        let expected_step = u32::try_from(index + 1).map_err(|_| {
+            checkpoint_resume_failed(CheckpointResumeFailure::StepTelemetryIndexOverflow)
+        })?;
+        if step.step != expected_step {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::StepTelemetrySequenceMismatch {
+                    actual: step.step,
+                    expected: expected_step,
+                },
+            ));
+        }
+        if !step.action_before.is_finite() {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::NonFiniteStepActionBefore { step: step.step },
+            ));
+        }
+        if let Some(delta_action) = step.delta_action
+            && !delta_action.is_finite()
+        {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::NonFiniteStepDeltaAction { step: step.step },
+            ));
+        }
+        if step.accepted && step.delta_action.is_none() {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::AcceptedStepMissingDeltaAction { step: step.step },
+            ));
+        }
+        match (step.accepted, step.action_after) {
+            (true, Some(action_after)) if action_after.is_finite() => {
+                if let Some(delta_action) = step.delta_action
+                    && !actions_match(action_after, step.action_before + delta_action)
+                {
+                    return Err(checkpoint_resume_failed(
+                        CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: step.step },
+                    ));
+                }
+            }
+            (true, Some(_)) => {
+                return Err(checkpoint_resume_failed(
+                    CheckpointResumeFailure::NonFiniteStepActionAfter { step: step.step },
+                ));
+            }
+            (true, None) => {
+                return Err(checkpoint_resume_failed(
+                    CheckpointResumeFailure::AcceptedStepMissingActionAfter { step: step.step },
+                ));
+            }
+            (false, Some(_)) => {
+                return Err(checkpoint_resume_failed(
+                    CheckpointResumeFailure::RejectedStepHasActionAfter { step: step.step },
+                ));
+            }
+            (false, None) => {}
+        }
+    }
+    Ok(())
+}
+
+/// Checks measurement cadence and finite measured actions.
+fn validate_result_measurements(
+    config: &MetropolisConfig,
+    steps: &[MonteCarloStep],
+    measurements: &[Measurement],
+) -> CdtResult<()> {
+    let current_step = u32::try_from(steps.len()).map_err(|_| {
+        checkpoint_resume_failed(CheckpointResumeFailure::StepTelemetryIndexOverflow)
+    })?;
+    let expected_measurements =
+        usize::try_from(u64::from(current_step) / u64::from(config.measurement_frequency()) + 1)
+            .map_err(|_| {
+                checkpoint_resume_failed(CheckpointResumeFailure::MeasurementCountOverflow)
+            })?;
+    if measurements.len() != expected_measurements {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::MeasurementCountMismatch {
+                actual: measurements.len(),
+                expected: expected_measurements,
+            },
+        ));
+    }
+
+    for (index, measurement) in measurements.iter().enumerate() {
+        let expected_step = u64::try_from(index)
+            .ok()
+            .and_then(|index| index.checked_mul(u64::from(config.measurement_frequency())))
+            .and_then(|step| u32::try_from(step).ok())
+            .ok_or_else(|| {
+                checkpoint_resume_failed(CheckpointResumeFailure::MeasurementStepOverflow)
+            })?;
+        if measurement.step != expected_step {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::MeasurementStepMismatch {
+                    actual: measurement.step,
+                    expected: expected_step,
+                },
+            ));
+        }
+        if !measurement.action.is_finite() {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::NonFiniteMeasurementAction {
+                    step: measurement.step,
+                },
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Checks proposal counters against step and move-counter outcomes.
+fn validate_result_proposal_stats(
+    proposal_stats: &ProposalStatistics,
+    steps: usize,
+    accepted: usize,
+    rejected: usize,
+) -> CdtResult<()> {
+    if proposal_stats.hard_failures() != 0 {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ProposalHardFailures {
+                actual: proposal_stats.hard_failures(),
+            },
+        ));
+    }
+    let steps = u64::try_from(steps).map_err(|_| {
+        checkpoint_resume_failed(CheckpointResumeFailure::ProposalCounterOverflow {
+            counter: ProposalTelemetryCounter::MoveFamilyProposals,
+        })
+    })?;
+    if proposal_stats.move_family_proposals() != steps {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ProposalMoveFamilyCountMismatch {
+                actual: proposal_stats.move_family_proposals(),
+                expected: steps,
+            },
+        ));
+    }
+
+    let accepted = u64::try_from(accepted).map_err(|_| {
+        checkpoint_resume_failed(CheckpointResumeFailure::ProposalCounterOverflow {
+            counter: ProposalTelemetryCounter::AcceptedTransitions,
+        })
+    })?;
+    if proposal_stats.accepted_transitions() != accepted {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ProposalAcceptedCountMismatch {
+                actual: proposal_stats.accepted_transitions(),
+                expected: accepted,
+            },
+        ));
+    }
+
+    let rejected = u64::try_from(rejected).map_err(|_| {
+        checkpoint_resume_failed(CheckpointResumeFailure::ProposalCounterOverflow {
+            counter: ProposalTelemetryCounter::RejectedTransitions,
+        })
+    })?;
+    let actual_rejected = proposal_stats.rejected_transitions();
+    if actual_rejected != rejected {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ProposalRejectedCountMismatch {
+                actual: actual_rejected,
+                expected: rejected,
+            },
+        ));
+    }
+    Ok(())
 }
 
 #[derive(Serialize)]
@@ -223,16 +478,18 @@ struct TriangulationSummary {
 }
 
 impl SimulationResultsBackend {
-    /// Creates a validated simulation result snapshot.
+    /// Creates a validated simulation result snapshot from explicit components.
     ///
-    /// Use this constructor for externally assembled results. Simulation runs
-    /// produced by [`MetropolisAlgorithm`](crate::cdt::metropolis::MetropolisAlgorithm)
-    /// use the same data shape but avoid revalidating immediately after the run has
-    /// already checked its final CDT invariants.
+    /// This constructor is crate-internal because the component set is
+    /// invariant-heavy: move counters, proposal counters, step telemetry,
+    /// measurement cadence, and final triangulation state must all describe the
+    /// same completed chain. Public callers normally obtain results from
+    /// [`MetropolisAlgorithm`](crate::cdt::metropolis::MetropolisAlgorithm) or
+    /// from deserializing a previously emitted result snapshot.
     ///
     /// The supplied [`MoveStatistics`] and [`ProposalStatistics`] are preserved
-    /// verbatim so serialized or externally reconstructed telemetry keeps the
-    /// same wire shape as results produced by the Metropolis runner.
+    /// verbatim after validation so serialized telemetry keeps the same wire
+    /// shape as results produced by the Metropolis runner.
     ///
     /// # Errors
     ///
@@ -247,37 +504,11 @@ impl SimulationResultsBackend {
     /// [`CdtError::Foliation`], [`CdtError::CausalityViolation`], and
     /// [`CdtError::ValidationFailed`].
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::moves::MoveStatistics;
-    /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, ProposalStatistics,
-    ///     SimulationResultsBackend,
-    /// };
-    /// use std::time::Duration;
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    ///     let results = SimulationResultsBackend::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1),
-    ///         ActionConfig::default(),
-    ///         MoveStatistics::new(),
-    ///         ProposalStatistics::new(),
-    ///         vec![],
-    ///         vec![],
-    ///         Duration::from_millis(0),
-    ///         tri,
-    ///     )?;
-    ///     assert!(results.steps().is_empty());
-    ///     Ok(())
-    /// }
-    /// ```
     #[expect(
         clippy::too_many_arguments,
-        reason = "public constructor mirrors the serialized simulation result components"
+        reason = "constructor mirrors the serialized simulation result components"
     )]
-    pub fn new(
+    pub(crate) fn new(
         config: MetropolisConfig,
         action_config: ActionConfig,
         move_stats: MoveStatistics,
@@ -287,9 +518,10 @@ impl SimulationResultsBackend {
         elapsed_time: Duration,
         triangulation: CdtTriangulation2D,
     ) -> CdtResult<Self> {
-        config.validate()?;
-        action_config.validate()?;
+        config.validate();
+        action_config.validate();
         triangulation.validate_evolved_cdt()?;
+        validate_result_telemetry(&config, &move_stats, &proposal_stats, &steps, &measurements)?;
         Ok(Self::from_parts(SimulationResultsParts {
             config,
             action_config,
@@ -321,24 +553,17 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::prelude::moves::MoveStatistics;
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let config = MetropolisConfig::new(1.0, 1, 0, 1);
-    ///     let results = SimulationResultsBackend::new(
+    ///     let config = MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(7);
+    ///     let results = MetropolisAlgorithm::new(
     ///         config.clone(),
     ///         ActionConfig::default(),
-    ///         MoveStatistics::new(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![],
-    ///         Duration::ZERO,
-    ///         CdtTriangulation::from_cdt_strip(4, 3)?,
-    ///     )?;
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
     ///     assert_eq!(results.config(), &config);
     ///     Ok(())
     /// }
@@ -353,24 +578,17 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::prelude::moves::MoveStatistics;
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let action_config = ActionConfig::new(1.0, 0.0, 0.1);
-    ///     let results = SimulationResultsBackend::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1),
+    ///     let action_config = ActionConfig::new(1.0, 0.0, 0.1)?;
+    ///     let results = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(7),
     ///         action_config.clone(),
-    ///         MoveStatistics::new(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![],
-    ///         Duration::ZERO,
-    ///         CdtTriangulation::from_cdt_strip(4, 3)?,
-    ///     )?;
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
     ///     assert_eq!(results.action_config(), &action_config);
     ///     Ok(())
     /// }
@@ -385,25 +603,17 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::prelude::moves::MoveStatistics;
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let move_stats = MoveStatistics::new();
-    ///     let results = SimulationResultsBackend::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1),
+    ///     let results = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(7),
     ///         ActionConfig::default(),
-    ///         move_stats,
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![],
-    ///         Duration::ZERO,
-    ///         CdtTriangulation::from_cdt_strip(4, 3)?,
-    ///     )?;
-    ///     assert_eq!(results.move_stats().total_attempted(), 0);
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///     assert_eq!(results.move_stats().total_attempted(), 1);
     ///     Ok(())
     /// }
     /// ```
@@ -423,12 +633,12 @@ impl SimulationResultsBackend {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let results = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1).with_seed(13),
+    ///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(13),
     ///         ActionConfig::default(),
     ///     )
     ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
     ///
-    ///     assert_eq!(results.proposal_stats().move_family_proposals, 1);
+    ///     assert_eq!(results.proposal_stats().move_family_proposals(), 1);
     ///     Ok(())
     /// }
     /// ```
@@ -442,24 +652,17 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::prelude::moves::MoveStatistics;
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let results = SimulationResultsBackend::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1),
+    ///     let results = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(7),
     ///         ActionConfig::default(),
-    ///         MoveStatistics::new(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![],
-    ///         Duration::ZERO,
-    ///         CdtTriangulation::from_cdt_strip(4, 3)?,
-    ///     )?;
-    ///     assert!(results.steps().is_empty());
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///     assert_eq!(results.steps().len(), 1);
     ///     Ok(())
     /// }
     /// ```
@@ -473,24 +676,17 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::prelude::moves::MoveStatistics;
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let results = SimulationResultsBackend::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1),
+    ///     let results = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(7),
     ///         ActionConfig::default(),
-    ///         MoveStatistics::new(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![],
-    ///         Duration::ZERO,
-    ///         CdtTriangulation::from_cdt_strip(4, 3)?,
-    ///     )?;
-    ///     assert!(results.measurements().is_empty());
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///     assert_eq!(results.measurements().len(), 2);
     ///     Ok(())
     /// }
     /// ```
@@ -504,25 +700,17 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::prelude::moves::MoveStatistics;
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let elapsed = Duration::from_millis(25);
-    ///     let results = SimulationResultsBackend::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1),
+    ///     let results = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(7),
     ///         ActionConfig::default(),
-    ///         MoveStatistics::new(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![],
-    ///         elapsed,
-    ///         CdtTriangulation::from_cdt_strip(4, 3)?,
-    ///     )?;
-    ///     assert_eq!(results.elapsed_time(), elapsed);
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///     let _elapsed = results.elapsed_time();
     ///     Ok(())
     /// }
     /// ```
@@ -536,23 +724,16 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::prelude::moves::MoveStatistics;
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let results = SimulationResultsBackend::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1),
+    ///     let results = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(7),
     ///         ActionConfig::default(),
-    ///         MoveStatistics::new(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![],
-    ///         Duration::ZERO,
-    ///         CdtTriangulation::from_cdt_strip(4, 3)?,
-    ///     )?;
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
     ///     assert_eq!(results.triangulation().slice_sizes(), &[4, 4, 4]);
     ///     Ok(())
     /// }
@@ -567,26 +748,17 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use approx::assert_relative_eq;
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    ///     let config = MetropolisConfig::new(1.0, 1, 0, 1).with_seed(7);
-    ///     let results = SimulationResultsBackend::new(
-    ///         config,
+    ///     let results = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(7),
     ///         ActionConfig::default(),
-    ///         Default::default(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![],
-    ///         Duration::from_millis(0),
-    ///         tri,
-    ///     )?;
-    ///     assert_relative_eq!(results.acceptance_rate(), 0.0);
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///     assert!((0.0..=1.0).contains(&results.acceptance_rate()));
     ///     Ok(())
     /// }
     /// ```
@@ -614,26 +786,17 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use approx::assert_relative_eq;
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    ///     let config = MetropolisConfig::new(1.0, 1, 0, 1).with_seed(7);
-    ///     let results = SimulationResultsBackend::new(
-    ///         config,
+    ///     let results = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(7),
     ///         ActionConfig::default(),
-    ///         Default::default(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![],
-    ///         Duration::from_millis(0),
-    ///         tri,
-    ///     )?;
-    ///     assert_relative_eq!(results.average_action(), 0.0);
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///     assert!(results.average_action().is_finite());
     ///     Ok(())
     /// }
     /// ```
@@ -662,34 +825,20 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use approx::assert_relative_eq;
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, Measurement, MetropolisConfig,
-    ///     SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    ///     let config = MetropolisConfig::new(1.0, 20, 10, 5).with_seed(7);
-    ///     let results = SimulationResultsBackend::new(
+    ///     let config = MetropolisConfig::new(1.0, 20, 10, 5)?.with_seed(7);
+    ///     let results = MetropolisAlgorithm::new(
     ///         config,
     ///         ActionConfig::default(),
-    ///         Default::default(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![
-    ///             Measurement::new(0, 1.0, 12, 26, 12)
-    ///                 .with_volume_profile(vec![6, 6, 0]),
-    ///             Measurement::new(10, 2.0, 12, 26, 12)
-    ///                 .with_volume_profile(vec![4, 8, 0]),
-    ///         ],
-    ///         Duration::from_millis(0),
-    ///         tri,
-    ///     )?;
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
     ///     let profile = results.average_volume_profile();
-    ///     assert_relative_eq!(profile[0], 4.0);
-    ///     assert_relative_eq!(profile[1], 8.0);
+    ///     assert_eq!(profile.len(), results.triangulation().slice_sizes().len());
+    ///     assert!(profile.iter().all(|volume| volume.is_finite()));
     ///     Ok(())
     /// }
     /// ```
@@ -728,34 +877,20 @@ impl SimulationResultsBackend {
     /// # Examples
     ///
     /// ```
-    /// use approx::assert_relative_eq;
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, Measurement, MetropolisConfig,
-    ///     SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    ///     let config = MetropolisConfig::new(1.0, 20, 10, 5).with_seed(7);
-    ///     let results = SimulationResultsBackend::new(
+    ///     let config = MetropolisConfig::new(1.0, 20, 10, 5)?.with_seed(7);
+    ///     let results = MetropolisAlgorithm::new(
     ///         config,
     ///         ActionConfig::default(),
-    ///         Default::default(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![
-    ///             Measurement::new(10, 2.0, 12, 26, 12)
-    ///                 .with_volume_profile(vec![4, 8, 0]),
-    ///             Measurement::new(15, 3.0, 12, 26, 12)
-    ///                 .with_volume_profile(vec![6, 6, 0]),
-    ///         ],
-    ///         Duration::from_millis(0),
-    ///         tri,
-    ///     )?;
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
     ///     let fluctuations = results.volume_fluctuations();
-    ///     assert_relative_eq!(fluctuations[0], 2.0_f64.sqrt());
-    ///     assert_relative_eq!(fluctuations[1], 2.0_f64.sqrt());
+    ///     assert_eq!(fluctuations.len(), results.triangulation().slice_sizes().len());
+    ///     assert!(fluctuations.iter().all(|volume| volume.is_finite()));
     ///     Ok(())
     /// }
     /// ```
@@ -801,22 +936,15 @@ impl SimulationResultsBackend {
     ///
     /// ```
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    ///     let results = SimulationResultsBackend::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1),
+    ///     let results = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(7),
     ///         ActionConfig::default(),
-    ///         Default::default(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![],
-    ///         Duration::from_millis(0),
-    ///         tri,
-    ///     )?;
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
     ///     assert!(results
     ///         .hausdorff_dimension_estimate()
     ///         .is_some_and(f64::is_finite));
@@ -842,22 +970,15 @@ impl SimulationResultsBackend {
     ///
     /// ```
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::from_toroidal_cdt(6, 6)?;
-    ///     let results = SimulationResultsBackend::new(
-    ///         MetropolisConfig::new(1.0, 1, 0, 1),
+    ///     let results = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(7),
     ///         ActionConfig::default(),
-    ///         Default::default(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![],
-    ///         Duration::from_millis(0),
-    ///         tri,
-    ///     )?;
+    ///     )
+    ///     .run(CdtTriangulation::from_toroidal_cdt(6, 6)?)?;
     ///     assert!(results
     ///         .spectral_dimension_estimate()
     ///         .is_some_and(f64::is_finite));
@@ -881,24 +1002,17 @@ impl SimulationResultsBackend {
     ///
     /// ```
     /// use causal_triangulations::prelude::simulation::{
-    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisConfig, SimulationResultsBackend,
+    ///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
     /// };
-    /// use std::time::Duration;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    ///     let config = MetropolisConfig::new(1.0, 2, 1, 1).with_seed(7);
-    ///     let results = SimulationResultsBackend::new(
+    ///     let config = MetropolisConfig::new(1.0, 2, 1, 1)?.with_seed(7);
+    ///     let results = MetropolisAlgorithm::new(
     ///         config,
     ///         ActionConfig::default(),
-    ///         Default::default(),
-    ///         Default::default(),
-    ///         vec![],
-    ///         vec![],
-    ///         Duration::from_millis(0),
-    ///         tri,
-    ///     )?;
-    ///     assert!(results.equilibrium_measurements().is_empty());
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///     assert_eq!(results.equilibrium_measurements().len(), 2);
     ///     Ok(())
     /// }
     /// ```
@@ -911,7 +1025,7 @@ impl SimulationResultsBackend {
     fn equilibrium_measurements_iter(&self) -> impl Iterator<Item = &Measurement> {
         self.measurements
             .iter()
-            .filter(|measurement| measurement.step >= self.config.thermalization_steps)
+            .filter(|measurement| measurement.step >= self.config.thermalization_steps())
     }
 
     /// Writes one CSV row per recorded measurement.
@@ -934,7 +1048,7 @@ impl SimulationResultsBackend {
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
     ///     let results = MetropolisAlgorithm::new(
-    ///         MetropolisConfig::new(1.0, 2, 1, 1),
+    ///         MetropolisConfig::new(1.0, 2, 1, 1)?,
     ///         ActionConfig::default(),
     ///     )
     ///     .run(tri)?;
@@ -982,11 +1096,16 @@ impl SimulationResultsBackend {
 
     /// Writes a JSON summary for external analysis and run bookkeeping.
     ///
-    /// The summary stores the top-level CLI/configuration parameters, action and
-    /// Metropolis configuration, aggregate statistics, final triangulation counts,
-    /// Monte Carlo step telemetry, and all measurements. The aggregate
-    /// `average_action` is computed from [`Self::equilibrium_measurements`] so
-    /// it excludes the initial snapshot and thermalization window.
+    /// The summary stores the validated top-level CLI/configuration parameters,
+    /// action and Metropolis configuration, aggregate statistics, final
+    /// triangulation counts, Monte Carlo step telemetry, and all measurements.
+    /// The aggregate `average_action` is computed from
+    /// [`Self::equilibrium_measurements`] so it excludes the initial snapshot and
+    /// thermalization window.
+    ///
+    /// Pass the same [`ValidatedCdtConfig`] used to create the run so the
+    /// serialized summary cannot pair accepted telemetry with an invalid or
+    /// unrelated raw configuration.
     ///
     /// # Errors
     ///
@@ -999,25 +1118,30 @@ impl SimulationResultsBackend {
     /// use causal_triangulations::prelude::simulation::*;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let config = CdtConfig {
+    ///     let validated = CdtConfig {
     ///         simulate: true,
     ///         steps: 2,
     ///         thermalization_steps: 1,
     ///         measurement_frequency: 1,
     ///         ..CdtConfig::new(12, 3)
-    ///     };
-    ///     let results = causal_triangulations::run_simulation(&config)?;
-    ///     results.write_summary_json(&config, "summary.json")?;
+    ///     }
+    ///     .into_validated()?;
+    ///     let results = causal_triangulations::run_simulation(&validated)?;
+    ///     results.write_summary_json(&validated, "summary.json")?;
     ///     Ok(())
     /// }
     /// ```
-    pub fn write_summary_json(&self, config: &CdtConfig, path: impl AsRef<Path>) -> CdtResult<()> {
+    pub fn write_summary_json(
+        &self,
+        config: &ValidatedCdtConfig,
+        path: impl AsRef<Path>,
+    ) -> CdtResult<()> {
         let path = path.as_ref();
         ensure_parent_directory(path, OutputFormat::Json)?;
         let file = File::create(path).map_err(|err| output_error(path, OutputFormat::Json, err))?;
         let mut writer = BufWriter::new(file);
         let summary = SimulationSummary {
-            config,
+            config: config.config(),
             metropolis_config: &self.config,
             action_config: &self.action_config,
             move_stats: &self.move_stats,
@@ -1036,7 +1160,7 @@ impl SimulationResultsBackend {
                 edges: self.triangulation.edge_count(),
                 triangles: self.triangulation.face_count(),
                 time_slices: self.triangulation.time_slices(),
-                topology: self.triangulation.metadata().topology,
+                topology: self.triangulation.metadata().topology(),
             },
             steps: &self.steps,
             measurements: &self.measurements,
@@ -1106,6 +1230,43 @@ mod tests {
     use std::process;
     use std::thread;
 
+    fn metropolis_config(
+        temperature: f64,
+        steps: u32,
+        thermalization_steps: u32,
+        measurement_frequency: u32,
+    ) -> MetropolisConfig {
+        MetropolisConfig::new(
+            temperature,
+            steps,
+            thermalization_steps,
+            measurement_frequency,
+        )
+        .expect("test Metropolis config should be valid")
+    }
+
+    fn seeded_metropolis_config(
+        temperature: f64,
+        steps: u32,
+        thermalization_steps: u32,
+        measurement_frequency: u32,
+        seed: u64,
+    ) -> MetropolisConfig {
+        MetropolisConfig::new_with_seed(
+            temperature,
+            steps,
+            thermalization_steps,
+            measurement_frequency,
+            Some(seed),
+        )
+        .expect("test Metropolis config should be valid")
+    }
+
+    fn action_config(coupling_0: f64, coupling_2: f64, cosmological_constant: f64) -> ActionConfig {
+        ActionConfig::new(coupling_0, coupling_2, cosmological_constant)
+            .expect("test action config should be valid")
+    }
+
     /// Builds a result container around deterministic geometry for summary-method tests.
     fn results_with(
         config: MetropolisConfig,
@@ -1123,6 +1284,32 @@ mod tests {
             elapsed_time: Duration::from_millis(100),
             triangulation,
         }
+    }
+
+    fn valid_rejected_result(triangulation: CdtTriangulation2D) -> SimulationResultsBackend {
+        let mut move_stats = MoveStatistics::new();
+        move_stats.record_attempt(MoveType::Move22);
+        SimulationResultsBackend::new(
+            metropolis_config(1.0, 1, 0, 1),
+            ActionConfig::default(),
+            move_stats,
+            ProposalStatistics::from_validated_parts(1, 0, 1, 0, 0, 0, 0, 0, 0),
+            vec![MonteCarloStep {
+                step: 1,
+                move_type: MoveType::Move22,
+                accepted: false,
+                action_before: 0.0,
+                action_after: None,
+                delta_action: None,
+            }],
+            vec![
+                Measurement::new(0, 0.0, 12, 26, 12),
+                Measurement::new(1, 0.0, 12, 26, 12),
+            ],
+            Duration::ZERO,
+            triangulation,
+        )
+        .expect("valid rejected result should construct")
     }
 
     /// Asserts two equal-length floating-point slices using relative tolerance.
@@ -1171,31 +1358,24 @@ mod tests {
 
     #[test]
     fn public_constructor_accepts_valid_components_and_preserves_accessors() {
-        let config = MetropolisConfig::new(1.5, 4, 1, 2).with_seed(23);
-        let action_config = ActionConfig::new(1.0, 0.5, 0.25);
+        let config = seeded_metropolis_config(1.5, 1, 0, 1, 23);
+        let action_config = action_config(1.0, 0.5, 0.25);
         let mut move_stats = MoveStatistics::new();
         move_stats.record_attempt(MoveType::Move22);
         move_stats.record_success(MoveType::Move22);
-        let proposal_stats = ProposalStatistics {
-            move_family_proposals: 2,
-            observed_forward_sites: 7,
-            no_site_proposals: 1,
-            site_causality_rejections: 0,
-            site_geometric_rejections: 0,
-            site_backend_rejections: 0,
-            metropolis_rejections: 0,
-            accepted_transitions: 1,
-            hard_failures: 0,
-        };
+        let proposal_stats = ProposalStatistics::from_validated_parts(1, 7, 0, 0, 0, 0, 0, 1, 0);
         let step = MonteCarloStep {
-            step: 2,
+            step: 1,
             move_type: MoveType::Move22,
             accepted: true,
             action_before: 4.0,
             action_after: Some(3.5),
             delta_action: Some(-0.5),
         };
-        let measurement = Measurement::new(2, 3.5, 12, 26, 12).with_volume_profile(vec![4, 4, 4]);
+        let measurements = vec![
+            Measurement::new(0, 4.0, 12, 26, 12).with_volume_profile(vec![4, 4, 4]),
+            Measurement::new(1, 3.5, 12, 26, 12).with_volume_profile(vec![4, 4, 4]),
+        ];
         let elapsed = Duration::from_millis(42);
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
@@ -1206,7 +1386,7 @@ mod tests {
             move_stats,
             proposal_stats.clone(),
             vec![step],
-            vec![measurement],
+            measurements,
             elapsed,
             triangulation,
         )
@@ -1217,28 +1397,53 @@ mod tests {
         assert_eq!(results.move_stats().total_attempted(), 1);
         assert_eq!(results.move_stats().total_accepted(), 1);
         assert_eq!(results.proposal_stats(), &proposal_stats);
-        assert_eq!(results.steps()[0].step, 2);
+        assert_eq!(results.steps()[0].step, 1);
         assert_eq!(results.measurements()[0].volume_profile, vec![4, 4, 4]);
         assert_eq!(results.elapsed_time(), elapsed);
         assert_eq!(results.triangulation().slice_sizes(), &[4, 4, 4]);
     }
 
     #[test]
-    fn public_constructor_rejects_invalid_metropolis_config() {
+    fn public_constructor_rejects_hard_proposal_failures_with_count() {
+        let mut move_stats = MoveStatistics::new();
+        move_stats.record_attempt(MoveType::Move22);
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
 
         let error = SimulationResultsBackend::new(
-            MetropolisConfig::new(0.0, 1, 0, 1),
+            metropolis_config(1.0, 1, 0, 1),
             ActionConfig::default(),
-            MoveStatistics::new(),
-            ProposalStatistics::new(),
-            vec![],
-            vec![],
+            move_stats,
+            ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 1),
+            vec![MonteCarloStep {
+                step: 1,
+                move_type: MoveType::Move22,
+                accepted: false,
+                action_before: 0.0,
+                action_after: None,
+                delta_action: None,
+            }],
+            vec![
+                Measurement::new(0, 0.0, 12, 26, 12),
+                Measurement::new(1, 0.0, 12, 26, 12),
+            ],
             Duration::ZERO,
             triangulation,
         )
-        .expect_err("zero temperature should be rejected");
+        .expect_err("hard proposal failures cannot appear in completed results");
+
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::ProposalHardFailures { actual: 1 }
+            }
+        );
+    }
+
+    #[test]
+    fn public_constructor_rejects_invalid_metropolis_config() {
+        let error =
+            MetropolisConfig::new(0.0, 1, 0, 1).expect_err("zero temperature should be rejected");
 
         assert_matches!(
             error,
@@ -1254,20 +1459,8 @@ mod tests {
 
     #[test]
     fn public_constructor_rejects_invalid_action_config() {
-        let triangulation =
-            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
-
-        let error = SimulationResultsBackend::new(
-            MetropolisConfig::new(1.0, 1, 0, 1),
-            ActionConfig::new(f64::NAN, 0.0, 0.0),
-            MoveStatistics::new(),
-            ProposalStatistics::new(),
-            vec![],
-            vec![],
-            Duration::ZERO,
-            triangulation,
-        )
-        .expect_err("non-finite action coupling should be rejected");
+        let error = ActionConfig::new(f64::NAN, 0.0, 0.0)
+            .expect_err("non-finite action coupling should be rejected");
 
         assert_matches!(
             error,
@@ -1297,12 +1490,22 @@ mod tests {
             .expect("rewriting an existing label should mark foliation stale");
 
         let error = SimulationResultsBackend::new(
-            MetropolisConfig::new(1.0, 1, 0, 1),
+            metropolis_config(1.0, 1, 0, 1),
             ActionConfig::default(),
             MoveStatistics::new(),
             ProposalStatistics::new(),
-            vec![],
-            vec![],
+            vec![MonteCarloStep {
+                step: 1,
+                move_type: MoveType::Move22,
+                accepted: false,
+                action_before: 0.0,
+                action_after: None,
+                delta_action: None,
+            }],
+            vec![
+                Measurement::new(0, 0.0, 12, 26, 12),
+                Measurement::new(1, 0.0, 12, 26, 12),
+            ],
             Duration::ZERO,
             triangulation,
         )
@@ -1318,21 +1521,11 @@ mod tests {
     fn deserialization_rejects_invalid_metropolis_config() {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
-        let results = SimulationResultsBackend::new(
-            MetropolisConfig::new(1.0, 1, 0, 1),
-            ActionConfig::default(),
-            MoveStatistics::new(),
-            ProposalStatistics::new(),
-            vec![],
-            vec![],
-            Duration::ZERO,
-            triangulation,
-        )
-        .expect("valid result components should construct");
+        let results = valid_rejected_result(triangulation);
         let json = serde_json::to_string(&results).expect("results should serialize");
         let roundtrip: SimulationResultsBackend =
             serde_json::from_str(&json).expect("valid serialized results should load");
-        assert_relative_eq!(roundtrip.config.temperature, 1.0);
+        assert_relative_eq!(roundtrip.config.temperature(), 1.0);
 
         let invalid_json = json.replacen("\"temperature\":1.0", "\"temperature\":0.0", 1);
         assert_ne!(invalid_json, json);
@@ -1350,31 +1543,20 @@ mod tests {
     fn deserialization_defaults_missing_proposal_stats() {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
-        let results = SimulationResultsBackend::new(
-            MetropolisConfig::new(1.0, 1, 0, 1),
-            ActionConfig::default(),
-            MoveStatistics::new(),
-            ProposalStatistics::new(),
-            vec![],
-            vec![],
-            Duration::ZERO,
-            triangulation,
-        )
-        .expect("valid result components should construct");
+        let results = valid_rejected_result(triangulation);
         let mut payload = to_value(&results).expect("results should serialize");
         payload
             .as_object_mut()
             .expect("results payload should be an object")
             .remove("proposal_stats");
 
-        let restored: SimulationResultsBackend =
-            from_str(&payload.to_string()).expect("legacy results should deserialize");
-
-        assert_eq!(restored.proposal_stats(), &ProposalStatistics::new());
-        restored
-            .triangulation()
-            .validate()
-            .expect("legacy results should still validate triangulation");
+        let error = from_str::<SimulationResultsBackend>(&payload.to_string())
+            .expect_err("missing proposal stats should fail result telemetry validation");
+        assert!(
+            error.to_string().contains("proposal")
+                || error.to_string().contains("move-family count mismatch"),
+            "unexpected serde error: {error}"
+        );
     }
 
     #[test]
@@ -1382,7 +1564,7 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let error = SimulationResultsBackend::try_from(SimulationResultsBackendWire {
-            config: MetropolisConfig::new(0.0, 1, 0, 1),
+            config: metropolis_config(1.0, 1, 0, 1),
             action_config: ActionConfig::default(),
             move_stats: MoveStatistics::new(),
             proposal_stats: ProposalStatistics::new(),
@@ -1391,15 +1573,13 @@ mod tests {
             elapsed_time: Duration::ZERO,
             triangulation,
         })
-        .expect_err("invalid wire Metropolis config should be rejected");
+        .expect_err("invalid result telemetry should be rejected");
 
         assert_matches!(
             error,
-            CdtError::InvalidSimulationConfiguration {
-                ref setting,
-                ref provided_value,
-                ref expected,
-            } if *setting == ConfigurationSetting::Temperature && provided_value == "0" && expected == "finite and positive"
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::StepTelemetryLengthMismatch { .. }
+            }
         );
     }
 
@@ -1408,8 +1588,8 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let error = SimulationResultsBackend::try_from(SimulationResultsBackendWire {
-            config: MetropolisConfig::new(1.0, 1, 0, 1),
-            action_config: ActionConfig::new(f64::NAN, 0.0, 0.0),
+            config: metropolis_config(1.0, 1, 0, 1),
+            action_config: ActionConfig::default(),
             move_stats: MoveStatistics::new(),
             proposal_stats: ProposalStatistics::new(),
             steps: vec![],
@@ -1417,15 +1597,13 @@ mod tests {
             elapsed_time: Duration::ZERO,
             triangulation,
         })
-        .expect_err("invalid wire action config should be rejected");
+        .expect_err("invalid result telemetry should be rejected");
 
         assert_matches!(
             error,
-            CdtError::InvalidConfiguration {
-                ref setting,
-                ref provided_value,
-                ref expected,
-            } if *setting == ConfigurationSetting::Coupling0 && provided_value == "NaN" && expected == "finite"
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::StepTelemetryLengthMismatch { .. }
+            }
         );
     }
 
@@ -1446,7 +1624,7 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let results = results_with(
-            MetropolisConfig::new(1.0, 2, 1, 1),
+            metropolis_config(1.0, 2, 1, 1),
             vec![MonteCarloStep {
                 step: 1,
                 move_type: MoveType::Move22,
@@ -1482,7 +1660,7 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let results = results_with(
-            MetropolisConfig::new(1.0, 1, 0, 1),
+            metropolis_config(1.0, 1, 0, 1),
             vec![MonteCarloStep {
                 step: 1,
                 move_type: MoveType::Move22,
@@ -1500,7 +1678,9 @@ mod tests {
             measurement_frequency: 1,
             simulate: true,
             ..CdtConfig::new(12, 3)
-        };
+        }
+        .into_validated()
+        .expect("summary config should validate");
         let path = temp_output_path("summary.json");
 
         results
@@ -1522,7 +1702,7 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let results = results_with(
-            MetropolisConfig::new(1.0, 1, 0, 1),
+            metropolis_config(1.0, 1, 0, 1),
             vec![],
             vec![],
             triangulation,
@@ -1547,7 +1727,9 @@ mod tests {
         assert!(!detail.is_empty());
 
         let json_path = parent_file.join("summary.json");
-        let config = CdtConfig::new(12, 3);
+        let config = CdtConfig::new(12, 3)
+            .into_validated()
+            .expect("summary config should validate");
         let json_error = results
             .write_summary_json(&config, &json_path)
             .expect_err("JSON writer should reject a parent path that is a file");
@@ -1571,7 +1753,7 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let results = results_with(
-            MetropolisConfig::new(1.0, 2, 1, 1),
+            metropolis_config(1.0, 2, 1, 1),
             vec![],
             vec![
                 Measurement::new(0, 100.0, 12, 26, 12),
@@ -1586,7 +1768,9 @@ mod tests {
             measurement_frequency: 1,
             simulate: true,
             ..CdtConfig::new(12, 3)
-        };
+        }
+        .into_validated()
+        .expect("summary config should validate");
         let path = temp_output_path("equilibrium-summary.json");
 
         results
@@ -1606,7 +1790,7 @@ mod tests {
 
     #[test]
     fn summaries_use_post_thermalization_measurements() {
-        let config = MetropolisConfig::new(1.0, 20, 10, 5);
+        let config = metropolis_config(1.0, 20, 10, 5);
         let steps = vec![
             MonteCarloStep {
                 step: 1,
@@ -1658,7 +1842,7 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let results = results_with(
-            MetropolisConfig::new(1.0, 20, 10, 5),
+            metropolis_config(1.0, 20, 10, 5),
             vec![],
             vec![
                 Measurement::new(10, 2.0, 4, 5, 2).with_volume_profile(vec![4, 8, 1]),
@@ -1679,7 +1863,7 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let results = results_with(
-            MetropolisConfig::new(1.0, 20, 10, 5),
+            metropolis_config(1.0, 20, 10, 5),
             vec![],
             vec![
                 Measurement::new(10, 2.0, 4, 5, 2),
@@ -1697,7 +1881,7 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let results = results_with(
-            MetropolisConfig::new(1.0, 20, 10, 5),
+            metropolis_config(1.0, 20, 10, 5),
             vec![],
             vec![
                 Measurement::new(0, 1.0, 3, 3, 1).with_volume_profile(vec![1]),
@@ -1715,7 +1899,7 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let results = results_with(
-            MetropolisConfig::new(1.0, 20, 10, 5),
+            metropolis_config(1.0, 20, 10, 5),
             vec![],
             vec![],
             triangulation,
@@ -1733,7 +1917,7 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_toroidal_cdt(6, 6).expect("periodic torus should build");
         let results = results_with(
-            MetropolisConfig::new(1.0, 1, 0, 1),
+            metropolis_config(1.0, 1, 0, 1),
             vec![],
             vec![],
             triangulation,
@@ -1754,7 +1938,7 @@ mod tests {
         let triangulation = CdtTriangulation::from_seeded_points(3, 1, 2, 53)
             .expect("seeded triangle should build");
         let results = results_with(
-            MetropolisConfig::new(1.0, 1, 0, 1),
+            metropolis_config(1.0, 1, 0, 1),
             vec![],
             vec![],
             triangulation,

--- a/src/cdt/results.rs
+++ b/src/cdt/results.rs
@@ -214,7 +214,7 @@ fn validate_result_telemetry(
         return Ok(());
     }
 
-    let expected_steps = usize::try_from(config.steps()).unwrap_or(usize::MAX);
+    let expected_steps = usize::try_from(config.steps().get()).unwrap_or(usize::MAX);
     if steps.len() != expected_steps {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::StepTelemetryLengthMismatch {
@@ -1175,7 +1175,7 @@ impl SimulationResultsBackend {
                 vertices: self.triangulation.vertex_count(),
                 edges: self.triangulation.edge_count(),
                 triangles: self.triangulation.face_count(),
-                time_slices: self.triangulation.time_slices(),
+                time_slices: self.triangulation.time_slices().get(),
                 topology: self.triangulation.metadata().topology(),
             },
             steps: &self.steps,

--- a/src/cdt/results.rs
+++ b/src/cdt/results.rs
@@ -11,7 +11,7 @@ use crate::cdt::ergodic_moves::MoveStatistics;
 use crate::cdt::metropolis::{
     MetropolisConfig, MonteCarloStep, ProposalStatistics,
     checkpoint::{chain_counters, checkpoint_resume_failed},
-    helpers::actions_match,
+    helpers::{actions_match, expected_measurement_count, expected_measurement_step},
 };
 use crate::cdt::observables::{estimate_hausdorff_dimension, estimate_spectral_dimension};
 use crate::config::{CdtConfig, CdtTopology, ValidatedCdtConfig};
@@ -335,7 +335,11 @@ fn validate_result_steps(steps: &[MonteCarloStep], accepted: usize) -> CdtResult
     Ok(())
 }
 
-/// Checks measurement cadence and finite measured actions.
+/// Checks post-thermalization measurement cadence and finite measured actions.
+///
+/// This mirrors the runner's measurement schedule so result deserialization
+/// rejects samples from the thermalization window instead of treating them as
+/// equilibrium data.
 fn validate_result_measurements(
     config: &MetropolisConfig,
     steps: &[MonteCarloStep],
@@ -344,11 +348,12 @@ fn validate_result_measurements(
     let current_step = u32::try_from(steps.len()).map_err(|_| {
         checkpoint_resume_failed(CheckpointResumeFailure::StepTelemetryIndexOverflow)
     })?;
-    let expected_measurements =
-        usize::try_from(u64::from(current_step) / u64::from(config.measurement_frequency()) + 1)
-            .map_err(|_| {
-                checkpoint_resume_failed(CheckpointResumeFailure::MeasurementCountOverflow)
-            })?;
+    let expected_measurements = expected_measurement_count(
+        current_step,
+        config.thermalization_steps(),
+        config.measurement_frequency(),
+    )
+    .ok_or_else(|| checkpoint_resume_failed(CheckpointResumeFailure::MeasurementCountOverflow))?;
     if measurements.len() != expected_measurements {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::MeasurementCountMismatch {
@@ -359,13 +364,14 @@ fn validate_result_measurements(
     }
 
     for (index, measurement) in measurements.iter().enumerate() {
-        let expected_step = u64::try_from(index)
-            .ok()
-            .and_then(|index| index.checked_mul(u64::from(config.measurement_frequency())))
-            .and_then(|step| u32::try_from(step).ok())
-            .ok_or_else(|| {
-                checkpoint_resume_failed(CheckpointResumeFailure::MeasurementStepOverflow)
-            })?;
+        let expected_step = expected_measurement_step(
+            index,
+            config.thermalization_steps(),
+            config.measurement_frequency(),
+        )
+        .ok_or_else(|| {
+            checkpoint_resume_failed(CheckpointResumeFailure::MeasurementStepOverflow)
+        })?;
         if measurement.step != expected_step {
             return Err(checkpoint_resume_failed(
                 CheckpointResumeFailure::MeasurementStepMismatch {
@@ -386,6 +392,11 @@ fn validate_result_measurements(
 }
 
 /// Checks proposal counters against step and move-counter outcomes.
+///
+/// Completed result snapshots must have one terminal proposal outcome per
+/// recorded step and no hard failures. This keeps public
+/// [`Self::proposal_stats`](SimulationResultsBackend::proposal_stats) accessors
+/// from exposing counters that cannot describe the recorded chain.
 fn validate_result_proposal_stats(
     proposal_stats: &ProposalStatistics,
     steps: usize,
@@ -672,6 +683,11 @@ impl SimulationResultsBackend {
     }
 
     /// Returns recorded measurements.
+    ///
+    /// For Metropolis runs, measurements are recorded on the configured cadence
+    /// at or after [`MetropolisConfig::thermalization_steps`]. Construction-only
+    /// results produced by [`run_simulation`](crate::run_simulation) with
+    /// simulation disabled contain a single step-0 construction snapshot.
     ///
     /// # Examples
     ///
@@ -992,8 +1008,8 @@ impl SimulationResultsBackend {
 
     /// Returns measurements after thermalization.
     ///
-    /// Measurements are recorded for the initial state at step 0, then after
-    /// completed-move counts divisible by
+    /// Metropolis runs record measurements only after the configured
+    /// thermalization boundary, at completed-move counts divisible by
     /// [`MetropolisConfig::measurement_frequency`]. This accessor defines
     /// equilibrium as `measurement.step >= thermalization_steps`, so a
     /// measurement taken exactly on the thermalization boundary is included.
@@ -1404,6 +1420,96 @@ mod tests {
     }
 
     #[test]
+    fn public_constructor_rejects_pre_thermalization_measurement_stream() {
+        let config = metropolis_config(1.0, 4, 2, 2);
+        let mut move_stats = MoveStatistics::new();
+        for _ in 0..4 {
+            move_stats.record_attempt(MoveType::Move22);
+        }
+        let steps = (1..=4)
+            .map(|step| MonteCarloStep {
+                step,
+                move_type: MoveType::Move22,
+                accepted: false,
+                action_before: f64::from(step),
+                action_after: None,
+                delta_action: None,
+            })
+            .collect::<Vec<_>>();
+        let measurements = vec![
+            Measurement::new(0, 0.0, 12, 26, 12),
+            Measurement::new(4, 4.0, 12, 26, 12),
+        ];
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+
+        let error = SimulationResultsBackend::new(
+            config,
+            ActionConfig::default(),
+            move_stats,
+            ProposalStatistics::from_validated_parts(4, 0, 4, 0, 0, 0, 0, 0, 0),
+            steps,
+            measurements,
+            Duration::ZERO,
+            triangulation,
+        )
+        .expect_err("pre-thermalization measurements should be rejected");
+
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::MeasurementStepMismatch {
+                    actual: 0,
+                    expected: 2
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn public_constructor_rejects_missing_scheduled_measurement() {
+        let config = metropolis_config(1.0, 4, 2, 2);
+        let mut move_stats = MoveStatistics::new();
+        for _ in 0..4 {
+            move_stats.record_attempt(MoveType::Move22);
+        }
+        let steps = (1..=4)
+            .map(|step| MonteCarloStep {
+                step,
+                move_type: MoveType::Move22,
+                accepted: false,
+                action_before: f64::from(step),
+                action_after: None,
+                delta_action: None,
+            })
+            .collect::<Vec<_>>();
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+
+        let error = SimulationResultsBackend::new(
+            config,
+            ActionConfig::default(),
+            move_stats,
+            ProposalStatistics::from_validated_parts(4, 0, 4, 0, 0, 0, 0, 0, 0),
+            steps,
+            vec![Measurement::new(2, 2.0, 12, 26, 12)],
+            Duration::ZERO,
+            triangulation,
+        )
+        .expect_err("missing scheduled measurement should be rejected");
+
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::MeasurementCountMismatch {
+                    actual: 1,
+                    expected: 2
+                }
+            }
+        );
+    }
+
+    #[test]
     fn public_constructor_rejects_hard_proposal_failures_with_count() {
         let mut move_stats = MoveStatistics::new();
         move_stats.record_attempt(MoveType::Move22);
@@ -1436,6 +1542,87 @@ mod tests {
             error,
             CdtError::CheckpointResumeFailed {
                 failure: CheckpointResumeFailure::ProposalHardFailures { actual: 1 }
+            }
+        );
+    }
+
+    #[test]
+    fn public_constructor_rejects_proposal_accepted_count_mismatch() {
+        let mut move_stats = MoveStatistics::new();
+        move_stats.record_attempt(MoveType::Move22);
+        move_stats.record_success(MoveType::Move22);
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+
+        let error = SimulationResultsBackend::new(
+            metropolis_config(1.0, 1, 0, 1),
+            ActionConfig::default(),
+            move_stats,
+            ProposalStatistics::from_validated_parts(1, 1, 1, 0, 0, 0, 0, 0, 0),
+            vec![MonteCarloStep {
+                step: 1,
+                move_type: MoveType::Move22,
+                accepted: true,
+                action_before: 0.0,
+                action_after: Some(0.0),
+                delta_action: Some(0.0),
+            }],
+            vec![
+                Measurement::new(0, 0.0, 12, 26, 12),
+                Measurement::new(1, 0.0, 12, 26, 12),
+            ],
+            Duration::ZERO,
+            triangulation,
+        )
+        .expect_err("accepted proposal totals must match accepted steps");
+
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::ProposalAcceptedCountMismatch {
+                    actual: 0,
+                    expected: 1
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn public_constructor_rejects_proposal_rejected_count_mismatch() {
+        let mut move_stats = MoveStatistics::new();
+        move_stats.record_attempt(MoveType::Move22);
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+
+        let error = SimulationResultsBackend::new(
+            metropolis_config(1.0, 1, 0, 1),
+            ActionConfig::default(),
+            move_stats,
+            ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 0),
+            vec![MonteCarloStep {
+                step: 1,
+                move_type: MoveType::Move22,
+                accepted: false,
+                action_before: 0.0,
+                action_after: None,
+                delta_action: None,
+            }],
+            vec![
+                Measurement::new(0, 0.0, 12, 26, 12),
+                Measurement::new(1, 0.0, 12, 26, 12),
+            ],
+            Duration::ZERO,
+            triangulation,
+        )
+        .expect_err("rejected proposal totals must match rejected steps");
+
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::ProposalRejectedCountMismatch {
+                    actual: 0,
+                    expected: 1
+                }
             }
         );
     }

--- a/src/cdt/triangulation/builders.rs
+++ b/src/cdt/triangulation/builders.rs
@@ -460,7 +460,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::from_random_points(5, 2, 2)?;
-    ///     assert_eq!(tri.time_slices(), 2);
+    ///     assert_eq!(tri.time_slices().get(), 2);
     ///     assert!(!tri.has_foliation());
     ///     Ok(())
     /// }
@@ -1024,7 +1024,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::from_toroidal_cdt_profile(&[3, 4, 5, 4])?;
     ///     assert_eq!(tri.slice_sizes(), &[3, 4, 5, 4]);
-    ///     assert_eq!(tri.time_slices(), 4);
+    ///     assert_eq!(tri.time_slices().get(), 4);
     ///     Ok(())
     /// }
     /// ```
@@ -1175,7 +1175,7 @@ mod tests {
             CdtTriangulation::from_random_points(10, 3, 2).expect("Failed to create triangulation");
 
         assert_eq!(triangulation.dimension(), 2);
-        assert_eq!(triangulation.time_slices(), 3);
+        assert_eq!(triangulation.time_slices().get(), 3);
         assert!(triangulation.vertex_count() > 0);
         assert!(triangulation.edge_count() > 0);
         assert!(triangulation.face_count() > 0);
@@ -1200,7 +1200,7 @@ mod tests {
                 "Dimension should be 2 for {description}"
             );
             assert_eq!(
-                triangulation.time_slices(),
+                triangulation.time_slices().get(),
                 time_slices,
                 "Time slices should match for {description}"
             );
@@ -1226,7 +1226,7 @@ mod tests {
             .expect("Failed to create seeded triangulation");
 
         assert_eq!(triangulation.dimension(), 2);
-        assert_eq!(triangulation.time_slices(), 2);
+        assert_eq!(triangulation.time_slices().get(), 2);
         assert!(triangulation.vertex_count() > 0);
         assert!(triangulation.edge_count() > 0);
         assert!(triangulation.face_count() > 0);
@@ -1679,7 +1679,7 @@ mod tests {
         assert_eq!(tri.edge_count(), 36);
         assert_eq!(tri.geometry().euler_characteristic(), 0);
         assert_eq!(tri.dimension(), 2);
-        assert_eq!(tri.time_slices(), 3);
+        assert_eq!(tri.time_slices().get(), 3);
         assert_matches!(tri.metadata().topology, CdtTopology::Toroidal);
     }
 

--- a/src/cdt/triangulation/foliation.rs
+++ b/src/cdt/triangulation/foliation.rs
@@ -7,7 +7,7 @@ use crate::cdt::foliation::{EdgeType, Foliation, FoliationError, SimplexType, cl
 use crate::config::CdtTopology;
 use crate::errors::{
     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
-    GenerationParameterIssue,
+    GenerationParameterIssue, TriangulationMetadataField,
 };
 use crate::geometry::DelaunayBackend2D;
 use crate::geometry::backends::delaunay::{
@@ -115,11 +115,18 @@ impl CdtTriangulation<DelaunayBackend2D> {
 
     /// Validates that the time direction wraps for toroidal topology.
     fn validate_toroidal_temporal_wraparound(&self) -> CdtResult<()> {
-        let total = self.metadata.time_slices;
+        let total = self.metadata.time_slices.get();
         if total < 2 {
             return Ok(());
         }
-        let num_slices = total as usize;
+        let Ok(num_slices) = usize::try_from(total) else {
+            return Err(CdtError::InvalidTriangulationMetadata {
+                field: TriangulationMetadataField::Timeslices,
+                topology: self.metadata.topology,
+                provided_value: total.to_string(),
+                expected: "representable as usize".to_string(),
+            });
+        };
 
         let mut neighbor_slices: Vec<HashSet<usize>> = vec![HashSet::new(); num_slices];
         for edge in self.geometry.edges() {
@@ -442,7 +449,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
             }
         }
 
-        self.metadata.time_slices = num_slices;
+        self.metadata.time_slices = Self::parse_time_slices(self.metadata.topology, num_slices)?;
         self.bump_modification_count();
         self.foliation = Some(foliation);
         self.mark_foliation_synchronized();
@@ -479,7 +486,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::from_cdt_strip(4, 2)?;
-    ///     assert_eq!(tri.foliation().map(Foliation::num_slices), Some(2));
+    ///     assert_eq!(tri.foliation().map(|foliation| foliation.num_slices().get()), Some(2));
     ///     Ok(())
     /// }
     /// ```
@@ -584,7 +591,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
             return Vec::new();
         }
 
-        let Ok(slice_count) = usize::try_from(self.metadata.time_slices) else {
+        let Ok(slice_count) = usize::try_from(self.metadata.time_slices.get()) else {
             return Vec::new();
         };
         let mut profile = vec![0_u32; slice_count];
@@ -609,8 +616,8 @@ impl CdtTriangulation<DelaunayBackend2D> {
     pub(super) fn time_step_distance(&self, t0: u32, t1: u32) -> u32 {
         let raw = t0.abs_diff(t1);
         if matches!(self.metadata.topology, CdtTopology::Toroidal) {
-            let total = self.metadata.time_slices;
-            if total > 0 && t0 < total && t1 < total {
+            let total = self.metadata.time_slices.get();
+            if t0 < total && t1 < total {
                 return raw.min(total - raw);
             }
         }
@@ -639,8 +646,8 @@ impl CdtTriangulation<DelaunayBackend2D> {
             return None;
         };
 
-        let total = self.metadata.time_slices;
-        let toroidal = matches!(self.metadata.topology, CdtTopology::Toroidal) && total > 0;
+        let total = self.metadata.time_slices.get();
+        let toroidal = matches!(self.metadata.topology, CdtTopology::Toroidal);
         let up_apex = if toroidal {
             (base_slice + 1) % total
         } else {
@@ -682,10 +689,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
         match self.metadata.topology {
             CdtTopology::OpenBoundary => Some(labels[0].min(labels[1]).min(labels[2])),
             CdtTopology::Toroidal => {
-                let total = self.metadata.time_slices;
-                if total == 0 {
-                    return None;
-                }
+                let total = self.metadata.time_slices.get();
 
                 let first = labels[0];
                 let mut second = None;
@@ -1004,9 +1008,11 @@ impl CdtTriangulation<DelaunayBackend2D> {
             return Ok(());
         }
 
-        let slice_sizes =
-            Self::live_slice_sizes_from_vertex_labels(&self.geometry, self.metadata.time_slices)?;
-        let foliation = Foliation::from_slice_sizes(slice_sizes, self.metadata.time_slices)
+        let slice_sizes = Self::live_slice_sizes_from_vertex_labels(
+            &self.geometry,
+            self.metadata.time_slices.get(),
+        )?;
+        let foliation = Foliation::from_slice_sizes(slice_sizes, self.metadata.time_slices.get())
             .map_err(CdtError::from)?;
 
         self.foliation = Some(foliation);
@@ -1174,7 +1180,7 @@ mod tests {
             .expect("Should assign foliation");
 
         assert!(tri.has_foliation());
-        assert_eq!(tri.time_slices(), 3);
+        assert_eq!(tri.time_slices().get(), 3);
         assert_eq!(tri.slice_sizes().iter().sum::<usize>(), tri.vertex_count());
         assert!(tri.metadata().last_modified > initial_last_modified);
         assert_eq!(
@@ -1246,7 +1252,7 @@ mod tests {
                 && provided_value == "2"
                 && expected == "≥ 3"
         );
-        assert_eq!(tri.time_slices(), 3);
+        assert_eq!(tri.time_slices().get(), 3);
         assert_eq!(tri.slice_sizes(), initial_slice_sizes.as_slice());
         assert!(tri.has_foliation());
     }
@@ -1422,7 +1428,7 @@ mod tests {
         tri.assign_foliation_by_y(2)
             .expect("Re-assignment with different slice count should succeed");
 
-        assert_eq!(tri.time_slices(), 2);
+        assert_eq!(tri.time_slices().get(), 2);
         assert_eq!(tri.slice_sizes().len(), 2);
         assert_eq!(tri.slice_sizes().iter().sum::<usize>(), tri.vertex_count());
         for face in tri.geometry().faces() {

--- a/src/cdt/triangulation/state.rs
+++ b/src/cdt/triangulation/state.rs
@@ -620,7 +620,13 @@ impl<B> CdtTriangulation<B> {
         self.invalidate_cache();
         self.invalidate_foliation_bookkeeping();
         self.metadata.last_modified = Instant::now();
-        self.metadata.modification_count += 1;
+        // Deserialized checkpoints can carry arbitrary counters; avoid wraparound
+        // so cache keys such as MoveSiteCache never see a stale version as fresh.
+        if self.metadata.modification_count == u64::MAX {
+            self.metadata.modification_count = 1;
+        } else {
+            self.metadata.modification_count += 1;
+        }
     }
 
     /// Records a simulation event without marking the geometry as mutated.
@@ -1494,6 +1500,10 @@ mod tests {
         let _geometry = triangulation.geometry();
         let _edge_count = triangulation.edge_count();
         assert_eq!(triangulation.metadata().modification_count, 2);
+
+        triangulation.metadata.modification_count = u64::MAX;
+        triangulation.bump_modification_count();
+        assert_eq!(triangulation.metadata().modification_count, 1);
     }
 
     #[test]

--- a/src/cdt/triangulation/state.rs
+++ b/src/cdt/triangulation/state.rs
@@ -1,9 +1,10 @@
 #![forbid(unsafe_code)]
 
-//! CDT triangulation wrapper - backend-agnostic.
+//! CDT triangulation state - backend-agnostic.
 //!
-//! This module provides CDT-specific triangulation data structures that work
-//! with any geometry backend implementing the trait interfaces.
+//! This module owns the backend-agnostic CDT triangulation state. It stores
+//! CDT metadata, cached derived quantities, foliation bookkeeping, and the
+//! underlying geometry backend behind validated construction and mutation paths.
 
 use crate::cdt::ergodic_moves::MoveType;
 use crate::cdt::foliation::{Foliation, FoliationError};
@@ -35,7 +36,10 @@ fn next_triangulation_instance_id() -> u64 {
     instance_id
 }
 
-/// CDT-specific triangulation wrapper - completely geometry-agnostic
+/// CDT triangulation state paired with a geometry backend.
+///
+/// Constructors and fallible setters validate CDT metadata before storage so
+/// normal accessors can expose the accepted state infallibly.
 pub struct CdtTriangulation<B> {
     /// Process-local identity used only to reject stale transient caches.
     instance_id: u64,
@@ -81,21 +85,164 @@ impl<B: Clone> Clone for CdtTriangulation<B> {
 #[derive(Debug, Clone)]
 pub struct CdtMetadata {
     /// Number of time slices in the CDT foliation
-    pub time_slices: u32,
+    time_slices: u32,
     /// Dimensionality of the spacetime
-    pub dimension: u8,
+    dimension: u8,
     /// Topology of the spatial slices
-    pub topology: CdtTopology,
+    topology: CdtTopology,
     /// Time when this triangulation was created
-    pub creation_time: Instant,
+    creation_time: Instant,
     /// Time of last modification
-    pub last_modified: Instant,
+    last_modified: Instant,
     /// Count of modifications made to the triangulation
-    pub modification_count: u64,
+    modification_count: u64,
     /// Ordered simulation event history recorded for this triangulation.
     ///
     /// Move events identify proposals and acceptances with [`MoveType`].
-    pub simulation_history: Vec<SimulationEvent>,
+    simulation_history: Vec<SimulationEvent>,
+}
+
+impl CdtMetadata {
+    /// Returns the number of time slices in the CDT foliation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
+    /// use causal_triangulations::geometry::backends::mock::MockBackend;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.metadata().time_slices(), 2);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn time_slices(&self) -> u32 {
+        self.time_slices
+    }
+
+    /// Returns the dimensionality of the spacetime.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
+    /// use causal_triangulations::geometry::backends::mock::MockBackend;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.metadata().dimension(), 2);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn dimension(&self) -> u8 {
+        self.dimension
+    }
+
+    /// Returns the spatial-slice topology.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
+    /// use causal_triangulations::config::CdtTopology;
+    /// use causal_triangulations::geometry::backends::mock::MockBackend;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.metadata().topology(), CdtTopology::OpenBoundary);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn topology(&self) -> CdtTopology {
+        self.topology
+    }
+
+    /// Returns the creation timestamp for this triangulation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
+    /// use causal_triangulations::geometry::backends::mock::MockBackend;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert!(tri.metadata().creation_time() <= tri.metadata().last_modified());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn creation_time(&self) -> Instant {
+        self.creation_time
+    }
+
+    /// Returns the timestamp for the most recent triangulation mutation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
+    /// use causal_triangulations::geometry::backends::mock::MockBackend;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert!(tri.metadata().last_modified() >= tri.metadata().creation_time());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn last_modified(&self) -> Instant {
+        self.last_modified
+    }
+
+    /// Returns the mutation counter used to invalidate derived caches.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
+    /// use causal_triangulations::geometry::backends::mock::MockBackend;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.metadata().modification_count(), 0);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn modification_count(&self) -> u64 {
+        self.modification_count
+    }
+
+    /// Returns the ordered simulation event history.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
+    /// use causal_triangulations::geometry::backends::mock::MockBackend;
+    /// use causal_triangulations::prelude::errors::CdtResult;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.metadata().simulation_history().len(), 1);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub fn simulation_history(&self) -> &[SimulationEvent] {
+        &self.simulation_history
+    }
 }
 
 /// Cached geometry measurements
@@ -113,7 +260,7 @@ struct CachedValue<T> {
 
 /// Event recorded in a CDT simulation history.
 ///
-/// The history is stored on [`CdtMetadata::simulation_history`]. Move events
+/// The history is exposed by [`CdtMetadata::simulation_history`]. Move events
 /// use [`MoveType`] to keep history, checkpoint serialization, and move
 /// statistics aligned with the crate's supported ergodic move set.
 ///
@@ -258,21 +405,250 @@ impl<'de> Deserialize<'de> for CdtTriangulation<DelaunayBackend2D> {
 }
 
 impl CdtTriangulation<DelaunayBackend2D> {
+    /// Validates a deserialized checkpoint before exposing restored CDT state.
+    ///
+    /// This keeps serde deserialization aligned with the public constructor and
+    /// post-move contracts: checkpoint data must restore to a fully valid CDT
+    /// triangulation, including geometry, topology, foliation, and causality.
     fn validate_checkpoint_invariants(&self) -> CdtResult<()> {
         self.validate_evolved_cdt()
     }
 }
 
-impl<B: TriangulationQuery> CdtTriangulation<B> {
-    /// Fallible constructor for a CDT triangulation with open boundary topology.
+impl<B> CdtTriangulation<B> {
+    /// Encodes topology-specific time-slice metadata invariants in one reusable check.
+    fn check_time_slices(topology: CdtTopology, time_slices: u32) -> CdtResult<()> {
+        if time_slices == 0 {
+            return Err(CdtError::InvalidTriangulationMetadata {
+                field: TriangulationMetadataField::Timeslices,
+                topology,
+                provided_value: "0".to_string(),
+                expected: "≥ 1".to_string(),
+            });
+        }
+
+        if matches!(topology, CdtTopology::Toroidal) && time_slices < 3 {
+            return Err(CdtError::InvalidTriangulationMetadata {
+                field: TriangulationMetadataField::Timeslices,
+                topology,
+                provided_value: time_slices.to_string(),
+                expected: "≥ 3".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Get immutable reference to underlying geometry.
     ///
-    /// Validates metadata before returning so callers cannot accidentally wrap a
-    /// backend with a mismatched dimension or zero time slices.
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::testing::*;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.geometry().vertex_count(), 3);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn geometry(&self) -> &B {
+        &self.geometry
+    }
+
+    /// Get the number of time slices in the CDT foliation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::testing::*;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.time_slices(), 2);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn time_slices(&self) -> u32 {
+        self.metadata.time_slices
+    }
+
+    /// Get the dimensionality of the spacetime.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::testing::*;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.dimension(), 2);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn dimension(&self) -> u8 {
+        self.metadata.dimension
+    }
+
+    /// Returns immutable CDT metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::testing::*;
+    /// use causal_triangulations::{CdtResult, CdtTriangulation};
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
+    ///     assert_eq!(tri.metadata().time_slices(), 2);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn metadata(&self) -> &CdtMetadata {
+        &self.metadata
+    }
+
+    /// Returns the transient process-local identity used for cache invalidation.
+    #[must_use]
+    pub(crate) const fn instance_id(&self) -> u64 {
+        self.instance_id
+    }
+
+    /// Writes time-slice metadata through the central invariant and foliation invalidation path.
+    fn apply_time_slices(&mut self, time_slices: u32) -> CdtResult<()> {
+        Self::check_time_slices(self.metadata.topology, time_slices)?;
+        self.metadata.time_slices = time_slices;
+        if self
+            .foliation
+            .as_ref()
+            .is_some_and(|foliation| foliation.num_slices() != time_slices)
+        {
+            self.foliation = None;
+            self.foliation_synced_at_modification = None;
+        }
+        Ok(())
+    }
+
+    /// Distinguishes synchronized foliation data from stale bookkeeping after geometry mutation.
+    #[must_use]
+    fn has_current_foliation(&self) -> bool {
+        self.foliation.is_some()
+            && self.foliation_synced_at_modification == Some(self.metadata.modification_count)
+    }
+
+    /// Records that stored foliation data matches the current geometry mutation count.
+    fn mark_foliation_synchronized(&mut self) {
+        self.foliation_synced_at_modification = self
+            .foliation
+            .as_ref()
+            .map(|_| self.metadata.modification_count);
+    }
+
+    /// Builds the typed error used when callers try to trust stale foliation data.
+    fn stale_foliation_error(&self) -> CdtError {
+        FoliationError::StaleBookkeeping {
+            synced_at_modification: self.foliation_synced_at_modification,
+            current_modification_count: self.metadata.modification_count,
+        }
+        .into()
+    }
+
+    /// Marks existing foliation data stale without dropping it when geometry has changed.
+    const fn invalidate_foliation_bookkeeping(&mut self) {
+        if self.foliation.is_some() {
+            self.foliation_synced_at_modification = None;
+        }
+    }
+
+    /// Updates the configured number of time slices.
+    ///
+    /// If an existing foliation uses a different slice count, the foliation is
+    /// cleared to avoid stale bookkeeping.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidTriangulationMetadata`] if the new slice
+    /// count would violate topology metadata invariants.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::errors::{CdtError, TriangulationMetadataField};
+    /// use causal_triangulations::prelude::triangulation::{CdtTopology, CdtTriangulation};
+    /// use std::assert_matches;
+    ///
+    /// fn main() -> causal_triangulations::CdtResult<()> {
+    /// let mut tri = CdtTriangulation::from_toroidal_cdt(4, 3)?;
+    ///
+    /// let err = tri.set_time_slices(2).expect_err("T < 3 is invalid");
+    /// assert_matches!(
+    ///     err,
+    ///     CdtError::InvalidTriangulationMetadata {
+    ///         field,
+    ///         topology,
+    ///         provided_value,
+    ///         expected,
+    ///     } if field == TriangulationMetadataField::Timeslices
+    ///         && topology == CdtTopology::Toroidal
+    ///         && provided_value == "2"
+    ///         && expected == "≥ 3"
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn set_time_slices(&mut self, time_slices: u32) -> CdtResult<()> {
+        if self.metadata.time_slices == time_slices {
+            return self.apply_time_slices(time_slices);
+        }
+
+        self.apply_time_slices(time_slices)?;
+        self.bump_modification_count();
+        Ok(())
+    }
+
+    /// Marks the triangulation metadata as modified.
+    ///
+    /// This crate-internal hook invalidates cached derived geometry quantities.
+    pub(crate) fn bump_modification_count(&mut self) {
+        self.invalidate_cache();
+        self.invalidate_foliation_bookkeeping();
+        self.metadata.last_modified = Instant::now();
+        self.metadata.modification_count += 1;
+    }
+
+    /// Records a simulation event without marking the geometry as mutated.
+    pub(crate) fn record_event(&mut self, event: SimulationEvent) {
+        self.metadata.simulation_history.push(event);
+        self.metadata.last_modified = Instant::now();
+    }
+
+    /// Clears derived geometry counts so later queries recompute from the backend.
+    fn invalidate_cache(&mut self) {
+        self.cache = GeometryCache::default();
+    }
+}
+
+impl<B: TriangulationQuery> CdtTriangulation<B> {
+    /// Fallible constructor for a CDT triangulation with open-boundary topology.
+    ///
+    /// Validates metadata and topology before returning so callers cannot
+    /// accidentally wrap a backend with a mismatched dimension, zero time slices,
+    /// or an Euler characteristic that cannot represent an open-boundary CDT
+    /// triangulation.
     ///
     /// # Errors
     ///
     /// Returns [`CdtError::InvalidTriangulationMetadata`] if the supplied
-    /// metadata is inconsistent with the backend or topology.
+    /// metadata is inconsistent with the backend or topology. Returns
+    /// [`CdtError::TopologyMismatch`] when the backend Euler characteristic does
+    /// not match open-boundary topology.
     ///
     /// # Examples
     ///
@@ -295,6 +671,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
             CdtTopology::OpenBoundary,
         );
         tri.validate_metadata()?;
+        tri.validate_topology()?;
         Ok(tri)
     }
 
@@ -337,7 +714,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///     })?;
     ///
     ///     let tri = CdtTriangulation::with_topology(backend, 2, 2, CdtTopology::OpenBoundary)?;
-    ///     assert_matches!(tri.metadata().topology, CdtTopology::OpenBoundary);
+    ///     assert_matches!(tri.metadata().topology(), CdtTopology::OpenBoundary);
     ///     assert_eq!(tri.time_slices(), 2);
     ///     assert_eq!(tri.dimension(), 2);
     ///     Ok(())
@@ -461,29 +838,6 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
         }
     }
 
-    /// Encodes topology-specific time-slice metadata invariants in one reusable check.
-    fn check_time_slices(topology: CdtTopology, time_slices: u32) -> CdtResult<()> {
-        if time_slices == 0 {
-            return Err(CdtError::InvalidTriangulationMetadata {
-                field: TriangulationMetadataField::Timeslices,
-                topology,
-                provided_value: "0".to_string(),
-                expected: "≥ 1".to_string(),
-            });
-        }
-
-        if matches!(topology, CdtTopology::Toroidal) && time_slices < 3 {
-            return Err(CdtError::InvalidTriangulationMetadata {
-                field: TriangulationMetadataField::Timeslices,
-                topology,
-                provided_value: time_slices.to_string(),
-                expected: "≥ 3".to_string(),
-            });
-        }
-
-        Ok(())
-    }
-
     /// Validates CDT metadata against backend and topology invariants.
     fn validate_metadata(&self) -> CdtResult<()> {
         Self::check_time_slices(self.metadata.topology, self.metadata.time_slices)?;
@@ -499,25 +853,6 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
         }
 
         Ok(())
-    }
-
-    /// Get immutable reference to underlying geometry.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::{CdtResult, CdtTriangulation};
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
-    ///     assert_eq!(tri.geometry().vertex_count(), 3);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub const fn geometry(&self) -> &B {
-        &self.geometry
     }
 
     /// Returns the number of vertices in the backend triangulation.
@@ -554,69 +889,6 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// ```
     pub fn face_count(&self) -> usize {
         self.geometry.face_count()
-    }
-
-    /// Get the number of time slices in the CDT foliation.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::{CdtResult, CdtTriangulation};
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
-    ///     assert_eq!(tri.time_slices(), 2);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub const fn time_slices(&self) -> u32 {
-        self.metadata.time_slices
-    }
-
-    /// Get the dimensionality of the spacetime.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::{CdtResult, CdtTriangulation};
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
-    ///     assert_eq!(tri.dimension(), 2);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub const fn dimension(&self) -> u8 {
-        self.metadata.dimension
-    }
-
-    /// Returns immutable CDT metadata.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::testing::*;
-    /// use causal_triangulations::{CdtResult, CdtTriangulation};
-    ///
-    /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
-    ///     assert_eq!(tri.metadata().time_slices, 2);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[must_use]
-    pub const fn metadata(&self) -> &CdtMetadata {
-        &self.metadata
-    }
-
-    /// Returns the transient process-local identity used for cache invalidation.
-    #[must_use]
-    pub(crate) const fn instance_id(&self) -> u64 {
-        self.instance_id
     }
 
     /// Cached edge count with automatic invalidation.
@@ -732,124 +1004,12 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
 
         Ok(())
     }
-
-    /// Writes time-slice metadata through the central invariant and foliation invalidation path.
-    fn apply_time_slices(&mut self, time_slices: u32) -> CdtResult<()> {
-        Self::check_time_slices(self.metadata.topology, time_slices)?;
-        self.metadata.time_slices = time_slices;
-        if self
-            .foliation
-            .as_ref()
-            .is_some_and(|foliation| foliation.num_slices() != time_slices)
-        {
-            self.foliation = None;
-            self.foliation_synced_at_modification = None;
-        }
-        Ok(())
-    }
-
-    /// Distinguishes synchronized foliation data from stale bookkeeping after geometry mutation.
-    #[must_use]
-    fn has_current_foliation(&self) -> bool {
-        self.foliation.is_some()
-            && self.foliation_synced_at_modification == Some(self.metadata.modification_count)
-    }
-
-    /// Records that stored foliation data matches the current geometry mutation count.
-    fn mark_foliation_synchronized(&mut self) {
-        self.foliation_synced_at_modification = self
-            .foliation
-            .as_ref()
-            .map(|_| self.metadata.modification_count);
-    }
-
-    /// Builds the typed error used when callers try to trust stale foliation data.
-    fn stale_foliation_error(&self) -> CdtError {
-        FoliationError::StaleBookkeeping {
-            synced_at_modification: self.foliation_synced_at_modification,
-            current_modification_count: self.metadata.modification_count,
-        }
-        .into()
-    }
-
-    /// Marks existing foliation data stale without dropping it when geometry has changed.
-    const fn invalidate_foliation_bookkeeping(&mut self) {
-        if self.foliation.is_some() {
-            self.foliation_synced_at_modification = None;
-        }
-    }
-
-    /// Updates the configured number of time slices.
-    ///
-    /// If an existing foliation uses a different slice count, the foliation is
-    /// cleared to avoid stale bookkeeping.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`CdtError::InvalidTriangulationMetadata`] if the new slice
-    /// count would violate topology metadata invariants.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use causal_triangulations::prelude::errors::{CdtError, TriangulationMetadataField};
-    /// use causal_triangulations::prelude::triangulation::{CdtTopology, CdtTriangulation};
-    /// use std::assert_matches;
-    ///
-    /// fn main() -> causal_triangulations::CdtResult<()> {
-    /// let mut tri = CdtTriangulation::from_toroidal_cdt(4, 3)?;
-    ///
-    /// let err = tri.set_time_slices(2).expect_err("T < 3 is invalid");
-    /// assert_matches!(
-    ///     err,
-    ///     CdtError::InvalidTriangulationMetadata {
-    ///         field,
-    ///         topology,
-    ///         provided_value,
-    ///         expected,
-    ///     } if field == TriangulationMetadataField::Timeslices
-    ///         && topology == CdtTopology::Toroidal
-    ///         && provided_value == "2"
-    ///         && expected == "≥ 3"
-    /// );
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn set_time_slices(&mut self, time_slices: u32) -> CdtResult<()> {
-        if self.metadata.time_slices == time_slices {
-            return self.apply_time_slices(time_slices);
-        }
-
-        self.apply_time_slices(time_slices)?;
-        self.bump_modification_count();
-        Ok(())
-    }
-
-    /// Marks the triangulation metadata as modified.
-    ///
-    /// This crate-internal hook invalidates cached derived geometry quantities.
-    pub(crate) fn bump_modification_count(&mut self) {
-        self.invalidate_cache();
-        self.invalidate_foliation_bookkeeping();
-        self.metadata.last_modified = Instant::now();
-        self.metadata.modification_count += 1;
-    }
-
-    /// Records a simulation event without marking the geometry as mutated.
-    pub(crate) fn record_event(&mut self, event: SimulationEvent) {
-        self.metadata.simulation_history.push(event);
-        self.metadata.last_modified = Instant::now();
-    }
-
-    /// Clears derived geometry counts so later queries recompute from the backend.
-    fn invalidate_cache(&mut self) {
-        self.cache = GeometryCache::default();
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::geometry::backends::mock::MockBackend;
     use crate::geometry::generators::build_delaunay2_with_data;
     use serde_json::error::Category;
     use serde_json::{from_str, from_value, json, to_string, to_value};
@@ -881,6 +1041,41 @@ mod tests {
         ])
         .expect("Should build labeled triangle");
         DelaunayBackend2D::from_triangulation(dt).expect("test Delaunay triangle should validate")
+    }
+
+    #[test]
+    fn metadata_accessors_do_not_require_backend_query_trait() {
+        struct MetadataOnlyBackend;
+
+        let now = Instant::now();
+        let mut triangulation = CdtTriangulation {
+            instance_id: next_triangulation_instance_id(),
+            geometry: MetadataOnlyBackend,
+            metadata: CdtMetadata {
+                time_slices: 2,
+                dimension: 2,
+                topology: CdtTopology::OpenBoundary,
+                creation_time: now,
+                last_modified: now,
+                modification_count: 0,
+                simulation_history: Vec::new(),
+            },
+            cache: GeometryCache::default(),
+            foliation: None,
+            foliation_synced_at_modification: None,
+        };
+
+        assert_eq!(triangulation.time_slices(), 2);
+        assert_eq!(triangulation.dimension(), 2);
+        assert_eq!(
+            triangulation.metadata().topology(),
+            CdtTopology::OpenBoundary
+        );
+        triangulation
+            .set_time_slices(3)
+            .expect("open-boundary metadata update should validate");
+        assert_eq!(triangulation.time_slices(), 3);
+        assert_eq!(triangulation.metadata().modification_count(), 1);
     }
 
     /// Builds intentionally unchecked metadata for legacy validation tests.
@@ -932,6 +1127,23 @@ mod tests {
                 && topology == CdtTopology::OpenBoundary
                 && provided_value == "3"
                 && expected == "backend dimension (2)"
+        );
+    }
+
+    #[test]
+    fn test_try_new_rejects_open_boundary_topology_mismatch() {
+        let backend = MockBackend::new_2d();
+        let result = CdtTriangulation::try_new(backend, 3, 2);
+
+        assert_matches!(
+            result,
+            Err(CdtError::TopologyMismatch {
+                topology,
+                euler_characteristic: 0,
+                ref expected_euler_characteristics,
+                ..
+            }) if topology == CdtTopology::OpenBoundary
+                && expected_euler_characteristics.as_slice() == [1, 2]
         );
     }
 
@@ -2046,7 +2258,7 @@ mod prop_tests {
 
             // Dimension should be consistent
             prop_assert_eq!(usize::from(triangulation.dimension()), triangulation.geometry().dimension(),
-                          "Dimension should be consistent between wrapper and geometry");
+                          "Dimension should be consistent between CDT state and geometry");
         }
 
     }

--- a/src/cdt/triangulation/state.rs
+++ b/src/cdt/triangulation/state.rs
@@ -15,6 +15,7 @@ use crate::geometry::traits::TriangulationQuery;
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
+use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
@@ -84,8 +85,8 @@ impl<B: Clone> Clone for CdtTriangulation<B> {
 /// Metadata describing the CDT foliation, topology, and simulation history.
 #[derive(Debug, Clone)]
 pub struct CdtMetadata {
-    /// Number of time slices in the CDT foliation
-    time_slices: u32,
+    /// Nonzero number of time slices in the CDT foliation
+    time_slices: NonZeroU32,
     /// Dimensionality of the spacetime
     dimension: u8,
     /// Topology of the spatial slices
@@ -114,12 +115,12 @@ impl CdtMetadata {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
-    ///     assert_eq!(tri.metadata().time_slices(), 2);
+    ///     assert_eq!(tri.metadata().time_slices().get(), 2);
     ///     Ok(())
     /// }
     /// ```
     #[must_use]
-    pub const fn time_slices(&self) -> u32 {
+    pub const fn time_slices(&self) -> NonZeroU32 {
         self.time_slices
     }
 
@@ -358,7 +359,7 @@ impl Serialize for CdtTriangulation<DelaunayBackend2D> {
         SerializedCdtTriangulation {
             geometry: &self.geometry,
             metadata: SerializedCdtMetadata {
-                time_slices: self.metadata.time_slices,
+                time_slices: self.metadata.time_slices.get(),
                 dimension: self.metadata.dimension,
                 topology: self.metadata.topology,
                 modification_count: self.metadata.modification_count,
@@ -385,7 +386,11 @@ impl<'de> Deserialize<'de> for CdtTriangulation<DelaunayBackend2D> {
             instance_id: next_triangulation_instance_id(),
             geometry: serialized.geometry,
             metadata: CdtMetadata {
-                time_slices: serialized.metadata.time_slices,
+                time_slices: Self::parse_time_slices(
+                    serialized.metadata.topology,
+                    serialized.metadata.time_slices,
+                )
+                .map_err(DeError::custom)?,
                 dimension: serialized.metadata.dimension,
                 topology: serialized.metadata.topology,
                 creation_time: now,
@@ -418,6 +423,11 @@ impl CdtTriangulation<DelaunayBackend2D> {
 impl<B> CdtTriangulation<B> {
     /// Encodes topology-specific time-slice metadata invariants in one reusable check.
     fn check_time_slices(topology: CdtTopology, time_slices: u32) -> CdtResult<()> {
+        Self::parse_time_slices(topology, time_slices).map(|_| ())
+    }
+
+    /// Parses raw time-slice metadata into a nonzero invariant-bearing count.
+    fn parse_time_slices(topology: CdtTopology, time_slices: u32) -> CdtResult<NonZeroU32> {
         if time_slices == 0 {
             return Err(CdtError::InvalidTriangulationMetadata {
                 field: TriangulationMetadataField::Timeslices,
@@ -436,7 +446,12 @@ impl<B> CdtTriangulation<B> {
             });
         }
 
-        Ok(())
+        NonZeroU32::new(time_slices).ok_or_else(|| CdtError::InvalidTriangulationMetadata {
+            field: TriangulationMetadataField::Timeslices,
+            topology,
+            provided_value: time_slices.to_string(),
+            expected: "≥ 1".to_string(),
+        })
     }
 
     /// Get immutable reference to underlying geometry.
@@ -468,12 +483,12 @@ impl<B> CdtTriangulation<B> {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
-    ///     assert_eq!(tri.time_slices(), 2);
+    ///     assert_eq!(tri.time_slices().get(), 2);
     ///     Ok(())
     /// }
     /// ```
     #[must_use]
-    pub const fn time_slices(&self) -> u32 {
+    pub const fn time_slices(&self) -> NonZeroU32 {
         self.metadata.time_slices
     }
 
@@ -506,7 +521,7 @@ impl<B> CdtTriangulation<B> {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
-    ///     assert_eq!(tri.metadata().time_slices(), 2);
+    ///     assert_eq!(tri.metadata().time_slices().get(), 2);
     ///     Ok(())
     /// }
     /// ```
@@ -523,7 +538,7 @@ impl<B> CdtTriangulation<B> {
 
     /// Writes time-slice metadata through the central invariant and foliation invalidation path.
     fn apply_time_slices(&mut self, time_slices: u32) -> CdtResult<()> {
-        Self::check_time_slices(self.metadata.topology, time_slices)?;
+        let time_slices = Self::parse_time_slices(self.metadata.topology, time_slices)?;
         self.metadata.time_slices = time_slices;
         if self
             .foliation
@@ -604,7 +619,7 @@ impl<B> CdtTriangulation<B> {
     /// # }
     /// ```
     pub fn set_time_slices(&mut self, time_slices: u32) -> CdtResult<()> {
-        if self.metadata.time_slices == time_slices {
+        if self.metadata.time_slices.get() == time_slices {
             return self.apply_time_slices(time_slices);
         }
 
@@ -665,7 +680,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// fn main() -> CdtResult<()> {
     ///     let backend = MockBackend::create_triangle();
     ///     let tri = CdtTriangulation::try_new(backend, 2, 2)?;
-    ///     assert_eq!(tri.time_slices(), 2);
+    ///     assert_eq!(tri.time_slices().get(), 2);
     ///     Ok(())
     /// }
     /// ```
@@ -675,7 +690,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
             time_slices,
             dimension,
             CdtTopology::OpenBoundary,
-        );
+        )?;
         tri.validate_metadata()?;
         tri.validate_topology()?;
         Ok(tri)
@@ -721,7 +736,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///
     ///     let tri = CdtTriangulation::with_topology(backend, 2, 2, CdtTopology::OpenBoundary)?;
     ///     assert_matches!(tri.metadata().topology(), CdtTopology::OpenBoundary);
-    ///     assert_eq!(tri.time_slices(), 2);
+    ///     assert_eq!(tri.time_slices().get(), 2);
     ///     assert_eq!(tri.dimension(), 2);
     ///     Ok(())
     /// }
@@ -806,7 +821,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
         topology: CdtTopology,
     ) -> CdtResult<Self> {
         let mut tri =
-            Self::from_parts_before_validation(geometry, time_slices, dimension, topology);
+            Self::from_parts_before_validation(geometry, time_slices, dimension, topology)?;
         tri.apply_time_slices(time_slices)?;
         tri.validate_metadata()?;
         tri.validate_topology()?;
@@ -819,18 +834,19 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
         time_slices: u32,
         dimension: u8,
         topology: CdtTopology,
-    ) -> Self {
+    ) -> CdtResult<Self> {
+        let parsed_time_slices = Self::parse_time_slices(topology, time_slices)?;
         let vertex_count = geometry.vertex_count();
         let creation_event = SimulationEvent::Created {
             vertex_count,
             time_slices,
         };
 
-        Self {
+        Ok(Self {
             instance_id: next_triangulation_instance_id(),
             geometry,
             metadata: CdtMetadata {
-                time_slices,
+                time_slices: parsed_time_slices,
                 dimension,
                 topology,
                 creation_time: Instant::now(),
@@ -841,12 +857,12 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
             cache: GeometryCache::default(),
             foliation: None,
             foliation_synced_at_modification: None,
-        }
+        })
     }
 
     /// Validates CDT metadata against backend and topology invariants.
     fn validate_metadata(&self) -> CdtResult<()> {
-        Self::check_time_slices(self.metadata.topology, self.metadata.time_slices)?;
+        Self::check_time_slices(self.metadata.topology, self.metadata.time_slices.get())?;
 
         let backend_dimension = self.geometry.dimension();
         if usize::from(self.metadata.dimension) != backend_dimension {
@@ -1058,7 +1074,7 @@ mod tests {
             instance_id: next_triangulation_instance_id(),
             geometry: MetadataOnlyBackend,
             metadata: CdtMetadata {
-                time_slices: 2,
+                time_slices: NonZeroU32::new(2).expect("test time-slice count should be nonzero"),
                 dimension: 2,
                 topology: CdtTopology::OpenBoundary,
                 creation_time: now,
@@ -1071,7 +1087,7 @@ mod tests {
             foliation_synced_at_modification: None,
         };
 
-        assert_eq!(triangulation.time_slices(), 2);
+        assert_eq!(triangulation.time_slices().get(), 2);
         assert_eq!(triangulation.dimension(), 2);
         assert_eq!(
             triangulation.metadata().topology(),
@@ -1080,7 +1096,7 @@ mod tests {
         triangulation
             .set_time_slices(3)
             .expect("open-boundary metadata update should validate");
-        assert_eq!(triangulation.time_slices(), 3);
+        assert_eq!(triangulation.time_slices().get(), 3);
         assert_eq!(triangulation.metadata().modification_count(), 1);
     }
 
@@ -1096,6 +1112,7 @@ mod tests {
             dimension,
             CdtTopology::OpenBoundary,
         )
+        .expect("unchecked test metadata should use nonzero time slices")
     }
 
     #[test]
@@ -1191,7 +1208,7 @@ mod tests {
 
         // Test basic property getters
         assert_eq!(triangulation.dimension(), 2);
-        assert_eq!(triangulation.time_slices(), 4);
+        assert_eq!(triangulation.time_slices().get(), 4);
         assert_eq!(triangulation.vertex_count(), 8);
 
         let edge_count = triangulation.edge_count();
@@ -1215,7 +1232,7 @@ mod tests {
 
         // Check that metadata is properly initialized
         assert_eq!(triangulation.dimension(), 2);
-        assert_eq!(triangulation.time_slices(), 3);
+        assert_eq!(triangulation.time_slices().get(), 3);
 
         // Metadata should be accessible through debug formatting
         let debug_output = format!("{triangulation:?}");
@@ -1531,7 +1548,7 @@ mod tests {
             .set_time_slices(2)
             .expect("unchanged time-slice count should be accepted");
 
-        assert_eq!(triangulation.time_slices(), 2);
+        assert_eq!(triangulation.time_slices().get(), 2);
         assert_eq!(
             triangulation.metadata().modification_count,
             initial_modification_count
@@ -1552,7 +1569,7 @@ mod tests {
         tri.set_time_slices(3)
             .expect("open-boundary time-slice metadata can be widened");
 
-        assert_eq!(tri.time_slices(), 3);
+        assert_eq!(tri.time_slices().get(), 3);
         assert_eq!(
             tri.metadata().modification_count,
             initial_modification_count + 1
@@ -1567,7 +1584,7 @@ mod tests {
         assert!(result.is_ok(), "Should allow large time slice count");
 
         let triangulation = result.unwrap();
-        assert_eq!(triangulation.time_slices(), 100);
+        assert_eq!(triangulation.time_slices().get(), 100);
     }
 
     #[test]
@@ -1790,7 +1807,7 @@ mod tests {
                 && provided_value == "2"
                 && expected == "≥ 3"
         );
-        assert_eq!(tri.time_slices(), 3);
+        assert_eq!(tri.time_slices().get(), 3);
         assert!(tri.validate_topology().is_ok());
     }
 
@@ -2093,7 +2110,7 @@ mod prop_tests {
             let mut triangulation = CdtTriangulation::from_random_points(vertices, timeslices, 2)?;
 
             // Initial metadata should be consistent
-            prop_assert_eq!(triangulation.time_slices(), timeslices, "Time slices should match input");
+            prop_assert_eq!(triangulation.time_slices().get(), timeslices, "Time slices should match input");
             prop_assert_eq!(triangulation.dimension(), 2, "Dimension should be 2");
             prop_assert_eq!(triangulation.metadata().modification_count, 0, "Initial modification count should be 0");
 
@@ -2233,7 +2250,7 @@ mod prop_tests {
                 let vertex_count_u32 =
                     u32::try_from(triangulation.vertex_count()).unwrap_or(u32::MAX);
                 prop_assert_eq!(vertex_count_u32, vertices, "Vertex count should match input");
-                prop_assert_eq!(triangulation.time_slices(), timeslices, "Time slices should match input");
+                prop_assert_eq!(triangulation.time_slices().get(), timeslices, "Time slices should match input");
                 prop_assert_eq!(triangulation.dimension(), 2, "Dimension should be 2");
             } else {
                 prop_assert!(

--- a/src/cdt/triangulation/validation.rs
+++ b/src/cdt/triangulation/validation.rs
@@ -355,6 +355,7 @@ mod tests {
             dimension,
             CdtTopology::OpenBoundary,
         )
+        .expect("unchecked test metadata should use nonzero time slices")
     }
 
     /// Builds stable diagnostic text for seeded-triangulation comparisons.

--- a/src/config.rs
+++ b/src/config.rs
@@ -157,6 +157,7 @@ pub struct CdtConfig {
 #[derive(Debug, Clone)]
 pub struct ValidatedCdtConfig {
     config: CdtConfig,
+    metropolis_config: MetropolisConfig,
 }
 
 /// Validated initial spatial-volume input for CDT construction.
@@ -217,7 +218,17 @@ impl ValidatedCdtConfig {
     /// ```
     pub fn new(config: CdtConfig) -> CdtResult<Self> {
         config.ensure_valid()?;
-        Ok(Self { config })
+        let metropolis_config = MetropolisConfig::new_with_seed(
+            config.temperature,
+            config.steps,
+            config.thermalization_steps,
+            config.measurement_frequency,
+            config.seed,
+        )?;
+        Ok(Self {
+            config,
+            metropolis_config,
+        })
     }
 
     /// Returns the validated configuration for serialization/reporting APIs.
@@ -521,8 +532,8 @@ impl ValidatedCdtConfig {
     /// }
     /// ```
     #[must_use]
-    pub const fn to_metropolis_config(&self) -> MetropolisConfig {
-        to_metropolis_config(&self.config)
+    pub fn to_metropolis_config(&self) -> MetropolisConfig {
+        self.metropolis_config.clone()
     }
 
     /// Creates a validated [`ActionConfig`].
@@ -1244,17 +1255,6 @@ pub(crate) fn validate_schedule(
     Ok(())
 }
 
-/// Builds the MCMC runtime configuration from an already validated raw config.
-const fn to_metropolis_config(config: &CdtConfig) -> MetropolisConfig {
-    MetropolisConfig::from_validated_parts(
-        config.temperature,
-        config.steps,
-        config.thermalization_steps,
-        config.measurement_frequency,
-        config.seed,
-    )
-}
-
 /// Builds the action runtime configuration from an already validated raw config.
 const fn to_action_config(config: &CdtConfig) -> ActionConfig {
     ActionConfig::from_validated_parts(
@@ -1784,7 +1784,7 @@ mod tests {
 
         let metropolis_config = config.to_metropolis_config();
         assert_relative_eq!(metropolis_config.temperature(), 1.0);
-        assert_eq!(metropolis_config.steps(), 1000);
+        assert_eq!(metropolis_config.steps().get(), 1000);
 
         let action_config = config.to_action_config();
         assert_relative_eq!(action_config.coupling_0(), 0.0);

--- a/src/config.rs
+++ b/src/config.rs
@@ -516,7 +516,7 @@ impl ValidatedCdtConfig {
     ///     }
     ///     .into_validated()?;
     ///     let metropolis = config.to_metropolis_config();
-    ///     assert_eq!(metropolis.seed, Some(42));
+    ///     assert_eq!(metropolis.seed(), Some(42));
     ///     Ok(())
     /// }
     /// ```
@@ -538,7 +538,7 @@ impl ValidatedCdtConfig {
     ///     let action = CdtConfig::new(16, 4)
     ///         .into_validated()?
     ///         .to_action_config();
-    ///     assert_relative_eq!(action.coupling_0, 0.0);
+    ///     assert_relative_eq!(action.coupling_0(), 0.0);
     ///     Ok(())
     /// }
     /// ```
@@ -861,11 +861,11 @@ impl CdtConfig {
         ValidatedCdtConfig::new(self)
     }
 
-    /// Merges this configuration with a set of override values, returning a new configuration.
+    /// Merges this configuration with a set of override values and validates the result.
     ///
     /// Override fields that are `None` are ignored, leaving the original configuration values
     /// unchanged. When an override value is provided, it replaces the corresponding field in
-    /// the returned configuration.
+    /// the returned validated configuration.
     ///
     /// A provided volume profile is an atomic override for its derived counts:
     /// the returned configuration recomputes `vertices` from the profile sum and
@@ -881,26 +881,30 @@ impl CdtConfig {
     /// };
     ///
     /// fn main() -> CdtResult<()> {
-    /// let base = CdtConfig::new(10, 2);
-    /// let overrides = CdtConfigOverrides {
-    ///     dimension: Some(DimensionOverride::Clear),
-    ///     vertices: Some(24),
-    ///     ..CdtConfigOverrides::default()
-    /// };
+    ///     let base = CdtConfig::new(10, 2);
+    ///     let overrides = CdtConfigOverrides {
+    ///         dimension: Some(DimensionOverride::Clear),
+    ///         vertices: Some(24),
+    ///         ..CdtConfigOverrides::default()
+    ///     };
     ///
-    /// let merged = base.merge_with_override(&overrides)?;
-    /// assert_eq!(merged.dimension, None);
-    /// assert_eq!(merged.vertices, 24);
-    /// assert_eq!(merged.timeslices, 2);
-    /// # Ok(())
+    ///     let merged = base.merge_with_override(&overrides)?;
+    ///     assert_eq!(merged.config().dimension, None);
+    ///     assert_eq!(merged.vertices(), 24);
+    ///     assert_eq!(merged.timeslices(), 2);
+    ///     Ok(())
     /// }
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`CdtError::InvalidConfiguration`] if an override volume profile cannot
-    /// be represented by the `u32` vertex or time-slice counts stored in [`CdtConfig`].
-    pub fn merge_with_override(&self, overrides: &CdtConfigOverrides) -> CdtResult<Self> {
+    /// Returns [`CdtError::InvalidConfiguration`] or
+    /// [`CdtError::InvalidSimulationConfiguration`] if the merged configuration
+    /// violates any geometry, topology, action, or schedule invariant.
+    pub fn merge_with_override(
+        &self,
+        overrides: &CdtConfigOverrides,
+    ) -> CdtResult<ValidatedCdtConfig> {
         let mut merged = self.clone();
 
         if let Some(dimension_override) = overrides.dimension {
@@ -999,7 +1003,7 @@ impl CdtConfig {
             merged.output_json.clone_from(output_json);
         }
 
-        Ok(merged)
+        ValidatedCdtConfig::new(merged)
     }
 
     /// Resolves a candidate path against a base directory, expanding user home references
@@ -1242,21 +1246,18 @@ pub(crate) fn validate_schedule(
 
 /// Builds the MCMC runtime configuration from an already validated raw config.
 const fn to_metropolis_config(config: &CdtConfig) -> MetropolisConfig {
-    let metropolis = MetropolisConfig::new(
+    MetropolisConfig::from_validated_parts(
         config.temperature,
         config.steps,
         config.thermalization_steps,
         config.measurement_frequency,
-    );
-    MetropolisConfig {
-        seed: config.seed,
-        ..metropolis
-    }
+        config.seed,
+    )
 }
 
 /// Builds the action runtime configuration from an already validated raw config.
 const fn to_action_config(config: &CdtConfig) -> ActionConfig {
-    ActionConfig::new(
+    ActionConfig::from_validated_parts(
         config.coupling_0,
         config.coupling_2,
         config.cosmological_constant,
@@ -1782,14 +1783,14 @@ mod tests {
             .expect("test config should validate");
 
         let metropolis_config = config.to_metropolis_config();
-        assert_relative_eq!(metropolis_config.temperature, 1.0);
-        assert_eq!(metropolis_config.steps, 1000);
+        assert_relative_eq!(metropolis_config.temperature(), 1.0);
+        assert_eq!(metropolis_config.steps(), 1000);
 
         let action_config = config.to_action_config();
-        assert_relative_eq!(action_config.coupling_0, 0.0);
-        assert_relative_eq!(action_config.coupling_2, 0.0);
+        assert_relative_eq!(action_config.coupling_0(), 0.0);
+        assert_relative_eq!(action_config.coupling_2(), 0.0);
         assert_relative_eq!(
-            action_config.cosmological_constant,
+            action_config.cosmological_constant(),
             DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT
         );
     }
@@ -2390,6 +2391,7 @@ mod tests {
         let merged = base
             .merge_with_override(&overrides)
             .expect("override merge should succeed");
+        let merged = merged.config();
 
         assert_eq!(merged.dimension, None);
         assert_eq!(merged.dimension(), 2);
@@ -2424,6 +2426,7 @@ mod tests {
         let merged = base
             .merge_with_override(&overrides)
             .expect("override merge should succeed");
+        let merged = merged.config();
 
         assert_eq!(merged.vertices, 15);
         assert_eq!(merged.timeslices, 3);
@@ -2454,6 +2457,7 @@ mod tests {
         let merged = base
             .merge_with_override(&overrides)
             .expect("override merge should succeed");
+        let merged = merged.config();
 
         assert_eq!(merged.seed, None);
     }
@@ -2474,6 +2478,7 @@ mod tests {
         let merged = base
             .merge_with_override(&overrides)
             .expect("override merge should succeed");
+        let merged = merged.config();
 
         assert_eq!(merged.volume_profile, None);
         assert_eq!(merged.vertices, 15);
@@ -2491,6 +2496,7 @@ mod tests {
         let merged = base
             .merge_with_override(&overrides)
             .expect("override merge should succeed");
+        let merged = merged.config();
         assert_eq!(merged.dimension, None);
         assert_eq!(merged.dimension(), 2); // dimension() defaults to 2 when None
     }
@@ -2513,6 +2519,45 @@ mod tests {
                 ref expected,
             }) if provided_value == "[4294967295, 1]"
                 && expected == "volume profile sum <= u32::MAX"
+        );
+    }
+
+    #[test]
+    fn test_merge_with_override_rejects_invalid_schedule() {
+        let base = CdtConfig::new(10, 2);
+        let overrides = CdtConfigOverrides {
+            measurement_frequency: Some(0),
+            ..CdtConfigOverrides::default()
+        };
+
+        let result = base.merge_with_override(&overrides);
+
+        assert_matches!(
+            result,
+            Err(CdtError::InvalidSimulationConfiguration {
+                setting: ConfigurationSetting::MeasurementFrequency,
+                ref provided_value,
+                ref expected,
+            }) if provided_value == "0" && expected == "≥ 1"
+        );
+    }
+
+    #[test]
+    fn test_merge_with_override_rejects_invalid_base_without_overrides() {
+        let base = CdtConfig {
+            measurement_frequency: 0,
+            ..CdtConfig::new(10, 2)
+        };
+
+        let result = base.merge_with_override(&CdtConfigOverrides::default());
+
+        assert_matches!(
+            result,
+            Err(CdtError::InvalidSimulationConfiguration {
+                setting: ConfigurationSetting::MeasurementFrequency,
+                ref provided_value,
+                ref expected,
+            }) if provided_value == "0" && expected == "≥ 1"
         );
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -503,6 +503,32 @@ impl fmt::Display for CheckpointMoveCounter {
     }
 }
 
+/// Proposal-statistics counter category used in result telemetry diagnostics.
+///
+/// Use this with [`CheckpointResumeFailure::ProposalCounterOverflow`] to
+/// distinguish which proposal telemetry counter could not be represented
+/// without parsing display text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ProposalTelemetryCounter {
+    /// Selected move-family proposal counter.
+    MoveFamilyProposals,
+    /// Accepted proposal transition counter.
+    AcceptedTransitions,
+    /// Rejected proposal transition counter.
+    RejectedTransitions,
+}
+
+impl fmt::Display for ProposalTelemetryCounter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MoveFamilyProposals => formatter.write_str("move-family proposals"),
+            Self::AcceptedTransitions => formatter.write_str("accepted transitions"),
+            Self::RejectedTransitions => formatter.write_str("rejected transitions"),
+        }
+    }
+}
+
 /// Structured reason a CDT checkpoint could not be resumed.
 ///
 /// [`CdtError::CheckpointResumeFailed`] wraps this enum for CDT-owned resume
@@ -703,6 +729,42 @@ pub enum CheckpointResumeFailure {
     CounterConversionOverflow {
         /// Counter category that could not fit in upstream chain counters.
         counter: CheckpointMoveCounter,
+    },
+    /// A proposal-statistics counter conversion overflowed.
+    #[error("{counter} proposal telemetry count exceeds u64::MAX")]
+    ProposalCounterOverflow {
+        /// Proposal telemetry counter that could not fit in the target type.
+        counter: ProposalTelemetryCounter,
+    },
+    /// Completed results cannot contain hard proposal failures.
+    #[error("completed result proposal telemetry has {actual} hard failures; expected 0")]
+    ProposalHardFailures {
+        /// Number of hard proposal failures recorded in result telemetry.
+        actual: u64,
+    },
+    /// Proposal move-family count disagrees with the number of sampler steps.
+    #[error("proposal move-family count mismatch: got {actual}, expected {expected}")]
+    ProposalMoveFamilyCountMismatch {
+        /// Number of move-family proposals recorded in proposal telemetry.
+        actual: u64,
+        /// Expected proposal count from step telemetry.
+        expected: u64,
+    },
+    /// Proposal accepted-transition count disagrees with step telemetry.
+    #[error("proposal accepted-transition count mismatch: got {actual}, expected {expected}")]
+    ProposalAcceptedCountMismatch {
+        /// Number of accepted transitions recorded in proposal telemetry.
+        actual: u64,
+        /// Expected accepted count from step telemetry.
+        expected: u64,
+    },
+    /// Proposal rejected-transition count disagrees with step telemetry.
+    #[error("proposal rejected-transition count mismatch: got {actual}, expected {expected}")]
+    ProposalRejectedCountMismatch {
+        /// Number of rejected transitions reconstructed from proposal telemetry.
+        actual: u64,
+        /// Expected rejected count from step telemetry.
+        expected: u64,
     },
 }
 
@@ -1414,6 +1476,28 @@ mod tests {
     }
 
     #[test]
+    fn proposal_telemetry_counter_display_covers_all_categories() {
+        let cases = [
+            (
+                ProposalTelemetryCounter::MoveFamilyProposals,
+                "move-family proposals",
+            ),
+            (
+                ProposalTelemetryCounter::AcceptedTransitions,
+                "accepted transitions",
+            ),
+            (
+                ProposalTelemetryCounter::RejectedTransitions,
+                "rejected transitions",
+            ),
+        ];
+
+        for (counter, expected) in cases {
+            assert_eq!(counter.to_string(), expected);
+        }
+    }
+
+    #[test]
     fn checkpoint_resume_failure_display_includes_structured_context() {
         let failure = CheckpointResumeFailure::ChainCounterMismatch {
             chain_accepted: 1,
@@ -1425,6 +1509,23 @@ mod tests {
         assert_eq!(
             failure.to_string(),
             "chain counters do not match move statistics: chain accepted=1, rejected=2; move accepted=3, rejected=4"
+        );
+    }
+
+    #[test]
+    fn proposal_resume_failures_display_structured_context() {
+        let overflow = CheckpointResumeFailure::ProposalCounterOverflow {
+            counter: ProposalTelemetryCounter::AcceptedTransitions,
+        };
+        assert_eq!(
+            overflow.to_string(),
+            "accepted transitions proposal telemetry count exceeds u64::MAX"
+        );
+
+        let hard_failures = CheckpointResumeFailure::ProposalHardFailures { actual: 3 };
+        assert_eq!(
+            hard_failures.to_string(),
+            "completed result proposal telemetry has 3 hard failures; expected 0"
         );
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -736,10 +736,10 @@ pub enum CheckpointResumeFailure {
         /// Proposal telemetry counter that could not fit in the target type.
         counter: ProposalTelemetryCounter,
     },
-    /// Completed results cannot contain hard proposal failures.
-    #[error("completed result proposal telemetry has {actual} hard failures; expected 0")]
+    /// Resume-validated proposal telemetry cannot contain hard failures.
+    #[error("proposal telemetry has {actual} hard failures; expected 0")]
     ProposalHardFailures {
-        /// Number of hard proposal failures recorded in result telemetry.
+        /// Number of hard proposal failures recorded in proposal telemetry.
         actual: u64,
     },
     /// Proposal move-family count disagrees with the number of sampler steps.
@@ -1525,7 +1525,7 @@ mod tests {
         let hard_failures = CheckpointResumeFailure::ProposalHardFailures { actual: 3 };
         assert_eq!(
             hard_failures.to_string(),
-            "completed result proposal telemetry has 3 hard failures; expected 0"
+            "proposal telemetry has 3 hard failures; expected 0"
         );
     }
 

--- a/src/geometry/backends/mock.rs
+++ b/src/geometry/backends/mock.rs
@@ -192,7 +192,8 @@ impl MockBackend {
     /// use causal_triangulations::geometry::traits::TriangulationQuery;
     /// use std::num::NonZeroUsize;
     ///
-    /// let Some(dimension) = NonZeroUsize::new(2) else {
+    /// let n = 2;
+    /// let Some(dimension) = NonZeroUsize::new(n) else {
     ///     return;
     /// };
     /// let backend = MockBackend::new(dimension);

--- a/src/geometry/backends/mock.rs
+++ b/src/geometry/backends/mock.rs
@@ -11,6 +11,7 @@ use crate::geometry::traits::{
 };
 use std::collections::HashMap;
 use std::fmt;
+use std::num::NonZeroUsize;
 
 /// Mock backend for testing
 #[derive(Debug, Clone)]
@@ -182,7 +183,36 @@ pub enum MockError {
 }
 
 impl MockBackend {
-    /// Create a new mock backend
+    /// Create a new mock backend with a nonzero coordinate dimension.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::geometry::backends::mock::MockBackend;
+    /// use causal_triangulations::geometry::traits::TriangulationQuery;
+    /// use std::num::NonZeroUsize;
+    ///
+    /// let Some(dimension) = NonZeroUsize::new(2) else {
+    ///     return;
+    /// };
+    /// let backend = MockBackend::new(dimension);
+    /// assert_eq!(backend.dimension(), 2);
+    /// assert_eq!(backend.vertex_count(), 0);
+    /// ```
+    #[must_use]
+    pub fn new(dimension: NonZeroUsize) -> Self {
+        Self {
+            vertices: HashMap::new(),
+            edges: HashMap::new(),
+            faces: HashMap::new(),
+            dimension: dimension.get(),
+            next_vertex_id: 0,
+            next_edge_id: 0,
+            next_face_id: 0,
+        }
+    }
+
+    /// Create an empty two-dimensional mock backend.
     ///
     /// # Examples
     ///
@@ -190,17 +220,16 @@ impl MockBackend {
     /// use causal_triangulations::geometry::backends::mock::MockBackend;
     /// use causal_triangulations::geometry::traits::TriangulationQuery;
     ///
-    /// let backend = MockBackend::new(2);
+    /// let backend = MockBackend::new_2d();
     /// assert_eq!(backend.dimension(), 2);
-    /// assert_eq!(backend.vertex_count(), 0);
     /// ```
     #[must_use]
-    pub fn new(dimension: usize) -> Self {
+    pub fn new_2d() -> Self {
         Self {
             vertices: HashMap::new(),
             edges: HashMap::new(),
             faces: HashMap::new(),
-            dimension,
+            dimension: 2,
             next_vertex_id: 0,
             next_edge_id: 0,
             next_face_id: 0,
@@ -222,7 +251,7 @@ impl MockBackend {
     /// ```
     #[must_use]
     pub fn create_triangle() -> Self {
-        let mut backend = Self::new(2);
+        let mut backend = Self::new_2d();
 
         // Add three vertices
         backend.vertices.insert(0, vec![0.0, 0.0]);
@@ -727,7 +756,7 @@ mod tests {
 
     #[test]
     fn test_mock_backend_creation() {
-        let backend = MockBackend::new(2);
+        let backend = MockBackend::new_2d();
         assert_eq!(backend.backend_name(), "mock");
         assert_eq!(backend.dimension(), 2);
         assert_eq!(backend.vertex_count(), 0);
@@ -948,7 +977,7 @@ mod tests {
 
     #[test]
     fn test_mock_backend_flips_interior_edge() {
-        let mut backend = MockBackend::new(2);
+        let mut backend = MockBackend::new_2d();
         backend.vertices.insert(0, vec![0.0, 0.0]);
         backend.vertices.insert(1, vec![1.0, 0.0]);
         backend.vertices.insert(2, vec![1.0, 1.0]);
@@ -1001,7 +1030,7 @@ mod tests {
 
     #[test]
     fn test_mock_backend_face_neighbors_return_shared_edge_faces() {
-        let mut backend = MockBackend::new(2);
+        let mut backend = MockBackend::new_2d();
         backend.vertices.insert(0, vec![0.0, 0.0]);
         backend.vertices.insert(1, vec![1.0, 0.0]);
         backend.vertices.insert(2, vec![1.0, 1.0]);
@@ -1027,7 +1056,7 @@ mod tests {
 
     #[test]
     fn test_mock_backend_rejects_malformed_edge_flips() {
-        let mut backend = MockBackend::new(2);
+        let mut backend = MockBackend::new_2d();
         backend.vertices.insert(0, vec![0.0, 0.0]);
         backend.vertices.insert(1, vec![1.0, 0.0]);
         backend.vertices.insert(2, vec![1.0, 1.0]);
@@ -1071,7 +1100,7 @@ mod tests {
 
     #[test]
     fn test_mock_backend_rejects_non_triangular_subdivision() {
-        let mut backend = MockBackend::new(2);
+        let mut backend = MockBackend::new_2d();
         backend.vertices.insert(0, vec![0.0, 0.0]);
         backend.vertices.insert(1, vec![1.0, 0.0]);
         backend.vertices.insert(2, vec![1.0, 1.0]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,7 +351,7 @@ pub mod prelude {
     /// };
     ///
     /// fn configured_steps(config: ValidatedCdtConfig) -> u32 {
-    ///     config.to_metropolis_config().steps()
+    ///     config.to_metropolis_config().steps().get()
     /// }
     ///
     /// fn main() -> CdtResult<()> {
@@ -966,7 +966,7 @@ mod tests {
         let results = run_simulation(&config).expect("simulation should run with real moves");
         assert_eq!(
             results.steps().len(),
-            usize::try_from(config.to_metropolis_config().steps()).unwrap()
+            usize::try_from(config.to_metropolis_config().steps().get()).unwrap()
         );
         assert!(results.triangulation().has_foliation());
         results
@@ -992,7 +992,7 @@ mod tests {
 
         let metropolis_config = config.to_metropolis_config();
         assert_relative_eq!(metropolis_config.temperature(), 1.0);
-        assert_eq!(metropolis_config.steps(), 10);
+        assert_eq!(metropolis_config.steps().get(), 10);
 
         let action_config = config.to_action_config();
         assert_relative_eq!(action_config.coupling_0(), 0.0);
@@ -1036,7 +1036,7 @@ mod tests {
             "Toroidal run_simulation must treat config.vertices as the TOTAL vertex count"
         );
         assert_eq!(
-            results.triangulation().time_slices(),
+            results.triangulation().time_slices().get(),
             3,
             "Toroidal run_simulation must preserve the configured timeslice count"
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,7 @@ pub use errors::{
 use crate::cdt::results::SimulationResultsParts;
 use crate::util::saturating_usize_to_u32;
 use std::env;
+use std::path::PathBuf;
 use std::time::Duration;
 
 // Trait-based triangulation (recommended)
@@ -518,9 +519,10 @@ pub mod prelude {
 /// If [`ValidatedCdtConfig::output_csv`] or [`ValidatedCdtConfig::output_json`] is set, returns
 /// [`CdtError::OutputPathResolutionFailed`] if the current working directory
 /// cannot be resolved. Returns [`CdtError::OutputPathConflict`] if CSV and JSON
-/// outputs resolve to the same file. Returns [`CdtError::OutputWriteFailed`] if
-/// the configured output file, parent directory creation, or JSON serialization
-/// fails.
+/// outputs resolve to the same file. Output path resolution and conflict checks
+/// happen before triangulation construction or sampling begins. Returns
+/// [`CdtError::OutputWriteFailed`] if the configured output file, parent
+/// directory creation, or JSON serialization fails after the run completes.
 ///
 /// # Examples
 ///
@@ -543,6 +545,7 @@ pub mod prelude {
 /// }
 /// ```
 pub fn run_simulation(config: &ValidatedCdtConfig) -> CdtResult<SimulationResultsBackend> {
+    let output_paths = resolve_configured_output_paths(config)?;
     let vertices = config.vertices();
     let timeslices = config.timeslices();
 
@@ -625,17 +628,24 @@ pub fn run_simulation(config: &ValidatedCdtConfig) -> CdtResult<SimulationResult
         })
     };
 
-    write_configured_outputs(config, &results)?;
+    write_configured_outputs(config, &results, &output_paths)?;
     Ok(results)
 }
 
-/// Writes configured result outputs after a run completes.
-fn write_configured_outputs(
+struct ResolvedOutputPaths {
+    csv: Option<PathBuf>,
+    json: Option<PathBuf>,
+}
+
+/// Resolves configured output paths before expensive triangulation or sampling work begins.
+fn resolve_configured_output_paths(
     validated_config: &ValidatedCdtConfig,
-    results: &SimulationResultsBackend,
-) -> CdtResult<()> {
+) -> CdtResult<ResolvedOutputPaths> {
     if validated_config.output_csv().is_none() && validated_config.output_json().is_none() {
-        return Ok(());
+        return Ok(ResolvedOutputPaths {
+            csv: None,
+            json: None,
+        });
     }
 
     let base_dir = env::current_dir().map_err(|err| CdtError::OutputPathResolutionFailed {
@@ -659,13 +669,25 @@ fn write_configured_outputs(
         });
     }
 
-    if let Some(resolved) = resolved_csv {
-        results.write_measurements_csv(&resolved)?;
+    Ok(ResolvedOutputPaths {
+        csv: resolved_csv,
+        json: resolved_json,
+    })
+}
+
+/// Writes configured result outputs after a run completes.
+fn write_configured_outputs(
+    validated_config: &ValidatedCdtConfig,
+    results: &SimulationResultsBackend,
+    output_paths: &ResolvedOutputPaths,
+) -> CdtResult<()> {
+    if let Some(resolved) = &output_paths.csv {
+        results.write_measurements_csv(resolved)?;
         log::info!("Wrote measurement CSV to {}", resolved.display());
     }
 
-    if let Some(resolved) = resolved_json {
-        results.write_summary_json(validated_config, &resolved)?;
+    if let Some(resolved) = &output_paths.json {
+        results.write_summary_json(validated_config, resolved)?;
         log::info!("Wrote simulation JSON summary to {}", resolved.display());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,12 +164,16 @@ pub mod cdt {
     pub mod observables;
     /// Simulation result containers and measurement summaries.
     pub mod results;
-    /// CDT triangulation wrapper.
+    /// CDT triangulation state.
+    #[path = "triangulation/state.rs"]
     pub mod triangulation;
 }
 
 // Re-exports for convenience
-pub use cdt::action::{ActionConfig, compute_regge_action};
+pub use cdt::action::{
+    ActionConfig, CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT,
+    DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT, compute_regge_action,
+};
 pub use cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveStatistics, MoveType};
 pub use cdt::foliation::{EdgeType, Foliation, FoliationError, SimplexType};
 pub use cdt::metropolis::{
@@ -186,7 +190,7 @@ pub use errors::{
     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
     CheckpointMoveCounter, CheckpointOperation, CheckpointResumeFailure, ConfigurationSetting,
     DelaunayValidationLevel, GenerationParameterIssue, MetropolisMoveApplicationFailure,
-    OutputFormat, TriangulationMetadataField,
+    OutputFormat, ProposalTelemetryCounter, TriangulationMetadataField,
 };
 
 use crate::cdt::results::SimulationResultsParts;
@@ -265,7 +269,7 @@ pub mod prelude {
             CdtValidationFailure, CheckpointMoveCounter, CheckpointOperation,
             CheckpointResumeFailure, ConfigurationSetting, DelaunayValidationLevel,
             GenerationParameterIssue, MetropolisMoveApplicationFailure, OutputFormat,
-            TriangulationMetadataField,
+            ProposalTelemetryCounter, TriangulationMetadataField,
         };
     }
 
@@ -275,12 +279,16 @@ pub mod prelude {
     /// use approx::assert_relative_eq;
     /// use causal_triangulations::prelude::action::*;
     ///
-    /// let config = ActionConfig::new(2.0, 1.5, 0.2);
+    /// let config = ActionConfig::new(2.0, 1.5, 0.2)?;
     /// let action = config.calculate_action(5, 10, 8);
     /// assert_relative_eq!(action, -20.0, epsilon = 1e-12);
+    /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     pub mod action {
-        pub use crate::cdt::action::{ActionConfig, compute_regge_action};
+        pub use crate::cdt::action::{
+            ActionConfig, CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT,
+            DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT, compute_regge_action,
+        };
     }
 
     /// Focused exports for CDT triangulation construction, queries, and history events.
@@ -317,7 +325,7 @@ pub mod prelude {
     ///
     /// let mut stats = MoveStatistics::new();
     /// stats.record_attempt(MoveType::Move22);
-    /// assert_eq!(stats.moves_22_attempted, 1);
+    /// assert_eq!(stats.attempted(MoveType::Move22), 1);
     /// ```
     pub mod moves {
         pub use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveStatistics, MoveType};
@@ -342,7 +350,7 @@ pub mod prelude {
     /// };
     ///
     /// fn configured_steps(config: ValidatedCdtConfig) -> u32 {
-    ///     config.to_metropolis_config().steps
+    ///     config.to_metropolis_config().steps()
     /// }
     ///
     /// fn main() -> CdtResult<()> {
@@ -482,19 +490,19 @@ pub mod prelude {
     }
 }
 
-/// Runs a CDT simulation with the specified configuration.
+/// Runs a CDT simulation with an already validated configuration.
 ///
 /// This function uses the trait-based geometry backend system, which provides
 /// better abstraction and testability compared to legacy approaches.
 /// Open-boundary runs construct a foliated strip; toroidal runs construct a
-/// periodic mesh. When [`CdtConfig::volume_profile`] is present, the initial
+/// periodic mesh. When [`ValidatedCdtConfig::volume_profile`] is present, the initial
 /// geometry uses those explicit per-slice spatial volumes. Otherwise the run
-/// uses regular equal-size slices derived from the total [`CdtConfig::vertices`]
-/// count and [`CdtConfig::timeslices`].
+/// uses regular equal-size slices derived from the total
+/// [`ValidatedCdtConfig::vertices`] count and [`ValidatedCdtConfig::timeslices`].
 ///
 /// # Arguments
 ///
-/// * `config` - Configuration parameters for the triangulation/simulation
+/// * `config` - Validated configuration parameters for the triangulation/simulation
 ///
 /// # Returns
 ///
@@ -503,15 +511,11 @@ pub mod prelude {
 ///
 /// # Errors
 ///
-/// Returns [`CdtError::InvalidConfiguration`] if geometry, topology, action, or
-/// initial-volume configuration fails validation, including unsupported
-/// dimensions, unsupported open-boundary or toroidal slice counts, invalid
-/// regular slice counts, or inconsistent explicit spatial volume profiles.
-/// Returns [`CdtError::InvalidSimulationConfiguration`] if the Metropolis
-/// temperature or measurement schedule is invalid.
-/// Returns triangulation generation, topology, foliation, or Metropolis errors
-/// from the selected construction and simulation path.
-/// If [`CdtConfig::output_csv`] or [`CdtConfig::output_json`] is set, returns
+/// The raw configuration has already been parsed into [`ValidatedCdtConfig`], so
+/// this function does not report raw configuration validation failures. It can
+/// still return triangulation generation, topology, foliation, or Metropolis
+/// errors from the selected construction and simulation path.
+/// If [`ValidatedCdtConfig::output_csv`] or [`ValidatedCdtConfig::output_json`] is set, returns
 /// [`CdtError::OutputPathResolutionFailed`] if the current working directory
 /// cannot be resolved. Returns [`CdtError::OutputPathConflict`] if CSV and JSON
 /// outputs resolve to the same file. Returns [`CdtError::OutputWriteFailed`] if
@@ -531,15 +535,14 @@ pub mod prelude {
 ///         seed: Some(7),
 ///         simulate: false,
 ///         ..CdtConfig::new(8, 2)
-///     };
+///     }
+///     .into_validated()?;
 ///     let results = run_simulation(&config)?;
 ///     assert_eq!(results.measurements().len(), 1);
 ///     Ok(())
 /// }
 /// ```
-pub fn run_simulation(config: &CdtConfig) -> CdtResult<SimulationResultsBackend> {
-    let config = config.clone().into_validated()?;
-
+pub fn run_simulation(config: &ValidatedCdtConfig) -> CdtResult<SimulationResultsBackend> {
     let vertices = config.vertices();
     let timeslices = config.timeslices();
 
@@ -622,7 +625,7 @@ pub fn run_simulation(config: &CdtConfig) -> CdtResult<SimulationResultsBackend>
         })
     };
 
-    write_configured_outputs(&config, &results)?;
+    write_configured_outputs(config, &results)?;
     Ok(results)
 }
 
@@ -662,7 +665,7 @@ fn write_configured_outputs(
     }
 
     if let Some(resolved) = resolved_json {
-        results.write_summary_json(validated_config.config(), &resolved)?;
+        results.write_summary_json(validated_config, &resolved)?;
         log::info!("Wrote simulation JSON summary to {}", resolved.display());
     }
 
@@ -672,6 +675,7 @@ fn write_configured_outputs(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cdt::action::DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT;
     use approx::assert_relative_eq;
     use serde_json::{Value, from_str};
     use std::assert_matches;
@@ -693,13 +697,19 @@ mod tests {
             measurement_frequency: 2,
             coupling_0: 0.0,
             coupling_2: 0.0,
-            cosmological_constant: crate::cdt::action::DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
+            cosmological_constant: DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
             simulate: false,
             seed: Some(42),
             topology: CdtTopology::OpenBoundary,
             output_csv: None,
             output_json: None,
         }
+    }
+
+    fn validated(config: CdtConfig) -> ValidatedCdtConfig {
+        config
+            .into_validated()
+            .expect("test config should validate")
     }
 
     fn temp_output_path(name: &str) -> PathBuf {
@@ -728,8 +738,8 @@ mod tests {
 
     #[test]
     fn test_run_simulation() {
-        let config = create_test_config();
-        assert!(config.dimension.is_some());
+        let config = validated(create_test_config());
+        assert_eq!(config.dimension(), 2);
         let results = run_simulation(&config).expect("Failed to run triangulation");
         assert!(results.triangulation().face_count() > 0);
         assert!(results.triangulation().has_foliation());
@@ -751,8 +761,36 @@ mod tests {
     }
 
     #[test]
+    fn construction_only_results_roundtrip_through_serde() {
+        let config = validated(create_test_config());
+        let results = run_simulation(&config).expect("construction-only run should succeed");
+        assert!(results.steps().is_empty());
+        assert_eq!(
+            results
+                .measurements()
+                .first()
+                .map(|measurement| measurement.step),
+            Some(0)
+        );
+
+        let json = serde_json::to_string(&results).expect("construction snapshot should serialize");
+        let roundtrip: SimulationResultsBackend =
+            from_str(&json).expect("construction snapshot should deserialize");
+
+        assert!(roundtrip.steps().is_empty());
+        assert_eq!(
+            roundtrip
+                .measurements()
+                .first()
+                .map(|measurement| measurement.step),
+            Some(0)
+        );
+        assert_eq!(roundtrip.triangulation().slice_sizes(), &[12, 12, 12]);
+    }
+
+    #[test]
     fn triangulation_contains_triangles() {
-        let config = create_test_config();
+        let config = validated(create_test_config());
         let results = run_simulation(&config).expect("Failed to run triangulation");
         // Check that we have some triangles
         assert!(results.triangulation().face_count() > 0);
@@ -765,6 +803,7 @@ mod tests {
         let mut config = create_test_config();
         config.output_csv = Some(csv_path.clone());
         config.output_json = Some(json_path.clone());
+        let config = validated(config);
 
         run_simulation(&config).expect("configured outputs should write");
 
@@ -775,10 +814,10 @@ mod tests {
         let parsed: Value = from_str(&json).expect("JSON output should parse");
 
         assert!(csv.starts_with("step,action,vertices,edges,triangles,accepted,delta_action\n"));
-        assert_eq!(parsed["config"]["vertices"], config.vertices);
+        assert_eq!(parsed["config"]["vertices"], config.vertices());
         assert_eq!(
             parsed["final_triangulation"]["time_slices"],
-            config.timeslices
+            config.timeslices()
         );
     }
 
@@ -788,6 +827,7 @@ mod tests {
         let mut config = create_test_config();
         config.output_csv = Some(path.clone());
         config.output_json = Some(path.clone());
+        let config = validated(config);
 
         let error = run_simulation(&config).expect_err("overlapping outputs should fail");
 
@@ -808,7 +848,7 @@ mod tests {
         let mut config = create_test_config();
         config.measurement_frequency = 0;
 
-        let result = run_simulation(&config);
+        let result = config.into_validated();
         assert!(result.is_err(), "Should reject zero measurement frequency");
 
         if let Err(CdtError::InvalidSimulationConfiguration {
@@ -831,7 +871,7 @@ mod tests {
         config.steps = 100;
         config.measurement_frequency = 200; // Greater than steps
 
-        let result = run_simulation(&config);
+        let result = config.into_validated();
         assert!(
             result.is_err(),
             "Should reject measurement frequency greater than steps"
@@ -856,7 +896,7 @@ mod tests {
         let mut config = create_test_config();
         config.vertices = 2; // Less than minimum of 3
 
-        let result = run_simulation(&config);
+        let result = config.into_validated();
         assert!(result.is_err(), "Should reject too few vertices");
 
         if let Err(CdtError::InvalidConfiguration {
@@ -878,7 +918,7 @@ mod tests {
         let mut config = create_test_config();
         config.temperature = -1.0;
 
-        let result = run_simulation(&config);
+        let result = config.into_validated();
         assert!(result.is_err(), "Should reject negative temperature");
 
         if let Err(CdtError::InvalidSimulationConfiguration {
@@ -899,11 +939,12 @@ mod tests {
     fn test_run_simulation_with_real_moves() {
         let mut config = create_test_config();
         config.simulate = true;
+        let config = validated(config);
 
         let results = run_simulation(&config).expect("simulation should run with real moves");
         assert_eq!(
             results.steps().len(),
-            usize::try_from(config.steps).unwrap()
+            usize::try_from(config.to_metropolis_config().steps()).unwrap()
         );
         assert!(results.triangulation().has_foliation());
         results
@@ -928,15 +969,15 @@ mod tests {
             .expect("test config should validate");
 
         let metropolis_config = config.to_metropolis_config();
-        assert_relative_eq!(metropolis_config.temperature, 1.0);
-        assert_eq!(metropolis_config.steps, 10);
+        assert_relative_eq!(metropolis_config.temperature(), 1.0);
+        assert_eq!(metropolis_config.steps(), 10);
 
         let action_config = config.to_action_config();
-        assert_relative_eq!(action_config.coupling_0, 0.0);
-        assert_relative_eq!(action_config.coupling_2, 0.0);
+        assert_relative_eq!(action_config.coupling_0(), 0.0);
+        assert_relative_eq!(action_config.coupling_2(), 0.0);
         assert_relative_eq!(
-            action_config.cosmological_constant,
-            crate::cdt::action::DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT
+            action_config.cosmological_constant(),
+            DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT
         );
     }
 
@@ -957,13 +998,14 @@ mod tests {
             measurement_frequency: 2,
             coupling_0: 0.0,
             coupling_2: 0.0,
-            cosmological_constant: crate::cdt::action::DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
+            cosmological_constant: DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
             simulate: false,
             seed: None,
             topology: CdtTopology::Toroidal,
             output_csv: None,
             output_json: None,
         };
+        let config = validated(config);
 
         let results = run_simulation(&config).expect("toroidal simulation should run");
         assert_eq!(
@@ -977,7 +1019,7 @@ mod tests {
             "Toroidal run_simulation must preserve the configured timeslice count"
         );
         assert_matches!(
-            results.triangulation().metadata().topology,
+            results.triangulation().metadata().topology(),
             CdtTopology::Toroidal
         );
     }
@@ -993,6 +1035,7 @@ mod tests {
             measurement_frequency: 1,
             ..create_test_config()
         };
+        let config = validated(config);
 
         let results = run_simulation(&config).expect("profile-based simulation should run");
 
@@ -1017,6 +1060,7 @@ mod tests {
             measurement_frequency: 1,
             ..create_test_config()
         };
+        let config = validated(config);
 
         let results =
             run_simulation(&config).expect("toroidal profile-based simulation should run");
@@ -1024,7 +1068,7 @@ mod tests {
         assert_eq!(results.triangulation().vertex_count(), 16);
         assert_eq!(results.triangulation().slice_sizes(), &[3, 4, 5, 4]);
         assert_matches!(
-            results.triangulation().metadata().topology,
+            results.triangulation().metadata().topology(),
             CdtTopology::Toroidal
         );
         results

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,13 @@ fn main() {
     // Initialize logging
     env_logger::init();
 
-    let config = CdtConfig::from_args();
+    let config = match CdtConfig::from_args().into_validated() {
+        Ok(config) => config,
+        Err(e) => {
+            log::error!("CDT configuration failed: {e}");
+            exit(1);
+        }
+    };
     match run_simulation(&config) {
         Ok(_results) => {
             log::info!("CDT simulation completed successfully");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6,9 +6,10 @@
 //! workflows, topology preservation, error handling, and consistency between components.
 
 use approx::{abs_diff_eq, assert_relative_eq};
-use causal_triangulations::cdt::action::DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT;
-use causal_triangulations::prelude::action::ActionConfig;
-use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveResult};
+use causal_triangulations::prelude::action::{
+    ActionConfig, DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT,
+};
+use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveResult, MoveType};
 use causal_triangulations::prelude::simulation::{MetropolisAlgorithm, MetropolisConfig};
 use causal_triangulations::prelude::triangulation::{
     CdtTopology, CdtTriangulation, TriangulationQuery,
@@ -31,7 +32,9 @@ mod integration_tests {
             .validate_causality()
             .expect("initial strip causality is valid");
 
-        let config = MetropolisConfig::new(1.0, 10, 5, 2).with_seed(42);
+        let config = MetropolisConfig::new(1.0, 10, 5, 2)
+            .expect("integration Metropolis config should be valid")
+            .with_seed(42);
         let action_config = ActionConfig::default();
         let algorithm = MetropolisAlgorithm::new(config, action_config);
 
@@ -70,7 +73,7 @@ mod integration_tests {
         const STEPS: u32 = 80;
 
         let triangulation = CdtTriangulation::from_toroidal_cdt(4, 3).expect("build toroidal CDT");
-        assert_eq!(triangulation.metadata().topology, CdtTopology::Toroidal);
+        assert_eq!(triangulation.metadata().topology(), CdtTopology::Toroidal);
         assert_eq!(triangulation.geometry().euler_characteristic(), 0);
         let initial_profile = triangulation.volume_profile();
         triangulation
@@ -80,7 +83,9 @@ mod integration_tests {
             .validate_foliation()
             .expect("initial toroidal foliation is valid");
 
-        let config = MetropolisConfig::new(1.0, STEPS, 0, 10).with_seed(105);
+        let config = MetropolisConfig::new(1.0, STEPS, 0, 10)
+            .expect("integration Metropolis config should be valid")
+            .with_seed(105);
         let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
         let results = algorithm
             .run(triangulation)
@@ -93,7 +98,7 @@ mod integration_tests {
             "periodic toroidal simulation should accept at least one move"
         );
         assert!(
-            results.move_stats().moves_13_accepted > 0,
+            results.move_stats().accepted(MoveType::Move13Add) > 0,
             "periodic toroidal simulation should accept at least one volume-increasing move"
         );
         assert_ne!(
@@ -102,7 +107,7 @@ mod integration_tests {
             "periodic toroidal volume moves should change the final volume profile"
         );
         assert_eq!(
-            results.triangulation().metadata().topology,
+            results.triangulation().metadata().topology(),
             CdtTopology::Toroidal
         );
         assert_eq!(results.triangulation().geometry().euler_characteristic(), 0);
@@ -274,7 +279,9 @@ mod integration_tests {
         let triangulation2 =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Failed to create second triangulation");
 
-        let config = MetropolisConfig::new(1.0, 10, 2, 2).with_seed(123);
+        let config = MetropolisConfig::new(1.0, 10, 2, 2)
+            .expect("integration Metropolis config should be valid")
+            .with_seed(123);
         let action_config = ActionConfig::default();
 
         let algorithm1 = MetropolisAlgorithm::new(config.clone(), action_config.clone());

--- a/tests/large_scale_debug.rs
+++ b/tests/large_scale_debug.rs
@@ -48,22 +48,22 @@ impl ProposalOutcomeCounts {
     /// Captures cumulative proposal-kernel counters.
     const fn from_stats(stats: &ProposalStatistics) -> Self {
         let site_rejections = stats
-            .site_causality_rejections
-            .saturating_add(stats.site_geometric_rejections)
-            .saturating_add(stats.site_backend_rejections);
+            .site_causality_rejections()
+            .saturating_add(stats.site_geometric_rejections())
+            .saturating_add(stats.site_backend_rejections());
         let rejected = stats
-            .no_site_proposals
+            .no_site_proposals()
             .saturating_add(site_rejections)
-            .saturating_add(stats.metropolis_rejections)
-            .saturating_add(stats.hard_failures);
+            .saturating_add(stats.metropolis_rejections())
+            .saturating_add(stats.hard_failures());
         Self {
-            proposals: stats.move_family_proposals,
-            accepted: stats.accepted_transitions,
+            proposals: stats.move_family_proposals(),
+            accepted: stats.accepted_transitions(),
             rejected,
-            no_site: stats.no_site_proposals,
+            no_site: stats.no_site_proposals(),
             site_rejections,
-            metropolis_rejections: stats.metropolis_rejections,
-            hard_failures: stats.hard_failures,
+            metropolis_rejections: stats.metropolis_rejections(),
+            hard_failures: stats.hard_failures(),
         }
     }
 
@@ -192,14 +192,16 @@ fn assert_toroidal_invariants(triangulation: &CdtTriangulation2D) {
     triangulation
         .validate()
         .expect("large-scale toroidal CDT should validate after random sweeps");
-    assert_eq!(triangulation.metadata().topology, CdtTopology::Toroidal);
+    assert_eq!(triangulation.metadata().topology(), CdtTopology::Toroidal);
     assert_eq!(triangulation.geometry().euler_characteristic(), 0);
 }
 
 /// Builds a chunk configuration for one unfixed-volume Metropolis debug sweep.
 fn sweep_config(attempts: usize, seed: u64) -> MetropolisConfig {
     let steps = u32::try_from(attempts).expect("sweep attempt count should fit in u32");
-    MetropolisConfig::new(1.0, steps, 0, 1).with_seed(seed)
+    MetropolisConfig::new(1.0, steps, 0, 1)
+        .expect("sweep config should be valid")
+        .with_seed(seed)
 }
 
 /// Runs one Metropolis chunk and keeps resumable checkpoint state for the next sweep.
@@ -229,12 +231,7 @@ fn run_metropolis_sweep(
 
 /// Reads the accepted counter for one move type.
 const fn accepted_count(stats: &MoveStatistics, move_type: MoveType) -> u64 {
-    match move_type {
-        MoveType::Move22 => stats.moves_22_accepted,
-        MoveType::Move13Add => stats.moves_13_accepted,
-        MoveType::Move31Remove => stats.moves_31_accepted,
-        MoveType::EdgeFlip => stats.edge_flips_accepted,
-    }
+    stats.accepted(move_type)
 }
 
 #[cfg(feature = "slow-tests")]
@@ -369,7 +366,7 @@ fn debug_large_scale_1p1() {
     let triangulation = checkpoint.triangulation();
     assert_eq!(checkpoint.move_stats().total_attempted(), expected_attempts);
     assert_eq!(
-        checkpoint.proposal_stats().move_family_proposals,
+        checkpoint.proposal_stats().move_family_proposals(),
         expected_attempts
     );
     assert!(
@@ -377,11 +374,11 @@ fn debug_large_scale_1p1() {
         "large-scale Metropolis sweeps should accept at least one move"
     );
     assert!(
-        checkpoint.move_stats().moves_13_accepted > 0,
+        checkpoint.move_stats().accepted(MoveType::Move13Add) > 0,
         "large-scale Metropolis sweeps should exercise toroidal Move13Add"
     );
     assert!(
-        checkpoint.move_stats().moves_31_accepted > 0,
+        checkpoint.move_stats().accepted(MoveType::Move31Remove) > 0,
         "large-scale Metropolis sweeps should exercise toroidal Move31Remove"
     );
     assert_ne!(

--- a/tests/physics_integration.rs
+++ b/tests/physics_integration.rs
@@ -2,7 +2,9 @@
 
 //! End-to-end physics integration tests for 1+1 CDT simulations.
 
-use causal_triangulations::{CdtConfig, CdtTopology, TestConfig, run_simulation};
+use causal_triangulations::{
+    CdtConfig, CdtTopology, TestConfig, ValidatedCdtConfig, run_simulation,
+};
 
 /// Enables real simulation mode on canned test configs with a deterministic seed.
 const fn simulated_config(mut config: CdtConfig, seed: u64) -> CdtConfig {
@@ -12,8 +14,11 @@ const fn simulated_config(mut config: CdtConfig, seed: u64) -> CdtConfig {
 }
 
 /// Verifies that an end-to-end run mutates geometry and preserves final invariants.
-fn assert_physics_pipeline(config: &CdtConfig) {
-    let results = run_simulation(config).expect("physics integration run should succeed");
+fn assert_physics_pipeline(config: CdtConfig) {
+    let config = config
+        .into_validated()
+        .expect("physics integration config should validate");
+    let results = run_simulation(&config).expect("physics integration run should succeed");
 
     let acceptance_rate = results.acceptance_rate();
     assert!(
@@ -46,13 +51,13 @@ fn assert_physics_pipeline(config: &CdtConfig) {
     let profile = results.average_volume_profile();
     assert_eq!(
         profile.len(),
-        usize::try_from(config.timeslices).expect("timeslices should fit usize"),
+        usize::try_from(config.timeslices()).expect("timeslices should fit usize"),
         "volume profile should cover every time slice"
     );
     assert!(
         profile
             .iter()
-            .take(occupied_time_slabs(config))
+            .take(occupied_time_slabs(&config))
             .all(|&volume| volume > 0.0),
         "empty time slice detected: {profile:?}"
     );
@@ -60,17 +65,17 @@ fn assert_physics_pipeline(config: &CdtConfig) {
     let stats = results.move_stats();
     assert_eq!(
         stats.total_attempted(),
-        u64::from(config.steps),
+        u64::from(config.to_metropolis_config().steps()),
         "one move proposal should be recorded for each configured simulation step"
     );
     assert!(stats.total_acceptance_rate() > 0.0);
 }
 
 /// Counts slabs expected to have volume in the measured CDT profile.
-fn occupied_time_slabs(config: &CdtConfig) -> usize {
-    let slabs = match config.topology {
-        CdtTopology::OpenBoundary => config.timeslices.saturating_sub(1),
-        CdtTopology::Toroidal => config.timeslices,
+fn occupied_time_slabs(config: &ValidatedCdtConfig) -> usize {
+    let slabs = match config.topology() {
+        CdtTopology::OpenBoundary => config.timeslices().saturating_sub(1),
+        CdtTopology::Toroidal => config.timeslices(),
     };
     usize::try_from(slabs).expect("time slab count should fit usize")
 }
@@ -79,7 +84,7 @@ fn occupied_time_slabs(config: &CdtConfig) -> usize {
 fn small_cdt_simulation_has_nontrivial_physics_signal() {
     let config = simulated_config(TestConfig::small(), 42);
 
-    assert_physics_pipeline(&config);
+    assert_physics_pipeline(config);
 }
 
 #[cfg(feature = "slow-tests")]
@@ -87,5 +92,5 @@ fn small_cdt_simulation_has_nontrivial_physics_signal() {
 fn medium_cdt_simulation_has_nontrivial_physics_signal() {
     let config = simulated_config(TestConfig::medium(), 42);
 
-    assert_physics_pipeline(&config);
+    assert_physics_pipeline(config);
 }

--- a/tests/physics_integration.rs
+++ b/tests/physics_integration.rs
@@ -65,7 +65,7 @@ fn assert_physics_pipeline(config: CdtConfig) {
     let stats = results.move_stats();
     assert_eq!(
         stats.total_attempted(),
-        u64::from(config.to_metropolis_config().steps()),
+        u64::from(config.to_metropolis_config().steps().get()),
         "one move proposal should be recorded for each configured simulation step"
     );
     assert!(stats.total_acceptance_rate() > 0.0);

--- a/tests/proptest_foliation.rs
+++ b/tests/proptest_foliation.rs
@@ -119,7 +119,7 @@ proptest! {
         let tri = CdtTriangulation::from_seeded_points(vertices, time_slices, 2, seed)
             .expect("valid seeded construction should preserve metadata");
 
-        prop_assert_eq!(tri.time_slices(), time_slices);
+        prop_assert_eq!(tri.time_slices().get(), time_slices);
         prop_assert_eq!(tri.dimension(), 2);
     }
 

--- a/tests/proptest_metropolis.rs
+++ b/tests/proptest_metropolis.rs
@@ -23,7 +23,8 @@ proptest! {
         temperature in 0.01f64..100.0,
     ) {
         let tri = test_triangulation();
-        let action_config = ActionConfig::new(coupling_0, coupling_2, cosmological_constant);
+        let action_config = ActionConfig::new(coupling_0, coupling_2, cosmological_constant)
+            .expect("generated couplings are finite");
 
         let target = CdtTarget::new(action_config.clone(), temperature)
             .expect("generated action config and temperature are valid");

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -17,7 +17,9 @@ fn toroidal_observables_run_accepts_periodic_moves_after_offset_support() {
     let triangulation =
         CdtTriangulation::from_toroidal_cdt(4, 3).expect("observables fixture should build");
 
-    let metropolis_config = MetropolisConfig::new(1.0, 20, 0, 5).with_seed(7);
+    let metropolis_config = MetropolisConfig::new(1.0, 20, 0, 5)
+        .expect("regression Metropolis config should be valid")
+        .with_seed(7);
     let results =
         MetropolisAlgorithm::new(metropolis_config, ActionConfig::default()).run(triangulation);
     let results = results.expect("toroidal observables regression run should complete");
@@ -58,7 +60,7 @@ fn proposal_site_cache_does_not_reuse_sites_for_replaced_triangulation_instances
     let mut system = ErgodicsSystem::with_seed(11);
     let mut triangulation =
         CdtTriangulation::from_toroidal_cdt(4, 3).expect("toroidal fixture should build");
-    assert_eq!(triangulation.metadata().modification_count, 0);
+    assert_eq!(triangulation.metadata().modification_count(), 0);
 
     let first_result = system.attempt_13_move(&mut triangulation);
     assert_matches!(
@@ -71,7 +73,7 @@ fn proposal_site_cache_does_not_reuse_sites_for_replaced_triangulation_instances
         .expect("initial cached triangulation should remain valid");
 
     triangulation = CdtTriangulation::from_cdt_strip(4, 3).expect("strip fixture should build");
-    assert_eq!(triangulation.metadata().modification_count, 0);
+    assert_eq!(triangulation.metadata().modification_count(), 0);
 
     let second_result = system.attempt_13_move(&mut triangulation);
     assert_eq!(


### PR DESCRIPTION
- Require action, Metropolis, and top-level simulation configuration to enter runtime code through validated private-field types.
- Validate result, checkpoint, move, and proposal telemetry before storage or deserialization so impossible counters and incoherent step records cannot be represented.
- Move CDT triangulation state into the triangulation module tree and expose metadata, statistics, and constants through focused accessors and preludes.

BREAKING CHANGE: ActionConfig::new and MetropolisConfig::new now return CdtResult, runtime config/statistics/metadata fields are private, run_simulation requires ValidatedCdtConfig, and CDT triangulation state moved from src/cdt/triangulation.rs to src/cdt/triangulation/state.rs.

Closes #170, closes #171, closes #172, closes #173.