### PR TITLE
ci(tooling): enforce MCMC sampler boundary

### DIFF
--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -185,9 +185,9 @@ Code outside `src/geometry/` must not import `delaunay::` directly. CDT modules 
 handle wrappers, `DelaunayBackend2D`, and generator functions from `crate::geometry`.
 
 Generic MCMC mechanics should be delegated to `markov-chain-monte-carlo` through thin CDT adapters. CDT owns domain state, proposal-site enumeration,
-foliation/topology validation, measurements, and result translation; the upstream MCMC crate should own Metropolis-Hastings acceptance, proposal-ratio
-application, chain counters, planned-proposal commit ordering, and reusable sampler continuation behavior. The current boundary refactor is tracked by
-[`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155).
+foliation/topology validation, measurements, and result translation; the upstream MCMC crate owns Metropolis-Hastings acceptance, proposal-ratio application,
+chain counters, planned-proposal commit ordering, and reusable sampler continuation behavior. Repository-owned Semgrep rules enforce the issue #155 boundary
+against new CDT-local generic acceptance draws or manual accepted/rejected sampler counters.
 
 ## Key Modules
 

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -107,6 +107,9 @@ The useful `justfile` updates ported from `delaunay` are:
   readable version comments. Dependabot remains the update path for pinned external actions, with review focused on preserving both the SHA and readable version
   comment.
 - Delaunay's non-Rust 160-column tooling policy, adapted for CDT while intentionally leaving Rust formatting at `rustfmt`'s 100-column width.
+- MCMC-boundary Semgrep rules for issue #155, which reject production CDT-local Metropolis-Hastings `exp(log_alpha)` acceptance draws and manual
+  accepted/rejected sampler counter increments. These are CDT-specific because this crate still owns proposal planning, proposal-site telemetry, and result
+  translation, while `markov-chain-monte-carlo` owns the reusable sampler mechanics.
 
 ## Issue #162 CI And Security Alignment
 

--- a/docs/metropolis.md
+++ b/docs/metropolis.md
@@ -2,8 +2,8 @@
 
 > **MCMC backend boundary:** this page describes the current CDT production Metropolis runner. Its proposal-before-mutation contract should be preserved, but
 > generic Metropolis-Hastings mechanics should live behind `markov-chain-monte-carlo` adapters rather than CDT-local sampler logic. Chunked continuation now
-> uses upstream proposal planning and checkpoint-compatible continuation from `markov-chain-monte-carlo` v0.4. The remaining boundary refactor is
-> tracked by [`causal-triangulations#155`](https://github.com/acgetchell/causal-triangulations/issues/155); any further upstream planned-step hooks and
+> uses upstream proposal planning and checkpoint-compatible continuation from `markov-chain-monte-carlo` v0.4. Repository-owned Semgrep rules enforce the
+> production boundary by rejecting CDT-local generic acceptance draws and manual accepted/rejected sampler counters; any further upstream planned-step hooks and
 > telemetry needs are tracked by [`markov-chain-monte-carlo#61`](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61).
 
 `MetropolisAlgorithm::run()` uses a proposal-before-mutation ordering for CDT Monte Carlo steps.

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -571,6 +571,74 @@ rules:
       )
       \s*;
 
+  - id: causal-triangulations.rust.no-local-metropolis-acceptance-draws
+    languages:
+      - rust
+    severity: WARNING
+    message: "Delegate Metropolis-Hastings acceptance draws to markov-chain-monte-carlo instead of recomputing exp(log_alpha) locally."
+    metadata:
+      category: architecture
+      rationale: >-
+        CDT owns proposal planning and telemetry, while markov-chain-monte-carlo
+        owns generic Metropolis-Hastings acceptance, RNG draws, and delayed
+        proposal commit ordering.
+      issue: "https://github.com/acgetchell/causal-triangulations/issues/155"
+    paths:
+      include:
+        - "/src/cdt/**/*.rs"
+        - "/tests/semgrep/src/**/*.rs"
+    patterns:
+      - pattern-regex: '\brandom\s*::\s*<\s*f64\s*>\s*\(\s*\)\s*<=?\s*[^;\n]*\.exp\s*\('
+      - pattern-not-inside: |
+          mod tests {
+              ...
+          }
+      - pattern-not-inside: |
+          #[cfg(test)]
+          mod $MOD {
+              ...
+          }
+      - pattern-not-inside: |
+          #[cfg(test)]
+          fn $FUNC(...) {
+              ...
+          }
+
+  - id: causal-triangulations.rust.no-local-mcmc-chain-counter-increments
+    languages:
+      - rust
+    severity: WARNING
+    message: "Use upstream Chain/Sampler counters instead of maintaining local generic accepted/rejected MCMC counters."
+    metadata:
+      category: architecture
+      rationale: >-
+        CDT may translate upstream outcomes into domain telemetry, but generic
+        accepted/rejected sampler counters should remain owned by
+        markov-chain-monte-carlo.
+      issue: "https://github.com/acgetchell/causal-triangulations/issues/155"
+    paths:
+      include:
+        - "/src/cdt/**/*.rs"
+        - "/tests/semgrep/src/**/*.rs"
+    patterns:
+      - pattern-either:
+          - pattern-regex: '\baccepted\s*(?:\+=|=\s*accepted\s*\+)'
+          - pattern-regex: '\brejected\s*(?:\+=|=\s*rejected\s*\+)'
+      - pattern-not-inside: |
+          mod tests {
+              ...
+          }
+      - pattern-not-inside: |
+          #[cfg(test)]
+          mod $MOD {
+              ...
+          }
+      - pattern-not-inside: |
+          #[cfg(test)]
+          fn $FUNC(...) {
+              ...
+          }
+
   - id: causal-triangulations.rust.planned-step-info-not-proposal-cache
     languages:
       - rust

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code, unused_imports)]
 
 use num_traits::cast::NumCast;
+use rand::Rng;
 
 struct ProposalRefFixture;
 
@@ -308,4 +309,48 @@ fn planned_step_record_with_sampler_sync_fixture(
     sampler.replace_state(state.triangulation)?;
     state.current_step = step;
     Ok(())
+}
+
+fn local_metropolis_acceptance_draw_fixture<R: Rng + ?Sized>(
+    log_alpha: f64,
+    rng: &mut R,
+) -> bool {
+    // ruleid: causal-triangulations.rust.no-local-metropolis-acceptance-draws
+    log_alpha >= 0.0 || rng.random::<f64>() < log_alpha.exp()
+}
+
+#[cfg(test)]
+fn test_only_metropolis_acceptance_draw_fixture<R: Rng + ?Sized>(
+    log_alpha: f64,
+    rng: &mut R,
+) -> bool {
+    // ok: causal-triangulations.rust.no-local-metropolis-acceptance-draws
+    log_alpha >= 0.0 || rng.random::<f64>() < log_alpha.exp()
+}
+
+fn local_mcmc_chain_counter_fixture(outcome: bool) -> (u64, u64) {
+    let mut accepted = 0_u64;
+    let mut rejected = 0_u64;
+    if outcome {
+        // ruleid: causal-triangulations.rust.no-local-mcmc-chain-counter-increments
+        accepted += 1;
+    } else {
+        // ruleid: causal-triangulations.rust.no-local-mcmc-chain-counter-increments
+        rejected = rejected + 1;
+    }
+    (accepted, rejected)
+}
+
+#[cfg(test)]
+fn test_only_mcmc_chain_counter_fixture(outcome: bool) -> (u64, u64) {
+    let mut accepted = 0_u64;
+    let mut rejected = 0_u64;
+    if outcome {
+        // ok: causal-triangulations.rust.no-local-mcmc-chain-counter-increments
+        accepted += 1;
+    } else {
+        // ok: causal-triangulations.rust.no-local-mcmc-chain-counter-increments
+        rejected = rejected + 1;
+    }
+    (accepted, rejected)
 }


### PR DESCRIPTION
- Add repository Semgrep rules that reject CDT-local Metropolis-Hastings acceptance draws and manual accepted/rejected sampler counters.
- Cover the new guardrails with positive and negative Semgrep fixtures.
- Document that CDT owns proposal planning and telemetry while markov-chain-monte-carlo owns reusable sampler mechanics

Closes #155