### PR TITLE
refactor(cdt)!: run continuation through planned proposals (#153)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ This crate is part of a broader Rust ecosystem for computational geometry and si
 
 - [`delaunay`](https://crates.io/crates/delaunay) — geometric primitives and triangulations
 - `la-stack` — linear algebra utilities
-- [`markov-chain-monte-carlo`](https://crates.io/crates/markov-chain-monte-carlo) — composable MCMC traits, including plan-before-commit proposals for CDT move
-  ordering
+- [`markov-chain-monte-carlo`](https://crates.io/crates/markov-chain-monte-carlo) — composable MCMC traits, including plan-before-commit proposals for CDT
+  move ordering
 
 The long-term design separates:
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This crate is part of a broader Rust ecosystem for computational geometry and si
 
 - [`delaunay`](https://crates.io/crates/delaunay) — geometric primitives and triangulations
 - `la-stack` — linear algebra utilities
-- [`markov-chain-monte-carlo`](https://crates.io/crates/markov-chain-monte-carlo) — composable MCMC traits, including delayed-commit proposals for CDT move
+- [`markov-chain-monte-carlo`](https://crates.io/crates/markov-chain-monte-carlo) — composable MCMC traits, including plan-before-commit proposals for CDT move
   ordering
 
 The long-term design separates:

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -249,13 +249,13 @@ geometric, and backend edit failures are self-loop proposal outcomes recorded in
 Toroidal move finalization rejects and rolls back candidate sites that would violate χ = 0 or the closed-S¹ per-slice foliation invariant.
 
 The module tree is declared from `src/lib.rs` to avoid the `metropolis.rs` plus `metropolis/` layout pattern. `adapter.rs` is the single CDT adapter boundary
-for `markov-chain-monte-carlo` proposal and target traits. `runner.rs` keeps the transitional production step loop, `checkpoint.rs` owns resumable checkpoint
-state and resume validation, `telemetry.rs` owns public step/proposal telemetry, and `helpers.rs` holds shared CDT-domain calculations.
+for `markov-chain-monte-carlo` proposal and target traits. `runner.rs` owns `MetropolisAlgorithm::run_steps`, which rebuilds the upstream `Chain`/`Sampler`
+continuation view, delegates generic acceptance, proposal-ratio application, chain counters, and planned-proposal commit ordering to the upstream MCMC crate,
+then records CDT-specific telemetry, measurements, and result state. `checkpoint.rs` owns resumable checkpoint state and resume validation, `telemetry.rs` owns
+public step/proposal telemetry, and `helpers.rs` holds shared CDT-domain calculations.
 
-This direct M-H loop is transitional. The production runner should migrate toward delegating generic acceptance, proposal-ratio application, chain counters, and
-planned-proposal commit ordering to the upstream MCMC crate while retaining CDT-specific telemetry and result conversion. See `docs/metropolis.md` for the
-detailed ordering and
-[`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155) for the boundary refactor.
+See `docs/metropolis.md` for the current planned-proposal ordering and
+[`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155) for the remaining MCMC boundary follow-up.
 
 ### `cdt/results.rs` — Simulation outputs
 

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -186,7 +186,7 @@ handle wrappers, `DelaunayBackend2D`, and generator functions from `crate::geome
 
 Generic MCMC mechanics should be delegated to `markov-chain-monte-carlo` through thin CDT adapters. CDT owns domain state, proposal-site enumeration,
 foliation/topology validation, measurements, and result translation; the upstream MCMC crate should own Metropolis-Hastings acceptance, proposal-ratio
-application, chain counters, delayed-proposal commit ordering, and reusable sampler continuation behavior. The current boundary refactor is tracked by
+application, chain counters, planned-proposal commit ordering, and reusable sampler continuation behavior. The current boundary refactor is tracked by
 [`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155).
 
 ## Key Modules
@@ -253,7 +253,7 @@ for `markov-chain-monte-carlo` proposal and target traits. `runner.rs` keeps the
 state and resume validation, `telemetry.rs` owns public step/proposal telemetry, and `helpers.rs` holds shared CDT-domain calculations.
 
 This direct M-H loop is transitional. The production runner should migrate toward delegating generic acceptance, proposal-ratio application, chain counters, and
-delayed-proposal commit ordering to the upstream MCMC crate while retaining CDT-specific telemetry and result conversion. See `docs/metropolis.md` for the
+planned-proposal commit ordering to the upstream MCMC crate while retaining CDT-specific telemetry and result conversion. See `docs/metropolis.md` for the
 detailed ordering and
 [`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155) for the boundary refactor.
 

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -353,7 +353,7 @@ Delegate generic sampler work to upstream APIs such as `Target`, `DelayedProposa
 - Metropolis-Hastings accept/reject decisions
 - proposal-ratio application
 - chain accepted/rejected counters
-- delayed-proposal commit ordering
+- planned-proposal commit ordering
 - RNG-driven acceptance draws
 - checkpoint-compatible sampler continuation mechanics
 
@@ -367,7 +367,7 @@ CDT may own thin domain adapters and result plumbing:
 Do not add new local generic M-H loops, direct `exp(log_alpha)` acceptance draws, one-off proposal schedulers, or generic chain counter logic in `src/cdt/` when
 `markov-chain-monte-carlo` can own that behavior. If CDT needs temporary local sampler logic because the upstream API lacks a hook, document the gap in the
 code or nearby docs and open or link an upstream issue before extending the local implementation. The current production migration is tracked by
-[`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155), with upstream delayed-step telemetry tracked by
+[`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155), with upstream planned-step telemetry tracked by
 [`markov-chain-monte-carlo#61`](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61).
 
 Once the production runner delegates fully to upstream sampler mechanics, add a static check so future CDT changes cannot reintroduce local generic

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -19,6 +19,8 @@ Non-Rust repository tooling is normalized to a 160-column width: Ruff for Python
 `dprint`/`pretty_yaml`, and the generated changelog postprocessor all use 160 columns. Rust remains on the narrower `rustfmt` `max_width = 100` setting because
 wide Rust signatures, trait bounds, and method chains become harder to scan at 160 columns.
 
+The Markdown raw line-length guard counts bytes with `LC_ALL=C` so macOS, Linux, and Windows agree on UTF-8 punctuation near the 160-column boundary.
+
 ## Python Tooling
 
 CDT's Python tooling is broader than MCMC's. MCMC currently has changelog and tag helpers; CDT also has benchmark, hardware, coverage, archive, and

--- a/docs/metropolis.md
+++ b/docs/metropolis.md
@@ -1,10 +1,10 @@
 # Metropolis Move Ordering And Detailed Balance
 
 > **MCMC backend boundary:** this page describes the current CDT production Metropolis runner. Its proposal-before-mutation contract should be preserved, but
-> generic Metropolis-Hastings mechanics should migrate behind `markov-chain-monte-carlo` adapters rather than remain as CDT-local sampler logic. The boundary
-> refactor is tracked by [`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155); upstream delayed-step hooks and
-> telemetry needs are tracked by
-> [`markov-chain-monte-carlo#61`](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61).
+> generic Metropolis-Hastings mechanics should live behind `markov-chain-monte-carlo` adapters rather than CDT-local sampler logic. Chunked continuation now
+> uses upstream proposal planning and checkpoint-compatible continuation from `markov-chain-monte-carlo` v0.4. The remaining boundary refactor is
+> tracked by [`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155); any further upstream planned-step hooks and
+> telemetry needs are tracked by [`markov-chain-monte-carlo#61`](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61).
 
 `MetropolisAlgorithm::run()` uses a proposal-before-mutation ordering for CDT Monte Carlo steps.
 
@@ -72,10 +72,12 @@ volume-fixing follow-up should cite the higher-dimensional CDT simulation litera
 checkpoint. This keeps the checkpointed triangulation, Metropolis acceptance RNG, ergodic proposal RNG, counters, measurements, and elapsed-time telemetry
 together between chunks.
 
-The large-scale 1+1 debug harness uses this CDT-local chunking path to run one Metropolis sweep at a time. This behavior should eventually align with the
-upstream resumable sampler pattern tracked by
-[`markov-chain-monte-carlo#60`](https://github.com/acgetchell/markov-chain-monte-carlo/issues/60) and
-[`causal-triangulations#153`](https://github.com/acgetchell/causal-triangulations/issues/153):
+Chunk execution is implemented through `markov-chain-monte-carlo::Sampler::step_delayed` on the CDT proposal-plan adapter. The upstream sampler owns the
+Metropolis-Hastings accept/reject draw, log-probability cache, chain counters, and checkpoint-compatible continuation view. CDT keeps domain-specific state
+outside that generic sampler: action and schedule metadata, proposal telemetry, move statistics, measurements, elapsed time, and the serialized ergodic proposal
+RNG.
+
+The large-scale 1+1 debug harness uses this upstream-backed chunking path to run one Metropolis sweep at a time:
 
 1. Read the current number of top-dimensional simplices at the start of the sweep.
 2. Run exactly that many Metropolis proposal steps.
@@ -200,4 +202,4 @@ These counters explain chain stickiness and backend behavior, but detailed balan
 empirical frequencies accumulated earlier in the run.
 
 The explicit-site model avoids dry-run cloning every candidate during site counting. The only required full triangulation clone is the planned proposed state
-used by delayed Metropolis acceptance, plus a narrow rollback snapshot around composite mutations whose intermediate backend steps can partially commit.
+used by planned Metropolis acceptance, plus a narrow rollback snapshot around composite mutations whose intermediate backend steps can partially commit.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ The v0.1.0 foundation work focuses on making the crate a usable, validated 1+1 C
 - [x] Explicit toroidal S¹×S¹ CDT construction with χ = 0 validation
 - [x] Per-vertex foliation labels, causality checks, and strict Up/Down simplex classification
 - [x] Real 2D ergodic move kernels over Delaunay backend edit operations
-- [x] Concrete delayed-proposal Metropolis-Hastings loop with forward/reverse local-site weighting
+- [x] Concrete planned-proposal Metropolis-Hastings loop with forward/reverse local-site weighting
 - [x] Toroidal Metropolis regression coverage requiring accepted periodic moves while preserving topology and foliation
 - [x] CLI and configuration support for open-boundary and toroidal topology selection
 - [x] Volume-profile, Hausdorff-dimension, and spectral-dimension observables on the combinatorial dual graph
@@ -27,13 +27,13 @@ The v0.1.0 foundation work focuses on making the crate a usable, validated 1+1 C
 - [x] Use chunked Metropolis sweeps in large-scale 1+1 CDT debug runs
   ([#152](https://github.com/acgetchell/causal-triangulations/issues/152)). The v0.1.0 scientific-utility bar requires the large-scale debug path to exercise
   Metropolis CDT behavior with literature-style sweeps sized from the current simplex count, not only the raw move kernel.
-- [ ] Align chunked Metropolis continuation with the upstream resumable sampler pattern
-  ([#153](https://github.com/acgetchell/causal-triangulations/issues/153)). Since #155 already requires a new `markov-chain-monte-carlo` release, chunked CDT
-  continuation should also move onto the upstream continuation/checkpoint API before the DOI-backed `v0.1.0` release.
+- [x] Align chunked Metropolis continuation with the upstream resumable sampler pattern
+  ([#153](https://github.com/acgetchell/causal-triangulations/issues/153)). CDT chunk execution now drives the proposal-plan adapter through
+  `markov-chain-monte-carlo` v0.4 sampler continuation while preserving CDT-owned measurements, proposal telemetry, and current-volume sweep sizing.
 - [ ] Enforce the MCMC backend boundary
   ([#155](https://github.com/acgetchell/causal-triangulations/issues/155)). Because GitHub releases are archived by Zenodo, the DOI-backed `v0.1.0` release
   should not ship with generic Metropolis-Hastings mechanics duplicated in CDT-local code. Complete this after an updated `markov-chain-monte-carlo` release
-  provides the needed upstream resumable-sampler and delayed-step telemetry APIs
+  provides the needed upstream resumable-sampler and planned-step telemetry APIs
   ([markov-chain-monte-carlo#60](https://github.com/acgetchell/markov-chain-monte-carlo/issues/60),
   [markov-chain-monte-carlo#61](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61)).
 

--- a/examples/output_and_checkpoint.rs
+++ b/examples/output_and_checkpoint.rs
@@ -42,10 +42,10 @@ fn main() -> CdtResult<()> {
         detail: err.to_string(),
     })?;
     assert!(csv.starts_with("step,action,vertices,edges,triangles,accepted,delta_action\n"));
-    assert_eq!(summary["config"]["vertices"], config.vertices());
+    assert_eq!(summary["config"]["vertices"], config.vertices().get());
     assert_eq!(
         summary["final_triangulation"]["time_slices"],
-        config.timeslices()
+        config.timeslices().get()
     );
     assert_eq!(
         summary["measurements"].as_array().map_or(0, Vec::len),

--- a/justfile
+++ b/justfile
@@ -443,8 +443,9 @@ markdown-check: _ensure-rumdl
             line_number=0
             while IFS= read -r line || [[ -n "$line" ]]; do
                 line_number=$((line_number + 1))
-                if [ "${#line}" -gt 160 ]; then
-                    printf '%s:%d: line length %d exceeds 160\n' "$file" "$line_number" "${#line}" >&2
+                line_length="$(LC_ALL=C printf '%s' "$line" | wc -c | tr -d ' ')"
+                if [ "$line_length" -gt 160 ]; then
+                    printf '%s:%d: line length %d exceeds 160\n' "$file" "$line_number" "$line_length" >&2
                     violations=$((violations + 1))
                 fi
             done < "$file"

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -571,6 +571,60 @@ rules:
       )
       \s*;
 
+  - id: causal-triangulations.rust.planned-step-info-not-proposal-cache
+    languages:
+      - rust
+    severity: WARNING
+    message: "Use the planned step's returned info for runtime bookkeeping; keep proposal cache reads to debug/test checks."
+    metadata:
+      category: correctness
+      rationale: >-
+        Planned-proposal telemetry should come from the step returned by the
+        upstream sampler. Reading CdtProposal::last_step_info() as the runtime
+        source of truth can drift from the authoritative sampler result.
+    paths:
+      include:
+        - "/src/cdt/metropolis/**/*.rs"
+        - "/tests/semgrep/src/**/*.rs"
+    patterns:
+      - pattern: $SAMPLER.proposal_ref().last_step_info()
+      - pattern-not-inside: |
+          debug_assert_eq!(
+              $SAMPLER.proposal_ref().last_step_info(),
+              ...,
+              ...
+          );
+      - pattern-not-inside: |
+          mod tests {
+              ...
+          }
+      - pattern-not-inside: |
+          #[cfg(test)]
+          mod $MOD {
+              ...
+          }
+
+  - id: causal-triangulations.rust.planned-step-record-requires-sampler-state-sync
+    languages:
+      - rust
+    severity: WARNING
+    message: "Sync the annotated CDT state back into the sampler after recording a planned proposal step."
+    metadata:
+      category: correctness
+      rationale: >-
+        CDT records metadata and history after planned-proposal outcomes, while
+        the upstream sampler owns the state used by later proposals. Advancing
+        the step counter without sampler.replace_state(...) can discard those
+        annotations on a later handoff.
+    paths:
+      include:
+        - "/src/cdt/metropolis/**/*.rs"
+        - "/tests/semgrep/src/**/*.rs"
+    pattern-regex: >-
+      (?s)record_planned_step\([^;]*\)\?;\s*
+      (?:(?!replace_state\s*\().)*?
+      state\.current_step\s*=
+
   - id: causal-triangulations.rust.expect-requires-reason
     languages:
       - rust

--- a/src/cdt/foliation.rs
+++ b/src/cdt/foliation.rs
@@ -378,7 +378,7 @@ impl<'de> Deserialize<'de> for Foliation {
         D: Deserializer<'de>,
     {
         let serialized = SerializedFoliation::deserialize(deserializer)?;
-        Self::from_slice_sizes(serialized.slice_sizes, serialized.num_slices)
+        Self::from_raw_slice_sizes(serialized.slice_sizes, serialized.num_slices)
             .map_err(D::Error::custom)
     }
 }
@@ -394,34 +394,59 @@ impl Foliation {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{CdtResult, Foliation, FoliationError};
+    /// use causal_triangulations::{CdtResult, Foliation};
+    /// use std::num::NonZeroU32;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let foliation = Foliation::from_slice_sizes(vec![3, 4], 2)?;
+    ///     let Some(num_slices) = NonZeroU32::new(2) else {
+    ///         return Ok(());
+    ///     };
+    ///     let foliation = Foliation::from_slice_sizes(vec![3, 4], num_slices)?;
     ///     assert_eq!(foliation.num_slices().get(), 2);
     ///     assert_eq!(foliation.labeled_vertex_count(), 7);
-    ///
-    ///     let err = Foliation::from_slice_sizes(vec![], 0).expect_err("zero slices are invalid");
-    ///     assert_eq!(err, FoliationError::EmptyFoliation);
     ///     Ok(())
     /// }
     /// ```
     pub fn from_slice_sizes(
         slice_sizes: Vec<usize>,
+        num_slices: NonZeroU32,
+    ) -> Result<Self, FoliationError> {
+        Self::from_nonzero_slice_sizes(slice_sizes, num_slices)
+    }
+
+    /// Parses raw serialized slice counts before rebuilding validated foliation state.
+    ///
+    /// Public constructors require [`NonZeroU32`], but checkpoint payloads still
+    /// carry raw integers. This helper keeps serde restore on the same
+    /// validation path as normal construction without exposing a raw-count API.
+    fn from_raw_slice_sizes(
+        slice_sizes: Vec<usize>,
         num_slices: u32,
+    ) -> Result<Self, FoliationError> {
+        let Some(num_slices) = NonZeroU32::new(num_slices) else {
+            return Err(FoliationError::EmptyFoliation);
+        };
+        Self::from_nonzero_slice_sizes(slice_sizes, num_slices)
+    }
+
+    /// Builds foliation bookkeeping after the slice-count nonzero proof exists.
+    ///
+    /// The remaining checks protect the public [`Self::from_slice_sizes`]
+    /// contract: the number of per-slice counts must match `num_slices`, and no
+    /// slice may be empty.
+    fn from_nonzero_slice_sizes(
+        slice_sizes: Vec<usize>,
+        num_slices: NonZeroU32,
     ) -> Result<Self, FoliationError> {
         if slice_sizes.is_empty() {
             return Err(FoliationError::EmptyFoliation);
         }
-        if slice_sizes.len() != num_slices as usize {
+        if slice_sizes.len() != num_slices.get() as usize {
             return Err(FoliationError::SliceSizeMismatch {
                 slice_sizes_len: slice_sizes.len(),
-                num_slices,
+                num_slices: num_slices.get(),
             });
         }
-        let Some(num_slices) = NonZeroU32::new(num_slices) else {
-            return Err(FoliationError::EmptyFoliation);
-        };
         if let Some(slice) = slice_sizes.iter().position(|&slice_size| slice_size == 0) {
             return Err(FoliationError::EmptySlice { slice });
         }
@@ -437,9 +462,16 @@ impl Foliation {
     ///
     /// ```
     /// use causal_triangulations::{CdtResult, Foliation};
+    /// use std::num::NonZeroU32;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let foliation = Foliation::from_slice_sizes(vec![3, 4], 2)?;
+    ///     let Some(num_slices) = NonZeroU32::new(2) else {
+    ///         return Ok(());
+    ///     };
+    ///     let foliation = Foliation::from_slice_sizes(
+    ///         vec![3, 4],
+    ///         num_slices,
+    ///     )?;
     ///     assert_eq!(foliation.slice_sizes(), &[3, 4]);
     ///     Ok(())
     /// }
@@ -455,9 +487,16 @@ impl Foliation {
     ///
     /// ```
     /// use causal_triangulations::{CdtResult, Foliation};
+    /// use std::num::NonZeroU32;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let foliation = Foliation::from_slice_sizes(vec![3, 4], 2)?;
+    ///     let Some(num_slices) = NonZeroU32::new(2) else {
+    ///         return Ok(());
+    ///     };
+    ///     let foliation = Foliation::from_slice_sizes(
+    ///         vec![3, 4],
+    ///         num_slices,
+    ///     )?;
     ///     assert_eq!(foliation.num_slices().get(), 2);
     ///     Ok(())
     /// }
@@ -473,9 +512,16 @@ impl Foliation {
     ///
     /// ```
     /// use causal_triangulations::{CdtResult, Foliation};
+    /// use std::num::NonZeroU32;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let foliation = Foliation::from_slice_sizes(vec![3, 4], 2)?;
+    ///     let Some(num_slices) = NonZeroU32::new(2) else {
+    ///         return Ok(());
+    ///     };
+    ///     let foliation = Foliation::from_slice_sizes(
+    ///         vec![3, 4],
+    ///         num_slices,
+    ///     )?;
     ///     assert_eq!(foliation.labeled_vertex_count(), 7);
     ///     Ok(())
     /// }
@@ -491,6 +537,10 @@ mod tests {
     use super::*;
     use serde_json::from_str;
 
+    fn slice_count(value: u32) -> NonZeroU32 {
+        NonZeroU32::new(value).expect("test slice count should be nonzero")
+    }
+
     #[test]
     fn test_edge_type_equality() {
         assert_eq!(EdgeType::Spacelike, EdgeType::Spacelike);
@@ -500,21 +550,21 @@ mod tests {
 
     #[test]
     fn test_foliation_empty_slice_rejected() {
-        let result = Foliation::from_slice_sizes(vec![0, 0, 0], 3);
+        let result = Foliation::from_slice_sizes(vec![0, 0, 0], slice_count(3));
         let err = result.expect_err("empty slices should be rejected");
         assert_eq!(err, FoliationError::EmptySlice { slice: 0 });
     }
 
     #[test]
     fn test_foliation_zero_slices_rejected() {
-        let result = Foliation::from_slice_sizes(vec![], 0);
+        let result = Foliation::from_raw_slice_sizes(vec![], 0);
         let err = result.expect_err("zero-slice foliations should be rejected");
         assert_eq!(err, FoliationError::EmptyFoliation);
     }
 
     #[test]
     fn test_foliation_populated() {
-        let fol = Foliation::from_slice_sizes(vec![3, 3], 2).expect("valid foliation");
+        let fol = Foliation::from_slice_sizes(vec![3, 3], slice_count(2)).expect("valid foliation");
         assert_eq!(fol.num_slices().get(), 2);
         assert_eq!(fol.labeled_vertex_count(), 6);
         assert_eq!(fol.slice_sizes()[0], 3);
@@ -523,7 +573,7 @@ mod tests {
 
     #[test]
     fn test_foliation_slice_size_mismatch() {
-        let result = Foliation::from_slice_sizes(vec![3, 3], 3);
+        let result = Foliation::from_slice_sizes(vec![3, 3], slice_count(3));
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(

--- a/src/cdt/metropolis/adapter.rs
+++ b/src/cdt/metropolis/adapter.rs
@@ -6,7 +6,9 @@ use crate::cdt::action::ActionConfig;
 use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveType, proposal_site_count};
 use crate::errors::{CdtError, CdtResult, MetropolisMoveApplicationFailure};
 use crate::geometry::CdtTriangulation2D;
-use markov_chain_monte_carlo::{Chain, ChainCheckpoint, DelayedProposal, McmcError, Target};
+use markov_chain_monte_carlo::{
+    Chain, ChainCheckpoint, DelayedProposal, DiscreteProposalRatio, McmcError, Target,
+};
 use rand::Rng;
 use std::error::Error;
 use std::fmt;
@@ -61,14 +63,15 @@ impl Target<CdtTriangulation2D> for CdtTarget {
     }
 }
 
-/// Concrete delayed CDT move proposal selected before committing live state.
+/// Concrete CDT proposal plan selected before committing live state.
 ///
 /// A plan records the selected [`MoveType`], the action before and after the
 /// move, and a cloned triangulation containing the proposed mutation. Planning
 /// may mutate that clone to realize a concrete local site, but it never mutates
-/// the live simulation state. The delayed proposal API scores this plan with
-/// the Metropolis-Hastings forward/reverse proposal-site ratio, then commits
-/// the cloned state only if the Metropolis step accepts it.
+/// the live simulation state. The sampler scores this plan with the
+/// Metropolis-Hastings forward/reverse proposal-site ratio, then commits the
+/// cloned state only if the Metropolis step accepts it. This planning boundary
+/// is the natural hook for future adaptive or self-learning proposal selection.
 ///
 /// # Examples
 ///
@@ -239,7 +242,7 @@ impl CdtProposalPlan {
     }
 }
 
-/// Telemetry returned by delayed CDT proposal steps.
+/// Telemetry returned by planned CDT proposal steps.
 ///
 /// The sampler receives this compact record after a plan has been scored. It is
 /// intended for diagnostics and measurement backends that need to report which
@@ -282,11 +285,11 @@ pub struct CdtProposalInfo {
     pub delta_action: Option<f64>,
 }
 
-/// Error reported by delayed CDT proposal planning or commit.
+/// Error reported by planned CDT proposal planning or commit.
 ///
 /// No-site outcomes are ordinary proposal absence and are reported from
 /// [`DelayedProposal::propose_plan`] as `Ok(None)`, matching the upstream
-/// delayed-commit contract. `ApplicationFailed` represents a hard backend or
+/// plan-before-commit contract. `ApplicationFailed` represents a hard backend or
 /// invariant failure while constructing or committing a concrete proposal, and
 /// preserves the typed [`CdtError`] that caused the failed application.
 ///
@@ -360,14 +363,16 @@ impl From<CdtProposalError> for CdtError {
     }
 }
 
-/// Delayed-commit CDT proposal distribution.
+/// Planned CDT proposal distribution.
 ///
-/// This adapter exposes CDT's clone-plan-commit move ordering through the
-/// [`DelayedProposal`] API. It plans a concrete local move on a cloned
+/// This adapter exposes CDT's clone-plan-score-commit move ordering through the
+/// upstream [`DelayedProposal`] API. It plans a concrete local move on a cloned
 /// triangulation, scores the proposed state with the same [`ActionConfig`] as
 /// the matching [`CdtTarget`] or [`MetropolisAlgorithm`](super::MetropolisAlgorithm), corrects for
 /// forward/reverse proposal-site counts, and commits the clone only after
-/// acceptance.
+/// acceptance. Future self-learning Metropolis-Hastings proposal policies
+/// should plug into this planner boundary instead of mutating the live chain
+/// before acceptance.
 ///
 /// # Examples
 ///
@@ -392,12 +397,15 @@ impl From<CdtProposalError> for CdtError {
 pub struct CdtProposal {
     action_config: ActionConfig,
     moves: ErgodicsSystem,
+    last_step_info: Option<CdtProposalInfo>,
+    last_no_plan_info: Option<CdtProposalInfo>,
+    last_proposal_stats: ProposalStatistics,
 }
 
 impl CdtProposal {
-    /// Creates a new unseeded delayed CDT proposal distribution.
+    /// Creates a new unseeded CDT proposal planner.
     ///
-    /// Delayed scoring is delegated to the target passed to
+    /// Proposed-state scoring is delegated to the target passed to
     /// [`DelayedProposal::proposed_log_prob`].
     ///
     /// # Examples
@@ -413,10 +421,13 @@ impl CdtProposal {
         Self {
             action_config,
             moves: ErgodicsSystem::new(),
+            last_step_info: None,
+            last_no_plan_info: None,
+            last_proposal_stats: ProposalStatistics::new(),
         }
     }
 
-    /// Creates a seeded delayed CDT proposal distribution.
+    /// Creates a seeded CDT proposal planner.
     ///
     /// The seed controls the internal move-family selector. The `rng` passed to
     /// [`DelayedProposal::propose_plan`] is still accepted for compatibility
@@ -435,7 +446,52 @@ impl CdtProposal {
         Self {
             action_config,
             moves: ErgodicsSystem::with_seed(seed),
+            last_step_info: None,
+            last_no_plan_info: None,
+            last_proposal_stats: ProposalStatistics::new(),
         }
+    }
+
+    /// Rebuilds a proposal planner from checkpointed ergodic-move state.
+    ///
+    /// Resumed simulations use this to hand the upstream sampler the exact
+    /// proposal RNG stream stored in a CDT checkpoint while resetting
+    /// per-step telemetry caches.
+    pub(crate) fn from_ergodics(action_config: ActionConfig, moves: ErgodicsSystem) -> Self {
+        action_config.validate();
+        Self {
+            action_config,
+            moves,
+            last_step_info: None,
+            last_no_plan_info: None,
+            last_proposal_stats: ProposalStatistics::new(),
+        }
+    }
+
+    /// Extracts the ergodic-move state after upstream sampler execution.
+    ///
+    /// The caller writes the returned state back into the CDT checkpoint/run
+    /// state so later chunks continue from the same proposal RNG stream.
+    pub(crate) fn into_ergodics(self) -> ErgodicsSystem {
+        self.moves
+    }
+
+    /// Returns telemetry recorded by the most recent planned proposal attempt.
+    ///
+    /// [`MetropolisAlgorithm`](super::runner::MetropolisAlgorithm) merges this
+    /// snapshot into CDT-owned proposal counters after the upstream sampler
+    /// reports the planned-step outcome.
+    pub(crate) const fn last_proposal_stats(&self) -> &ProposalStatistics {
+        &self.last_proposal_stats
+    }
+
+    /// Returns proposal metadata recorded by the most recent planned sampler step.
+    ///
+    /// CDT step history and move statistics depend on this metadata even for
+    /// self-loop proposals, so missing values are translated into an explicit
+    /// telemetry error during runner bookkeeping.
+    pub(crate) const fn last_step_info(&self) -> Option<CdtProposalInfo> {
+        self.last_step_info
     }
 }
 
@@ -451,6 +507,12 @@ impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
     ) -> Result<Option<Self::Plan>, Self::Error> {
         let move_type = self.moves.select_random_move();
         let action_before = action_for(&self.action_config, state);
+        let no_plan_info = CdtProposalInfo {
+            move_type,
+            action_before,
+            action_after: None,
+            delta_action: None,
+        };
         let mut proposal_stats = ProposalStatistics::new();
         let plan = match propose_concrete_plan(
             state,
@@ -462,10 +524,17 @@ impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
         ) {
             Ok(Some(plan)) => plan,
             Ok(None) => {
+                self.last_step_info = Some(no_plan_info);
+                self.last_no_plan_info = Some(no_plan_info);
+                self.last_proposal_stats = proposal_stats;
                 cold_path();
                 return Ok(None);
             }
             Err(err) => {
+                self.last_step_info = Some(no_plan_info);
+                self.last_no_plan_info = None;
+                proposal_stats.record_hard_failure();
+                self.last_proposal_stats = proposal_stats;
                 cold_path();
                 return Err(CdtProposalError::ApplicationFailed {
                     move_type,
@@ -474,7 +543,19 @@ impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
                 });
             }
         };
+        self.last_step_info = Some(CdtProposalInfo {
+            move_type: plan.move_type,
+            action_before: plan.action_before,
+            action_after: plan.action_after,
+            delta_action: plan.delta_action,
+        });
+        self.last_no_plan_info = None;
+        self.last_proposal_stats = proposal_stats;
         Ok(Some(plan))
+    }
+
+    fn no_plan_info(&mut self) -> Option<Self::Info> {
+        self.last_no_plan_info.take()
     }
 
     fn proposed_log_prob<T: Target<CdtTriangulation2D>>(
@@ -527,7 +608,7 @@ pub(crate) struct MoveApplicationError {
 /// The helper samples a local site, applies it to a cloned triangulation, and
 /// records the forward and reverse proposal-site counts needed for the
 /// Hastings correction. Ordinary no-site, causality, geometry, and recoverable
-/// backend rejections return `Ok(None)` so the public delayed proposal API can
+/// backend rejections return `Ok(None)` so the public planned-proposal API can
 /// expose them as self-loop proposals.
 ///
 /// # Errors
@@ -600,17 +681,8 @@ pub(crate) fn propose_concrete_plan(
 /// the selected move family. Zero denominators represent impossible proposal
 /// weights and are scored as negative infinity rather than panicking.
 pub(crate) fn concrete_log_q_ratio(_state: &CdtTriangulation2D, plan: &CdtProposalPlan) -> f64 {
-    let forward_sites = plan.forward_site_count;
-    if forward_sites == 0 {
-        return f64::NEG_INFINITY;
-    }
-
-    let reverse_sites = plan.reverse_site_count;
-    if reverse_sites == 0 {
-        return f64::NEG_INFINITY;
-    }
-
-    site_count_to_f64(forward_sites).ln() - site_count_to_f64(reverse_sites).ln()
+    DiscreteProposalRatio::from_counts(plan.forward_site_count, plan.reverse_site_count)
+        .map_or(f64::NEG_INFINITY, DiscreteProposalRatio::log_q_ratio)
 }
 
 /// Restores a checkpointed triangulation through the upstream MCMC chain type.
@@ -637,13 +709,4 @@ const fn reverse_move_type(move_type: MoveType) -> MoveType {
         MoveType::Move31Remove => MoveType::Move13Add,
         MoveType::EdgeFlip => MoveType::EdgeFlip,
     }
-}
-
-/// Converts local-site counts to finite values for proposal-ratio accounting.
-#[expect(
-    clippy::cast_precision_loss,
-    reason = "site counts are converted only for logarithmic Metropolis-Hastings ratios"
-)]
-pub(crate) const fn site_count_to_f64(count: usize) -> f64 {
-    count as f64
 }

--- a/src/cdt/metropolis/checkpoint.rs
+++ b/src/cdt/metropolis/checkpoint.rs
@@ -13,6 +13,7 @@ use markov_chain_monte_carlo::ChainCheckpoint;
 use rand::rngs::Xoshiro256PlusPlus;
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize};
+use std::num::NonZeroU32;
 use std::time::Duration;
 
 use super::helpers::{actions_match, expected_measurement_count, expected_measurement_step};
@@ -25,7 +26,7 @@ pub(crate) struct CdtMcmcCheckpointParts {
     pub(crate) rejected: usize,
     pub(crate) config: MetropolisConfig,
     pub(crate) action_config: ActionConfig,
-    pub(crate) current_step: u32,
+    pub(crate) current_step: NonZeroU32,
     pub(crate) current_action: f64,
     pub(crate) move_stats: MoveStatistics,
     pub(crate) proposal_stats: ProposalStatistics,
@@ -44,6 +45,11 @@ pub(crate) struct CdtMcmcCheckpointParts {
 /// scientific continuation: action/config metadata, accumulated telemetry,
 /// both RNG streams, and the ergodic move system.
 ///
+/// Checkpoints represent resumable runs after at least one completed
+/// Metropolis step. Their current step is therefore stored and exposed as a
+/// [`NonZeroU32`]; initial step-0 samples are measurement telemetry, not a
+/// checkpoint position.
+///
 /// # Examples
 ///
 /// ```
@@ -59,7 +65,7 @@ pub(crate) struct CdtMcmcCheckpointParts {
 ///     )
 ///     .run_to_checkpoint(tri)?;
 ///
-///     assert_eq!(checkpoint.current_step(), 1);
+///     assert_eq!(checkpoint.current_step().get(), 1);
 ///     assert_eq!(checkpoint.measurements().len(), 2);
 ///     Ok(())
 /// }
@@ -69,7 +75,7 @@ pub struct CdtMcmcCheckpoint {
     pub(crate) chain: ChainCheckpoint<CdtTriangulation2D>,
     pub(crate) config: MetropolisConfig,
     pub(crate) action_config: ActionConfig,
-    pub(crate) current_step: u32,
+    pub(crate) current_step: NonZeroU32,
     pub(crate) current_action: f64,
     pub(crate) move_stats: MoveStatistics,
     #[serde(default)]
@@ -104,11 +110,13 @@ impl<'de> Deserialize<'de> for CdtMcmcCheckpoint {
         D: Deserializer<'de>,
     {
         let wire = CdtMcmcCheckpointWire::deserialize(deserializer)?;
+        let current_step = NonZeroU32::new(wire.current_step)
+            .ok_or_else(|| DeError::custom("checkpoint current_step must be nonzero"))?;
         let checkpoint = Self {
             chain: wire.chain,
             config: wire.config,
             action_config: wire.action_config,
-            current_step: wire.current_step,
+            current_step,
             current_action: wire.current_action,
             move_stats: wire.move_stats,
             proposal_stats: wire.proposal_stats,
@@ -246,7 +254,12 @@ impl CdtMcmcCheckpoint {
         &self.action_config
     }
 
-    /// Returns the last completed Monte Carlo step.
+    /// Returns the nonzero last completed Monte Carlo step.
+    ///
+    /// The value is a [`NonZeroU32`] because checkpoints are produced only
+    /// after at least one Metropolis step has completed. Use
+    /// [`NonZeroU32::get`] when interoperating with raw serialized step
+    /// counters or measurement rows.
     ///
     /// # Examples
     ///
@@ -264,11 +277,11 @@ impl CdtMcmcCheckpoint {
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
     /// # }
     /// # let checkpoint = checkpoint()?;
-    /// assert_eq!(checkpoint.current_step(), 1);
+    /// assert_eq!(checkpoint.current_step().get(), 1);
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     #[must_use]
-    pub const fn current_step(&self) -> u32 {
+    pub const fn current_step(&self) -> NonZeroU32 {
         self.current_step
     }
 
@@ -356,6 +369,11 @@ impl CdtMcmcCheckpoint {
 
     /// Returns accumulated step telemetry through the checkpoint step.
     ///
+    /// Step telemetry starts at step 1 and uses
+    /// [`MonteCarloStep::step`](super::MonteCarloStep::step) to preserve that
+    /// nonzero invariant. Initial step-0 samples, when present, are returned by
+    /// [`Self::measurements`].
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -372,7 +390,7 @@ impl CdtMcmcCheckpoint {
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
     /// # }
     /// # let checkpoint = checkpoint()?;
-    /// assert_eq!(checkpoint.steps().len(), checkpoint.current_step() as usize);
+    /// assert_eq!(checkpoint.steps().len(), checkpoint.current_step().get() as usize);
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     #[must_use]
@@ -529,12 +547,13 @@ pub(crate) fn validate_checkpoint_counters(checkpoint: &CdtMcmcCheckpoint) -> Cd
             },
         ));
     }
-    let checkpoint_step = usize::try_from(checkpoint.current_step).unwrap_or(usize::MAX);
+    let current_step = checkpoint.current_step.get();
+    let checkpoint_step = usize::try_from(current_step).unwrap_or(usize::MAX);
     if checkpoint.chain.total_steps() != checkpoint_step {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::ChainStepMismatch {
                 chain_steps: checkpoint.chain.total_steps(),
-                checkpoint_step: checkpoint.current_step,
+                checkpoint_step: current_step,
             },
         ));
     }
@@ -632,29 +651,30 @@ fn validate_checkpoint_steps(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
         let expected_step = u32::try_from(index + 1).map_err(|_| {
             checkpoint_resume_failed(CheckpointResumeFailure::StepTelemetryIndexOverflow)
         })?;
-        if step.step != expected_step {
+        let step_number = step.step.get();
+        if step_number != expected_step {
             return Err(checkpoint_resume_failed(
                 CheckpointResumeFailure::StepTelemetrySequenceMismatch {
-                    actual: step.step,
+                    actual: step_number,
                     expected: expected_step,
                 },
             ));
         }
         if !step.action_before.is_finite() {
             return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::NonFiniteStepActionBefore { step: step.step },
+                CheckpointResumeFailure::NonFiniteStepActionBefore { step: step_number },
             ));
         }
         if let Some(delta_action) = step.delta_action
             && !delta_action.is_finite()
         {
             return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::NonFiniteStepDeltaAction { step: step.step },
+                CheckpointResumeFailure::NonFiniteStepDeltaAction { step: step_number },
             ));
         }
         if step.accepted && step.delta_action.is_none() {
             return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::AcceptedStepMissingDeltaAction { step: step.step },
+                CheckpointResumeFailure::AcceptedStepMissingDeltaAction { step: step_number },
             ));
         }
         match (step.accepted, step.action_after) {
@@ -663,23 +683,23 @@ fn validate_checkpoint_steps(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
                     && !actions_match(action_after, step.action_before + delta_action)
                 {
                     return Err(checkpoint_resume_failed(
-                        CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: step.step },
+                        CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: step_number },
                     ));
                 }
             }
             (true, Some(_)) => {
                 return Err(checkpoint_resume_failed(
-                    CheckpointResumeFailure::NonFiniteStepActionAfter { step: step.step },
+                    CheckpointResumeFailure::NonFiniteStepActionAfter { step: step_number },
                 ));
             }
             (true, None) => {
                 return Err(checkpoint_resume_failed(
-                    CheckpointResumeFailure::AcceptedStepMissingActionAfter { step: step.step },
+                    CheckpointResumeFailure::AcceptedStepMissingActionAfter { step: step_number },
                 ));
             }
             (false, Some(_)) => {
                 return Err(checkpoint_resume_failed(
-                    CheckpointResumeFailure::RejectedStepHasActionAfter { step: step.step },
+                    CheckpointResumeFailure::RejectedStepHasActionAfter { step: step_number },
                 ));
             }
             (false, None) => {}
@@ -691,7 +711,7 @@ fn validate_checkpoint_steps(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
 /// Checks that serialized measurements match the configured post-thermalization schedule.
 fn validate_checkpoint_measurements(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
     let expected_measurements = expected_measurement_count(
-        checkpoint.current_step,
+        checkpoint.current_step.get(),
         checkpoint.config.thermalization_steps(),
         checkpoint.config.measurement_frequency(),
     )

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -19,12 +19,16 @@ use crate::errors::{
     MetropolisMoveApplicationFailure,
 };
 use crate::geometry::CdtTriangulation2D;
-use rand::{Rng, RngExt, SeedableRng, rngs::Xoshiro256PlusPlus};
+use markov_chain_monte_carlo::{
+    Chain, ChainCheckpoint, DelayedStep, DelayedStepError, Sampler, StepOutcome,
+};
+use rand::{SeedableRng, rngs::Xoshiro256PlusPlus};
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroU32;
 use std::time::{Duration, Instant};
 
 use super::adapter::{
-    CdtTarget, concrete_log_q_ratio, propose_concrete_plan, restore_checkpoint_state,
+    CdtProposal, CdtProposalError, CdtProposalInfo, CdtTarget, restore_checkpoint_state,
 };
 use super::checkpoint::{
     CdtMcmcCheckpoint, CdtMcmcCheckpointParts, chain_counters, checkpoint_resume_failed,
@@ -34,7 +38,6 @@ use super::helpers::{
     action_for, actions_match, measurement_for, measurement_is_due, validate_metropolis_schedule,
 };
 use super::telemetry::{MonteCarloStep, ProposalStatistics};
-use std::num::NonZeroU32;
 
 /// Validated configuration for the Metropolis-Hastings algorithm.
 ///
@@ -495,7 +498,7 @@ impl MetropolisAlgorithm {
     /// Run the simulation and return a resumable checkpoint.
     ///
     /// The checkpoint embeds the current triangulation in the MCMC crate's
-    /// [`ChainCheckpoint`](markov_chain_monte_carlo::ChainCheckpoint) and stores CDT-specific
+    /// [`ChainCheckpoint`] and stores CDT-specific
     /// proposal state, telemetry, and RNG streams beside it.
     ///
     /// Direct in-memory resume through [`Self::resume_from_checkpoint`] or
@@ -691,19 +694,72 @@ impl MetropolisAlgorithm {
         }
     }
 
+    /// Advances mutable run state through the planned-proposal sampler.
+    ///
+    /// This is the only step loop used by fresh runs and checkpoint
+    /// continuation. It rebuilds the generic chain view from CDT counters,
+    /// persists the proposal RNG stream after each chunk, and keeps CDT-owned
+    /// telemetry synchronized with upstream planned-proposal outcomes.
     fn run_steps(
         &self,
         state: &mut MetropolisRunState,
         additional_steps: NonZeroU32,
     ) -> CdtResult<()> {
         let start = Instant::now();
-        for _ in 0..additional_steps.get() {
-            let step = state.current_step.checked_add(1).ok_or_else(|| {
-                checkpoint_resume_failed(CheckpointResumeFailure::StepCountOverflow)
-            })?;
-            run_one_step(self, state, step)?;
-            state.current_step = step;
+        let target = CdtTarget::new(self.action_config.clone(), self.config.temperature())?;
+        let (accepted, rejected) = chain_counters(&state.move_stats)?;
+        let checkpoint = ChainCheckpoint::new(state.triangulation.clone(), accepted, rejected);
+        let chain = Chain::from_checkpoint(checkpoint, &target)?;
+        let mut proposal =
+            CdtProposal::from_ergodics(self.action_config.clone(), state.ergodics.clone());
+        let mut acceptance_rng = state.acceptance_rng.clone();
+
+        {
+            let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut acceptance_rng)?;
+
+            for _ in 0..additional_steps.get() {
+                let step = state.current_step.checked_add(1).ok_or_else(|| {
+                    checkpoint_resume_failed(CheckpointResumeFailure::StepCountOverflow)
+                })?;
+                let planned_step = match sampler.step_delayed() {
+                    Ok(planned_step) => planned_step,
+                    Err(err) => {
+                        let error = planned_step_error(step, err);
+                        state.triangulation = sampler.chain_ref().state().clone();
+                        drop(sampler);
+                        state.acceptance_rng = acceptance_rng;
+                        state.ergodics = proposal.into_ergodics();
+                        state.elapsed_time += start.elapsed();
+                        return Err(error);
+                    }
+                };
+                debug_assert_eq!(
+                    sampler.proposal_ref().last_step_info(),
+                    planned_step.info,
+                    "CDT proposal telemetry cache should mirror the upstream planned-step info"
+                );
+                record_planned_step(
+                    self,
+                    state,
+                    step,
+                    &planned_step,
+                    planned_step
+                        .info
+                        .ok_or_else(|| missing_planned_step_info(step))?,
+                    sampler.proposal_ref().last_proposal_stats(),
+                    sampler.chain_ref().state(),
+                )?;
+                // The upstream chain owns the geometry used by later proposals,
+                // while CDT owns simulation metadata/history. Keep them in sync
+                // after annotating the CDT state so final handoff and future
+                // accepted proposals cannot discard recorded events.
+                sampler.replace_state(state.triangulation.clone())?;
+                state.current_step = step;
+            }
         }
+
+        state.acceptance_rng = acceptance_rng;
+        state.ergodics = proposal.into_ergodics();
         state.elapsed_time += start.elapsed();
         Ok(())
     }
@@ -778,17 +834,73 @@ impl MetropolisRunState {
     }
 }
 
-/// Executes one additional Metropolis step against an initialized run state.
+/// Records one upstream planned-proposal result into CDT-specific telemetry.
 ///
-/// Fresh and resumed simulations use this shared path so checkpoint
-/// continuation cannot drift from ordinary sampling behavior.
-fn run_one_step(
+/// Fresh and resumed simulations use the same upstream sampler path so
+/// checkpoint continuation cannot drift from ordinary sampling behavior.
+fn record_planned_step(
     algorithm: &MetropolisAlgorithm,
     state: &mut MetropolisRunState,
     step: u32,
+    planned_step: &DelayedStep<CdtProposalInfo>,
+    info: CdtProposalInfo,
+    proposal_stats: &ProposalStatistics,
+    triangulation: &CdtTriangulation2D,
 ) -> CdtResult<()> {
-    let move_type = state.ergodics.select_random_move();
+    record_planned_step_parts(
+        algorithm,
+        state,
+        step,
+        PlannedStepRecord {
+            outcome: planned_step.outcome,
+            log_prob_before: planned_step.log_prob_before,
+            log_prob_after: planned_step.log_prob_after,
+            info,
+            proposal_stats,
+            triangulation,
+        },
+    )
+}
+
+#[derive(Clone, Copy)]
+struct PlannedStepRecord<'a> {
+    outcome: StepOutcome,
+    log_prob_before: f64,
+    log_prob_after: Option<f64>,
+    info: CdtProposalInfo,
+    proposal_stats: &'a ProposalStatistics,
+    triangulation: &'a CdtTriangulation2D,
+}
+
+fn record_planned_step_parts(
+    algorithm: &MetropolisAlgorithm,
+    state: &mut MetropolisRunState,
+    step: u32,
+    record: PlannedStepRecord<'_>,
+) -> CdtResult<()> {
+    let PlannedStepRecord {
+        outcome,
+        log_prob_before,
+        log_prob_after,
+        info,
+        proposal_stats,
+        triangulation,
+    } = record;
+    let move_type = info.move_type;
     state.move_stats.record_attempt(move_type);
+
+    let action_before = state.current_action;
+    let accepted = outcome == StepOutcome::Accepted;
+    let action_after = accepted.then(|| {
+        info.action_after.unwrap_or_else(|| {
+            -algorithm.config.temperature() * log_prob_after.unwrap_or(log_prob_before)
+        })
+    });
+    if let Some(applied_action) = action_after {
+        state.triangulation = triangulation.clone();
+        state.current_action = applied_action;
+    }
+
     state
         .triangulation
         .record_event(SimulationEvent::MoveAttempted {
@@ -796,60 +908,22 @@ fn run_one_step(
             step: step.into(),
         });
 
-    let action_before = state.current_action;
-    // A selected move family is not yet a concrete proposal; self-loop outcomes
-    // such as no usable site or a rejected sampled site must not report a ΔS.
-    let mut delta_action = None;
-
-    let mut accepted = false;
-    let mut action_after = None;
-
-    let plan = match propose_concrete_plan(
-        &state.triangulation,
-        &mut state.ergodics,
-        &mut state.proposal_stats,
-        &algorithm.action_config,
-        move_type,
-        action_before,
-    ) {
-        Ok(plan) => plan,
-        Err(err) => {
-            state.move_stats.record_hard_failure(move_type);
-            state.proposal_stats.record_hard_failure();
-            return Err(accepted_move_error(
-                step,
+    if let Some(applied_action) = action_after {
+        state.move_stats.record_success(move_type);
+        state
+            .triangulation
+            .record_event(SimulationEvent::MoveAccepted {
                 move_type,
-                err.attempt,
-                err.source,
-            ));
-        }
-    };
-
-    if let Some(plan) = plan {
-        delta_action = plan.delta_action;
-        let log_alpha = -(plan.action_after.expect("planned moves have actions") - action_before)
-            / algorithm.config.temperature()
-            + concrete_log_q_ratio(&state.triangulation, &plan);
-
-        if metropolis_accept_log_alpha(log_alpha, &mut state.acceptance_rng) {
-            let applied_action = plan.action_after.expect("planned moves have actions");
-            state.triangulation = plan.proposed_state;
-            accepted = true;
-            action_after = Some(applied_action);
-            state.current_action = applied_action;
-            state.move_stats.record_success(move_type);
-            state.proposal_stats.record_accepted_transition();
-            state
-                .triangulation
-                .record_event(SimulationEvent::MoveAccepted {
-                    move_type,
-                    step: step.into(),
-                    action_change: applied_action - action_before,
-                });
-            validate_evolved_cdt_if_due(state)?;
-        } else {
-            state.proposal_stats.record_metropolis_rejection();
-        }
+                step: step.into(),
+                action_change: applied_action - action_before,
+            });
+        validate_evolved_cdt_if_due(state)?;
+    }
+    state.proposal_stats.extend(proposal_stats);
+    if outcome == StepOutcome::Accepted {
+        state.proposal_stats.record_accepted_transition();
+    } else if outcome == StepOutcome::RejectedProposal {
+        state.proposal_stats.record_metropolis_rejection();
     }
 
     state.steps.push(MonteCarloStep {
@@ -858,7 +932,7 @@ fn run_one_step(
         accepted,
         action_before,
         action_after,
-        delta_action,
+        delta_action: info.delta_action,
     });
 
     if measurement_is_due(
@@ -882,6 +956,45 @@ fn run_one_step(
     Ok(())
 }
 
+/// Maps upstream planned-proposal failures into CDT runner errors.
+///
+/// Proposal-stage errors preserve move-family context through
+/// [`CdtError::MetropolisMoveApplicationFailed`]. Future upstream variants use
+/// [`CdtError::PlannedProposalStepFailed`] so they remain distinct from CDT's
+/// own missing-telemetry invariant.
+fn planned_step_error(step: u32, error: DelayedStepError<CdtProposalError>) -> CdtError {
+    match error {
+        DelayedStepError::Mcmc(err) => CdtError::Mcmc(err),
+        DelayedStepError::Plan(err)
+        | DelayedStepError::ProposedLogProb(err)
+        | DelayedStepError::LogQRatio(err)
+        | DelayedStepError::Commit(err) => proposal_step_error(step, err),
+        unexpected => CdtError::PlannedProposalStepFailed {
+            step,
+            detail: unexpected.to_string(),
+        },
+    }
+}
+
+/// Converts a CDT proposal error into the public accepted-move failure shape.
+///
+/// This keeps planned-proposal sampler errors compatible with the historical CDT error
+/// contract for hard move-application failures.
+fn proposal_step_error(step: u32, error: CdtProposalError) -> CdtError {
+    match error {
+        CdtProposalError::ApplicationFailed {
+            move_type,
+            attempt,
+            source,
+        } => accepted_move_error(step, move_type, attempt, source),
+    }
+}
+
+/// Builds the explicit error used when upstream planned-step telemetry is absent.
+const fn missing_planned_step_info(step: u32) -> CdtError {
+    CdtError::PlannedProposalTelemetryMissing { step }
+}
+
 /// Runs the expensive full evolved-state validation only when the backend policy is due.
 fn validate_evolved_cdt_if_due(state: &MetropolisRunState) -> CdtResult<()> {
     if state
@@ -900,19 +1013,6 @@ fn validate_evolved_cdt_if_due(state: &MetropolisRunState) -> CdtResult<()> {
 /// simulations are reproducible while unseeded simulations still draw fresh entropy.
 fn simulation_rng(seed: Option<u64>) -> Xoshiro256PlusPlus {
     seed.map_or_else(rand::make_rng, Xoshiro256PlusPlus::seed_from_u64)
-}
-
-/// Applies the Metropolis acceptance rule to a proposed action change.
-///
-/// Factoring this out keeps the probability rule isolated from move selection
-/// and makes deterministic unit tests possible with a seeded RNG.
-#[cfg(test)]
-fn metropolis_accept<R: Rng + ?Sized>(delta_action: f64, temperature: f64, rng: &mut R) -> bool {
-    metropolis_accept_log_alpha(-delta_action / temperature, rng)
-}
-
-fn metropolis_accept_log_alpha<R: Rng + ?Sized>(log_alpha: f64, rng: &mut R) -> bool {
-    log_alpha >= 0.0 || rng.random::<f64>() < log_alpha.exp()
 }
 
 /// Builds the simulation-level error for an accepted move that could not be applied.
@@ -937,7 +1037,7 @@ fn accepted_move_error(
 #[cfg(test)]
 mod tests {
     use super::super::adapter::{
-        CdtProposal, CdtProposalError, CdtProposalPlan, site_count_to_f64,
+        CdtProposal, CdtProposalError, CdtProposalPlan, concrete_log_q_ratio, propose_concrete_plan,
     };
     use super::super::helpers::{SimplexCounts, proposed_delta_action, simplex_counts};
     use super::super::telemetry::CdtProposalSiteRejection;
@@ -948,12 +1048,28 @@ mod tests {
     use crate::errors::{BackendMutationOperation, CheckpointMoveCounter, ConfigurationSetting};
     use crate::geometry::traits::TriangulationQuery;
     use approx::assert_relative_eq;
-    use markov_chain_monte_carlo::{Chain, DelayedProposal, Target};
-    use rand::rngs::StdRng;
+    use markov_chain_monte_carlo::{Chain, DelayedProposal, DiscreteProposalRatio, Target};
+    use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
     use serde_json::{from_str, to_string, to_value};
     use std::assert_matches;
     use std::error::Error;
     use std::num::NonZeroUsize;
+
+    /// Applies the Metropolis acceptance rule to a proposed action change.
+    ///
+    /// Factoring this out keeps the probability rule isolated from move selection
+    /// and makes deterministic unit tests possible with a seeded RNG.
+    fn metropolis_accept<R: Rng + ?Sized>(
+        delta_action: f64,
+        temperature: f64,
+        rng: &mut R,
+    ) -> bool {
+        metropolis_accept_log_alpha(-delta_action / temperature, rng)
+    }
+
+    fn metropolis_accept_log_alpha<R: Rng + ?Sized>(log_alpha: f64, rng: &mut R) -> bool {
+        log_alpha >= 0.0 || rng.random::<f64>() < log_alpha.exp()
+    }
 
     fn assert_optional_relative_eq(left: Option<f64>, right: Option<f64>) {
         match (left, right) {
@@ -2399,6 +2515,63 @@ mod tests {
     }
 
     #[test]
+    fn accepted_planned_step_records_attempt_on_committed_state() {
+        let config = seeded_metropolis_config(1.0, 1, 0, 1, 2);
+        let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let committed = triangulation.clone();
+        let mut state = algorithm.initial_state(triangulation);
+        let action = state.current_action;
+        let move_type = MoveType::Move22;
+        let info = CdtProposalInfo {
+            move_type,
+            action_before: action,
+            action_after: Some(action),
+            delta_action: Some(0.0),
+        };
+        let proposal_stats = ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 0);
+
+        record_planned_step_parts(
+            &algorithm,
+            &mut state,
+            1,
+            PlannedStepRecord {
+                outcome: StepOutcome::Accepted,
+                log_prob_before: -action,
+                log_prob_after: Some(-action),
+                info,
+                proposal_stats: &proposal_stats,
+                triangulation: &committed,
+            },
+        )
+        .expect("accepted planned step should record telemetry");
+
+        let history = state.triangulation.metadata().simulation_history();
+        assert!(
+            history.iter().any(|event| matches!(
+                event,
+                SimulationEvent::MoveAttempted {
+                    move_type: recorded_move,
+                    step
+                } if *recorded_move == move_type && *step == 1
+            )),
+            "attempt event should remain on the committed triangulation"
+        );
+        assert!(
+            history.iter().any(|event| matches!(
+                event,
+                SimulationEvent::MoveAccepted {
+                    move_type: recorded_move,
+                    step,
+                    ..
+                } if *recorded_move == move_type && *step == 1
+            )),
+            "accepted move event should remain on the committed triangulation"
+        );
+    }
+
+    #[test]
     fn run_rejects_zero_frequency() {
         let err = MetropolisConfig::new(1.0, 10, 2, 0).expect_err("zero cadence is invalid");
         match err {
@@ -2586,7 +2759,7 @@ mod tests {
     }
 
     #[test]
-    fn cdt_proposal_scores_delayed_plan() {
+    fn cdt_proposal_scores_planned_proposal() {
         let action_config = ActionConfig::default();
         let target =
             CdtTarget::new(action_config.clone(), 1.0).expect("valid target configuration");
@@ -2636,8 +2809,9 @@ mod tests {
         assert!(forward_sites > 0);
         assert!(reverse_sites > 0);
 
-        let expected =
-            site_count_to_f64(forward_sites).ln() - site_count_to_f64(reverse_sites).ln();
+        let expected = DiscreteProposalRatio::from_counts(forward_sites, reverse_sites)
+            .expect("positive forward proposal sites should build a ratio")
+            .log_q_ratio();
         assert_relative_eq!(
             concrete_log_q_ratio(&triangulation, &plan),
             expected,
@@ -2704,7 +2878,7 @@ mod tests {
     }
 
     #[test]
-    fn cdt_proposal_uses_delayed_chain() {
+    fn cdt_proposal_uses_planned_sampler_path() {
         let action_config = ActionConfig::default();
         let target =
             CdtTarget::new(action_config.clone(), 1.0).expect("valid target configuration");
@@ -2716,9 +2890,15 @@ mod tests {
 
         let step = chain
             .step_delayed(&target, &mut proposal, &mut rng)
-            .expect("ordinary no-site outcomes must be delayed-step rejections, not errors");
+            .expect("ordinary no-site outcomes must be planned-step rejections, not errors");
 
-        assert_eq!(step.outcome.has_proposal(), step.info.is_some());
+        let info = step
+            .info
+            .expect("planned CDT steps should report proposal info");
+        assert_eq!(proposal.last_step_info(), Some(info));
+        assert_eq!(proposal.last_proposal_stats().move_family_proposals(), 1);
+        assert_eq!(proposal.last_proposal_stats().accepted_transitions(), 0);
+        assert_eq!(proposal.last_proposal_stats().metropolis_rejections(), 0);
         assert!(!step.outcome.is_accepted() || step.log_prob_after.is_some());
     }
 

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -412,11 +412,12 @@ impl MetropolisAlgorithm {
 
     /// Run the Monte Carlo simulation.
     ///
-    /// Each step proposes a move type, computes the Metropolis-Hastings
-    /// acceptance probability from the move's simplex-count delta, and only
-    /// mutates the triangulation when that proposal is accepted. Accepted moves
-    /// that fail during backend application are rolled back and retried at
-    /// another randomly selected local site.
+    /// Each step runs through the upstream planned-proposal sampler. CDT plans
+    /// a concrete local move on a cloned state, the sampler applies the
+    /// Metropolis-Hastings proposal-ratio correction and accept/reject draw, and
+    /// CDT records domain telemetry after the sampler reports the outcome.
+    /// Ordinary no-site and recoverable local-site rejections are recorded as
+    /// self-loop proposals.
     ///
     /// # Errors
     ///
@@ -424,10 +425,10 @@ impl MetropolisAlgorithm {
     /// configuration is invalid, [`CdtError::InvalidConfiguration`] if the
     /// action configuration is invalid,
     /// [`CdtError::MetropolisMoveApplicationFailed`] if an accepted move causes
-    /// a hard backend mutation failure, or a validation error for
-    /// unrecoverable triangulation failures. Accepted move types that cannot
-    /// find a realizable local site after bounded retries are recorded as
-    /// rejected proposals.
+    /// a hard backend mutation failure,
+    /// [`CdtError::PlannedProposalTelemetryMissing`] if the upstream sampler
+    /// omits CDT step metadata or accepted-step action evidence, or a validation
+    /// error for unrecoverable triangulation failures.
     ///
     /// # Examples
     ///
@@ -463,8 +464,10 @@ impl MetropolisAlgorithm {
     /// configuration is invalid, [`CdtError::InvalidConfiguration`] if the
     /// action configuration is invalid,
     /// [`CdtError::MetropolisMoveApplicationFailed`] if an accepted move causes
-    /// a hard backend mutation failure, or a validation error for
-    /// unrecoverable triangulation failures.
+    /// a hard backend mutation failure,
+    /// [`CdtError::PlannedProposalTelemetryMissing`] if the upstream sampler
+    /// omits CDT step metadata or accepted-step action evidence, or a validation
+    /// error for unrecoverable triangulation failures.
     ///
     /// # Examples
     ///
@@ -482,7 +485,7 @@ impl MetropolisAlgorithm {
     ///     let (results, checkpoint) = algorithm.run_with_checkpoint(tri)?;
     ///
     ///     assert_eq!(results.steps().len(), checkpoint.steps().len());
-    ///     assert_eq!(checkpoint.current_step(), 2);
+    ///     assert_eq!(checkpoint.current_step().get(), 2);
     ///     Ok(())
     /// }
     /// ```
@@ -513,8 +516,10 @@ impl MetropolisAlgorithm {
     /// configuration is invalid, [`CdtError::InvalidConfiguration`] if the
     /// action configuration is invalid,
     /// [`CdtError::MetropolisMoveApplicationFailed`] if an accepted move causes
-    /// a hard backend mutation failure, or a validation error for
-    /// unrecoverable triangulation failures.
+    /// a hard backend mutation failure,
+    /// [`CdtError::PlannedProposalTelemetryMissing`] if the upstream sampler
+    /// omits CDT step metadata or accepted-step action evidence, or a validation
+    /// error for unrecoverable triangulation failures.
     ///
     /// # Examples
     ///
@@ -531,7 +536,7 @@ impl MetropolisAlgorithm {
     ///     )
     ///     .run_to_checkpoint(tri)?;
     ///
-    ///     assert_eq!(checkpoint.current_step(), 2);
+    ///     assert_eq!(checkpoint.current_step().get(), 2);
     ///     Ok(())
     /// }
     /// ```
@@ -560,8 +565,10 @@ impl MetropolisAlgorithm {
     /// if the action configuration is invalid, or
     /// [`CdtError::CheckpointResumeFailed`] if the checkpoint is incompatible
     /// with this algorithm or internally inconsistent. Returns
-    /// [`CdtError::MetropolisMoveApplicationFailed`] or validation errors for
-    /// failures during resumed sampling.
+    /// [`CdtError::MetropolisMoveApplicationFailed`],
+    /// [`CdtError::PlannedProposalTelemetryMissing`] if resumed sampling omits
+    /// CDT step metadata or accepted-step action evidence, or validation errors
+    /// for failures during resumed sampling.
     ///
     /// # Examples
     ///
@@ -613,8 +620,10 @@ impl MetropolisAlgorithm {
     /// if the action configuration is invalid, or
     /// [`CdtError::CheckpointResumeFailed`] if the checkpoint is incompatible
     /// with this algorithm or internally inconsistent. Returns
-    /// [`CdtError::MetropolisMoveApplicationFailed`] or validation errors for
-    /// failures during resumed sampling.
+    /// [`CdtError::MetropolisMoveApplicationFailed`],
+    /// [`CdtError::PlannedProposalTelemetryMissing`] if resumed sampling omits
+    /// CDT step metadata or accepted-step action evidence, or validation errors
+    /// for failures during resumed sampling.
     ///
     /// # Examples
     ///
@@ -637,7 +646,7 @@ impl MetropolisAlgorithm {
     ///     )
     ///     .resume_to_checkpoint(checkpoint)?;
     ///
-    ///     assert_eq!(checkpoint.current_step(), 5);
+    ///     assert_eq!(checkpoint.current_step().get(), 5);
     ///     assert_eq!(checkpoint.config().steps().get(), 5);
     ///     Ok(())
     /// }
@@ -653,6 +662,7 @@ impl MetropolisAlgorithm {
         let mut result_config = checkpoint.config.clone();
         let steps = checkpoint
             .current_step
+            .get()
             .checked_add(self.config.steps.get())
             .ok_or_else(|| checkpoint_resume_failed(CheckpointResumeFailure::StepCountOverflow))?;
         result_config.steps = NonZeroU32::new(steps)
@@ -718,13 +728,17 @@ impl MetropolisAlgorithm {
             let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut acceptance_rng)?;
 
             for _ in 0..additional_steps.get() {
-                let step = state.current_step.checked_add(1).ok_or_else(|| {
-                    checkpoint_resume_failed(CheckpointResumeFailure::StepCountOverflow)
-                })?;
+                let step = state
+                    .current_step
+                    .checked_add(1)
+                    .and_then(NonZeroU32::new)
+                    .ok_or_else(|| {
+                        checkpoint_resume_failed(CheckpointResumeFailure::StepCountOverflow)
+                    })?;
                 let planned_step = match sampler.step_delayed() {
                     Ok(planned_step) => planned_step,
                     Err(err) => {
-                        let error = planned_step_error(step, err);
+                        let error = planned_step_error(step.get(), err);
                         state.triangulation = sampler.chain_ref().state().clone();
                         drop(sampler);
                         state.acceptance_rng = acceptance_rng;
@@ -745,7 +759,7 @@ impl MetropolisAlgorithm {
                     &planned_step,
                     planned_step
                         .info
-                        .ok_or_else(|| missing_planned_step_info(step))?,
+                        .ok_or_else(|| missing_planned_step_info(step.get()))?,
                     sampler.proposal_ref().last_proposal_stats(),
                     sampler.chain_ref().state(),
                 )?;
@@ -754,7 +768,7 @@ impl MetropolisAlgorithm {
                 // after annotating the CDT state so final handoff and future
                 // accepted proposals cannot discard recorded events.
                 sampler.replace_state(state.triangulation.clone())?;
-                state.current_step = step;
+                state.current_step = step.get();
             }
         }
 
@@ -791,7 +805,7 @@ impl MetropolisRunState {
 
         Ok(Self {
             triangulation,
-            current_step: checkpoint.current_step,
+            current_step: checkpoint.current_step.get(),
             current_action: checkpoint.current_action,
             acceptance_rng: checkpoint.acceptance_rng,
             ergodics: checkpoint.ergodics,
@@ -815,13 +829,19 @@ impl MetropolisRunState {
     ) -> CdtResult<CdtMcmcCheckpoint> {
         self.triangulation.validate_evolved_cdt()?;
         let (accepted, rejected) = chain_counters(&self.move_stats)?;
+        let current_step = NonZeroU32::new(self.current_step).ok_or_else(|| {
+            checkpoint_resume_failed(CheckpointResumeFailure::StepTelemetryLengthMismatch {
+                actual: 0,
+                expected: 1,
+            })
+        })?;
         CdtMcmcCheckpoint::from_parts(CdtMcmcCheckpointParts {
             triangulation: self.triangulation,
             accepted,
             rejected,
             config,
             action_config,
-            current_step: self.current_step,
+            current_step,
             current_action: self.current_action,
             move_stats: self.move_stats,
             proposal_stats: self.proposal_stats,
@@ -841,7 +861,7 @@ impl MetropolisRunState {
 fn record_planned_step(
     algorithm: &MetropolisAlgorithm,
     state: &mut MetropolisRunState,
-    step: u32,
+    step: NonZeroU32,
     planned_step: &DelayedStep<CdtProposalInfo>,
     info: CdtProposalInfo,
     proposal_stats: &ProposalStatistics,
@@ -853,7 +873,6 @@ fn record_planned_step(
         step,
         PlannedStepRecord {
             outcome: planned_step.outcome,
-            log_prob_before: planned_step.log_prob_before,
             log_prob_after: planned_step.log_prob_after,
             info,
             proposal_stats,
@@ -862,40 +881,62 @@ fn record_planned_step(
     )
 }
 
+/// CDT-owned state needed to translate one upstream planned step.
+///
+/// Keeping these fields together lets production code and regression tests run
+/// the same translation path while preserving the relationship between
+/// reconstructed `action_after` values and public `delta_action` telemetry.
+/// Accepted records must carry either CDT's `action_after` or the upstream
+/// `log_prob_after` needed to reconstruct it.
 #[derive(Clone, Copy)]
 struct PlannedStepRecord<'a> {
     outcome: StepOutcome,
-    log_prob_before: f64,
     log_prob_after: Option<f64>,
     info: CdtProposalInfo,
     proposal_stats: &'a ProposalStatistics,
     triangulation: &'a CdtTriangulation2D,
 }
 
+/// Apply one planned-step record to CDT run state and public telemetry.
+///
+/// Accepted steps may reconstruct `action_after` from upstream log-probability
+/// data. When that happens, the public [`MonteCarloStep`] receives a matching
+/// `delta_action` derived from the same reconstructed action. Missing
+/// accepted-step action evidence is rejected before any run state or telemetry
+/// is mutated.
 fn record_planned_step_parts(
     algorithm: &MetropolisAlgorithm,
     state: &mut MetropolisRunState,
-    step: u32,
+    step: NonZeroU32,
     record: PlannedStepRecord<'_>,
 ) -> CdtResult<()> {
     let PlannedStepRecord {
         outcome,
-        log_prob_before,
         log_prob_after,
         info,
         proposal_stats,
         triangulation,
     } = record;
     let move_type = info.move_type;
-    state.move_stats.record_attempt(move_type);
-
     let action_before = state.current_action;
     let accepted = outcome == StepOutcome::Accepted;
-    let action_after = accepted.then(|| {
-        info.action_after.unwrap_or_else(|| {
-            -algorithm.config.temperature() * log_prob_after.unwrap_or(log_prob_before)
-        })
+    let action_after = if accepted {
+        Some(
+            info.action_after
+                .or_else(|| {
+                    log_prob_after
+                        .map(|log_prob_after| -algorithm.config.temperature() * log_prob_after)
+                })
+                .ok_or_else(|| missing_planned_step_info(step.get()))?,
+        )
+    } else {
+        None
+    };
+    let delta_action = action_after.map_or(info.delta_action, |applied_action| {
+        Some(applied_action - action_before)
     });
+
+    state.move_stats.record_attempt(move_type);
     if let Some(applied_action) = action_after {
         state.triangulation = triangulation.clone();
         state.current_action = applied_action;
@@ -905,7 +946,7 @@ fn record_planned_step_parts(
         .triangulation
         .record_event(SimulationEvent::MoveAttempted {
             move_type,
-            step: step.into(),
+            step: step.get().into(),
         });
 
     if let Some(applied_action) = action_after {
@@ -914,7 +955,7 @@ fn record_planned_step_parts(
             .triangulation
             .record_event(SimulationEvent::MoveAccepted {
                 move_type,
-                step: step.into(),
+                step: step.get().into(),
                 action_change: applied_action - action_before,
             });
         validate_evolved_cdt_if_due(state)?;
@@ -932,23 +973,23 @@ fn record_planned_step_parts(
         accepted,
         action_before,
         action_after,
-        delta_action: info.delta_action,
+        delta_action,
     });
 
     if measurement_is_due(
-        step,
+        step.get(),
         algorithm.config.thermalization_steps(),
         algorithm.config.measurement_frequency(),
     ) {
         state.measurements.push(measurement_for(
-            step,
+            step.get(),
             state.current_action,
             &state.triangulation,
         ));
         state
             .triangulation
             .record_event(SimulationEvent::MeasurementTaken {
-                step: step.into(),
+                step: step.get().into(),
                 action: state.current_action,
             });
     }
@@ -1048,12 +1089,14 @@ mod tests {
     use crate::errors::{BackendMutationOperation, CheckpointMoveCounter, ConfigurationSetting};
     use crate::geometry::traits::TriangulationQuery;
     use approx::assert_relative_eq;
-    use markov_chain_monte_carlo::{Chain, DelayedProposal, DiscreteProposalRatio, Target};
+    use markov_chain_monte_carlo::{
+        Chain, DelayedProposal, DelayedStepError, DiscreteProposalRatio, McmcError, Target,
+    };
     use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
     use serde_json::{from_str, to_string, to_value};
     use std::assert_matches;
     use std::error::Error;
-    use std::num::NonZeroUsize;
+    use std::num::{NonZeroU32, NonZeroUsize};
 
     /// Applies the Metropolis acceptance rule to a proposed action change.
     ///
@@ -1069,6 +1112,10 @@ mod tests {
 
     fn metropolis_accept_log_alpha<R: Rng + ?Sized>(log_alpha: f64, rng: &mut R) -> bool {
         log_alpha >= 0.0 || rng.random::<f64>() < log_alpha.exp()
+    }
+
+    fn step_number(step: u32) -> NonZeroU32 {
+        NonZeroU32::new(step).expect("test step number should be nonzero")
     }
 
     fn assert_optional_relative_eq(left: Option<f64>, right: Option<f64>) {
@@ -1234,7 +1281,7 @@ mod tests {
             .triangulation
             .record_event(SimulationEvent::MoveAttempted { move_type, step: 1 });
         state.steps.push(MonteCarloStep {
-            step: 1,
+            step: step_number(1),
             move_type,
             accepted: false,
             action_before: state.current_action,
@@ -1284,7 +1331,7 @@ mod tests {
             rejected: usize::from(!accepted),
             config,
             action_config,
-            current_step: 1,
+            current_step: step_number(1),
             current_action,
             move_stats,
             proposal_stats: if accepted {
@@ -1293,7 +1340,7 @@ mod tests {
                 ProposalStatistics::from_validated_parts(1, 1, 0, 0, 0, 0, 1, 0, 0)
             },
             steps: vec![MonteCarloStep {
-                step: 1,
+                step: step_number(1),
                 move_type,
                 accepted,
                 action_before: current_action,
@@ -1538,7 +1585,7 @@ mod tests {
             .run_with_checkpoint(triangulation)
             .expect("checkpointed run should complete");
 
-        assert_eq!(checkpoint.current_step(), 3);
+        assert_eq!(checkpoint.current_step().get(), 3);
         assert_eq!(results.steps().len(), checkpoint.steps().len());
         assert_eq!(results.config(), checkpoint.config());
         let checkpoint_results = checkpoint.into_results();
@@ -1555,8 +1602,8 @@ mod tests {
     #[test]
     fn checkpoint_accessors_report_consistent_snapshot() {
         let checkpoint = short_checkpoint();
-        let current_step =
-            usize::try_from(checkpoint.current_step()).expect("u32 step count should fit usize");
+        let current_step = usize::try_from(checkpoint.current_step().get())
+            .expect("u32 step count should fit usize");
         let accepted_moves = usize::try_from(checkpoint.move_stats().total_accepted())
             .expect("test accepted move count should fit usize");
         let last_step = checkpoint
@@ -1574,19 +1621,19 @@ mod tests {
         );
         assert_eq!(checkpoint.chain().total_steps(), current_step);
         assert_eq!(checkpoint.chain().accepted(), accepted_moves);
-        assert_eq!(checkpoint.config().steps().get(), checkpoint.current_step());
+        assert_eq!(checkpoint.config().steps(), checkpoint.current_step());
         assert_eq!(checkpoint.action_config(), &ActionConfig::default());
         assert!(checkpoint.current_action().is_finite());
         assert_eq!(
             checkpoint.move_stats().total_attempted(),
-            u64::from(checkpoint.current_step())
+            u64::from(checkpoint.current_step().get())
         );
         assert_eq!(
             checkpoint.proposal_stats().move_family_proposals(),
-            u64::from(checkpoint.current_step())
+            u64::from(checkpoint.current_step().get())
         );
         assert_eq!(last_step.step, checkpoint.current_step());
-        assert_eq!(last_measurement.step, checkpoint.current_step());
+        assert_eq!(last_measurement.step, checkpoint.current_step().get());
         assert_relative_eq!(
             last_measurement.action,
             checkpoint.current_action(),
@@ -1618,7 +1665,7 @@ mod tests {
 
         assert_eq!(first_resumed.config().steps().get(), 7);
         assert_eq!(first_resumed.steps().len(), 7);
-        assert_eq!(first_resumed.steps()[1].step, 2);
+        assert_eq!(first_resumed.steps()[1].step.get(), 2);
         first_resumed
             .triangulation()
             .validate_topology()
@@ -1732,6 +1779,44 @@ mod tests {
                 .to_string()
                 .contains("proposal move-family count mismatch"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn serialized_checkpoint_rejects_zero_current_step() {
+        let checkpoint = serializable_rejected_checkpoint(ActionConfig::default());
+        let mut payload = to_value(&checkpoint).expect("checkpoint should serialize");
+        payload
+            .as_object_mut()
+            .expect("checkpoint payload should be an object")
+            .insert(
+                "current_step".to_string(),
+                to_value(0_u32).expect("step should serialize"),
+            );
+
+        let Err(error) = from_str::<CdtMcmcCheckpoint>(&payload.to_string()) else {
+            panic!("checkpoint step zero should fail while parsing");
+        };
+
+        assert!(
+            error.to_string().contains("current_step must be nonzero"),
+            "unexpected serde error: {error}"
+        );
+    }
+
+    #[test]
+    fn serialized_checkpoint_rejects_zero_step_telemetry() {
+        let checkpoint = serializable_rejected_checkpoint(ActionConfig::default());
+        let mut payload = to_value(&checkpoint).expect("checkpoint should serialize");
+        payload["steps"][0]["step"] = to_value(0_u32).expect("step should serialize");
+
+        let Err(error) = from_str::<CdtMcmcCheckpoint>(&payload.to_string()) else {
+            panic!("checkpoint telemetry step zero should fail while parsing");
+        };
+
+        assert!(
+            error.to_string().contains("nonzero") || error.to_string().contains("invalid value"),
+            "unexpected serde error: {error}"
         );
     }
 
@@ -1856,9 +1941,9 @@ mod tests {
     #[test]
     fn resume_rejects_chain_step_mismatch() {
         let mut checkpoint = short_checkpoint();
-        checkpoint.current_step += 1;
+        checkpoint.current_step = step_number(checkpoint.current_step.get() + 1);
         let chain_steps = checkpoint.chain.total_steps();
-        let checkpoint_step = checkpoint.current_step;
+        let checkpoint_step = checkpoint.current_step.get();
         let algorithm = MetropolisAlgorithm::new(
             seeded_metropolis_config(1.0, 2, 0, 1, 999),
             ActionConfig::default(),
@@ -1925,7 +2010,7 @@ mod tests {
     #[test]
     fn resume_rejects_nonsequential_step_telemetry() {
         let mut checkpoint = short_checkpoint();
-        checkpoint.steps[0].step = 2;
+        checkpoint.steps[0].step = step_number(2);
         let algorithm = MetropolisAlgorithm::new(
             seeded_metropolis_config(1.0, 2, 0, 1, 999),
             ActionConfig::default(),
@@ -2535,10 +2620,9 @@ mod tests {
         record_planned_step_parts(
             &algorithm,
             &mut state,
-            1,
+            step_number(1),
             PlannedStepRecord {
                 outcome: StepOutcome::Accepted,
-                log_prob_before: -action,
                 log_prob_after: Some(-action),
                 info,
                 proposal_stats: &proposal_stats,
@@ -2568,6 +2652,230 @@ mod tests {
                 } if *recorded_move == move_type && *step == 1
             )),
             "accepted move event should remain on the committed triangulation"
+        );
+    }
+
+    #[test]
+    fn accepted_planned_step_reconstructs_missing_action_after_from_log_prob() {
+        let temperature = 2.0;
+        let config = seeded_metropolis_config(temperature, 1, 0, 1, 2);
+        let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let committed = triangulation.clone();
+        let mut state = algorithm.initial_state(triangulation);
+        let action_before = state.current_action;
+        let reconstructed_action = action_before + 0.25;
+        let move_type = MoveType::Move22;
+        let proposal_stats = ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 0);
+
+        record_planned_step_parts(
+            &algorithm,
+            &mut state,
+            step_number(1),
+            PlannedStepRecord {
+                outcome: StepOutcome::Accepted,
+                log_prob_after: Some(-reconstructed_action / temperature),
+                info: CdtProposalInfo {
+                    move_type,
+                    action_before,
+                    action_after: None,
+                    delta_action: None,
+                },
+                proposal_stats: &proposal_stats,
+                triangulation: &committed,
+            },
+        )
+        .expect("accepted planned step should record fallback action");
+
+        assert_relative_eq!(state.current_action, reconstructed_action, epsilon = 1e-12);
+        assert_relative_eq!(
+            state.steps[0]
+                .action_after
+                .expect("accepted step should record reconstructed action"),
+            reconstructed_action,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            state.steps[0]
+                .delta_action
+                .expect("accepted step should record reconstructed action change"),
+            reconstructed_action - action_before,
+            epsilon = 1e-12
+        );
+    }
+
+    #[test]
+    fn accepted_planned_step_derives_delta_action_from_recorded_action_after() {
+        let temperature = 2.0;
+        let config = seeded_metropolis_config(temperature, 1, 0, 1, 2);
+        let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let committed = triangulation.clone();
+        let mut state = algorithm.initial_state(triangulation);
+        let action_before = state.current_action;
+        let action_after = action_before + 0.5;
+        let proposal_stats = ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 0);
+
+        record_planned_step_parts(
+            &algorithm,
+            &mut state,
+            step_number(1),
+            PlannedStepRecord {
+                outcome: StepOutcome::Accepted,
+                log_prob_after: None,
+                info: CdtProposalInfo {
+                    move_type: MoveType::Move22,
+                    action_before,
+                    action_after: Some(action_after),
+                    delta_action: Some(999.0),
+                },
+                proposal_stats: &proposal_stats,
+                triangulation: &committed,
+            },
+        )
+        .expect("accepted planned step should record explicit action_after");
+
+        assert_relative_eq!(
+            state.steps[0]
+                .delta_action
+                .expect("accepted step should record action change"),
+            action_after - action_before,
+            epsilon = 1e-12
+        );
+    }
+
+    #[test]
+    fn accepted_planned_step_rejects_missing_action_evidence_without_mutating_state() {
+        let temperature = 2.0;
+        let config = seeded_metropolis_config(temperature, 1, 0, 1, 2);
+        let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let committed = triangulation.clone();
+        let mut state = algorithm.initial_state(triangulation);
+        let action_before = state.current_action;
+        let steps_before = state.steps.len();
+        let measurements_before = state.measurements.len();
+        let attempted_before = state.move_stats.total_attempted();
+        let accepted_before = state.move_stats.total_accepted();
+        let proposal_stats_before = state.proposal_stats.clone();
+        let proposal_stats = ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 0);
+
+        let err = record_planned_step_parts(
+            &algorithm,
+            &mut state,
+            step_number(23),
+            PlannedStepRecord {
+                outcome: StepOutcome::Accepted,
+                log_prob_after: None,
+                info: CdtProposalInfo {
+                    move_type: MoveType::Move22,
+                    action_before,
+                    action_after: None,
+                    delta_action: None,
+                },
+                proposal_stats: &proposal_stats,
+                triangulation: &committed,
+            },
+        )
+        .expect_err("accepted step without action evidence should be rejected");
+
+        assert_matches!(err, CdtError::PlannedProposalTelemetryMissing { step: 23 });
+        assert_relative_eq!(state.current_action, action_before, epsilon = 1e-12);
+        assert_eq!(state.steps.len(), steps_before);
+        assert_eq!(state.measurements.len(), measurements_before);
+        assert_eq!(state.move_stats.total_attempted(), attempted_before);
+        assert_eq!(state.move_stats.total_accepted(), accepted_before);
+        assert_eq!(state.proposal_stats, proposal_stats_before);
+    }
+
+    #[test]
+    fn run_steps_rejects_step_count_overflow_before_planned_sampler_step() {
+        let config = seeded_metropolis_config(1.0, 1, 0, 1, 2);
+        let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let mut state = algorithm.initial_state(triangulation);
+        state.current_step = u32::MAX;
+        let steps_before = state.steps.len();
+        let measurements_before = state.measurements.len();
+        let attempted_before = state.move_stats.total_attempted();
+        let accepted_before = state.move_stats.total_accepted();
+        let proposal_stats_before = state.proposal_stats.clone();
+
+        let err = algorithm
+            .run_steps(
+                &mut state,
+                NonZeroU32::new(1).expect("one additional step is nonzero"),
+            )
+            .expect_err("overflowing step counter should reject continuation");
+
+        assert_matches!(
+            err,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::StepCountOverflow
+            }
+        );
+        assert_eq!(state.current_step, u32::MAX);
+        assert_eq!(state.steps.len(), steps_before);
+        assert_eq!(state.measurements.len(), measurements_before);
+        assert_eq!(state.move_stats.total_attempted(), attempted_before);
+        assert_eq!(state.move_stats.total_accepted(), accepted_before);
+        assert_eq!(state.proposal_stats, proposal_stats_before);
+    }
+
+    #[test]
+    fn planned_step_error_preserves_upstream_mcmc_error() {
+        assert_matches!(
+            planned_step_error(23, DelayedStepError::Mcmc(McmcError::NanLogQRatio)),
+            CdtError::Mcmc(McmcError::NanLogQRatio)
+        );
+    }
+
+    #[test]
+    fn planned_step_error_maps_proposal_failures_to_accepted_move_error() {
+        fn proposal_error() -> CdtProposalError {
+            CdtProposalError::ApplicationFailed {
+                move_type: MoveType::Move31Remove,
+                attempt: 3,
+                source: CdtError::BackendMutationFailed {
+                    operation: BackendMutationOperation::RemoveVertex,
+                    target: "vertex VertexKey(7v1)".to_string(),
+                    detail: "backend rejected removal".to_string(),
+                },
+            }
+        }
+
+        let cases = [
+            DelayedStepError::Plan(proposal_error()),
+            DelayedStepError::ProposedLogProb(proposal_error()),
+            DelayedStepError::LogQRatio(proposal_error()),
+            DelayedStepError::Commit(proposal_error()),
+        ];
+
+        for error in cases {
+            assert_matches!(
+                planned_step_error(23, error),
+                CdtError::MetropolisMoveApplicationFailed {
+                    step: 23,
+                    move_type: MoveType::Move31Remove,
+                    attempts: 3,
+                    source: MetropolisMoveApplicationFailure::BackendMutation {
+                        operation: BackendMutationOperation::RemoveVertex,
+                        ..
+                    }
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn missing_planned_step_info_reports_step_context() {
+        assert_matches!(
+            missing_planned_step_info(23),
+            CdtError::PlannedProposalTelemetryMissing { step: 23 }
         );
     }
 

--- a/src/cdt/metropolis/telemetry.rs
+++ b/src/cdt/metropolis/telemetry.rs
@@ -208,8 +208,7 @@ impl ProposalStatistics {
             wire.hard_failures,
         ]
         .into_iter()
-        .try_fold(0_u64, u64::checked_add)
-        .ok_or_else(|| "proposal terminal-outcome counters exceed u64::MAX".to_string())?;
+        .fold(0_u64, u64::saturating_add);
         if terminal_outcomes != wire.move_family_proposals {
             return Err(format!(
                 "proposal terminal outcomes ({terminal_outcomes}) do not match move-family proposals ({})",
@@ -440,6 +439,39 @@ impl ProposalStatistics {
     pub(crate) const fn record_hard_failure(&mut self) {
         self.hard_failures = self.hard_failures.saturating_add(1);
     }
+
+    /// Adds another proposal-telemetry snapshot into this accumulator.
+    ///
+    /// Chunked Metropolis continuation merges per-step telemetry from the
+    /// upstream planned-proposal sampler into CDT-owned counters. All additions saturate
+    /// so already-saturated checkpoint telemetry remains serializable.
+    pub(crate) const fn extend(&mut self, other: &Self) {
+        self.move_family_proposals = self
+            .move_family_proposals
+            .saturating_add(other.move_family_proposals);
+        self.observed_forward_sites = self
+            .observed_forward_sites
+            .saturating_add(other.observed_forward_sites);
+        self.no_site_proposals = self
+            .no_site_proposals
+            .saturating_add(other.no_site_proposals);
+        self.site_causality_rejections = self
+            .site_causality_rejections
+            .saturating_add(other.site_causality_rejections);
+        self.site_geometric_rejections = self
+            .site_geometric_rejections
+            .saturating_add(other.site_geometric_rejections);
+        self.site_backend_rejections = self
+            .site_backend_rejections
+            .saturating_add(other.site_backend_rejections);
+        self.metropolis_rejections = self
+            .metropolis_rejections
+            .saturating_add(other.metropolis_rejections);
+        self.accepted_transitions = self
+            .accepted_transitions
+            .saturating_add(other.accepted_transitions);
+        self.hard_failures = self.hard_failures.saturating_add(other.hard_failures);
+    }
 }
 
 #[cfg(test)]
@@ -513,5 +545,34 @@ mod tests {
             error.to_string().contains("forward-site"),
             "serde error should explain forward-site invariant, got {error}"
         );
+    }
+
+    #[test]
+    fn proposal_statistics_extend_preserves_saturated_round_trip_invariant() {
+        let mut stats = ProposalStatistics::from_validated_parts(
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        );
+        let other = ProposalStatistics::from_validated_parts(1, 1, 0, 0, 0, 0, 0, 1, 0);
+
+        stats.extend(&other);
+
+        assert_eq!(stats.move_family_proposals(), u64::MAX);
+        assert_eq!(stats.no_site_proposals(), u64::MAX);
+        assert_eq!(stats.accepted_transitions(), 1);
+
+        let serialized =
+            serde_json::to_string(&stats).expect("saturated telemetry should serialize");
+        let round_tripped: ProposalStatistics = serde_json::from_str(&serialized)
+            .expect("saturated merged telemetry should deserialize");
+
+        assert_eq!(round_tripped, stats);
     }
 }

--- a/src/cdt/metropolis/telemetry.rs
+++ b/src/cdt/metropolis/telemetry.rs
@@ -475,8 +475,11 @@ impl ProposalStatistics {
     /// Adds another proposal-telemetry snapshot into this accumulator.
     ///
     /// Chunked Metropolis continuation merges per-step telemetry from the
-    /// upstream planned-proposal sampler into CDT-owned counters. All additions saturate
-    /// so already-saturated checkpoint telemetry remains serializable.
+    /// upstream planned-proposal sampler into CDT-owned counters. All additions
+    /// saturate at `u64::MAX`, so already-saturated checkpoint telemetry remains
+    /// serializable. Once any counter saturates, the merged totals may no longer
+    /// preserve an exact one-to-one terminal-outcome partition; saturation can
+    /// coarsen the precise accepted, rejected, and hard-failure split.
     pub(crate) const fn extend(&mut self, other: &Self) {
         self.move_family_proposals = self
             .move_family_proposals

--- a/src/cdt/metropolis/telemetry.rs
+++ b/src/cdt/metropolis/telemetry.rs
@@ -7,21 +7,53 @@ use crate::errors::CdtError;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::error::Error;
 use std::fmt;
+use std::num::NonZeroU32;
 
-/// Result of a Monte Carlo step.
+/// Telemetry for one completed Monte Carlo step.
+///
+/// Step telemetry is emitted only for completed Metropolis transitions, so
+/// [`Self::step`] is always nonzero. A step-0 construction or initial-state
+/// sample appears as a [`Measurement`](crate::cdt::results::Measurement), not as
+/// a `MonteCarloStep`.
+///
+/// Accepted steps include both [`Self::action_after`] and [`Self::delta_action`]
+/// from the same recorded action. Rejected self-loop steps leave
+/// `action_after` empty while retaining the proposed action change when it was
+/// available.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::simulation::{
+///     ActionConfig, CdtResult, CdtTriangulation, MetropolisAlgorithm, MetropolisConfig,
+/// };
+///
+/// fn main() -> CdtResult<()> {
+///     let results = MetropolisAlgorithm::new(
+///         MetropolisConfig::new(1.0, 1, 0, 1)?.with_seed(7),
+///         ActionConfig::default(),
+///     )
+///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+///
+///     let step = &results.steps()[0];
+///     assert_eq!(step.step.get(), 1);
+///     assert!(step.action_before.is_finite());
+///     Ok(())
+/// }
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MonteCarloStep {
-    /// Step number
-    pub step: u32,
-    /// Move type attempted
+    /// Nonzero Monte Carlo step number.
+    pub step: NonZeroU32,
+    /// Move type attempted during this step.
     pub move_type: MoveType,
-    /// Whether the move was accepted
+    /// Whether the move was accepted by the Metropolis-Hastings transition.
     pub accepted: bool,
-    /// Action before the move
+    /// Action before the proposed move.
     pub action_before: f64,
-    /// Action after the move (if accepted)
+    /// Action after the move, present only for accepted steps.
     pub action_after: Option<f64>,
-    /// Change in action (ΔS)
+    /// Proposed or accepted change in action.
     pub delta_action: Option<f64>,
 }
 

--- a/src/cdt/results.rs
+++ b/src/cdt/results.rs
@@ -279,29 +279,30 @@ fn validate_result_steps(steps: &[MonteCarloStep], accepted: usize) -> CdtResult
         let expected_step = u32::try_from(index + 1).map_err(|_| {
             checkpoint_resume_failed(CheckpointResumeFailure::StepTelemetryIndexOverflow)
         })?;
-        if step.step != expected_step {
+        let step_number = step.step.get();
+        if step_number != expected_step {
             return Err(checkpoint_resume_failed(
                 CheckpointResumeFailure::StepTelemetrySequenceMismatch {
-                    actual: step.step,
+                    actual: step_number,
                     expected: expected_step,
                 },
             ));
         }
         if !step.action_before.is_finite() {
             return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::NonFiniteStepActionBefore { step: step.step },
+                CheckpointResumeFailure::NonFiniteStepActionBefore { step: step_number },
             ));
         }
         if let Some(delta_action) = step.delta_action
             && !delta_action.is_finite()
         {
             return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::NonFiniteStepDeltaAction { step: step.step },
+                CheckpointResumeFailure::NonFiniteStepDeltaAction { step: step_number },
             ));
         }
         if step.accepted && step.delta_action.is_none() {
             return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::AcceptedStepMissingDeltaAction { step: step.step },
+                CheckpointResumeFailure::AcceptedStepMissingDeltaAction { step: step_number },
             ));
         }
         match (step.accepted, step.action_after) {
@@ -310,23 +311,23 @@ fn validate_result_steps(steps: &[MonteCarloStep], accepted: usize) -> CdtResult
                     && !actions_match(action_after, step.action_before + delta_action)
                 {
                     return Err(checkpoint_resume_failed(
-                        CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: step.step },
+                        CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: step_number },
                     ));
                 }
             }
             (true, Some(_)) => {
                 return Err(checkpoint_resume_failed(
-                    CheckpointResumeFailure::NonFiniteStepActionAfter { step: step.step },
+                    CheckpointResumeFailure::NonFiniteStepActionAfter { step: step_number },
                 ));
             }
             (true, None) => {
                 return Err(checkpoint_resume_failed(
-                    CheckpointResumeFailure::AcceptedStepMissingActionAfter { step: step.step },
+                    CheckpointResumeFailure::AcceptedStepMissingActionAfter { step: step_number },
                 ));
             }
             (false, Some(_)) => {
                 return Err(checkpoint_resume_failed(
-                    CheckpointResumeFailure::RejectedStepHasActionAfter { step: step.step },
+                    CheckpointResumeFailure::RejectedStepHasActionAfter { step: step_number },
                 ));
             }
             (false, None) => {}
@@ -660,6 +661,10 @@ impl SimulationResultsBackend {
 
     /// Returns recorded Monte Carlo step telemetry.
     ///
+    /// These entries describe completed Metropolis transitions and therefore
+    /// start at step 1. Step-0 construction or initial-state snapshots are
+    /// represented by [`Measurement`] values returned from [`Self::measurements`].
+    ///
     /// # Examples
     ///
     /// ```
@@ -674,6 +679,7 @@ impl SimulationResultsBackend {
     ///     )
     ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
     ///     assert_eq!(results.steps().len(), 1);
+    ///     assert_eq!(results.steps()[0].step.get(), 1);
     ///     Ok(())
     /// }
     /// ```
@@ -1083,8 +1089,11 @@ impl SimulationResultsBackend {
         )
         .map_err(|err| output_error(path, OutputFormat::Csv, err))?;
 
-        let steps_by_number: HashMap<_, _> =
-            self.steps.iter().map(|step| (step.step, step)).collect();
+        let steps_by_number: HashMap<_, _> = self
+            .steps
+            .iter()
+            .map(|step| (step.step.get(), step))
+            .collect();
         for measurement in &self.measurements {
             let step = steps_by_number.get(&measurement.step).copied();
             let accepted = step.map_or(String::new(), |step| step.accepted.to_string());
@@ -1242,6 +1251,7 @@ mod tests {
     use std::assert_matches;
     use std::env;
     use std::fs;
+    use std::num::NonZeroU32;
     use std::path::PathBuf;
     use std::process;
     use std::thread;
@@ -1283,6 +1293,10 @@ mod tests {
             .expect("test action config should be valid")
     }
 
+    fn step_number(step: u32) -> NonZeroU32 {
+        NonZeroU32::new(step).expect("test step number should be nonzero")
+    }
+
     /// Builds a result container around deterministic geometry for summary-method tests.
     fn results_with(
         config: MetropolisConfig,
@@ -1311,7 +1325,7 @@ mod tests {
             move_stats,
             ProposalStatistics::from_validated_parts(1, 0, 1, 0, 0, 0, 0, 0, 0),
             vec![MonteCarloStep {
-                step: 1,
+                step: step_number(1),
                 move_type: MoveType::Move22,
                 accepted: false,
                 action_before: 0.0,
@@ -1381,7 +1395,7 @@ mod tests {
         move_stats.record_success(MoveType::Move22);
         let proposal_stats = ProposalStatistics::from_validated_parts(1, 7, 0, 0, 0, 0, 0, 1, 0);
         let step = MonteCarloStep {
-            step: 1,
+            step: step_number(1),
             move_type: MoveType::Move22,
             accepted: true,
             action_before: 4.0,
@@ -1413,7 +1427,7 @@ mod tests {
         assert_eq!(results.move_stats().total_attempted(), 1);
         assert_eq!(results.move_stats().total_accepted(), 1);
         assert_eq!(results.proposal_stats(), &proposal_stats);
-        assert_eq!(results.steps()[0].step, 1);
+        assert_eq!(results.steps()[0].step.get(), 1);
         assert_eq!(results.measurements()[0].volume_profile, vec![4, 4, 4]);
         assert_eq!(results.elapsed_time(), elapsed);
         assert_eq!(results.triangulation().slice_sizes(), &[4, 4, 4]);
@@ -1428,7 +1442,7 @@ mod tests {
         }
         let steps = (1..=4)
             .map(|step| MonteCarloStep {
-                step,
+                step: step_number(step),
                 move_type: MoveType::Move22,
                 accepted: false,
                 action_before: f64::from(step),
@@ -1475,7 +1489,7 @@ mod tests {
         }
         let steps = (1..=4)
             .map(|step| MonteCarloStep {
-                step,
+                step: step_number(step),
                 move_type: MoveType::Move22,
                 accepted: false,
                 action_before: f64::from(step),
@@ -1522,7 +1536,7 @@ mod tests {
             move_stats,
             ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 1),
             vec![MonteCarloStep {
-                step: 1,
+                step: step_number(1),
                 move_type: MoveType::Move22,
                 accepted: false,
                 action_before: 0.0,
@@ -1560,7 +1574,7 @@ mod tests {
             move_stats,
             ProposalStatistics::from_validated_parts(1, 1, 1, 0, 0, 0, 0, 0, 0),
             vec![MonteCarloStep {
-                step: 1,
+                step: step_number(1),
                 move_type: MoveType::Move22,
                 accepted: true,
                 action_before: 0.0,
@@ -1600,7 +1614,7 @@ mod tests {
             move_stats,
             ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 0),
             vec![MonteCarloStep {
-                step: 1,
+                step: step_number(1),
                 move_type: MoveType::Move22,
                 accepted: false,
                 action_before: 0.0,
@@ -1682,7 +1696,7 @@ mod tests {
             MoveStatistics::new(),
             ProposalStatistics::new(),
             vec![MonteCarloStep {
-                step: 1,
+                step: step_number(1),
                 move_type: MoveType::Move22,
                 accepted: false,
                 action_before: 0.0,
@@ -1723,6 +1737,22 @@ mod tests {
         assert!(
             message.contains("temperature") && message.contains("finite and positive"),
             "serde error should preserve validation context, got {message}"
+        );
+    }
+
+    #[test]
+    fn deserialization_rejects_zero_step_telemetry() {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let results = valid_rejected_result(triangulation);
+        let mut payload = to_value(&results).expect("results should serialize");
+        payload["steps"][0]["step"] = to_value(0_u32).expect("step should serialize");
+
+        let error = from_str::<SimulationResultsBackend>(&payload.to_string())
+            .expect_err("zero Monte Carlo step telemetry should fail while parsing");
+        assert!(
+            error.to_string().contains("nonzero") || error.to_string().contains("invalid value"),
+            "unexpected serde error: {error}"
         );
     }
 
@@ -1813,7 +1843,7 @@ mod tests {
         let results = results_with(
             metropolis_config(1.0, 2, 1, 1),
             vec![MonteCarloStep {
-                step: 1,
+                step: step_number(1),
                 move_type: MoveType::Move22,
                 accepted: true,
                 action_before: 3.0,
@@ -1849,7 +1879,7 @@ mod tests {
         let results = results_with(
             metropolis_config(1.0, 1, 0, 1),
             vec![MonteCarloStep {
-                step: 1,
+                step: step_number(1),
                 move_type: MoveType::Move22,
                 accepted: true,
                 action_before: 3.0,
@@ -1980,7 +2010,7 @@ mod tests {
         let config = metropolis_config(1.0, 20, 10, 5);
         let steps = vec![
             MonteCarloStep {
-                step: 1,
+                step: step_number(1),
                 move_type: MoveType::Move22,
                 accepted: true,
                 action_before: 3.0,
@@ -1988,7 +2018,7 @@ mod tests {
                 delta_action: Some(-0.5),
             },
             MonteCarloStep {
-                step: 2,
+                step: step_number(2),
                 move_type: MoveType::Move13Add,
                 accepted: false,
                 action_before: 2.5,
@@ -1996,7 +2026,7 @@ mod tests {
                 delta_action: Some(0.8),
             },
             MonteCarloStep {
-                step: 3,
+                step: step_number(3),
                 move_type: MoveType::Move31Remove,
                 accepted: true,
                 action_before: 2.5,

--- a/src/cdt/triangulation/builders.rs
+++ b/src/cdt/triangulation/builders.rs
@@ -12,6 +12,7 @@ use crate::geometry::generators::{
     generate_delaunay2,
 };
 use crate::geometry::traits::TriangulationQuery;
+use std::num::NonZeroU32;
 
 /// Rewrites toroidal builder failures with CDT-level generation context.
 ///
@@ -292,6 +293,15 @@ fn profile_slice_sizes(
         .iter()
         .map(|&volume| usize::try_from(volume).map_err(|err| generation_failed(err.to_string())))
         .collect()
+}
+
+/// Carries constructor-validated slice counts into foliation construction.
+///
+/// CDT builders validate topology-specific slice bounds before constructing
+/// foliation metadata, so reaching this helper with zero would indicate an
+/// internal constructor invariant regression.
+const fn checked_nonzero_slice_count(num_slices: u32) -> NonZeroU32 {
+    NonZeroU32::new(num_slices).expect("validated CDT slice count should be nonzero")
 }
 
 /// Builds labeled periodic coordinates for a toroidal CDT profile.
@@ -594,7 +604,8 @@ impl CdtTriangulation<DelaunayBackend2D> {
             }
         }
         let foliation =
-            Foliation::from_slice_sizes(slice_sizes, time_slices).map_err(CdtError::from)?;
+            Foliation::from_slice_sizes(slice_sizes, checked_nonzero_slice_count(time_slices))
+                .map_err(CdtError::from)?;
 
         let mut tri = Self::try_new(backend, time_slices, dimension)?;
         tri.foliation = Some(foliation);
@@ -758,7 +769,8 @@ impl CdtTriangulation<DelaunayBackend2D> {
         )?;
         let slice_sizes = vec![n; t_count];
         let foliation =
-            Foliation::from_slice_sizes(slice_sizes, num_slices).map_err(CdtError::from)?;
+            Foliation::from_slice_sizes(slice_sizes, checked_nonzero_slice_count(num_slices))
+                .map_err(CdtError::from)?;
 
         let mut tri = Self::try_new(backend, num_slices, 2)?;
         tri.foliation = Some(foliation);
@@ -831,7 +843,8 @@ impl CdtTriangulation<DelaunayBackend2D> {
         })?;
 
         let foliation =
-            Foliation::from_slice_sizes(slice_sizes, num_slices).map_err(CdtError::from)?;
+            Foliation::from_slice_sizes(slice_sizes, checked_nonzero_slice_count(num_slices))
+                .map_err(CdtError::from)?;
         let mut tri = Self::try_new(backend, num_slices, 2)?;
         tri.foliation = Some(foliation);
         tri.mark_foliation_synchronized();
@@ -983,7 +996,8 @@ impl CdtTriangulation<DelaunayBackend2D> {
 
         let slice_sizes = vec![n; t_count];
         let foliation =
-            Foliation::from_slice_sizes(slice_sizes, num_slices).map_err(CdtError::from)?;
+            Foliation::from_slice_sizes(slice_sizes, checked_nonzero_slice_count(num_slices))
+                .map_err(CdtError::from)?;
 
         let mut tri = Self::with_topology(backend, num_slices, 2, CdtTopology::Toroidal)?;
         tri.foliation = Some(foliation);
@@ -1066,7 +1080,8 @@ impl CdtTriangulation<DelaunayBackend2D> {
 
         let slice_sizes = profile_slice_sizes(volume_profile, generation_failed)?;
         let foliation =
-            Foliation::from_slice_sizes(slice_sizes, num_slices).map_err(CdtError::from)?;
+            Foliation::from_slice_sizes(slice_sizes, checked_nonzero_slice_count(num_slices))
+                .map_err(CdtError::from)?;
 
         let mut tri = Self::with_topology(backend, num_slices, 2, CdtTopology::Toroidal)?;
         tri.foliation = Some(foliation);

--- a/src/cdt/triangulation/foliation.rs
+++ b/src/cdt/triangulation/foliation.rs
@@ -7,7 +7,7 @@ use crate::cdt::foliation::{EdgeType, Foliation, FoliationError, SimplexType, cl
 use crate::config::CdtTopology;
 use crate::errors::{
     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
-    GenerationParameterIssue, TriangulationMetadataField,
+    TriangulationMetadataField,
 };
 use crate::geometry::DelaunayBackend2D;
 use crate::geometry::backends::delaunay::{
@@ -16,6 +16,7 @@ use crate::geometry::backends::delaunay::{
 use crate::geometry::traits::TriangulationQuery;
 use crate::util::f64_band_to_u32;
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroU32;
 
 impl CdtTriangulation<DelaunayBackend2D> {
     /// Validate foliation consistency.
@@ -38,10 +39,14 @@ impl CdtTriangulation<DelaunayBackend2D> {
     ///
     /// ```
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use std::num::NonZeroU32;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let mut tri = CdtTriangulation::from_seeded_points(12, 3, 2, 42)?;
-    ///     tri.assign_foliation_by_y(3)?;
+    ///     let Some(num_slices) = NonZeroU32::new(3) else {
+    ///         return Ok(());
+    ///     };
+    ///     tri.assign_foliation_by_y(num_slices)?;
     ///     tri.validate_foliation()?;
     ///     Ok(())
     /// }
@@ -282,19 +287,23 @@ impl CdtTriangulation<DelaunayBackend2D> {
     ///
     /// # Errors
     ///
-    /// Returns error if `num_slices` is zero, if vertex coordinates cannot be
-    /// read, if y-bucket assignment would leave any time slice empty, if the
-    /// requested slice count violates the triangulation topology, or if writing
-    /// vertex labels or clearing stale simplex labels in the backend fails.
+    /// Returns error if vertex coordinates cannot be read, if y-bucket
+    /// assignment would leave any time slice empty, if the requested slice count
+    /// violates the triangulation topology, or if writing vertex labels or
+    /// clearing stale simplex labels in the backend fails.
     ///
     /// # Examples
     ///
     /// ```
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use std::num::NonZeroU32;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let mut tri = CdtTriangulation::from_seeded_points(12, 3, 2, 42)?;
-    ///     tri.assign_foliation_by_y(3)?;
+    ///     let Some(num_slices) = NonZeroU32::new(3) else {
+    ///         return Ok(());
+    ///     };
+    ///     tri.assign_foliation_by_y(num_slices)?;
     ///
     ///     assert!(tri.has_foliation());
     ///     assert_eq!(tri.slice_sizes().iter().sum::<usize>(), tri.vertex_count());
@@ -305,15 +314,8 @@ impl CdtTriangulation<DelaunayBackend2D> {
         clippy::too_many_lines,
         reason = "foliation assignment stages labels, writes backend payloads, and rolls back on failure to preserve atomic metadata/foliation invariants"
     )]
-    pub fn assign_foliation_by_y(&mut self, num_slices: u32) -> CdtResult<()> {
-        if num_slices == 0 {
-            return Err(CdtError::InvalidGenerationParameters {
-                issue: GenerationParameterIssue::NonPositiveSliceCount,
-                provided_value: "0".to_string(),
-                expected_range: "≥ 1".to_string(),
-            });
-        }
-
+    pub fn assign_foliation_by_y(&mut self, num_slices: NonZeroU32) -> CdtResult<()> {
+        let raw_num_slices = num_slices.get();
         let y_coords: Vec<(DelaunayVertexHandle, f64)> = self
             .geometry
             .vertices()
@@ -354,23 +356,23 @@ impl CdtTriangulation<DelaunayBackend2D> {
         let band_height = if range.abs() < f64::EPSILON {
             1.0
         } else {
-            range / f64::from(num_slices)
+            range / f64::from(raw_num_slices)
         };
 
         let mut assignments = Vec::with_capacity(y_coords.len());
-        let mut slice_sizes = vec![0usize; num_slices as usize];
+        let mut slice_sizes = vec![0usize; raw_num_slices as usize];
         for (vh, y) in &y_coords {
             let t = if range.abs() < f64::EPSILON {
                 0
             } else {
                 let band_index = ((y - y_min) / band_height).floor();
-                f64_band_to_u32(band_index, num_slices - 1)
+                f64_band_to_u32(band_index, raw_num_slices - 1)
             };
             assignments.push((vh.vertex_key(), t));
             slice_sizes[t as usize] += 1;
         }
 
-        Self::check_time_slices(self.metadata.topology, num_slices)?;
+        Self::check_time_slices(self.metadata.topology, raw_num_slices)?;
 
         let foliation =
             Foliation::from_slice_sizes(slice_sizes, num_slices).map_err(CdtError::from)?;
@@ -449,7 +451,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
             }
         }
 
-        self.metadata.time_slices = Self::parse_time_slices(self.metadata.topology, num_slices)?;
+        self.metadata.time_slices = num_slices;
         self.bump_modification_count();
         self.foliation = Some(foliation);
         self.mark_foliation_synchronized();
@@ -1012,7 +1014,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
             &self.geometry,
             self.metadata.time_slices.get(),
         )?;
-        let foliation = Foliation::from_slice_sizes(slice_sizes, self.metadata.time_slices.get())
+        let foliation = Foliation::from_slice_sizes(slice_sizes, self.metadata.time_slices)
             .map_err(CdtError::from)?;
 
         self.foliation = Some(foliation);
@@ -1036,6 +1038,10 @@ mod tests {
     use std::assert_matches;
     use std::thread;
     use std::time::Duration;
+
+    fn slice_count(value: u32) -> NonZeroU32 {
+        NonZeroU32::new(value).expect("test slice count should be nonzero")
+    }
 
     /// Builds a minimal labeled Delaunay backend for foliation tests.
     fn labeled_triangle_backend(labels: [u32; 3]) -> DelaunayBackend2D {
@@ -1152,8 +1158,11 @@ mod tests {
         let mut tri = CdtTriangulation::from_labeled_delaunay(backend, 2, 2)
             .expect("Should preserve labels as foliation");
         tri.foliation = Some(
-            Foliation::from_slice_sizes(vec![1, 1], 2)
-                .expect("non-empty mismatched bookkeeping is constructible"),
+            Foliation::from_slice_sizes(
+                vec![1, 1],
+                NonZeroU32::new(2).expect("test slice count should be nonzero"),
+            )
+            .expect("non-empty mismatched bookkeeping is constructible"),
         );
 
         assert_matches!(
@@ -1176,7 +1185,7 @@ mod tests {
         assert!(tri.cache.edge_count.is_some());
 
         thread::sleep(Duration::from_millis(5));
-        tri.assign_foliation_by_y(3)
+        tri.assign_foliation_by_y(slice_count(3))
             .expect("Should assign foliation");
 
         assert!(tri.has_foliation());
@@ -1206,7 +1215,7 @@ mod tests {
             .map(|vh| vh.vertex_key())
             .collect();
 
-        assert!(tri.assign_foliation_by_y(0).is_err());
+        assert!(NonZeroU32::new(0).is_none());
         assert_eq!(tri.time_slices(), initial_time_slices);
         assert_eq!(
             tri.metadata().modification_count,
@@ -1216,7 +1225,7 @@ mod tests {
         let requested_slices = u32::try_from(tri.vertex_count())
             .expect("vertex count should fit into u32 for this test")
             .saturating_add(1);
-        let result = tri.assign_foliation_by_y(requested_slices);
+        let result = tri.assign_foliation_by_y(slice_count(requested_slices));
 
         assert_matches!(
             result,
@@ -1238,7 +1247,7 @@ mod tests {
         let mut tri = CdtTriangulation::from_toroidal_cdt(4, 3).expect("build toroidal CDT");
         let initial_slice_sizes = tri.slice_sizes().to_vec();
 
-        let result = tri.assign_foliation_by_y(2);
+        let result = tri.assign_foliation_by_y(slice_count(2));
 
         assert_matches!(
             result,
@@ -1266,7 +1275,7 @@ mod tests {
         assert!(tri.slice_sizes().is_empty());
         assert!(tri.vertices_at_time(0).is_empty());
 
-        tri.assign_foliation_by_y(1)
+        tri.assign_foliation_by_y(slice_count(1))
             .expect("Should assign single-slice foliation");
 
         assert!(tri.has_foliation());
@@ -1419,13 +1428,13 @@ mod tests {
         let mut tri =
             CdtTriangulation::from_cdt_strip(5, 3).expect("Failed to create deterministic strip");
 
-        tri.assign_foliation_by_y(3)
+        tri.assign_foliation_by_y(slice_count(3))
             .expect("First foliation assignment should succeed");
         tri.classify_all_simplices()
             .expect("classify_all_simplices should succeed")
             .expect("foliation is present");
 
-        tri.assign_foliation_by_y(2)
+        tri.assign_foliation_by_y(slice_count(2))
             .expect("Re-assignment with different slice count should succeed");
 
         assert_eq!(tri.time_slices().get(), 2);

--- a/src/cdt/triangulation/validation.rs
+++ b/src/cdt/triangulation/validation.rs
@@ -331,6 +331,7 @@ mod tests {
     use crate::config::CdtTopology;
     use crate::geometry::generators::build_delaunay2_with_data;
     use std::assert_matches;
+    use std::num::NonZeroU32;
 
     /// Builds a minimal labeled Delaunay backend for validation tests.
     fn labeled_triangle_backend(labels: [u32; 3]) -> DelaunayBackend2D {
@@ -432,7 +433,7 @@ mod tests {
             .expect("test Delaunay triangle should validate");
         let mut tri = unchecked_open_boundary(backend, 2, 2);
 
-        tri.assign_foliation_by_y(2)
+        tri.assign_foliation_by_y(NonZeroU32::new(2).expect("test slice count should be nonzero"))
             .expect("Should derive foliation from triangle coordinates");
 
         assert_eq!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ use dirs::home_dir;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
 use std::fmt::{self, Display};
+use std::num::NonZeroU32;
 use std::path::{Component, Path, PathBuf};
 
 /// Topology of the spatial slices in the CDT triangulation.
@@ -140,7 +141,7 @@ pub struct CdtConfig {
 ///
 /// [`CdtConfig`] remains the raw DTO for CLI, file, and test construction. Convert it
 /// into [`ValidatedCdtConfig`] before running algorithms that rely on topology,
-/// schedule, dimensionality, and finite-coupling invariants.
+/// schedule, dimensionality, finite-coupling, and nonzero count invariants.
 ///
 /// # Examples
 ///
@@ -150,7 +151,7 @@ pub struct CdtConfig {
 ///
 /// fn main() -> CdtResult<()> {
 ///     let validated = ValidatedCdtConfig::new(CdtConfig::new(16, 4))?;
-///     assert_eq!(validated.regular_vertices_per_slice(), Some(4));
+///     assert_eq!(validated.regular_vertices_per_slice().map(|count| count.get()), Some(4));
 ///     Ok(())
 /// }
 /// ```
@@ -158,6 +159,15 @@ pub struct CdtConfig {
 pub struct ValidatedCdtConfig {
     config: CdtConfig,
     metropolis_config: MetropolisConfig,
+    vertices: NonZeroU32,
+    timeslices: NonZeroU32,
+    initial_volume: ValidatedInitialVolumeData,
+}
+
+#[derive(Debug, Clone)]
+enum ValidatedInitialVolumeData {
+    Regular { vertices_per_slice: NonZeroU32 },
+    ExplicitProfile(Vec<NonZeroU32>),
 }
 
 /// Validated initial spatial-volume input for CDT construction.
@@ -178,8 +188,8 @@ pub struct ValidatedCdtConfig {
 ///     assert_matches!(
 ///         config.initial_volume(),
 ///         ValidatedInitialVolume::Regular {
-///             vertices_per_slice: 4
-///         }
+///             vertices_per_slice
+///         } if vertices_per_slice.get() == 4
 ///     );
 ///     Ok(())
 /// }
@@ -189,10 +199,10 @@ pub enum ValidatedInitialVolume<'a> {
     /// Regular equal-size spatial slices.
     Regular {
         /// Number of vertices in each slice.
-        vertices_per_slice: u32,
+        vertices_per_slice: NonZeroU32,
     },
     /// Explicit nonuniform spatial slice volumes.
-    ExplicitProfile(&'a [u32]),
+    ExplicitProfile(&'a [NonZeroU32]),
 }
 
 impl ValidatedCdtConfig {
@@ -212,12 +222,31 @@ impl ValidatedCdtConfig {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let validated = ValidatedCdtConfig::new(CdtConfig::new(16, 4))?;
-    ///     assert_eq!(validated.timeslices(), 4);
+    ///     assert_eq!(validated.timeslices().get(), 4);
     ///     Ok(())
     /// }
     /// ```
     pub fn new(config: CdtConfig) -> CdtResult<Self> {
         config.ensure_valid()?;
+        let vertices = nonzero_config_count(ConfigurationSetting::Vertices, config.vertices)?;
+        let timeslices = nonzero_config_count(ConfigurationSetting::Timeslices, config.timeslices)?;
+        let initial_volume = if let Some(profile) = &config.volume_profile {
+            ValidatedInitialVolumeData::ExplicitProfile(
+                profile
+                    .iter()
+                    .copied()
+                    .map(|volume| nonzero_config_count(ConfigurationSetting::VolumeProfile, volume))
+                    .collect::<CdtResult<Vec<_>>>()?,
+            )
+        } else {
+            let vertices_per_slice = config.vertices / config.timeslices;
+            ValidatedInitialVolumeData::Regular {
+                vertices_per_slice: nonzero_config_count(
+                    ConfigurationSetting::Vertices,
+                    vertices_per_slice,
+                )?,
+            }
+        };
         let metropolis_config = MetropolisConfig::new_with_seed(
             config.temperature,
             config.steps,
@@ -228,6 +257,9 @@ impl ValidatedCdtConfig {
         Ok(Self {
             config,
             metropolis_config,
+            vertices,
+            timeslices,
+            initial_volume,
         })
     }
 
@@ -293,7 +325,7 @@ impl ValidatedCdtConfig {
         }
     }
 
-    /// Total number of vertices in the initial triangulation.
+    /// Returns the nonzero total number of vertices in the initial triangulation.
     ///
     /// # Examples
     ///
@@ -303,16 +335,16 @@ impl ValidatedCdtConfig {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let config = CdtConfig::new(16, 4).into_validated()?;
-    ///     assert_eq!(config.vertices(), 16);
+    ///     assert_eq!(config.vertices().get(), 16);
     ///     Ok(())
     /// }
     /// ```
     #[must_use]
-    pub const fn vertices(&self) -> u32 {
-        self.config.vertices
+    pub const fn vertices(&self) -> NonZeroU32 {
+        self.vertices
     }
 
-    /// Number of initial time slices.
+    /// Returns the nonzero number of initial time slices.
     ///
     /// # Examples
     ///
@@ -322,16 +354,19 @@ impl ValidatedCdtConfig {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let config = CdtConfig::new(16, 4).into_validated()?;
-    ///     assert_eq!(config.timeslices(), 4);
+    ///     assert_eq!(config.timeslices().get(), 4);
     ///     Ok(())
     /// }
     /// ```
     #[must_use]
-    pub const fn timeslices(&self) -> u32 {
-        self.config.timeslices
+    pub const fn timeslices(&self) -> NonZeroU32 {
+        self.timeslices
     }
 
-    /// Optional explicit initial spatial volume profile.
+    /// Returns the optional explicit initial spatial volume profile.
+    ///
+    /// Each returned profile entry is nonzero because [`Self::new`] has already
+    /// rejected empty slices.
     ///
     /// # Examples
     ///
@@ -347,16 +382,22 @@ impl ValidatedCdtConfig {
     ///         ..CdtConfig::new(15, 3)
     ///     }
     ///     .into_validated()?;
-    ///     assert_eq!(config.volume_profile(), Some([4, 6, 5].as_slice()));
+    ///     let Some(profile) = config.volume_profile() else {
+    ///         return Ok(());
+    ///     };
+    ///     assert!(profile.iter().map(|volume| volume.get()).eq([4, 6, 5]));
     ///     Ok(())
     /// }
     /// ```
     #[must_use]
-    pub fn volume_profile(&self) -> Option<&[u32]> {
-        self.config.volume_profile.as_deref()
+    pub fn volume_profile(&self) -> Option<&[NonZeroU32]> {
+        match &self.initial_volume {
+            ValidatedInitialVolumeData::Regular { .. } => None,
+            ValidatedInitialVolumeData::ExplicitProfile(profile) => Some(profile),
+        }
     }
 
-    /// Vertices per slice for validated regular equal-slice initial data.
+    /// Returns the nonzero vertices per slice for regular equal-slice initial data.
     ///
     /// Returns `None` when the configuration uses an explicit volume profile.
     ///
@@ -368,19 +409,19 @@ impl ValidatedCdtConfig {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let regular = CdtConfig::new(16, 4).into_validated()?;
-    ///     assert_eq!(regular.regular_vertices_per_slice(), Some(4));
+    ///     assert_eq!(regular.regular_vertices_per_slice().map(|count| count.get()), Some(4));
     ///     Ok(())
     /// }
     /// ```
     #[must_use]
-    pub fn regular_vertices_per_slice(&self) -> Option<u32> {
-        self.config
-            .volume_profile
-            .is_none()
-            .then_some(self.config.vertices / self.config.timeslices)
+    pub const fn regular_vertices_per_slice(&self) -> Option<NonZeroU32> {
+        match &self.initial_volume {
+            ValidatedInitialVolumeData::Regular { vertices_per_slice } => Some(*vertices_per_slice),
+            ValidatedInitialVolumeData::ExplicitProfile(_) => None,
+        }
     }
 
-    /// Initial spatial-volume input with validation proof attached.
+    /// Returns initial spatial-volume input with validation proof attached.
     ///
     /// The returned value is safe to feed directly into CDT constructors because
     /// [`Self::new`] has already checked topology-specific slice constraints.
@@ -403,19 +444,24 @@ impl ValidatedCdtConfig {
     ///
     ///     assert_matches!(
     ///         config.initial_volume(),
-    ///         ValidatedInitialVolume::ExplicitProfile([4, 6, 5])
+    ///         ValidatedInitialVolume::ExplicitProfile(profile)
+    ///             if profile.iter().map(|volume| volume.get()).eq([4, 6, 5])
     ///     );
     ///     Ok(())
     /// }
     /// ```
     #[must_use]
     pub fn initial_volume(&self) -> ValidatedInitialVolume<'_> {
-        self.config.volume_profile.as_ref().map_or_else(
-            || ValidatedInitialVolume::Regular {
-                vertices_per_slice: self.config.vertices / self.config.timeslices,
-            },
-            |profile| ValidatedInitialVolume::ExplicitProfile(profile),
-        )
+        match &self.initial_volume {
+            ValidatedInitialVolumeData::Regular { vertices_per_slice } => {
+                ValidatedInitialVolume::Regular {
+                    vertices_per_slice: *vertices_per_slice,
+                }
+            }
+            ValidatedInitialVolumeData::ExplicitProfile(profile) => {
+                ValidatedInitialVolume::ExplicitProfile(profile)
+            }
+        }
     }
 
     /// Selected initial topology.
@@ -864,7 +910,7 @@ impl CdtConfig {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let config = CdtConfig::new(16, 4).into_validated()?;
-    ///     assert_eq!(config.vertices(), 16);
+    ///     assert_eq!(config.vertices().get(), 16);
     ///     Ok(())
     /// }
     /// ```
@@ -901,8 +947,8 @@ impl CdtConfig {
     ///
     ///     let merged = base.merge_with_override(&overrides)?;
     ///     assert_eq!(merged.config().dimension, None);
-    ///     assert_eq!(merged.vertices(), 24);
-    ///     assert_eq!(merged.timeslices(), 2);
+    ///     assert_eq!(merged.vertices().get(), 24);
+    ///     assert_eq!(merged.timeslices().get(), 2);
     ///     Ok(())
     /// }
     /// ```
@@ -1155,6 +1201,15 @@ fn validate_coupling(setting: ConfigurationSetting, value: f64) -> CdtResult<()>
     }
 }
 
+/// Converts a validated positive configuration count into a `NonZeroU32`.
+///
+/// [`ValidatedCdtConfig`] uses this helper after raw [`CdtConfig`] validation so
+/// downstream callers can preserve nonzero proof instead of rechecking raw
+/// counts.
+fn nonzero_config_count(setting: ConfigurationSetting, value: u32) -> CdtResult<NonZeroU32> {
+    NonZeroU32::new(value).ok_or_else(|| invalid_config(setting, &value, &"≥ 1"))
+}
+
 /// Parses a comma-separated spatial volume profile from the CLI.
 fn parse_volume_profile(raw: &str) -> Result<Vec<u32>, String> {
     let mut profile = Vec::new();
@@ -1404,7 +1459,7 @@ impl CdtConfig {
     /// use causal_triangulations::CdtConfig;
     ///
     /// let config = CdtConfig::new(16, 4).into_validated()?;
-    /// assert_eq!(config.timeslices(), 4);
+    /// assert_eq!(config.timeslices().get(), 4);
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     fn ensure_valid(&self) -> CdtResult<()> {
@@ -1801,14 +1856,17 @@ mod tests {
             .into_validated()
             .expect("regular config should validate");
         assert_eq!(regular.dimension(), 2);
-        assert_eq!(regular.vertices(), 64);
-        assert_eq!(regular.timeslices(), 4);
-        assert_eq!(regular.regular_vertices_per_slice(), Some(16));
+        assert_eq!(regular.vertices().get(), 64);
+        assert_eq!(regular.timeslices().get(), 4);
+        assert_eq!(
+            regular.regular_vertices_per_slice().map(NonZeroU32::get),
+            Some(16)
+        );
         assert_matches!(
             regular.initial_volume(),
             ValidatedInitialVolume::Regular {
-                vertices_per_slice: 16
-            }
+                vertices_per_slice
+            } if vertices_per_slice.get() == 16
         );
 
         let profiled = CdtConfig {
@@ -1821,9 +1879,18 @@ mod tests {
         .expect("profile config should validate");
 
         assert_eq!(profiled.regular_vertices_per_slice(), None);
+        assert!(
+            profiled
+                .volume_profile()
+                .expect("explicit profile should be present")
+                .iter()
+                .map(|volume| volume.get())
+                .eq([4, 6, 5])
+        );
         assert_matches!(
             profiled.initial_volume(),
-            ValidatedInitialVolume::ExplicitProfile([4, 6, 5])
+            ValidatedInitialVolume::ExplicitProfile(profile)
+                if profile.iter().map(|volume| volume.get()).eq([4, 6, 5])
         );
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -932,6 +932,8 @@ impl From<CdtError> for MetropolisMoveApplicationFailure {
             | CdtError::InvalidGenerationParameters { .. }
             | CdtError::InvalidConfiguration { .. }
             | CdtError::InvalidSimulationConfiguration { .. }
+            | CdtError::PlannedProposalStepFailed { .. }
+            | CdtError::PlannedProposalTelemetryMissing { .. }
             | CdtError::InvalidTriangulationMetadata { .. }
             | CdtError::VertexBuildFailed { .. }
             | CdtError::Mcmc(_)
@@ -1031,7 +1033,7 @@ pub enum CdtError {
         /// Most specific lower-level rejection or failure observed.
         source: MetropolisMoveApplicationFailure,
     },
-    /// Planning or committing a standalone delayed CDT proposal hit a hard failure.
+    /// Planning or committing a standalone planned CDT proposal hit a hard failure.
     #[error("CDT proposal failed while applying {move_type:?} on attempt {attempt}: {source}")]
     ProposalApplicationFailed {
         /// Move type whose concrete proposal application failed.
@@ -1040,6 +1042,20 @@ pub enum CdtError {
         attempt: usize,
         /// Most specific lower-level rejection or failure observed.
         source: MetropolisMoveApplicationFailure,
+    },
+    /// A planned CDT proposal step completed without proposal telemetry.
+    #[error("planned CDT proposal step {step} completed without proposal telemetry")]
+    PlannedProposalTelemetryMissing {
+        /// Monte Carlo step that was missing planned-proposal telemetry.
+        step: u32,
+    },
+    /// A planned CDT proposal step failed in a way CDT cannot classify yet.
+    #[error("planned CDT proposal step {step} failed: {detail}")]
+    PlannedProposalStepFailed {
+        /// Monte Carlo step whose planned-proposal execution failed.
+        step: u32,
+        /// Upstream sampler diagnostic.
+        detail: String,
     },
     /// Constructed triangulation metadata is internally inconsistent.
     #[error(
@@ -1755,6 +1771,31 @@ mod tests {
             Error::source(&error).map(ToString::to_string),
             Some(source.to_string())
         );
+    }
+
+    #[test]
+    fn planned_proposal_telemetry_missing_reports_step_without_fake_move_type() {
+        let error = CdtError::PlannedProposalTelemetryMissing { step: 23 };
+
+        assert_eq!(
+            format!("{error}"),
+            "planned CDT proposal step 23 completed without proposal telemetry"
+        );
+        assert!(Error::source(&error).is_none());
+    }
+
+    #[test]
+    fn planned_proposal_step_failed_preserves_upstream_detail() {
+        let error = CdtError::PlannedProposalStepFailed {
+            step: 23,
+            detail: "future upstream sampler failure".to_string(),
+        };
+
+        assert_eq!(
+            format!("{error}"),
+            "planned CDT proposal step 23 failed: future upstream sampler failure"
+        );
+        assert!(Error::source(&error).is_none());
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1043,10 +1043,10 @@ pub enum CdtError {
         /// Most specific lower-level rejection or failure observed.
         source: MetropolisMoveApplicationFailure,
     },
-    /// A planned CDT proposal step completed without proposal telemetry.
-    #[error("planned CDT proposal step {step} completed without proposal telemetry")]
+    /// A planned CDT proposal step completed without required proposal telemetry.
+    #[error("planned CDT proposal step {step} completed without required proposal telemetry")]
     PlannedProposalTelemetryMissing {
-        /// Monte Carlo step that was missing planned-proposal telemetry.
+        /// Monte Carlo step that was missing metadata or accepted-step action evidence.
         step: u32,
     },
     /// A planned CDT proposal step failed in a way CDT cannot classify yet.
@@ -1779,7 +1779,7 @@ mod tests {
 
         assert_eq!(
             format!("{error}"),
-            "planned CDT proposal step 23 completed without proposal telemetry"
+            "planned CDT proposal step 23 completed without required proposal telemetry"
         );
         assert!(Error::source(&error).is_none());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub mod cdt {
     ///
     /// The module is split by API boundary:
     /// [`adapter`](crate::cdt::metropolis::adapter) exposes the CDT target and
-    /// delayed proposal types used by `markov-chain-monte-carlo`,
+    /// planned proposal types used through `markov-chain-monte-carlo`,
     /// [`runner`](crate::cdt::metropolis::runner) provides the transitional
     /// [`MetropolisAlgorithm`](crate::cdt::metropolis::MetropolisAlgorithm)
     /// facade, [`checkpoint`](crate::cdt::metropolis::checkpoint) owns
@@ -335,7 +335,7 @@ pub mod prelude {
     /// Focused exports for running CDT simulations.
     ///
     /// This prelude includes [`run_simulation`], validated simulation
-    /// configuration, the Metropolis runner, delayed proposal adapter, telemetry
+    /// configuration, the Metropolis runner, proposal-plan adapter, telemetry
     /// structs, result containers, and typed proposal errors needed by MCMC
     /// workflows. It also includes the triangulation query trait so callers can
     /// inspect final or checkpointed states returned by simulation APIs. The
@@ -562,19 +562,21 @@ pub fn run_simulation(config: &ValidatedCdtConfig) -> CdtResult<SimulationResult
     let triangulation = match (config.topology(), config.initial_volume()) {
         (CdtTopology::Toroidal, ValidatedInitialVolume::ExplicitProfile(profile)) => {
             log::info!("Constructing toroidal CDT (S¹×S¹)");
-            CdtTriangulation::from_toroidal_cdt_profile(profile)?
+            let profile: Vec<_> = profile.iter().map(|volume| volume.get()).collect();
+            CdtTriangulation::from_toroidal_cdt_profile(&profile)?
         }
         (CdtTopology::Toroidal, ValidatedInitialVolume::Regular { vertices_per_slice }) => {
             log::info!("Constructing toroidal CDT (S¹×S¹)");
-            CdtTriangulation::from_toroidal_cdt(vertices_per_slice, timeslices)?
+            CdtTriangulation::from_toroidal_cdt(vertices_per_slice.get(), timeslices.get())?
         }
         (CdtTopology::OpenBoundary, ValidatedInitialVolume::ExplicitProfile(profile)) => {
             log::info!("Constructing open-boundary CDT strip");
-            CdtTriangulation::from_cdt_strip_profile(profile)?
+            let profile: Vec<_> = profile.iter().map(|volume| volume.get()).collect();
+            CdtTriangulation::from_cdt_strip_profile(&profile)?
         }
         (CdtTopology::OpenBoundary, ValidatedInitialVolume::Regular { vertices_per_slice }) => {
             log::info!("Constructing open-boundary CDT strip");
-            CdtTriangulation::from_cdt_strip(vertices_per_slice, timeslices)?
+            CdtTriangulation::from_cdt_strip(vertices_per_slice.get(), timeslices.get())?
         }
     };
 
@@ -836,10 +838,10 @@ mod tests {
         let parsed: Value = from_str(&json).expect("JSON output should parse");
 
         assert!(csv.starts_with("step,action,vertices,edges,triangles,accepted,delta_action\n"));
-        assert_eq!(parsed["config"]["vertices"], config.vertices());
+        assert_eq!(parsed["config"]["vertices"], config.vertices().get());
         assert_eq!(
             parsed["final_triangulation"]["time_slices"],
-            config.timeslices()
+            config.timeslices().get()
         );
     }
 

--- a/tests/physics_integration.rs
+++ b/tests/physics_integration.rs
@@ -51,7 +51,7 @@ fn assert_physics_pipeline(config: CdtConfig) {
     let profile = results.average_volume_profile();
     assert_eq!(
         profile.len(),
-        usize::try_from(config.timeslices()).expect("timeslices should fit usize"),
+        usize::try_from(config.timeslices().get()).expect("timeslices should fit usize"),
         "volume profile should cover every time slice"
     );
     assert!(
@@ -74,8 +74,8 @@ fn assert_physics_pipeline(config: CdtConfig) {
 /// Counts slabs expected to have volume in the measured CDT profile.
 fn occupied_time_slabs(config: &ValidatedCdtConfig) -> usize {
     let slabs = match config.topology() {
-        CdtTopology::OpenBoundary => config.timeslices().saturating_sub(1),
-        CdtTopology::Toroidal => config.timeslices(),
+        CdtTopology::OpenBoundary => config.timeslices().get().saturating_sub(1),
+        CdtTopology::Toroidal => config.timeslices().get(),
     };
     usize::try_from(slabs).expect("time slab count should fit usize")
 }

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -4,7 +4,7 @@
 
 use causal_triangulations::{
     ActionConfig, CdtTriangulation, ErgodicsSystem, MetropolisAlgorithm, MetropolisConfig,
-    MoveResult,
+    MoveResult, SimulationEvent,
 };
 use std::assert_matches;
 
@@ -48,6 +48,50 @@ fn toroidal_observables_run_accepts_periodic_moves_after_offset_support() {
     assert!(
         results.spectral_dimension_estimate().is_some(),
         "observables workflow should still report a spectral estimate"
+    );
+}
+
+#[test]
+fn accepted_move_history_keeps_matching_attempt_after_planned_proposal_handoff() {
+    // Regression for causal-triangulations#153: accepted planned-proposal steps
+    // replace the live triangulation with the committed chain state. The final
+    // state must retain the MoveAttempted event for each accepted move, not only
+    // the MoveAccepted event recorded after the replacement.
+    let triangulation =
+        CdtTriangulation::from_toroidal_cdt(4, 3).expect("history fixture should build");
+    let metropolis_config = MetropolisConfig::new(1.0, 20, 0, 5)
+        .expect("history regression Metropolis config should be valid")
+        .with_seed(7);
+
+    let results =
+        MetropolisAlgorithm::new(metropolis_config, ActionConfig::default()).run(triangulation);
+    let results = results.expect("history regression run should complete");
+    let history = results.triangulation().metadata().simulation_history();
+
+    let mut accepted_events = 0_u64;
+    for event in history {
+        let SimulationEvent::MoveAccepted {
+            move_type, step, ..
+        } = event
+        else {
+            continue;
+        };
+        accepted_events = accepted_events.saturating_add(1);
+        assert!(
+            history.iter().any(|candidate| matches!(
+                candidate,
+                SimulationEvent::MoveAttempted {
+                    move_type: attempted_move,
+                    step: attempted_step,
+                } if attempted_move == move_type && attempted_step == step
+            )),
+            "accepted move {move_type:?} at step {step} should retain its matching attempt event"
+        );
+    }
+
+    assert!(
+        accepted_events > 0,
+        "deterministic history regression should accept at least one move"
     );
 }
 

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -2,6 +2,7 @@
 
 //! Regression tests for previously observed CDT failures.
 
+use approx::assert_relative_eq;
 use causal_triangulations::{
     ActionConfig, CdtTriangulation, ErgodicsSystem, MetropolisAlgorithm, MetropolisConfig,
     MoveResult, SimulationEvent,
@@ -92,6 +93,50 @@ fn accepted_move_history_keeps_matching_attempt_after_planned_proposal_handoff()
     assert!(
         accepted_events > 0,
         "deterministic history regression should accept at least one move"
+    );
+}
+
+#[test]
+fn accepted_step_telemetry_keeps_action_delta_consistent_after_planned_proposal_handoff() {
+    // Regression for causal-triangulations#153: accepted public telemetry must
+    // keep reconstructed action_after and delta_action in sync after the
+    // planned-proposal sampler hands the committed state back to CDT.
+    let triangulation =
+        CdtTriangulation::from_toroidal_cdt(4, 3).expect("telemetry fixture should build");
+    let metropolis_config = MetropolisConfig::new(1.0, 20, 0, 5)
+        .expect("telemetry regression Metropolis config should be valid")
+        .with_seed(7);
+
+    let results =
+        MetropolisAlgorithm::new(metropolis_config, ActionConfig::default()).run(triangulation);
+    let results = results.expect("telemetry regression run should complete");
+
+    let mut accepted_steps = 0_u64;
+    for step in results.steps() {
+        if step.accepted {
+            accepted_steps = accepted_steps.saturating_add(1);
+            let action_after = step
+                .action_after
+                .expect("accepted steps should expose action_after");
+            let delta_action = step
+                .delta_action
+                .expect("accepted steps should expose delta_action");
+            assert_relative_eq!(
+                delta_action,
+                action_after - step.action_before,
+                epsilon = 1e-12
+            );
+        } else {
+            assert!(
+                step.action_after.is_none(),
+                "rejected steps should not expose action_after"
+            );
+        }
+    }
+
+    assert!(
+        accepted_steps > 0,
+        "deterministic telemetry regression should accept at least one move"
     );
 }
 

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -3,6 +3,38 @@
 
 use num_traits::cast::NumCast;
 
+struct ProposalRefFixture;
+
+impl ProposalRefFixture {
+    fn last_step_info(&self) -> Option<u32> {
+        Some(1)
+    }
+}
+
+struct SamplerFixture;
+
+impl SamplerFixture {
+    fn proposal_ref(&self) -> ProposalRefFixture {
+        ProposalRefFixture
+    }
+
+    fn replace_state(&mut self, _state: u32) -> Result<(), &'static str> {
+        Ok(())
+    }
+}
+
+struct StateFixture {
+    current_step: u32,
+    triangulation: u32,
+}
+
+fn record_planned_step(
+    _sampler: &SamplerFixture,
+    _state: &mut StateFixture,
+) -> Result<(), &'static str> {
+    Ok(())
+}
+
 // ruleid: causal-triangulations.rust.no-direct-delaunay-imports-outside-geometry
 use delaunay::prelude::DelaunayTriangulation;
 
@@ -238,4 +270,42 @@ fn stringly_domain_validation_errors() {
         check: "geometry".to_string(),
         detail: "backend rejected structure".to_string(),
     };
+}
+
+fn planned_step_info_from_proposal_cache_fixture(sampler: &SamplerFixture, step_info: Option<u32>) {
+    // ruleid: causal-triangulations.rust.planned-step-info-not-proposal-cache
+    let _ = sampler.proposal_ref().last_step_info();
+
+    // ok: causal-triangulations.rust.planned-step-info-not-proposal-cache
+    let _ = step_info.expect("planned step should provide proposal info");
+
+    // ok: causal-triangulations.rust.planned-step-info-not-proposal-cache
+    debug_assert_eq!(
+        sampler.proposal_ref().last_step_info(),
+        step_info,
+        "proposal telemetry cache should mirror planned step info"
+    );
+}
+
+fn planned_step_record_without_sampler_sync_fixture(
+    sampler: &mut SamplerFixture,
+    state: &mut StateFixture,
+    step: u32,
+) -> Result<(), &'static str> {
+    // ruleid: causal-triangulations.rust.planned-step-record-requires-sampler-state-sync
+    record_planned_step(sampler, state)?;
+    state.current_step = step;
+    Ok(())
+}
+
+fn planned_step_record_with_sampler_sync_fixture(
+    sampler: &mut SamplerFixture,
+    state: &mut StateFixture,
+    step: u32,
+) -> Result<(), &'static str> {
+    // ok: causal-triangulations.rust.planned-step-record-requires-sampler-state-sync
+    record_planned_step(sampler, state)?;
+    sampler.replace_state(state.triangulation)?;
+    state.current_step = step;
+    Ok(())
 }


### PR DESCRIPTION
- Drive chunked Metropolis runs and checkpoint resume through the upstream sampler planned-step handoff while preserving CDT measurements, telemetry, and move history.
- Carry validated config, volume, and foliation counts as NonZeroU32 so downstream construction can rely on nonzero invariants.
- Add Semgrep guardrails around planned-step telemetry and sampler-state synchronization.

BREAKING CHANGE: ValidatedCdtConfig count accessors and ValidatedInitialVolume now return NonZeroU32 values, and foliation construction APIs accept NonZeroU32 slice counts. CDT proposal errors now use planned-proposal variants for missing telemetry and failed upstream planned steps.

Closes #153