### PR TITLE
refactor(cdt)!: encode trace and count invariants (#164)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,8 @@ docs/dev/testing.md
 Key principle:
 
 - Rust changes must pass unit tests, integration tests, and documentation builds.
+- Do not pass multiple test-name filters to `cargo test`; Cargo accepts only one. Use a shared substring, a module/path filter, or run the broader suite
+  instead.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve periodic toroidal moves with Simplex APIs
 - Complete 1+1 toroidal CDT sampling
 - Add proposal-site accounting and profiled CDT starts
+- Require validated CDT runtime configs [#163](https://github.com/acgetchell/causal-triangulations/pull/163)
 - Harden foliation validation and unify backend payload APIs
+- Split Metropolis into module tree
+- Validate runtime invariants at parse boundaries
+- Enforce simulation state invariants [#174](https://github.com/acgetchell/causal-triangulations/pull/174)
+- Encode nonzero CDT invariants
+- Run continuation through planned proposals [#153](https://github.com/acgetchell/causal-triangulations/pull/153)
 - Enforce CDT and backend invariants
 - Harden CDT telemetry and profiled initialization
 - Reject volume-profile override overflows
+- Make Metropolis step telemetry nonzero [#153](https://github.com/acgetchell/causal-triangulations/pull/153)
 - Align tooling and CDT error APIs
 - Align repository tooling with MCMC
 
 ### Merged Pull Requests
 
+- Enforce simulation state invariants [#174](https://github.com/acgetchell/causal-triangulations/pull/174)
+- Require validated CDT runtime configs [#163](https://github.com/acgetchell/causal-triangulations/pull/163)
+- Tighten coverage and doctest assertion checks [#163](https://github.com/acgetchell/causal-triangulations/pull/163)
+- Tighten Semgrep fixture coverage [#162](https://github.com/acgetchell/causal-triangulations/pull/162)
+- Harden Semgrep and zizmor checks [#162](https://github.com/acgetchell/causal-triangulations/pull/162)
+- Run continuation through planned proposals [#153](https://github.com/acgetchell/causal-triangulations/pull/153)
+- Make Metropolis step telemetry nonzero [#153](https://github.com/acgetchell/causal-triangulations/pull/153)
+- Add chunked Metropolis checkpoint sweeps [#152](https://github.com/acgetchell/causal-triangulations/pull/152)
+- Support fallible public examples [#151](https://github.com/acgetchell/causal-triangulations/pull/151)
+- Tighten unwrap Semgrep fixtures [#151](https://github.com/acgetchell/causal-triangulations/pull/151)
+- Anchor unwrap fixture exclusions [#151](https://github.com/acgetchell/causal-triangulations/pull/151)
 - Replace Node formatters with Rust-native checks [#129](https://github.com/acgetchell/causal-triangulations/pull/129)
 - Add toroidal topology infrastructure [#61](https://github.com/acgetchell/causal-triangulations/pull/61)
 - Implement foliation for 1+1 CDT [#57](https://github.com/acgetchell/causal-triangulations/pull/57)
@@ -242,6 +260,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     failures.
   - Replace stringly validation and history fields with typed error categories and move enums.
   - Document detailed-balance semantics and add proposal-site benchmark coverage.
+- Add chunked Metropolis checkpoint sweeps [#152](https://github.com/acgetchell/causal-triangulations/pull/152)
+  [`5065bd2`](https://github.com/acgetchell/causal-triangulations/commit/5065bd253b75812ac691ee7ca1e4bf69e5ce3cbf)
+
+  - Add resumable Metropolis checkpoint continuation so chunked drivers can inspect checkpointed triangulations between sweeps.
+  - Route the large-scale 1+1 debug harness through checkpoint-preserving Metropolis chunks sized from the current simplex count.
+  - Document the MCMC backend boundary and roadmap blockers for upstream markov-chain-monte-carlo continuation work.
+- Support fallible public examples [#151](https://github.com/acgetchell/causal-triangulations/pull/151)
+  [`9c10f0b`](https://github.com/acgetchell/causal-triangulations/commit/9c10f0b5daa1e6deea9c04c1f1af8474e0d26f28)
+
+  - Convert public Rust doctests to CdtResult-based flows with typed error propagation.
+  - Add Semgrep guardrails for unwrap/expect in doctests, benches, and examples.
+  - Preserve standalone CDT proposal application failures as typed CdtError variants.
+  - Re-export MCMC simulation traits from the simulation prelude for proposal workflows.
+  - Replace benchmark fixture expect paths with operation-aware setup helpers.
+- [**breaking**] Require validated CDT runtime configs [#163](https://github.com/acgetchell/causal-triangulations/pull/163)
+  [`fbdcc41`](https://github.com/acgetchell/causal-triangulations/commit/fbdcc417583966faf6e7c68fb253b07197f3335f)
+
+  - Add `ValidatedCdtConfig` and `ValidatedInitialVolume` so runtime construction consumes topology, volume, schedule, dimensionality, and coupling invariants
+    after validation.
+  - Move Metropolis/action runtime conversion behind validated configs and route `run_simulation` and examples through the proof-bearing API.
+  - Report invalid Metropolis schedules and temperatures with `InvalidSimulationConfiguration` while keeping geometry, topology, and action failures on
+    `InvalidConfiguration` .
+  - Bump the Rust baseline to 1.96.0, update the MCMC backend to 0.4.0, and align docs.rs metadata, API docs, and test assertions with the new baseline.
 
 ### Changed
 
@@ -440,6 +481,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor!(cdt): split triangulation modules and harden invariants
   [`aa08007`](https://github.com/acgetchell/causal-triangulations/commit/aa08007cdb662d9e8863c4954a9294501f7dee0b)
 
+- Refine Semgrep unwrap fixture exclusion patterns
+  [`0f4fb0f`](https://github.com/acgetchell/causal-triangulations/commit/0f4fb0fc89bd62c0786b25482f6b58dd8e0e4fc2)
+
+  Replace wildcard function arguments with explicit signatures for internal
+  Semgrep unwrap/expect rule exclusions. This ensures more precise pattern
+  matching and prevents unintended false negatives for doctests and internal
+  utility functions.
+  Refs: #151
+
+- Update tooling documentation on Semgrep unwrap/expect rules
+  [`8ac8398`](https://github.com/acgetchell/causal-triangulations/commit/8ac839845bbaeb8deaa35c59d5ef9530147a5902)
+
+  Document refinements to Semgrep rules for `unwrap()` and `expect()`.
+  This clarifies how rules distinguish code from prose mentions and
+  anchor fixture exclusions, preventing false positives in doctests
+  and ensuring accurate public-surface checks.
+
+- [**breaking**] Split Metropolis into module tree
+  [`3d602c5`](https://github.com/acgetchell/causal-triangulations/commit/3d602c5139fbfae35d7eec1ceb3d7f07697ae314)
+
+  - Move CDT Metropolis adapter, runner, checkpoint, telemetry, and shared helper logic into an explicit `src/cdt/metropolis/` module tree.
+  - Keep `adapter.rs` as the single boundary to `markov-chain-monte-carlo` while preserving existing public simulation re-exports.
+  - Calibrate the default 1+1 CDT action constants to `kappa_0 = 0`, `kappa_2 = 0`, and `lambda_edge = (2 / 3) ln 2`.
+  - Document the Metropolis module layout, Delaunay initialization role, and 1+1 CDT coupling calibration.
+
+- [**breaking**] Validate runtime invariants at parse boundaries
+  [`8a03da7`](https://github.com/acgetchell/causal-triangulations/commit/8a03da753747d6374ddf1da94f30ccb5b0194de3)
+
+  - Require action, Metropolis, and top-level simulation configuration to enter runtime code through validated private-field types.
+  - Validate result, checkpoint, move, and proposal telemetry before storage or deserialization so impossible counters and incoherent step records cannot be
+    represented.
+  - Move CDT triangulation state into the triangulation module tree and expose metadata, statistics, and constants through focused accessors and preludes.
+
+- [**breaking**] Enforce simulation state invariants [#174](https://github.com/acgetchell/causal-triangulations/pull/174)
+  [`583e5d4`](https://github.com/acgetchell/causal-triangulations/commit/583e5d485f35d9124cb85afd1bca4754d0537497)
+
+  - Reject checkpoints and completed results whose proposal telemetry does not match recorded sampler steps, accepted transitions, or rejected transitions
+  - Record Metropolis measurements only on the configured post-thermalization cadence and validate deserialized measurement streams against the same schedule
+  - Resolve configured output paths before triangulation or sampling begins, and prevent CDT modification counters from wrapping into stale cache versions
+
+- [**breaking**] Encode nonzero CDT invariants [`938d712`](https://github.com/acgetchell/causal-triangulations/commit/938d712175c35fe85aa893042f159afe0593f6ce)
+
+  - Store Metropolis step counts, measurement cadence, foliation slice counts, and CDT time-slice metadata as NonZeroU32.
+  - Preserve validated Metropolis configuration inside ValidatedCdtConfig instead of rebuilding from raw fields.
+  - Move time-slice parsing into construction and deserialization boundaries so downstream accessors can stay infallible.
+  - Widen measurement-count arithmetic before including the current step to avoid overflow.
+
+- [**breaking**] Run continuation through planned proposals [#153](https://github.com/acgetchell/causal-triangulations/pull/153)
+  [`262518f`](https://github.com/acgetchell/causal-triangulations/commit/262518fee46949251b4f77003270e6eff990a4df)
+
+  - Drive chunked Metropolis runs and checkpoint resume through the upstream sampler planned-step handoff while preserving CDT measurements, telemetry, and move
+    history.
+  - Carry validated config, volume, and foliation counts as NonZeroU32 so downstream construction can rely on nonzero invariants.
+  - Add Semgrep guardrails around planned-step telemetry and sampler-state synchronization.
+
 ### Dependencies
 
 - Bump actions/cache from 5.0.1 to 5.0.4 [`063c3fc`](https://github.com/acgetchell/causal-triangulations/commit/063c3fc7601935b9399be2105e5359e1a39fade9)
@@ -481,6 +577,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump codecov/codecov-action from 6.0.0 to 6.0.1
   [`3847062`](https://github.com/acgetchell/causal-triangulations/commit/38470624f992c3fca087228d663fd6dcf8af864d)
 - Bump serde_json [`1780261`](https://github.com/acgetchell/causal-triangulations/commit/1780261e6f13fc4f222f02ae220145cb0ca8c6a4)
+- Bump log from 0.4.29 to 0.4.30 in the dependencies group
+  [`ac3237f`](https://github.com/acgetchell/causal-triangulations/commit/ac3237fff81a4d1c0233cfc9125a87d7cbca56ed)
+- Bump taiki-e/install-action from 2.79.2 to 2.79.9
+  [`788eea8`](https://github.com/acgetchell/causal-triangulations/commit/788eea8b1cc1b9b91773c53d5c6a1cc172d1c369)
 
 ### Documentation
 
@@ -494,6 +594,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   - Document that src/geometry/ wraps upstream Delaunay operations through crate-owned traits.
   - Spell out its conversion, validation, and error translation role between Delaunay and CDT geometry types.
+- Clarify Metropolis proposal cache identity [`b3bfa4b`](https://github.com/acgetchell/causal-triangulations/commit/b3bfa4b58d8be05423dc305f00e08a377edc0698)
+
+  - Document that proposal-site cache validity uses `(instance_id, modification_count)`.
+  - Explain the reverse proposal-site denominator stored on CDT proposal plans.
+- Wrap volume-fixing citation prose [`7cf8ffd`](https://github.com/acgetchell/causal-triangulations/commit/7cf8ffd6bdf19ce885359d5ce9df5c3baea9fc33)
+
+  - Keep the Metropolis documentation within the raw Markdown line-length limit.
+- Clarify saturated proposal telemetry merging [`3e218da`](https://github.com/acgetchell/causal-triangulations/commit/3e218da37312875587ca2970885324c5c4797bc0)
+
+  - Document that ProposalStatistics::extend uses saturating counter addition.
+  - Explain that saturated telemetry remains serializable while exact terminal-outcome partitions may be coarsened.
 
 ### Fixed
 
@@ -701,6 +812,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Make CdtConfig::merge_with_override fail on volume-profile count overflow instead of clamping derived vertices and timeslices.
   - Preserve profile-derived configuration invariants before post-merge validation runs.
   - Track the v0.1.0 public doctest error-handling audit in the roadmap.
+- Tighten unwrap Semgrep fixtures [#151](https://github.com/acgetchell/causal-triangulations/pull/151)
+  [`2e44e17`](https://github.com/acgetchell/causal-triangulations/commit/2e44e1771d98ac03f62ebb7b8c09f785a7bd0831)
+
+  - Avoid flagging doctest prose that merely mentions .unwrap() or .expect().
+  - Keep bench/example unwrap checks scoped away from rust-style fixture helpers.
+  - Remove stale bench/example annotations from the rust-style Semgrep fixture.
+- Anchor unwrap fixture exclusions [#151](https://github.com/acgetchell/causal-triangulations/pull/151)
+  [`5048842`](https://github.com/acgetchell/causal-triangulations/commit/50488420a926e795701938240cb5f8863ae043c1)
+
+  - Tie Semgrep bench/example unwrap exclusions to the rust-style fixture path.
+  - Mirror the fixture-path anchors beside the rust-style unwrap fixture helpers.
+- Count multi-rule Semgrep fixtures [`657f478`](https://github.com/acgetchell/causal-triangulations/commit/657f478c14dda6d141df6696d50b7ba64e2c7408)
+
+  - Split comma-separated Semgrep fixture annotations before comparing expected findings.
+  - Keep Python fixture helpers typed and remove a stale unwrap expectation from the bench/example fixture.
+- Require literal UTF-8 test fixture I/O [`759437b`](https://github.com/acgetchell/causal-triangulations/commit/759437bd5b5f6e83394124a536540356390bafda)
+
+  - Tighten the Python test encoding Semgrep rule so Path.read_text and Path.write_text only pass with explicit encoding="utf-8".
+- [**breaking**] Make Metropolis step telemetry nonzero [#153](https://github.com/acgetchell/causal-triangulations/pull/153)
+  [`f736b97`](https://github.com/acgetchell/causal-triangulations/commit/f736b970c194ec4f71422b3d2120b7aee84d5b48)
+
+  - Store completed Metropolis step numbers as NonZeroU32 in public telemetry and resumable checkpoints.
+  - Reject zero-valued completed-step telemetry while preserving step 0 for initial measurement records.
+  - Derive accepted planned-step delta_action from the same action_after value used to update CDT state, including reconstructed action values.
+  - Return a typed telemetry error when an accepted planned proposal lacks action evidence.
 
 ### Maintenance
 
@@ -768,6 +904,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Limit dprint to YAML formatting with the pretty_yaml plugin and add check/fix aliases for TOML, YAML, and shell tooling.
   - Enforce workflow action pinning, allowlisting, and version comments with Semgrep fixtures.
   - Document the Rust-native tooling setup and check-before-fix workflow guidance.
+- Tighten coverage and doctest assertion checks [#163](https://github.com/acgetchell/causal-triangulations/pull/163)
+  [`36be83f`](https://github.com/acgetchell/causal-triangulations/commit/36be83f18d36d12d3fc079efa4b1f1fa091aea7d)
+
+  - Include `src/lib.rs` in Codecov analysis so public API and `run_simulation` changes are visible in patch coverage.
+  - Add a Semgrep rule that rejects `assert!(matches!(...))` in public Rust doctests.
+  - Update public examples and development docs to use `std::assert_matches` for diagnostic-friendly enum and result assertions.
+- Align security checks with shared Rust workflow
+  [`3d5fbec`](https://github.com/acgetchell/causal-triangulations/commit/3d5fbecdf869df9d6d7e98de555eb14f360df9d7)
+
+  - Run the CI matrix through pinned `just ci` tooling on Linux, macOS, and Windows.
+  - Move workflow tool installation to cached Cargo installs and uv-managed Python tooling.
+  - Add zizmor workflow coverage, SECURITY.md, and Dependabot cooldowns for security maintenance.
+  - Expand repository Semgrep rules for GitHub Actions hardening, subprocess wrapper usage, and MCMC adapter boundaries.
+  - Mirror pinned tool versions across workflows and justfile setup checks.
+- Lock local Python tool installs [`9cf18d7`](https://github.com/acgetchell/causal-triangulations/commit/9cf18d76aa9d9e261593cd2a3b4593ed153dcbf1)
+
+  - Require `setup-tools` to sync uv dependencies with the lockfile.
+  - Pin pytest and ty in the dev dependency group so local installs match the locked tooling set.
+- Make Semgrep fixture cleanup Windows-safe [`2bec72a`](https://github.com/acgetchell/causal-triangulations/commit/2bec72a7468fd6c250b23ea0e6cf254f42bbfb93)
+
+  - Remove the temporary mirrored Semgrep config directory in one guarded cleanup step.
+  - Avoid manual symlink unlinking and directory removal that fails on Windows runners.
+- Tighten Semgrep fixture coverage [#162](https://github.com/acgetchell/causal-triangulations/pull/162)
+  [`5ff5abe`](https://github.com/acgetchell/causal-triangulations/commit/5ff5abe26511f9e64d340c3f7e8c003a4b0b1376)
+
+  - Port low-risk MCMC Semgrep rules for unchecked Rust APIs and dynamic error erasure in public examples.
+  - Check repository Semgrep fixtures with direct annotation counts so path-sensitive rules stay covered.
+  - Require explicit UTF-8 fixture I/O in benchmark utility tests to keep Windows runs portable.
+- Harden Semgrep and zizmor checks [#162](https://github.com/acgetchell/causal-triangulations/pull/162)
+  [`acbf1ad`](https://github.com/acgetchell/causal-triangulations/commit/acbf1ad1673372e05af9f0eb2e49b760d40d0298)
+
+  - Avoid zizmor concurrency group collisions across refs and runs.
+  - Validate Semgrep fixture checker inputs before comparing rule results.
+  - Accept explicit UTF-8 encodings in fixture rules for both quote styles and the shared UTF8 constant.
+- Enforce MCMC sampler boundary [`d523854`](https://github.com/acgetchell/causal-triangulations/commit/d523854737a2b77395741a761b707c85cbea52a8)
+
+  - Add repository Semgrep rules that reject CDT-local Metropolis-Hastings acceptance draws and manual accepted/rejected sampler counters.
+  - Cover the new guardrails with positive and negative Semgrep fixtures.
+  - Document that CDT owns proposal planning and telemetry while markov-chain-monte-carlo owns reusable sampler mechanics
 
 ### Performance
 
@@ -782,6 +957,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Wire benchmark analysis and baseline comparison tooling to use stable Criterion benchmark IDs from the new suite.
   - Keep Linux, macOS, and Windows CI coverage while speeding Windows Rust validation with nextest.
   - Align coverage and changelog tooling with the Delaunay refresh, including cargo-llvm-cov 0.8.7 and archive heading normalization.
+- Cache Metropolis proposal-site universes [`6b3bfbe`](https://github.com/acgetchell/causal-triangulations/commit/6b3bfbe8643816ec1cb87ff5664330c756adaa19)
+
+  - Cache sampleable local sites per move family and triangulation instance so Metropolis sampling and proposal denominators share the same candidate set
+    without repeatedly re-enumerating sites.
+  - Give cloned and deserialized triangulations fresh transient identities so cached backend handles cannot leak across distinct states with matching
+    modification counts.
+  - Store reverse proposal-site counts on concrete CDT proposal plans to keep Hastings ratios tied to the proposed state that was actually planned.
+  - Document cached proposal-site semantics and the v0.1.x roadmap split for chunked Metropolis sweeps.
+  - Harden changelog formatting when no archived changelog files are present.
 
 ## [0.0.1] - 2026-03-23
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The library leverages high-performance [Delaunay triangulation] backends and pro
 - [x] Regge action calculation with configurable coupling constants
 - [x] Alexander/Pachner-style local move proposals with causal constraints
 - [x] Volume-profile, Hausdorff-dimension, and spectral-dimension observables for CDT analysis
-- [x] Trace CSV/JSON simulation output for external analysis workflows
+- [x] Trace CSV simulation output for external analysis workflows; JSON summary/metadata for CLI/config export
 - [x] Resumable serde-backed CDT/MCMC checkpoints for durable chain continuation
 - [x] Focused public preludes for simulation, triangulation, geometry, action, and observables
 - [x] Command-line interface, examples, Criterion benchmarks, and CI-aligned validation tooling
@@ -58,7 +58,7 @@ See [`docs/roadmap.md`](docs/roadmap.md) for current direction, near-term candid
 ## 📋 Running The Binary
 
 The crate installs a `cdt` binary. Use it to construct an initial 1+1 CDT triangulation, optionally run the Metropolis move loop, and write analysis-friendly
-trace CSV/JSON output.
+trace CSV output plus JSON summary/metadata.
 
 ```bash
 # Build the binary

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The library leverages high-performance [Delaunay triangulation] backends and pro
 - [x] Regge action calculation with configurable coupling constants
 - [x] Alexander/Pachner-style local move proposals with causal constraints
 - [x] Volume-profile, Hausdorff-dimension, and spectral-dimension observables for CDT analysis
-- [x] CSV/JSON simulation output for external analysis workflows
+- [x] Trace CSV/JSON simulation output for external analysis workflows
 - [x] Resumable serde-backed CDT/MCMC checkpoints for durable chain continuation
 - [x] Focused public preludes for simulation, triangulation, geometry, action, and observables
 - [x] Command-line interface, examples, Criterion benchmarks, and CI-aligned validation tooling
@@ -58,7 +58,7 @@ See [`docs/roadmap.md`](docs/roadmap.md) for current direction, near-term candid
 ## 📋 Running The Binary
 
 The crate installs a `cdt` binary. Use it to construct an initial 1+1 CDT triangulation, optionally run the Metropolis move loop, and write analysis-friendly
-CSV/JSON output.
+trace CSV/JSON output.
 
 ```bash
 # Build the binary
@@ -84,7 +84,7 @@ cargo build --release
   --temperature 1.5 \
   --seed 105 \
   --simulate \
-  --output-csv toroidal-measurements.csv \
+  --output-csv toroidal-trace.csv \
   --output-json toroidal-summary.json
 ```
 

--- a/benches/cdt_benchmarks.rs
+++ b/benches/cdt_benchmarks.rs
@@ -195,14 +195,14 @@ fn bench_action_calculations(c: &mut Criterion) {
     let config = ActionConfig::default();
 
     // Test different triangulation sizes
-    let test_cases = [
-        (10, 15, 6),     // Small triangulation
-        (50, 140, 92),   // Medium triangulation
-        (100, 290, 192), // Large triangulation
+    let test_cases: [(usize, usize, usize, u64); 3] = [
+        (10, 15, 6, 10),      // Small triangulation
+        (50, 140, 92, 50),    // Medium triangulation
+        (100, 290, 192, 100), // Large triangulation
     ];
 
-    for (vertices, edges, faces) in test_cases {
-        group.throughput(Throughput::Elements(u64::from(vertices)));
+    for (vertices, edges, faces, throughput_vertices) in test_cases {
+        group.throughput(Throughput::Elements(throughput_vertices));
         group.bench_with_input(
             BenchmarkId::new("calculate_action", vertices),
             &(vertices, edges, faces),

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -208,6 +208,8 @@ through to upstream `delaunay::` APIs directly.
 
 - Owns the `CdtTriangulation` state, `CdtMetadata`, `SimulationEvent`, metadata validation, cached simplex-count accessors, and common backend-agnostic state
   methods
+- `CdtSimplexCounts` carries the CDT-domain proof that constructed triangulations have positive vertex, edge, and triangle counts as `NonZeroUsize`, while
+  raw geometry queries remain `usize` so backend construction, clearing, and collection-style count APIs can represent zero
 - `from_cdt_strip(vertices_per_slice, num_slices)` — Delaunay-built open-boundary 1+1 CDT strip with strict Up/Down simplex classification and upstream Level
   1–4 Delaunay validation before wrapping
 - `from_cdt_strip_profile(volume_profile)` — open-boundary 1+1 CDT strip from explicit nonuniform per-slice vertex counts; builds labeled point data and
@@ -260,9 +262,11 @@ See `docs/metropolis.md` for the current planned-proposal ordering and
 ### `cdt/results.rs` — Simulation outputs
 
 - `Measurement` records per-step action, simplex counts, and optional per-slice volume profiles.
-- `SimulationResultsBackend` owns the final triangulation, Monte Carlo step telemetry, move statistics, and measurement history.
+- `SimulationResultsBackend` owns the final triangulation, Monte Carlo step telemetry, upstream scalar trace rows, move statistics, and measurement history.
 - Result methods summarize acceptance rate, average action, post-thermalization volume profiles, sample volume fluctuations, and final-state Hausdorff/spectral
   dimension estimates.
+- `scalar_trace()` and `write_trace_csv()` expose step diagnostics through `markov-chain-monte-carlo::Trace`, using a rectangular CSV table suitable for Polars
+  and other downstream dataframe tools.
 
 ### `cdt/observables.rs` — User-facing estimators
 
@@ -310,7 +314,8 @@ Delaunay triangulation before CDT foliation, causality, topology, and simplex-cl
 ### `util.rs` — Numeric helpers
 
 - `saturating_usize_to_i32` — crate-internal usize→i32 conversion for Euler characteristic arithmetic
-- `saturating_usize_to_u32` — crate-internal usize→u32 conversion for simulation measurements and action inputs
+- Simulation action inputs use native `usize` topology counts; validated CDT count snapshots use `NonZeroUsize`; measurement and trace telemetry downcasts to
+  `u32` are checked at construction boundaries
 - `y_to_time_bucket` — f64→Option<u32> via round(), for time-slice assignment
 - `f64_band_to_u32` — f64→u32 clamped, for y-coordinate binning
 

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -110,6 +110,9 @@ The useful `justfile` updates ported from `delaunay` are:
 - MCMC-boundary Semgrep rules for issue #155, which reject production CDT-local Metropolis-Hastings `exp(log_alpha)` acceptance draws and manual
   accepted/rejected sampler counter increments. These are CDT-specific because this crate still owns proposal planning, proposal-site telemetry, and result
   translation, while `markov-chain-monte-carlo` owns the reusable sampler mechanics.
+- The planned-step sampler-state sync rule now anchors `record_planned_step(...)` to call statements so it continues to catch missing
+  `sampler.replace_state(...)` after recorded planned steps without false-positive matches on the helper function declaration when that helper contains fallible
+  telemetry construction.
 
 ## Issue #162 CI And Security Alignment
 

--- a/docs/metropolis.md
+++ b/docs/metropolis.md
@@ -77,6 +77,20 @@ Metropolis-Hastings accept/reject draw, log-probability cache, chain counters, a
 outside that generic sampler: action and schedule metadata, proposal telemetry, move statistics, measurements, elapsed time, and the serialized ergodic proposal
 RNG.
 
+## Trace CSV Diagnostics
+
+Completed Metropolis steps are recorded as upstream `markov-chain-monte-carlo::Trace` records. `SimulationResultsBackend::scalar_trace()` builds the in-memory
+trace, and `SimulationResultsBackend::write_trace_csv()` writes the same rectangular table through the upstream CSV writer. The configured `--output-csv` path
+therefore exports one row per completed step, not one row per scheduled measurement.
+
+The fixed upstream columns are `chain_id`, `step`, `accepted`, `proposed`, and `log_prob`. CDT adds numeric observable columns for the current action,
+vertex/edge/triangle counts, stable move-family code, action delta and before/after action fields with presence flags, optional seed split into exactly
+representable `u32` halves, and zero-filled `volume_profile_*` columns. The `proposed` column distinguishes no-site/no-plan self-loops from concrete proposals
+that were rejected by Metropolis-Hastings or CDT-local proposal checks.
+
+CSV is the core export format so downstream tools such as Polars can load the data without coupling the crate to a dataframe or Parquet dependency. Plotting,
+Parquet conversion, and wider ensemble analysis belong downstream of this typed trace export.
+
 The large-scale 1+1 debug harness uses this upstream-backed chunking path to run one Metropolis sweep at a time:
 
 1. Read the current number of top-dimensional simplices at the start of the sweep.

--- a/examples/basic_cdt.rs
+++ b/examples/basic_cdt.rs
@@ -76,11 +76,11 @@ fn main() -> CdtResult<()> {
         for measurement in results.measurements().iter().take(5) {
             info!(
                 "  Step {}: Action={:.3}, V={}, E={}, T={}",
-                measurement.step,
-                measurement.action,
-                measurement.vertices,
-                measurement.edges,
-                measurement.triangles
+                measurement.step(),
+                measurement.action(),
+                measurement.vertices().get(),
+                measurement.edges().get(),
+                measurement.triangles().get()
             );
         }
 

--- a/examples/output_and_checkpoint.rs
+++ b/examples/output_and_checkpoint.rs
@@ -2,9 +2,9 @@
 
 //! Example: writing simulation output files and using CDT checkpoints.
 //!
-//! This example runs a short CDT simulation, writes the configured CSV and JSON
-//! outputs, round-trips a Delaunay-valid triangulation checkpoint, and resumes an
-//! in-memory MCMC checkpoint.
+//! This example runs a short CDT simulation, writes the configured trace CSV and
+//! JSON outputs, round-trips a Delaunay-valid triangulation checkpoint, and
+//! resumes an in-memory MCMC checkpoint.
 
 use causal_triangulations::prelude::errors::{CheckpointOperation, OutputFormat};
 use causal_triangulations::prelude::simulation::*;
@@ -17,7 +17,7 @@ use std::process;
 fn main() -> CdtResult<()> {
     let output_dir =
         env::temp_dir().join(format!("causal-triangulations-output-{}", process::id()));
-    let csv_path = output_dir.join("measurements.csv");
+    let csv_path = output_dir.join("trace.csv");
     let json_path = output_dir.join("summary.json");
 
     let config = CdtConfig {
@@ -41,7 +41,9 @@ fn main() -> CdtResult<()> {
         format: OutputFormat::Json,
         detail: err.to_string(),
     })?;
-    assert!(csv.starts_with("step,action,vertices,edges,triangles,accepted,delta_action\n"));
+    assert!(csv.starts_with(
+        "chain_id,step,accepted,proposed,log_prob,action,vertices,edges,triangles,move_family"
+    ));
     assert_eq!(summary["config"]["vertices"], config.vertices().get());
     assert_eq!(
         summary["final_triangulation"]["time_slices"],
@@ -81,7 +83,7 @@ fn main() -> CdtResult<()> {
     )
     .resume_from_checkpoint(mcmc_checkpoint)?;
 
-    println!("CSV output rows: {}", csv.lines().count().saturating_sub(1));
+    println!("Trace CSV rows: {}", csv.lines().count().saturating_sub(1));
     println!(
         "JSON summary measurements: {}",
         summary["measurements"].as_array().map_or(0, Vec::len)

--- a/scripts/run_all_examples.sh
+++ b/scripts/run_all_examples.sh
@@ -190,7 +190,7 @@ validate_example_output() {
 		require_marker "$example" "$output" "Final spectral-dimension estimate"
 		;;
 	output_and_checkpoint)
-		require_marker "$example" "$output" "CSV output rows"
+		require_marker "$example" "$output" "Trace CSV rows"
 		require_marker "$example" "$output" "JSON summary measurements"
 		require_marker "$example" "$output" "Resumed MCMC checkpoint steps"
 		require_marker "$example" "$output" "Output and checkpoint example completed successfully"

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -689,7 +689,7 @@ rules:
         - "/src/cdt/metropolis/**/*.rs"
         - "/tests/semgrep/src/**/*.rs"
     pattern-regex: >-
-      (?s)record_planned_step\([^;]*\)\?;\s*
+      (?ms)^\s*record_planned_step\([^;]*\)\?;\s*
       (?:(?!replace_state\s*\().)*?
       state\.current_step\s*=
 

--- a/src/cdt/action.rs
+++ b/src/cdt/action.rs
@@ -6,6 +6,7 @@
 //! which is based on the Regge calculus formulation of general relativity.
 
 use crate::errors::{CdtError, CdtResult, ConfigurationSetting};
+use num_traits::cast::NumCast;
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// Critical cosmological coupling for pure 1+1 CDT in the triangle-volume convention.
@@ -48,6 +49,12 @@ pub const DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT: f64 =
 ///
 /// The calculated Regge Action value
 ///
+/// # Panics
+///
+/// Panics only if the platform cannot represent a `usize` simplex count as a
+/// finite `f64`. Supported targets represent all `usize` counts as finite
+/// floating-point values, though very large counts may lose integer precision.
+///
 /// # Examples
 ///
 /// ```
@@ -59,16 +66,16 @@ pub const DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT: f64 =
 /// ```
 #[must_use]
 pub fn compute_regge_action(
-    vertices: u32,
-    edges: u32,
-    triangles: u32,
+    vertices: usize,
+    edges: usize,
+    triangles: usize,
     coupling_0: f64,
     coupling_2: f64,
     cosmological_constant: f64,
 ) -> f64 {
-    let n_0 = f64::from(vertices);
-    let n_1 = f64::from(edges);
-    let n_2 = f64::from(triangles);
+    let n_0: f64 = NumCast::from(vertices).expect("usize vertex counts should fit finite f64");
+    let n_1: f64 = NumCast::from(edges).expect("usize edge counts should fit finite f64");
+    let n_2: f64 = NumCast::from(triangles).expect("usize triangle counts should fit finite f64");
 
     cosmological_constant.mul_add(n_1, (-coupling_0).mul_add(n_0, -(coupling_2 * n_2)))
 }
@@ -239,6 +246,12 @@ impl ActionConfig {
 
     /// Calculates the action for given simplex counts.
     ///
+    /// # Panics
+    ///
+    /// Panics only if the platform cannot represent a `usize` simplex count as a
+    /// finite `f64`. Supported targets represent all `usize` counts as finite
+    /// floating-point values, though very large counts may lose integer precision.
+    ///
     /// # Examples
     ///
     /// ```
@@ -251,7 +264,7 @@ impl ActionConfig {
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     #[must_use]
-    pub fn calculate_action(&self, vertices: u32, edges: u32, triangles: u32) -> f64 {
+    pub fn calculate_action(&self, vertices: usize, edges: usize, triangles: usize) -> f64 {
         compute_regge_action(
             vertices,
             edges,
@@ -357,9 +370,9 @@ mod prop_tests {
     proptest! {
         #[test]
         fn action_always_finite(
-            vertices in 0u32..100,
-            edges in 0u32..500,
-            triangles in 0u32..300,
+            vertices in 0usize..100,
+            edges in 0usize..500,
+            triangles in 0usize..300,
             coupling_0 in -10.0f64..10.0,
             coupling_2 in -10.0f64..10.0,
             cosmological_constant in -5.0f64..5.0
@@ -375,9 +388,9 @@ mod prop_tests {
 
         #[test]
         fn action_config_consistency(
-            vertices in 0u32..50,
-            edges in 0u32..150,
-            triangles in 0u32..100,
+            vertices in 0usize..50,
+            edges in 0usize..150,
+            triangles in 0usize..100,
             coupling_0 in -5.0f64..5.0,
             coupling_2 in -5.0f64..5.0,
             cosmological_constant in -2.0f64..2.0

--- a/src/cdt/metropolis/checkpoint.rs
+++ b/src/cdt/metropolis/checkpoint.rs
@@ -4,7 +4,10 @@
 
 use crate::cdt::action::ActionConfig;
 use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveStatistics, MoveType};
-use crate::cdt::results::{Measurement, SimulationResultsBackend, SimulationResultsParts};
+use crate::cdt::results::{
+    CdtScalarTraceRow, Measurement, SimulationResultsBackend, SimulationResultsParts,
+    validate_scalar_trace_rows,
+};
 use crate::errors::{
     CdtError, CdtResult, CheckpointMoveCounter, CheckpointResumeFailure, ProposalTelemetryCounter,
 };
@@ -32,6 +35,7 @@ pub(crate) struct CdtMcmcCheckpointParts {
     pub(crate) proposal_stats: ProposalStatistics,
     pub(crate) steps: Vec<MonteCarloStep>,
     pub(crate) measurements: Vec<Measurement>,
+    pub(crate) scalar_trace_rows: Vec<CdtScalarTraceRow>,
     pub(crate) elapsed_time: Duration,
     pub(crate) acceptance_rng: Xoshiro256PlusPlus,
     pub(crate) ergodics: ErgodicsSystem,
@@ -82,6 +86,7 @@ pub struct CdtMcmcCheckpoint {
     pub(crate) proposal_stats: ProposalStatistics,
     pub(crate) steps: Vec<MonteCarloStep>,
     pub(crate) measurements: Vec<Measurement>,
+    pub(crate) scalar_trace_rows: Vec<CdtScalarTraceRow>,
     pub(crate) elapsed_time: Duration,
     pub(crate) acceptance_rng: Xoshiro256PlusPlus,
     pub(crate) ergodics: ErgodicsSystem,
@@ -99,6 +104,7 @@ struct CdtMcmcCheckpointWire {
     proposal_stats: ProposalStatistics,
     steps: Vec<MonteCarloStep>,
     measurements: Vec<Measurement>,
+    scalar_trace_rows: Vec<CdtScalarTraceRow>,
     elapsed_time: Duration,
     acceptance_rng: Xoshiro256PlusPlus,
     ergodics: ErgodicsSystem,
@@ -122,6 +128,7 @@ impl<'de> Deserialize<'de> for CdtMcmcCheckpoint {
             proposal_stats: wire.proposal_stats,
             steps: wire.steps,
             measurements: wire.measurements,
+            scalar_trace_rows: wire.scalar_trace_rows,
             elapsed_time: wire.elapsed_time,
             acceptance_rng: wire.acceptance_rng,
             ergodics: wire.ergodics,
@@ -143,6 +150,7 @@ impl CdtMcmcCheckpoint {
             proposal_stats: parts.proposal_stats,
             steps: parts.steps,
             measurements: parts.measurements,
+            scalar_trace_rows: parts.scalar_trace_rows,
             elapsed_time: parts.elapsed_time,
             acceptance_rng: parts.acceptance_rng,
             ergodics: parts.ergodics,
@@ -420,7 +428,7 @@ impl CdtMcmcCheckpoint {
     /// .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)
     /// # }
     /// # let checkpoint = checkpoint()?;
-    /// assert_eq!(checkpoint.measurements().first().map(|m| m.step), Some(0));
+    /// assert_eq!(checkpoint.measurements().first().map(|m| m.step()), Some(0));
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     #[must_use]
@@ -463,6 +471,7 @@ impl CdtMcmcCheckpoint {
             proposal_stats: self.proposal_stats,
             steps: self.steps,
             measurements: self.measurements,
+            scalar_trace_rows: self.scalar_trace_rows,
             elapsed_time: self.elapsed_time,
             triangulation,
         })
@@ -568,6 +577,12 @@ pub(crate) fn validate_checkpoint_counters(checkpoint: &CdtMcmcCheckpoint) -> Cd
     validate_checkpoint_proposal_stats(checkpoint, accepted, rejected)?;
     validate_checkpoint_steps(checkpoint)?;
     validate_checkpoint_measurements(checkpoint)?;
+    validate_scalar_trace_rows(
+        &checkpoint.config,
+        &checkpoint.proposal_stats,
+        &checkpoint.steps,
+        &checkpoint.scalar_trace_rows,
+    )?;
     Ok(())
 }
 
@@ -637,7 +652,11 @@ fn validate_checkpoint_proposal_stats(
 
 /// Checks that serialized per-step telemetry forms the exact prefix being resumed.
 fn validate_checkpoint_steps(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
-    let accepted_steps = checkpoint.steps.iter().filter(|step| step.accepted).count();
+    let accepted_steps = checkpoint
+        .steps
+        .iter()
+        .filter(|step| step.accepted())
+        .count();
     if accepted_steps != checkpoint.chain.accepted() {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::StepTelemetryAcceptedCountMismatch {
@@ -651,7 +670,7 @@ fn validate_checkpoint_steps(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
         let expected_step = u32::try_from(index + 1).map_err(|_| {
             checkpoint_resume_failed(CheckpointResumeFailure::StepTelemetryIndexOverflow)
         })?;
-        let step_number = step.step.get();
+        let step_number = step.step().get();
         if step_number != expected_step {
             return Err(checkpoint_resume_failed(
                 CheckpointResumeFailure::StepTelemetrySequenceMismatch {
@@ -659,50 +678,6 @@ fn validate_checkpoint_steps(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
                     expected: expected_step,
                 },
             ));
-        }
-        if !step.action_before.is_finite() {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::NonFiniteStepActionBefore { step: step_number },
-            ));
-        }
-        if let Some(delta_action) = step.delta_action
-            && !delta_action.is_finite()
-        {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::NonFiniteStepDeltaAction { step: step_number },
-            ));
-        }
-        if step.accepted && step.delta_action.is_none() {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::AcceptedStepMissingDeltaAction { step: step_number },
-            ));
-        }
-        match (step.accepted, step.action_after) {
-            (true, Some(action_after)) if action_after.is_finite() => {
-                if let Some(delta_action) = step.delta_action
-                    && !actions_match(action_after, step.action_before + delta_action)
-                {
-                    return Err(checkpoint_resume_failed(
-                        CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: step_number },
-                    ));
-                }
-            }
-            (true, Some(_)) => {
-                return Err(checkpoint_resume_failed(
-                    CheckpointResumeFailure::NonFiniteStepActionAfter { step: step_number },
-                ));
-            }
-            (true, None) => {
-                return Err(checkpoint_resume_failed(
-                    CheckpointResumeFailure::AcceptedStepMissingActionAfter { step: step_number },
-                ));
-            }
-            (false, Some(_)) => {
-                return Err(checkpoint_resume_failed(
-                    CheckpointResumeFailure::RejectedStepHasActionAfter { step: step_number },
-                ));
-            }
-            (false, None) => {}
         }
     }
     Ok(())
@@ -734,18 +709,11 @@ fn validate_checkpoint_measurements(checkpoint: &CdtMcmcCheckpoint) -> CdtResult
         .ok_or_else(|| {
             checkpoint_resume_failed(CheckpointResumeFailure::MeasurementStepOverflow)
         })?;
-        if measurement.step != expected_step {
+        if measurement.step() != expected_step {
             return Err(checkpoint_resume_failed(
                 CheckpointResumeFailure::MeasurementStepMismatch {
-                    actual: measurement.step,
+                    actual: measurement.step(),
                     expected: expected_step,
-                },
-            ));
-        }
-        if !measurement.action.is_finite() {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::NonFiniteMeasurementAction {
-                    step: measurement.step,
                 },
             ));
         }

--- a/src/cdt/metropolis/helpers.rs
+++ b/src/cdt/metropolis/helpers.rs
@@ -122,8 +122,8 @@ pub fn measurement_for(
     triangulation: &CdtTriangulation2D,
 ) -> CdtResult<Measurement> {
     let counts = triangulation.simplex_counts()?;
-    Ok(Measurement::try_from_simplex_counts(step, action, counts)?
-        .with_volume_profile(triangulation.volume_profile()))
+    Measurement::try_from_simplex_counts(step, action, counts)?
+        .try_with_volume_profile(triangulation.volume_profile())
 }
 
 /// Returns true when a completed step is on the post-thermalization measurement cadence.

--- a/src/cdt/metropolis/helpers.rs
+++ b/src/cdt/metropolis/helpers.rs
@@ -8,17 +8,16 @@ use crate::cdt::results::Measurement;
 use crate::config::validate_schedule;
 use crate::errors::{CdtError, CdtResult, ConfigurationSetting};
 use crate::geometry::CdtTriangulation2D;
-use crate::util::saturating_usize_to_u32;
 use std::num::NonZeroU32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SimplexCounts {
     /// Number of vertices in the live CDT triangulation.
-    pub vertices: u32,
+    pub vertices: usize,
     /// Number of edges in the live CDT triangulation.
-    pub edges: u32,
+    pub edges: usize,
     /// Number of triangular 2-simplices in the live CDT triangulation.
-    pub triangles: u32,
+    pub triangles: usize,
 }
 
 /// Adapts shared schedule validation errors to the Metropolis-specific error variant.
@@ -86,13 +85,13 @@ pub fn validate_temperature(temperature: f64) -> CdtResult<()> {
 
 /// Reads simplex counts through the CDT wrapper for action and measurement code.
 ///
-/// Centralizing these conversions keeps cached query paths authoritative and
-/// makes integer saturation explicit at the simulation boundary.
+/// Centralizing these reads keeps cached query paths authoritative for action,
+/// measurement, and trace telemetry.
 pub fn simplex_counts(triangulation: &CdtTriangulation2D) -> SimplexCounts {
     SimplexCounts {
-        vertices: saturating_usize_to_u32(triangulation.vertex_count()),
-        edges: saturating_usize_to_u32(triangulation.edge_count()),
-        triangles: saturating_usize_to_u32(triangulation.face_count()),
+        vertices: triangulation.vertex_count(),
+        edges: triangulation.edge_count(),
+        triangles: triangulation.face_count(),
     }
 }
 
@@ -109,16 +108,22 @@ pub fn action_for(action_config: &ActionConfig, triangulation: &CdtTriangulation
 ///
 /// Keeping measurement construction in one helper ensures recorded actions and
 /// simplex counts use the same query path at every measurement step.
-pub fn measurement_for(step: u32, action: f64, triangulation: &CdtTriangulation2D) -> Measurement {
-    let counts = simplex_counts(triangulation);
-    Measurement {
-        step,
-        action,
-        vertices: counts.vertices,
-        edges: counts.edges,
-        triangles: counts.triangles,
-        volume_profile: triangulation.volume_profile(),
-    }
+///
+/// # Errors
+///
+/// Returns [`CdtError::InvalidSimplexCount`] if the live triangulation reports
+/// zero vertices, edges, or triangles,
+/// [`CdtError::MeasurementCountOverflow`] if any live count cannot fit compact
+/// measurement storage, or [`CdtError::InvalidMeasurementAction`] if `action` is
+/// not finite.
+pub fn measurement_for(
+    step: u32,
+    action: f64,
+    triangulation: &CdtTriangulation2D,
+) -> CdtResult<Measurement> {
+    let counts = triangulation.simplex_counts()?;
+    Ok(Measurement::try_from_simplex_counts(step, action, counts)?
+        .with_volume_profile(triangulation.volume_profile()))
 }
 
 /// Returns true when a completed step is on the post-thermalization measurement cadence.

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -12,7 +12,9 @@
 
 use crate::cdt::action::ActionConfig;
 use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveStatistics, MoveType};
-use crate::cdt::results::{Measurement, SimulationResultsBackend};
+use crate::cdt::results::{
+    CdtScalarTraceOutcome, CdtScalarTraceRow, Measurement, SimulationResultsBackend,
+};
 use crate::cdt::triangulation::SimulationEvent;
 use crate::errors::{
     CdtError, CdtResult, CheckpointResumeFailure, ConfigurationSetting,
@@ -37,7 +39,7 @@ use super::checkpoint::{
 use super::helpers::{
     action_for, actions_match, measurement_for, measurement_is_due, validate_metropolis_schedule,
 };
-use super::telemetry::{MonteCarloStep, ProposalStatistics};
+use super::telemetry::{MonteCarloStep, MonteCarloStepOutcome, ProposalStatistics};
 
 /// Validated configuration for the Metropolis-Hastings algorithm.
 ///
@@ -367,6 +369,7 @@ struct MetropolisRunState {
     proposal_stats: ProposalStatistics,
     steps: Vec<MonteCarloStep>,
     measurements: Vec<Measurement>,
+    scalar_trace_rows: Vec<CdtScalarTraceRow>,
     elapsed_time: Duration,
 }
 
@@ -427,8 +430,13 @@ impl MetropolisAlgorithm {
     /// [`CdtError::MetropolisMoveApplicationFailed`] if an accepted move causes
     /// a hard backend mutation failure,
     /// [`CdtError::PlannedProposalTelemetryMissing`] if the upstream sampler
-    /// omits CDT step metadata or accepted-step action evidence, or a validation
-    /// error for unrecoverable triangulation failures.
+    /// omits CDT step metadata or accepted-step action evidence,
+    /// [`CdtError::InvalidSimplexCount`] if a live triangulation has zero
+    /// vertices, edges, or triangles,
+    /// [`CdtError::MeasurementCountOverflow`] if a measurement count cannot fit
+    /// compact telemetry storage, [`CdtError::InvalidMeasurementAction`] if a
+    /// measurement action is non-finite, or a validation error for unrecoverable
+    /// triangulation failures.
     ///
     /// # Examples
     ///
@@ -466,8 +474,13 @@ impl MetropolisAlgorithm {
     /// [`CdtError::MetropolisMoveApplicationFailed`] if an accepted move causes
     /// a hard backend mutation failure,
     /// [`CdtError::PlannedProposalTelemetryMissing`] if the upstream sampler
-    /// omits CDT step metadata or accepted-step action evidence, or a validation
-    /// error for unrecoverable triangulation failures.
+    /// omits CDT step metadata or accepted-step action evidence,
+    /// [`CdtError::InvalidSimplexCount`] if a live triangulation has zero
+    /// vertices, edges, or triangles,
+    /// [`CdtError::MeasurementCountOverflow`] if a measurement count cannot fit
+    /// compact telemetry storage, [`CdtError::InvalidMeasurementAction`] if a
+    /// measurement action is non-finite, or a validation error for unrecoverable
+    /// triangulation failures.
     ///
     /// # Examples
     ///
@@ -518,8 +531,13 @@ impl MetropolisAlgorithm {
     /// [`CdtError::MetropolisMoveApplicationFailed`] if an accepted move causes
     /// a hard backend mutation failure,
     /// [`CdtError::PlannedProposalTelemetryMissing`] if the upstream sampler
-    /// omits CDT step metadata or accepted-step action evidence, or a validation
-    /// error for unrecoverable triangulation failures.
+    /// omits CDT step metadata or accepted-step action evidence,
+    /// [`CdtError::InvalidSimplexCount`] if a live triangulation has zero
+    /// vertices, edges, or triangles,
+    /// [`CdtError::MeasurementCountOverflow`] if a measurement count cannot fit
+    /// compact telemetry storage, [`CdtError::InvalidMeasurementAction`] if a
+    /// measurement action is non-finite, or a validation error for unrecoverable
+    /// triangulation failures.
     ///
     /// # Examples
     ///
@@ -547,7 +565,7 @@ impl MetropolisAlgorithm {
         self.config.validate();
         self.action_config.validate();
 
-        let mut state = self.initial_state(triangulation);
+        let mut state = self.initial_state(triangulation)?;
         self.run_steps(&mut state, self.config.steps)?;
         state.into_checkpoint(self.config.clone(), self.action_config.clone())
     }
@@ -567,8 +585,13 @@ impl MetropolisAlgorithm {
     /// with this algorithm or internally inconsistent. Returns
     /// [`CdtError::MetropolisMoveApplicationFailed`],
     /// [`CdtError::PlannedProposalTelemetryMissing`] if resumed sampling omits
-    /// CDT step metadata or accepted-step action evidence, or validation errors
-    /// for failures during resumed sampling.
+    /// CDT step metadata or accepted-step action evidence,
+    /// [`CdtError::InvalidSimplexCount`] if a resumed live triangulation has zero
+    /// vertices, edges, or triangles,
+    /// [`CdtError::MeasurementCountOverflow`] if a resumed measurement count
+    /// cannot fit compact telemetry storage,
+    /// [`CdtError::InvalidMeasurementAction`] if a resumed measurement action is
+    /// non-finite, or validation errors for failures during resumed sampling.
     ///
     /// # Examples
     ///
@@ -622,8 +645,13 @@ impl MetropolisAlgorithm {
     /// with this algorithm or internally inconsistent. Returns
     /// [`CdtError::MetropolisMoveApplicationFailed`],
     /// [`CdtError::PlannedProposalTelemetryMissing`] if resumed sampling omits
-    /// CDT step metadata or accepted-step action evidence, or validation errors
-    /// for failures during resumed sampling.
+    /// CDT step metadata or accepted-step action evidence,
+    /// [`CdtError::InvalidSimplexCount`] if a resumed live triangulation has zero
+    /// vertices, edges, or triangles,
+    /// [`CdtError::MeasurementCountOverflow`] if a resumed measurement count
+    /// cannot fit compact telemetry storage,
+    /// [`CdtError::InvalidMeasurementAction`] if a resumed measurement action is
+    /// non-finite, or validation errors for failures during resumed sampling.
     ///
     /// # Examples
     ///
@@ -673,7 +701,10 @@ impl MetropolisAlgorithm {
         state.into_checkpoint(result_config, self.action_config.clone())
     }
 
-    fn initial_state(&self, mut triangulation: CdtTriangulation2D) -> MetropolisRunState {
+    fn initial_state(
+        &self,
+        mut triangulation: CdtTriangulation2D,
+    ) -> CdtResult<MetropolisRunState> {
         let current_action = action_for(&self.action_config, &triangulation);
         let mut measurements = Vec::new();
         if measurement_is_due(
@@ -681,14 +712,14 @@ impl MetropolisAlgorithm {
             self.config.thermalization_steps(),
             self.config.measurement_frequency(),
         ) {
-            measurements.push(measurement_for(0, current_action, &triangulation));
+            measurements.push(measurement_for(0, current_action, &triangulation)?);
             triangulation.record_event(SimulationEvent::MeasurementTaken {
                 step: 0,
                 action: current_action,
             });
         }
 
-        MetropolisRunState {
+        Ok(MetropolisRunState {
             triangulation,
             current_step: 0,
             current_action,
@@ -700,8 +731,9 @@ impl MetropolisAlgorithm {
             proposal_stats: ProposalStatistics::new(),
             steps: Vec::new(),
             measurements,
+            scalar_trace_rows: Vec::new(),
             elapsed_time: Duration::ZERO,
-        }
+        })
     }
 
     /// Advances mutable run state through the planned-proposal sampler.
@@ -813,6 +845,7 @@ impl MetropolisRunState {
             proposal_stats: checkpoint.proposal_stats,
             steps: checkpoint.steps,
             measurements: checkpoint.measurements,
+            scalar_trace_rows: checkpoint.scalar_trace_rows,
             elapsed_time: checkpoint.elapsed_time,
         })
     }
@@ -847,6 +880,7 @@ impl MetropolisRunState {
             proposal_stats: self.proposal_stats,
             steps: self.steps,
             measurements: self.measurements,
+            scalar_trace_rows: self.scalar_trace_rows,
             elapsed_time: self.elapsed_time,
             acceptance_rng: self.acceptance_rng,
             ergodics: self.ergodics,
@@ -897,6 +931,50 @@ struct PlannedStepRecord<'a> {
     triangulation: &'a CdtTriangulation2D,
 }
 
+/// Converts upstream step outcomes into CDT scalar trace outcomes.
+const fn scalar_trace_outcome_for_step(
+    step: u32,
+    outcome: StepOutcome,
+) -> CdtResult<CdtScalarTraceOutcome> {
+    match outcome {
+        StepOutcome::Accepted => Ok(CdtScalarTraceOutcome::Accepted),
+        StepOutcome::RejectedProposal => Ok(CdtScalarTraceOutcome::RejectedProposal),
+        StepOutcome::NoProposal => Ok(CdtScalarTraceOutcome::NoProposal),
+        outcome => Err(CdtError::UnexpectedPlannedStepOutcome { step, outcome }),
+    }
+}
+
+/// Builds validated public step telemetry outcome from upstream planned-step data.
+fn step_outcome_for_trace(
+    config: &MetropolisConfig,
+    step: NonZeroU32,
+    trace_outcome: CdtScalarTraceOutcome,
+    action_before: f64,
+    log_prob_after: Option<f64>,
+    info: &CdtProposalInfo,
+) -> CdtResult<MonteCarloStepOutcome> {
+    match trace_outcome {
+        CdtScalarTraceOutcome::Accepted => {
+            let applied_action = info
+                .action_after
+                .or_else(|| {
+                    log_prob_after.map(|log_prob_after| -config.temperature() * log_prob_after)
+                })
+                .ok_or_else(|| missing_planned_step_info(step.get()))?;
+            MonteCarloStepOutcome::accepted_transition(
+                step,
+                action_before,
+                applied_action,
+                applied_action - action_before,
+            )
+        }
+        CdtScalarTraceOutcome::RejectedProposal => {
+            MonteCarloStepOutcome::rejected_proposal(step, info.delta_action)
+        }
+        CdtScalarTraceOutcome::NoProposal => Ok(MonteCarloStepOutcome::NoProposal),
+    }
+}
+
 /// Apply one planned-step record to CDT run state and public telemetry.
 ///
 /// Accepted steps may reconstruct `action_after` from upstream log-probability
@@ -919,22 +997,17 @@ fn record_planned_step_parts(
     } = record;
     let move_type = info.move_type;
     let action_before = state.current_action;
-    let accepted = outcome == StepOutcome::Accepted;
-    let action_after = if accepted {
-        Some(
-            info.action_after
-                .or_else(|| {
-                    log_prob_after
-                        .map(|log_prob_after| -algorithm.config.temperature() * log_prob_after)
-                })
-                .ok_or_else(|| missing_planned_step_info(step.get()))?,
-        )
-    } else {
-        None
-    };
-    let delta_action = action_after.map_or(info.delta_action, |applied_action| {
-        Some(applied_action - action_before)
-    });
+    let trace_outcome = scalar_trace_outcome_for_step(step.get(), outcome)?;
+    let step_outcome = step_outcome_for_trace(
+        &algorithm.config,
+        step,
+        trace_outcome,
+        action_before,
+        log_prob_after,
+        &info,
+    )?;
+    let action_after = step_outcome.action_after();
+    let delta_action = step_outcome.delta_action();
 
     state.move_stats.record_attempt(move_type);
     if let Some(applied_action) = action_after {
@@ -961,20 +1034,32 @@ fn record_planned_step_parts(
         validate_evolved_cdt_if_due(state)?;
     }
     state.proposal_stats.extend(proposal_stats);
-    if outcome == StepOutcome::Accepted {
-        state.proposal_stats.record_accepted_transition();
-    } else if outcome == StepOutcome::RejectedProposal {
-        state.proposal_stats.record_metropolis_rejection();
+    match trace_outcome {
+        CdtScalarTraceOutcome::Accepted => state.proposal_stats.record_accepted_transition(),
+        CdtScalarTraceOutcome::RejectedProposal => {
+            state.proposal_stats.record_metropolis_rejection();
+        }
+        CdtScalarTraceOutcome::NoProposal => {}
     }
 
-    state.steps.push(MonteCarloStep {
+    state.steps.push(MonteCarloStep::new(
         step,
         move_type,
-        accepted,
+        action_before,
+        step_outcome,
+    )?);
+    state.scalar_trace_rows.push(CdtScalarTraceRow::new(
+        step,
+        trace_outcome,
+        -state.current_action / algorithm.config.temperature(),
+        state.current_action,
+        &state.triangulation,
+        move_type,
+        delta_action,
         action_before,
         action_after,
-        delta_action,
-    });
+        algorithm.config.seed(),
+    )?);
 
     if measurement_is_due(
         step.get(),
@@ -985,7 +1070,7 @@ fn record_planned_step_parts(
             step.get(),
             state.current_action,
             &state.triangulation,
-        ));
+        )?);
         state
             .triangulation
             .record_event(SimulationEvent::MeasurementTaken {
@@ -1001,8 +1086,8 @@ fn record_planned_step_parts(
 ///
 /// Proposal-stage errors preserve move-family context through
 /// [`CdtError::MetropolisMoveApplicationFailed`]. Future upstream variants use
-/// [`CdtError::PlannedProposalStepFailed`] so they remain distinct from CDT's
-/// own missing-telemetry invariant.
+/// [`CdtError::PlannedProposalStepFailed`] so they remain distinct from CDT's own
+/// missing-telemetry and unsupported-outcome invariants.
 fn planned_step_error(step: u32, error: DelayedStepError<CdtProposalError>) -> CdtError {
     match error {
         DelayedStepError::Mcmc(err) => CdtError::Mcmc(err),
@@ -1116,6 +1201,37 @@ mod tests {
 
     fn step_number(step: u32) -> NonZeroU32 {
         NonZeroU32::new(step).expect("test step number should be nonzero")
+    }
+
+    fn accepted_step(
+        step: u32,
+        move_type: MoveType,
+        action_before: f64,
+        action_after: f64,
+    ) -> MonteCarloStep {
+        MonteCarloStep::accepted_step(
+            step_number(step),
+            move_type,
+            action_before,
+            action_after,
+            action_after - action_before,
+        )
+        .expect("test accepted step should satisfy action invariants")
+    }
+
+    fn rejected_proposal_step(
+        step: u32,
+        move_type: MoveType,
+        action_before: f64,
+        delta_action: Option<f64>,
+    ) -> MonteCarloStep {
+        MonteCarloStep::rejected_proposal(step_number(step), move_type, action_before, delta_action)
+            .expect("test rejected step should satisfy action invariants")
+    }
+
+    fn no_proposal_step(step: u32, move_type: MoveType, action_before: f64) -> MonteCarloStep {
+        MonteCarloStep::no_proposal(step_number(step), move_type, action_before)
+            .expect("test no-proposal step should satisfy action invariants")
     }
 
     fn assert_optional_relative_eq(left: Option<f64>, right: Option<f64>) {
@@ -1272,7 +1388,9 @@ mod tests {
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let config = seeded_metropolis_config(1.0, 1, 0, 1, 13);
         let algorithm = MetropolisAlgorithm::new(config.clone(), action_config.clone());
-        let mut state = algorithm.initial_state(triangulation);
+        let mut state = algorithm
+            .initial_state(triangulation)
+            .expect("initial state should build");
         let move_type = state.ergodics.select_random_move();
         let _acceptance_rng_marker: f64 = state.acceptance_rng.random();
 
@@ -1280,26 +1398,38 @@ mod tests {
         state
             .triangulation
             .record_event(SimulationEvent::MoveAttempted { move_type, step: 1 });
-        state.steps.push(MonteCarloStep {
-            step: step_number(1),
+        state.steps.push(rejected_proposal_step(
+            1,
             move_type,
-            accepted: false,
-            action_before: state.current_action,
-            action_after: None,
-            delta_action: proposed_delta_action(
+            state.current_action,
+            proposed_delta_action(
                 &action_config,
                 simplex_counts(&state.triangulation),
                 move_type,
             ),
-        });
+        ));
         state.current_step = 1;
         state.proposal_stats.record_move_family(1);
         state.proposal_stats.record_metropolis_rejection();
-        state.measurements.push(measurement_for(
-            1,
-            state.current_action,
-            &state.triangulation,
-        ));
+        state.scalar_trace_rows.push(
+            CdtScalarTraceRow::new(
+                step_number(1),
+                CdtScalarTraceOutcome::RejectedProposal,
+                -state.current_action / config.temperature(),
+                state.current_action,
+                &state.triangulation,
+                move_type,
+                state.steps[0].delta_action(),
+                state.current_action,
+                None,
+                config.seed(),
+            )
+            .expect("trace row should build"),
+        );
+        state.measurements.push(
+            measurement_for(1, state.current_action, &state.triangulation)
+                .expect("measurement should build"),
+        );
         state
             .triangulation
             .record_event(SimulationEvent::MeasurementTaken {
@@ -1318,12 +1448,19 @@ mod tests {
         let config = seeded_metropolis_config(1.0, 1, 0, 1, 13);
         let action_config = ActionConfig::default();
         let current_action = action_for(&action_config, &triangulation);
+        let temperature = config.temperature();
+        let seed = config.seed();
         let move_type = MoveType::Move22;
         let mut move_stats = MoveStatistics::new();
         move_stats.record_attempt(move_type);
         if accepted {
             move_stats.record_success(move_type);
         }
+        let outcome = if accepted {
+            CdtScalarTraceOutcome::Accepted
+        } else {
+            CdtScalarTraceOutcome::RejectedProposal
+        };
 
         CdtMcmcCheckpoint::from_parts(CdtMcmcCheckpointParts {
             triangulation: triangulation.clone(),
@@ -1339,17 +1476,31 @@ mod tests {
             } else {
                 ProposalStatistics::from_validated_parts(1, 1, 0, 0, 0, 0, 1, 0, 0)
             },
-            steps: vec![MonteCarloStep {
-                step: step_number(1),
-                move_type,
-                accepted,
-                action_before: current_action,
-                action_after: accepted.then_some(current_action),
-                delta_action: accepted.then_some(0.0),
+            steps: vec![if accepted {
+                accepted_step(1, move_type, current_action, current_action)
+            } else {
+                rejected_proposal_step(1, move_type, current_action, None)
             }],
             measurements: vec![
-                measurement_for(0, current_action, &triangulation),
-                measurement_for(1, current_action, &triangulation),
+                measurement_for(0, current_action, &triangulation)
+                    .expect("initial measurement should build"),
+                measurement_for(1, current_action, &triangulation)
+                    .expect("step measurement should build"),
+            ],
+            scalar_trace_rows: vec![
+                CdtScalarTraceRow::new(
+                    step_number(1),
+                    outcome,
+                    -current_action / temperature,
+                    current_action,
+                    &triangulation,
+                    move_type,
+                    accepted.then_some(0.0),
+                    current_action,
+                    accepted.then_some(current_action),
+                    seed,
+                )
+                .expect("trace row should build"),
             ],
             elapsed_time: Duration::ZERO,
             acceptance_rng: simulation_rng(Some(1)),
@@ -1369,6 +1520,7 @@ mod tests {
             proposal_stats: ProposalStatistics::new(),
             steps: Vec::new(),
             measurements: Vec::new(),
+            scalar_trace_rows: Vec::new(),
             elapsed_time: Duration::ZERO,
         }
     }
@@ -1492,9 +1644,9 @@ mod tests {
 
         let geometry = triangulation.geometry();
         let action = action_config.calculate_action(
-            u32::try_from(geometry.vertex_count()).unwrap_or_default(),
-            u32::try_from(geometry.edge_count()).unwrap_or_default(),
-            u32::try_from(geometry.face_count()).unwrap_or_default(),
+            geometry.vertex_count(),
+            geometry.edge_count(),
+            geometry.face_count(),
         );
 
         // Since we're using a random triangulation, just verify it returns a finite value
@@ -1515,9 +1667,9 @@ mod tests {
         // log_prob = -action/T, so with T=1 it should be the negative of the action
         let g = triangulation.geometry();
         let action = ActionConfig::default().calculate_action(
-            u32::try_from(g.vertex_count()).unwrap_or_default(),
-            u32::try_from(g.edge_count()).unwrap_or_default(),
-            u32::try_from(g.face_count()).unwrap_or_default(),
+            g.vertex_count(),
+            g.edge_count(),
+            g.face_count(),
         );
         assert_relative_eq!(log_prob, -action);
     }
@@ -1540,10 +1692,10 @@ mod tests {
             results.acceptance_rate()
         );
         assert!(results.measurements().iter().all(|measurement| {
-            measurement.action.is_finite()
-                && measurement.vertices > 0
-                && measurement.edges > 0
-                && measurement.triangles > 0
+            measurement.action().is_finite()
+                && measurement.vertices().get() > 0
+                && measurement.edges().get() > 0
+                && measurement.triangles().get() > 0
         }));
     }
 
@@ -1560,7 +1712,7 @@ mod tests {
         let measurement_steps = results
             .measurements()
             .iter()
-            .map(|measurement| measurement.step)
+            .map(Measurement::step)
             .collect::<Vec<_>>();
 
         assert_eq!(measurement_steps, vec![2, 4]);
@@ -1568,7 +1720,7 @@ mod tests {
             results
                 .measurements()
                 .iter()
-                .all(|measurement| measurement.step >= results.config().thermalization_steps())
+                .all(|measurement| measurement.step() >= results.config().thermalization_steps())
         );
     }
 
@@ -1632,10 +1784,10 @@ mod tests {
             checkpoint.proposal_stats().move_family_proposals(),
             u64::from(checkpoint.current_step().get())
         );
-        assert_eq!(last_step.step, checkpoint.current_step());
-        assert_eq!(last_measurement.step, checkpoint.current_step().get());
+        assert_eq!(last_step.step(), checkpoint.current_step());
+        assert_eq!(last_measurement.step(), checkpoint.current_step().get());
         assert_relative_eq!(
-            last_measurement.action,
+            last_measurement.action(),
             checkpoint.current_action(),
             epsilon = 1e-12
         );
@@ -1665,7 +1817,7 @@ mod tests {
 
         assert_eq!(first_resumed.config().steps().get(), 7);
         assert_eq!(first_resumed.steps().len(), 7);
-        assert_eq!(first_resumed.steps()[1].step.get(), 2);
+        assert_eq!(first_resumed.steps()[1].step().get(), 2);
         first_resumed
             .triangulation()
             .validate_topology()
@@ -1816,6 +1968,84 @@ mod tests {
 
         assert!(
             error.to_string().contains("nonzero") || error.to_string().contains("invalid value"),
+            "unexpected serde error: {error}"
+        );
+    }
+
+    #[test]
+    fn serialized_checkpoint_rejects_zero_scalar_trace_step() {
+        let checkpoint = serializable_rejected_checkpoint(ActionConfig::default());
+        let mut payload = to_value(&checkpoint).expect("checkpoint should serialize");
+        payload["scalar_trace_rows"][0]["step"] = to_value(0_u32).expect("step should serialize");
+
+        let Err(error) = from_str::<CdtMcmcCheckpoint>(&payload.to_string()) else {
+            panic!("zero scalar trace step should fail while parsing checkpoint");
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("scalar trace step must be nonzero"),
+            "unexpected serde error: {error}"
+        );
+    }
+
+    #[test]
+    fn serialized_checkpoint_rejects_zero_measurement_counts_by_field() {
+        let checkpoint = serializable_rejected_checkpoint(ActionConfig::default());
+
+        for field in ["vertices", "edges", "triangles"] {
+            let mut payload = to_value(&checkpoint).expect("checkpoint should serialize");
+            payload["measurements"][0][field] = to_value(0_u32).expect("count should serialize");
+
+            let Err(error) = from_str::<CdtMcmcCheckpoint>(&payload.to_string()) else {
+                panic!("zero measurement count should fail while parsing checkpoint");
+            };
+            let message = error.to_string();
+            assert!(
+                message.contains("Invalid measurement count") && message.contains(field),
+                "unexpected serde error for {field}: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn serialized_checkpoint_rejects_zero_scalar_trace_counts_by_field() {
+        let checkpoint = serializable_rejected_checkpoint(ActionConfig::default());
+
+        for field in ["vertices", "edges", "triangles"] {
+            let mut payload = to_value(&checkpoint).expect("checkpoint should serialize");
+            payload["scalar_trace_rows"][0][field] =
+                to_value(0_u32).expect("count should serialize");
+
+            let Err(error) = from_str::<CdtMcmcCheckpoint>(&payload.to_string()) else {
+                panic!("zero scalar trace count should fail while parsing checkpoint");
+            };
+            let message = error.to_string();
+            assert!(
+                message.contains("Invalid measurement count") && message.contains(field),
+                "unexpected serde error for {field}: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn serialized_checkpoint_rejects_missing_scalar_trace_rows() {
+        let checkpoint = serializable_rejected_checkpoint(ActionConfig::default());
+        let mut payload = to_value(&checkpoint).expect("checkpoint should serialize");
+        payload
+            .as_object_mut()
+            .expect("checkpoint payload should be an object")
+            .remove("scalar_trace_rows");
+
+        let Err(error) = from_str::<CdtMcmcCheckpoint>(&payload.to_string()) else {
+            panic!("missing scalar trace rows should fail while parsing checkpoint");
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing field `scalar_trace_rows`"),
             "unexpected serde error: {error}"
         );
     }
@@ -2010,7 +2240,9 @@ mod tests {
     #[test]
     fn resume_rejects_nonsequential_step_telemetry() {
         let mut checkpoint = short_checkpoint();
-        checkpoint.steps[0].step = step_number(2);
+        let move_type = checkpoint.steps[0].move_type();
+        let action_before = checkpoint.steps[0].action_before();
+        checkpoint.steps[0] = no_proposal_step(2, move_type, action_before);
         let algorithm = MetropolisAlgorithm::new(
             seeded_metropolis_config(1.0, 2, 0, 1, 999),
             ActionConfig::default(),
@@ -2030,16 +2262,13 @@ mod tests {
 
     #[test]
     fn resume_rejects_step_acceptance_counter_mismatch() {
-        let mut checkpoint = short_checkpoint();
-        if let Some(step) = checkpoint.steps.iter_mut().find(|step| step.accepted) {
-            step.accepted = false;
-            step.action_after = None;
-        } else {
-            let step = &mut checkpoint.steps[0];
-            step.accepted = true;
-            step.delta_action = Some(0.0);
-            step.action_after = Some(step.action_before);
-        }
+        let mut checkpoint = synthetic_one_step_checkpoint(true);
+        checkpoint.steps[0] = rejected_proposal_step(
+            1,
+            checkpoint.steps[0].move_type(),
+            checkpoint.current_action,
+            None,
+        );
         let algorithm = MetropolisAlgorithm::new(
             seeded_metropolis_config(1.0, 2, 0, 1, 999),
             ActionConfig::default(),
@@ -2118,121 +2347,60 @@ mod tests {
     }
 
     #[test]
-    fn resume_rejects_nonfinite_step_action_before() {
-        let mut checkpoint = synthetic_one_step_checkpoint(true);
-        checkpoint.steps[0].action_before = f64::NAN;
+    fn step_constructor_rejects_nonfinite_action_before() {
+        let error = MonteCarloStep::no_proposal(step_number(1), MoveType::Move22, f64::NAN)
+            .expect_err("non-finite action_before should be rejected before storage");
 
-        assert_checkpoint_resume_failed(
-            validate_checkpoint_counters(&checkpoint),
-            |failure| {
-                matches!(
-                    failure,
-                    CheckpointResumeFailure::NonFiniteStepActionBefore { step: 1 }
-                )
-            },
-            "non-finite action_before",
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::NonFiniteStepActionBefore { step: 1 }
+            }
         );
     }
 
     #[test]
-    fn resume_rejects_nonfinite_step_delta_action() {
-        let mut checkpoint = synthetic_one_step_checkpoint(true);
-        checkpoint.steps[0].delta_action = Some(f64::NAN);
+    fn step_constructor_rejects_nonfinite_delta_action() {
+        let error = MonteCarloStep::rejected_proposal(
+            step_number(1),
+            MoveType::Move22,
+            0.0,
+            Some(f64::NAN),
+        )
+        .expect_err("non-finite delta_action should be rejected before storage");
 
-        assert_checkpoint_resume_failed(
-            validate_checkpoint_counters(&checkpoint),
-            |failure| {
-                matches!(
-                    failure,
-                    CheckpointResumeFailure::NonFiniteStepDeltaAction { step: 1 }
-                )
-            },
-            "non-finite delta_action",
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::NonFiniteStepDeltaAction { step: 1 }
+            }
         );
     }
 
     #[test]
-    fn resume_rejects_accepted_step_missing_delta_action() {
-        let mut checkpoint = synthetic_one_step_checkpoint(true);
-        checkpoint.steps[0].delta_action = None;
+    fn step_constructor_rejects_action_after_delta_mismatch() {
+        let error = MonteCarloStep::accepted_step(step_number(1), MoveType::Move22, 0.0, 1.0, 0.0)
+            .expect_err("action_after/delta mismatch should be rejected before storage");
 
-        assert_checkpoint_resume_failed(
-            validate_checkpoint_counters(&checkpoint),
-            |failure| {
-                matches!(
-                    failure,
-                    CheckpointResumeFailure::AcceptedStepMissingDeltaAction { step: 1 }
-                )
-            },
-            "missing delta_action",
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: 1 }
+            }
         );
     }
 
     #[test]
-    fn resume_rejects_action_after_delta_mismatch() {
-        let mut checkpoint = synthetic_one_step_checkpoint(true);
-        checkpoint.steps[0].action_after = Some(checkpoint.steps[0].action_before + 1.0);
+    fn step_constructor_rejects_nonfinite_step_action_after() {
+        let error =
+            MonteCarloStep::accepted_step(step_number(1), MoveType::Move22, 0.0, f64::NAN, 0.0)
+                .expect_err("non-finite action_after should be rejected before storage");
 
-        assert_checkpoint_resume_failed(
-            validate_checkpoint_counters(&checkpoint),
-            |failure| {
-                matches!(
-                    failure,
-                    CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: 1 }
-                )
-            },
-            "action_after does not match",
-        );
-    }
-
-    #[test]
-    fn resume_rejects_nonfinite_step_action_after() {
-        let mut checkpoint = synthetic_one_step_checkpoint(true);
-        checkpoint.steps[0].action_after = Some(f64::NAN);
-
-        assert_checkpoint_resume_failed(
-            validate_checkpoint_counters(&checkpoint),
-            |failure| {
-                matches!(
-                    failure,
-                    CheckpointResumeFailure::NonFiniteStepActionAfter { step: 1 }
-                )
-            },
-            "non-finite action_after",
-        );
-    }
-
-    #[test]
-    fn resume_rejects_accepted_step_missing_action_after() {
-        let mut checkpoint = synthetic_one_step_checkpoint(true);
-        checkpoint.steps[0].action_after = None;
-
-        assert_checkpoint_resume_failed(
-            validate_checkpoint_counters(&checkpoint),
-            |failure| {
-                matches!(
-                    failure,
-                    CheckpointResumeFailure::AcceptedStepMissingActionAfter { step: 1 }
-                )
-            },
-            "missing action_after",
-        );
-    }
-
-    #[test]
-    fn resume_rejects_rejected_step_with_action_after() {
-        let mut checkpoint = synthetic_one_step_checkpoint(false);
-        checkpoint.steps[0].action_after = Some(checkpoint.steps[0].action_before);
-
-        assert_checkpoint_resume_failed(
-            validate_checkpoint_counters(&checkpoint),
-            |failure| {
-                matches!(
-                    failure,
-                    CheckpointResumeFailure::RejectedStepHasActionAfter { step: 1 }
-                )
-            },
-            "unexpectedly has action_after",
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::NonFiniteStepActionAfter { step: 1 }
+            }
         );
     }
 
@@ -2260,7 +2428,9 @@ mod tests {
     #[test]
     fn resume_rejects_measurement_step_mismatch() {
         let mut checkpoint = synthetic_one_step_checkpoint(true);
-        checkpoint.measurements[1].step = 2;
+        checkpoint.measurements[1] =
+            Measurement::try_new(2, checkpoint.measurements[1].action(), 12, 26, 12)
+                .expect("replacement measurement should satisfy invariants");
 
         assert_checkpoint_resume_failed(
             validate_checkpoint_counters(&checkpoint),
@@ -2274,23 +2444,6 @@ mod tests {
                 )
             },
             "measurement telemetry step mismatch",
-        );
-    }
-
-    #[test]
-    fn resume_rejects_nonfinite_measurement_action() {
-        let mut checkpoint = synthetic_one_step_checkpoint(true);
-        checkpoint.measurements[1].action = f64::NAN;
-
-        assert_checkpoint_resume_failed(
-            validate_checkpoint_counters(&checkpoint),
-            |failure| {
-                matches!(
-                    failure,
-                    CheckpointResumeFailure::NonFiniteMeasurementAction { step: 1 }
-                )
-            },
-            "non-finite action",
         );
     }
 
@@ -2387,12 +2540,13 @@ mod tests {
     #[test]
     fn measurement_records_volume_profile_for_foliated_triangulation() {
         let triangulation = CdtTriangulation::from_cdt_strip(4, 3).expect("create Delaunay strip");
-        let measurement = measurement_for(0, 1.0, &triangulation);
+        let measurement =
+            measurement_for(0, 1.0, &triangulation).expect("measurement should build");
 
-        assert_eq!(measurement.volume_profile, vec![6, 6, 0]);
+        assert_eq!(measurement.volume_profile(), &[6, 6, 0]);
         assert_eq!(
-            measurement.volume_profile.iter().sum::<u32>(),
-            measurement.triangles
+            measurement.volume_profile().iter().sum::<u32>(),
+            measurement.triangles().get()
         );
     }
 
@@ -2400,11 +2554,12 @@ mod tests {
     fn volume_profile_is_empty_without_current_foliation() {
         let triangulation =
             CdtTriangulation::from_seeded_points(5, 2, 2, 53).expect("create seeded triangulation");
-        let measurement = measurement_for(0, 1.0, &triangulation);
+        let measurement =
+            measurement_for(0, 1.0, &triangulation).expect("measurement should build");
 
         assert!(!triangulation.has_foliation());
         assert!(triangulation.volume_profile().is_empty());
-        assert!(measurement.volume_profile.is_empty());
+        assert!(measurement.volume_profile().is_empty());
     }
 
     #[test]
@@ -2421,10 +2576,10 @@ mod tests {
 
         assert_eq!(first.steps().len(), second.steps().len());
         for (first, second) in first.steps().iter().zip(second.steps().iter()) {
-            assert_eq!(first.move_type, second.move_type);
-            assert_eq!(first.accepted, second.accepted);
-            assert_relative_eq!(first.action_before, second.action_before);
-            assert_optional_relative_eq(first.delta_action, second.delta_action);
+            assert_eq!(first.move_type(), second.move_type());
+            assert_eq!(first.accepted(), second.accepted());
+            assert_relative_eq!(first.action_before(), second.action_before());
+            assert_optional_relative_eq(first.delta_action(), second.delta_action());
         }
     }
 
@@ -2481,7 +2636,7 @@ mod tests {
             proposed_delta_action(
                 &action_config,
                 SimplexCounts {
-                    vertices: u32::MAX,
+                    vertices: usize::MAX,
                     edges: 8,
                     triangles: 4,
                 },
@@ -2606,7 +2761,9 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let committed = triangulation.clone();
-        let mut state = algorithm.initial_state(triangulation);
+        let mut state = algorithm
+            .initial_state(triangulation)
+            .expect("initial state should build");
         let action = state.current_action;
         let move_type = MoveType::Move22;
         let info = CdtProposalInfo {
@@ -2663,7 +2820,9 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let committed = triangulation.clone();
-        let mut state = algorithm.initial_state(triangulation);
+        let mut state = algorithm
+            .initial_state(triangulation)
+            .expect("initial state should build");
         let action_before = state.current_action;
         let reconstructed_action = action_before + 0.25;
         let move_type = MoveType::Move22;
@@ -2691,14 +2850,14 @@ mod tests {
         assert_relative_eq!(state.current_action, reconstructed_action, epsilon = 1e-12);
         assert_relative_eq!(
             state.steps[0]
-                .action_after
+                .action_after()
                 .expect("accepted step should record reconstructed action"),
             reconstructed_action,
             epsilon = 1e-12
         );
         assert_relative_eq!(
             state.steps[0]
-                .delta_action
+                .delta_action()
                 .expect("accepted step should record reconstructed action change"),
             reconstructed_action - action_before,
             epsilon = 1e-12
@@ -2713,7 +2872,9 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let committed = triangulation.clone();
-        let mut state = algorithm.initial_state(triangulation);
+        let mut state = algorithm
+            .initial_state(triangulation)
+            .expect("initial state should build");
         let action_before = state.current_action;
         let action_after = action_before + 0.5;
         let proposal_stats = ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -2739,7 +2900,7 @@ mod tests {
 
         assert_relative_eq!(
             state.steps[0]
-                .delta_action
+                .delta_action()
                 .expect("accepted step should record action change"),
             action_after - action_before,
             epsilon = 1e-12
@@ -2754,7 +2915,9 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let committed = triangulation.clone();
-        let mut state = algorithm.initial_state(triangulation);
+        let mut state = algorithm
+            .initial_state(triangulation)
+            .expect("initial state should build");
         let action_before = state.current_action;
         let steps_before = state.steps.len();
         let measurements_before = state.measurements.len();
@@ -2797,7 +2960,9 @@ mod tests {
         let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
-        let mut state = algorithm.initial_state(triangulation);
+        let mut state = algorithm
+            .initial_state(triangulation)
+            .expect("initial state should build");
         state.current_step = u32::MAX;
         let steps_before = state.steps.len();
         let measurements_before = state.measurements.len();
@@ -2976,7 +3141,7 @@ mod tests {
             results
                 .measurements()
                 .iter()
-                .any(|measurement| measurement.step >= 15)
+                .any(|measurement| measurement.step() >= 15)
         );
     }
 

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -363,6 +363,7 @@ struct MetropolisRunState {
     triangulation: CdtTriangulation2D,
     current_step: u32,
     current_action: f64,
+    trace_seed: Option<u64>,
     acceptance_rng: Xoshiro256PlusPlus,
     ergodics: ErgodicsSystem,
     move_stats: MoveStatistics,
@@ -723,6 +724,7 @@ impl MetropolisAlgorithm {
             triangulation,
             current_step: 0,
             current_action,
+            trace_seed: self.config.seed,
             acceptance_rng: simulation_rng(self.config.seed),
             ergodics: self.config.seed.map_or_else(ErgodicsSystem::new, |seed| {
                 ErgodicsSystem::with_seed(seed.wrapping_add(0x9E37_79B9_7F4A_7C15))
@@ -839,6 +841,7 @@ impl MetropolisRunState {
             triangulation,
             current_step: checkpoint.current_step.get(),
             current_action: checkpoint.current_action,
+            trace_seed: checkpoint.config.seed(),
             acceptance_rng: checkpoint.acceptance_rng,
             ergodics: checkpoint.ergodics,
             move_stats: checkpoint.move_stats,
@@ -1058,7 +1061,7 @@ fn record_planned_step_parts(
         delta_action,
         action_before,
         action_after,
-        algorithm.config.seed(),
+        state.trace_seed,
     )?);
 
     if measurement_is_due(
@@ -1514,6 +1517,7 @@ mod tests {
             triangulation,
             current_step: 0,
             current_action: 0.0,
+            trace_seed: Some(1),
             acceptance_rng: simulation_rng(Some(1)),
             ergodics: ErgodicsSystem::with_seed(2),
             move_stats: MoveStatistics::new(),
@@ -2023,7 +2027,7 @@ mod tests {
             };
             let message = error.to_string();
             assert!(
-                message.contains("Invalid measurement count") && message.contains(field),
+                message.contains("Invalid scalar trace count") && message.contains(field),
                 "unexpected serde error for {field}: {message}"
             );
         }

--- a/src/cdt/metropolis/telemetry.rs
+++ b/src/cdt/metropolis/telemetry.rs
@@ -3,11 +3,14 @@
 //! Proposal and step telemetry for CDT Metropolis sampling.
 
 use crate::cdt::ergodic_moves::MoveType;
-use crate::errors::CdtError;
+use crate::errors::{CdtError, CdtResult, CheckpointResumeFailure};
+use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::error::Error;
 use std::fmt;
 use std::num::NonZeroU32;
+
+use super::helpers::actions_match;
 
 /// Telemetry for one completed Monte Carlo step.
 ///
@@ -16,10 +19,9 @@ use std::num::NonZeroU32;
 /// sample appears as a [`Measurement`](crate::cdt::results::Measurement), not as
 /// a `MonteCarloStep`.
 ///
-/// Accepted steps include both [`Self::action_after`] and [`Self::delta_action`]
-/// from the same recorded action. Rejected self-loop steps leave
-/// `action_after` empty while retaining the proposed action change when it was
-/// available.
+/// Accepted, rejected-proposal, and no-proposal outcomes are stored as
+/// [`MonteCarloStepOutcome`] variants, so accepted action payloads cannot be
+/// partially present and rejected steps cannot carry an action-after value.
 ///
 /// # Examples
 ///
@@ -36,25 +38,778 @@ use std::num::NonZeroU32;
 ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
 ///
 ///     let step = &results.steps()[0];
-///     assert_eq!(step.step.get(), 1);
-///     assert!(step.action_before.is_finite());
+///     assert_eq!(step.step().get(), 1);
+///     assert!(step.action_before().is_finite());
 ///     Ok(())
 /// }
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct MonteCarloStep {
-    /// Nonzero Monte Carlo step number.
-    pub step: NonZeroU32,
-    /// Move type attempted during this step.
-    pub move_type: MoveType,
-    /// Whether the move was accepted by the Metropolis-Hastings transition.
-    pub accepted: bool,
-    /// Action before the proposed move.
-    pub action_before: f64,
-    /// Action after the move, present only for accepted steps.
-    pub action_after: Option<f64>,
-    /// Proposed or accepted change in action.
-    pub delta_action: Option<f64>,
+    step: NonZeroU32,
+    move_type: MoveType,
+    action_before: f64,
+    outcome: MonteCarloStepOutcome,
+}
+
+#[derive(Deserialize)]
+struct MonteCarloStepWire {
+    step: NonZeroU32,
+    move_type: MoveType,
+    action_before: f64,
+    outcome: MonteCarloStepOutcomeWire,
+}
+
+impl<'de> Deserialize<'de> for MonteCarloStep {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = MonteCarloStepWire::deserialize(deserializer)?;
+        let outcome = MonteCarloStepOutcome::from_wire(wire.step, wire.action_before, wire.outcome)
+            .map_err(DeError::custom)?;
+        Self::new(wire.step, wire.move_type, wire.action_before, outcome).map_err(DeError::custom)
+    }
+}
+
+impl MonteCarloStep {
+    /// Creates validated telemetry for one completed Monte Carlo step.
+    ///
+    /// Use the outcome-specific constructors such as [`Self::accepted_step`] for
+    /// the common public cases. This constructor is useful when code already has a
+    /// validated [`MonteCarloStepOutcome`] from another boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::CheckpointResumeFailed`] when `action_before` is
+    /// non-finite or when the supplied outcome carries non-finite or inconsistent
+    /// action telemetry for this step.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStep, MonteCarloStepOutcome, MoveType,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let outcome = MonteCarloStepOutcome::accepted_transition(
+    ///         step_number,
+    ///         4.0,
+    ///         3.5,
+    ///         -0.5,
+    ///     )?;
+    ///     let step = MonteCarloStep::new(step_number, MoveType::Move22, 4.0, outcome)?;
+    ///
+    ///     assert!(step.accepted());
+    ///     assert_eq!(step.action_after(), Some(3.5));
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn new(
+        step: NonZeroU32,
+        move_type: MoveType,
+        action_before: f64,
+        outcome: MonteCarloStepOutcome,
+    ) -> CdtResult<Self> {
+        validate_action_before(step, action_before)?;
+        outcome.validate_for_step(step, action_before)?;
+        Ok(Self {
+            step,
+            move_type,
+            action_before,
+            outcome,
+        })
+    }
+
+    /// Creates validated telemetry for an accepted Metropolis step.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::CheckpointResumeFailed`] when any action value is
+    /// non-finite or `action_after` does not match `action_before + delta_action`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStep, MoveType,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let step = MonteCarloStep::accepted_step(
+    ///         step_number,
+    ///         MoveType::Move22,
+    ///         4.0,
+    ///         3.5,
+    ///         -0.5,
+    ///     )?;
+    ///
+    ///     assert!(step.accepted());
+    ///     assert_eq!(step.delta_action(), Some(-0.5));
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn accepted_step(
+        step: NonZeroU32,
+        move_type: MoveType,
+        action_before: f64,
+        action_after: f64,
+        delta_action: f64,
+    ) -> CdtResult<Self> {
+        Self::new(
+            step,
+            move_type,
+            action_before,
+            MonteCarloStepOutcome::accepted_transition(
+                step,
+                action_before,
+                action_after,
+                delta_action,
+            )?,
+        )
+    }
+
+    /// Creates validated telemetry for a rejected step with a sampled proposal.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::CheckpointResumeFailed`] when `action_before` or the
+    /// optional proposal delta is non-finite.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStep, MoveType,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let step = MonteCarloStep::rejected_proposal(
+    ///         step_number,
+    ///         MoveType::Move13Add,
+    ///         4.0,
+    ///         Some(0.25),
+    ///     )?;
+    ///
+    ///     assert!(!step.accepted());
+    ///     assert_eq!(step.action_after(), None);
+    ///     assert_eq!(step.delta_action(), Some(0.25));
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn rejected_proposal(
+        step: NonZeroU32,
+        move_type: MoveType,
+        action_before: f64,
+        delta_action: Option<f64>,
+    ) -> CdtResult<Self> {
+        Self::new(
+            step,
+            move_type,
+            action_before,
+            MonteCarloStepOutcome::rejected_proposal(step, delta_action)?,
+        )
+    }
+
+    /// Creates validated telemetry for a selected move family with no local proposal.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::CheckpointResumeFailed`] when `action_before` is
+    /// non-finite.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStep, MoveType,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let step = MonteCarloStep::no_proposal(step_number, MoveType::EdgeFlip, 4.0)?;
+    ///
+    ///     assert!(!step.accepted());
+    ///     assert_eq!(step.action_after(), None);
+    ///     assert_eq!(step.delta_action(), None);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn no_proposal(
+        step: NonZeroU32,
+        move_type: MoveType,
+        action_before: f64,
+    ) -> CdtResult<Self> {
+        Self::new(
+            step,
+            move_type,
+            action_before,
+            MonteCarloStepOutcome::NoProposal,
+        )
+    }
+
+    /// Returns the nonzero Monte Carlo step number.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStep, MoveType,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 2, 0, 1)?.steps();
+    ///     let step = MonteCarloStep::no_proposal(step_number, MoveType::EdgeFlip, 4.0)?;
+    ///
+    ///     assert_eq!(step.step().get(), 2);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn step(&self) -> NonZeroU32 {
+        self.step
+    }
+
+    /// Returns the move type attempted during this step.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStep, MoveType,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let step = MonteCarloStep::no_proposal(step_number, MoveType::EdgeFlip, 4.0)?;
+    ///
+    ///     assert_eq!(step.move_type(), MoveType::EdgeFlip);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn move_type(&self) -> MoveType {
+        self.move_type
+    }
+
+    /// Returns the action before the proposed move.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStep, MoveType,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let step = MonteCarloStep::no_proposal(step_number, MoveType::EdgeFlip, 4.0)?;
+    ///
+    ///     assert_eq!(step.action_before(), 4.0);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn action_before(&self) -> f64 {
+        self.action_before
+    }
+
+    /// Returns the validated step outcome.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStep, MonteCarloStepOutcome, MoveType,
+    /// };
+    /// use std::assert_matches;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let step = MonteCarloStep::no_proposal(step_number, MoveType::EdgeFlip, 4.0)?;
+    ///
+    ///     assert_matches!(step.outcome(), MonteCarloStepOutcome::NoProposal);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn outcome(&self) -> &MonteCarloStepOutcome {
+        &self.outcome
+    }
+
+    /// Returns whether the step was accepted by the Metropolis-Hastings transition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStep, MoveType,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let step = MonteCarloStep::accepted_step(
+    ///         step_number,
+    ///         MoveType::Move22,
+    ///         4.0,
+    ///         3.5,
+    ///         -0.5,
+    ///     )?;
+    ///
+    ///     assert!(step.accepted());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn accepted(&self) -> bool {
+        matches!(self.outcome, MonteCarloStepOutcome::Accepted(_))
+    }
+
+    /// Returns the action after the step when the proposal was accepted.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStep, MoveType,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let step = MonteCarloStep::accepted_step(
+    ///         step_number,
+    ///         MoveType::Move22,
+    ///         4.0,
+    ///         3.5,
+    ///         -0.5,
+    ///     )?;
+    ///
+    ///     assert_eq!(step.action_after(), Some(3.5));
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn action_after(&self) -> Option<f64> {
+        self.outcome.action_after()
+    }
+
+    /// Returns the proposed or accepted action delta when available.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStep, MoveType,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let step = MonteCarloStep::rejected_proposal(
+    ///         step_number,
+    ///         MoveType::Move13Add,
+    ///         4.0,
+    ///         Some(0.25),
+    ///     )?;
+    ///
+    ///     assert_eq!(step.delta_action(), Some(0.25));
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn delta_action(&self) -> Option<f64> {
+        self.outcome.delta_action()
+    }
+}
+
+/// Action payload for an accepted Monte Carlo step.
+///
+/// This payload is present only in [`MonteCarloStepOutcome::Accepted`]. It keeps
+/// `action_after` and `delta_action` together so accepted telemetry cannot store
+/// one without the other.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct AcceptedStepTelemetry {
+    action_after: f64,
+    delta_action: f64,
+}
+
+impl AcceptedStepTelemetry {
+    /// Returns the action after the accepted transition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStepOutcome,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let outcome =
+    ///         MonteCarloStepOutcome::accepted_transition(step_number, 4.0, 3.5, -0.5)?;
+    ///
+    ///     if let MonteCarloStepOutcome::Accepted(payload) = outcome {
+    ///         assert_eq!(payload.action_after(), 3.5);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn action_after(self) -> f64 {
+        self.action_after
+    }
+
+    /// Returns the accepted action delta.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStepOutcome,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let outcome =
+    ///         MonteCarloStepOutcome::accepted_transition(step_number, 4.0, 3.5, -0.5)?;
+    ///
+    ///     if let MonteCarloStepOutcome::Accepted(payload) = outcome {
+    ///         assert_eq!(payload.delta_action(), -0.5);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn delta_action(self) -> f64 {
+        self.delta_action
+    }
+}
+
+/// Action payload for a rejected concrete proposal.
+///
+/// Rejected proposals never carry an action-after value, but the proposal kernel
+/// may still report the action delta for the rejected candidate.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct RejectedProposalStepTelemetry {
+    delta_action: Option<f64>,
+}
+
+impl RejectedProposalStepTelemetry {
+    /// Returns the proposed action delta when the proposal kernel supplied one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStepOutcome,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let outcome = MonteCarloStepOutcome::rejected_proposal(step_number, Some(0.25))?;
+    ///
+    ///     if let MonteCarloStepOutcome::RejectedProposal(payload) = outcome {
+    ///         assert_eq!(payload.delta_action(), Some(0.25));
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn delta_action(self) -> Option<f64> {
+        self.delta_action
+    }
+}
+
+/// Validated outcome for one completed Monte Carlo step.
+///
+/// The variants encode which action payloads are legal for the step outcome.
+/// Accepted steps carry both an action-after value and a delta, rejected
+/// proposals may carry only a candidate delta, and no-proposal steps carry no
+/// action payload.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::simulation::{
+///     CdtResult, MetropolisConfig, MonteCarloStepOutcome,
+/// };
+/// use std::assert_matches;
+///
+/// fn main() -> CdtResult<()> {
+///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+///     let outcome =
+///         MonteCarloStepOutcome::accepted_transition(step_number, 4.0, 3.5, -0.5)?;
+///
+///     assert_matches!(outcome, MonteCarloStepOutcome::Accepted(_));
+///     if let MonteCarloStepOutcome::Accepted(payload) = outcome {
+///         assert_eq!(payload.action_after(), 3.5);
+///         assert_eq!(payload.delta_action(), -0.5);
+///     }
+///     Ok(())
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub enum MonteCarloStepOutcome {
+    /// A proposal was accepted and committed to the CDT chain.
+    Accepted(AcceptedStepTelemetry),
+    /// A valid proposal was sampled but rejected by the Metropolis draw.
+    RejectedProposal(RejectedProposalStepTelemetry),
+    /// The selected move family had no sampleable local proposal.
+    NoProposal,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+enum MonteCarloStepOutcomeWire {
+    Accepted {
+        action_after: f64,
+        delta_action: f64,
+    },
+    RejectedProposal {
+        delta_action: Option<f64>,
+    },
+    NoProposal,
+}
+
+impl MonteCarloStepOutcome {
+    /// Creates a validated accepted-step outcome.
+    ///
+    /// Use this when a boundary already has the move-independent action telemetry
+    /// and needs an invariant-bearing outcome before constructing a
+    /// [`MonteCarloStep`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::CheckpointResumeFailed`] when either action value is
+    /// non-finite or `action_after` does not match `action_before + delta_action`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStepOutcome,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let outcome =
+    ///         MonteCarloStepOutcome::accepted_transition(step_number, 4.0, 3.5, -0.5)?;
+    ///
+    ///     assert!(outcome.accepted());
+    ///     assert_eq!(outcome.action_after(), Some(3.5));
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn accepted_transition(
+        step: NonZeroU32,
+        action_before: f64,
+        action_after: f64,
+        delta_action: f64,
+    ) -> CdtResult<Self> {
+        validate_action_after(step, action_after)?;
+        validate_delta_action(step, delta_action)?;
+        if !actions_match(action_after, action_before + delta_action) {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: step.get() },
+            ));
+        }
+        Ok(Self::Accepted(AcceptedStepTelemetry {
+            action_after,
+            delta_action,
+        }))
+    }
+
+    /// Creates a validated rejected-proposal outcome.
+    ///
+    /// Use this for a concrete proposal that was sampled and rejected by the
+    /// Metropolis draw. Use [`Self::NoProposal`] when no local candidate was
+    /// available.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::CheckpointResumeFailed`] when the optional proposal
+    /// delta is non-finite.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStepOutcome,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let outcome = MonteCarloStepOutcome::rejected_proposal(step_number, Some(0.5))?;
+    ///
+    ///     assert!(!outcome.accepted());
+    ///     assert_eq!(outcome.delta_action(), Some(0.5));
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn rejected_proposal(step: NonZeroU32, delta_action: Option<f64>) -> CdtResult<Self> {
+        if let Some(delta_action) = delta_action {
+            validate_delta_action(step, delta_action)?;
+        }
+        Ok(Self::RejectedProposal(RejectedProposalStepTelemetry {
+            delta_action,
+        }))
+    }
+
+    /// Returns whether this outcome accepted the proposed transition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStepOutcome,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let outcome =
+    ///         MonteCarloStepOutcome::accepted_transition(step_number, 4.0, 3.5, -0.5)?;
+    ///
+    ///     assert!(outcome.accepted());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn accepted(self) -> bool {
+        matches!(self, Self::Accepted(_))
+    }
+
+    /// Returns the action after the step when this is an accepted outcome.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStepOutcome,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let outcome =
+    ///         MonteCarloStepOutcome::accepted_transition(step_number, 4.0, 3.5, -0.5)?;
+    ///
+    ///     assert_eq!(outcome.action_after(), Some(3.5));
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn action_after(self) -> Option<f64> {
+        match self {
+            Self::Accepted(payload) => Some(payload.action_after()),
+            Self::RejectedProposal(_) | Self::NoProposal => None,
+        }
+    }
+
+    /// Returns the proposal or accepted action delta when available.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     CdtResult, MetropolisConfig, MonteCarloStepOutcome,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let step_number = MetropolisConfig::new(1.0, 1, 0, 1)?.steps();
+    ///     let outcome = MonteCarloStepOutcome::rejected_proposal(step_number, Some(0.25))?;
+    ///
+    ///     assert_eq!(outcome.delta_action(), Some(0.25));
+    ///     Ok(())
+    /// }
+    /// ```
+    #[must_use]
+    pub const fn delta_action(self) -> Option<f64> {
+        match self {
+            Self::Accepted(payload) => Some(payload.delta_action()),
+            Self::RejectedProposal(payload) => payload.delta_action(),
+            Self::NoProposal => None,
+        }
+    }
+
+    /// Re-validates an outcome with the step-local action-before context.
+    ///
+    /// Public constructors call this before storing caller-supplied outcomes so
+    /// deserialized or externally assembled telemetry cannot bypass the accepted
+    /// action-after/delta consistency contract.
+    fn validate_for_step(self, step: NonZeroU32, action_before: f64) -> CdtResult<()> {
+        match self {
+            Self::Accepted(payload) => {
+                Self::accepted_transition(
+                    step,
+                    action_before,
+                    payload.action_after(),
+                    payload.delta_action(),
+                )?;
+            }
+            Self::RejectedProposal(payload) => {
+                Self::rejected_proposal(step, payload.delta_action())?;
+            }
+            Self::NoProposal => {}
+        }
+        Ok(())
+    }
+
+    /// Converts the raw serialized outcome shape into validated domain telemetry.
+    ///
+    /// The wire payload is intentionally private because finite-action and
+    /// accepted-step delta consistency checks need the enclosing step number and
+    /// action-before value for precise diagnostics.
+    fn from_wire(
+        step: NonZeroU32,
+        action_before: f64,
+        wire: MonteCarloStepOutcomeWire,
+    ) -> CdtResult<Self> {
+        match wire {
+            MonteCarloStepOutcomeWire::Accepted {
+                action_after,
+                delta_action,
+            } => Self::accepted_transition(step, action_before, action_after, delta_action),
+            MonteCarloStepOutcomeWire::RejectedProposal { delta_action } => {
+                Self::rejected_proposal(step, delta_action)
+            }
+            MonteCarloStepOutcomeWire::NoProposal => Ok(Self::NoProposal),
+        }
+    }
+}
+
+const fn checkpoint_resume_failed(failure: CheckpointResumeFailure) -> CdtError {
+    CdtError::CheckpointResumeFailed { failure }
+}
+
+const fn validate_action_before(step: NonZeroU32, action_before: f64) -> CdtResult<()> {
+    if action_before.is_finite() {
+        Ok(())
+    } else {
+        Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::NonFiniteStepActionBefore { step: step.get() },
+        ))
+    }
+}
+
+const fn validate_action_after(step: NonZeroU32, action_after: f64) -> CdtResult<()> {
+    if action_after.is_finite() {
+        Ok(())
+    } else {
+        Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::NonFiniteStepActionAfter { step: step.get() },
+        ))
+    }
+}
+
+const fn validate_delta_action(step: NonZeroU32, delta_action: f64) -> CdtResult<()> {
+    if delta_action.is_finite() {
+        Ok(())
+    } else {
+        Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::NonFiniteStepDeltaAction { step: step.get() },
+        ))
+    }
 }
 
 /// Local-site rejection observed while trying to realize an accepted CDT proposal.
@@ -164,7 +919,7 @@ impl<'de> Deserialize<'de> for ProposalStatistics {
         D: Deserializer<'de>,
     {
         let wire = ProposalStatisticsWire::deserialize(deserializer)?;
-        Self::from_wire(&wire).map_err(serde::de::Error::custom)
+        Self::from_wire(&wire).map_err(DeError::custom)
     }
 }
 
@@ -225,10 +980,11 @@ impl ProposalStatistics {
 
     /// Rebuilds proposal telemetry from the serialized wire shape.
     ///
-    /// The wire form is rejected when terminal outcomes do not exactly account
-    /// for selected move families, or when forward-site observations exist
-    /// without any selected move family. That keeps deserialized result and
-    /// checkpoint telemetry coherent before public accessors expose the counters.
+    /// The wire form is rejected when terminal outcomes cannot be summed without
+    /// overflow, do not exactly account for selected move families, or when
+    /// forward-site observations exist without any selected move family. That
+    /// keeps deserialized result and checkpoint telemetry coherent before public
+    /// accessors expose the counters.
     fn from_wire(wire: &ProposalStatisticsWire) -> Result<Self, String> {
         let terminal_outcomes = [
             wire.no_site_proposals,
@@ -240,7 +996,11 @@ impl ProposalStatistics {
             wire.hard_failures,
         ]
         .into_iter()
-        .fold(0_u64, u64::saturating_add);
+        .try_fold(0_u64, |total, count| {
+            total
+                .checked_add(count)
+                .ok_or_else(|| "proposal terminal outcome counters exceed u64::MAX".to_string())
+        })?;
         if terminal_outcomes != wire.move_family_proposals {
             return Err(format!(
                 "proposal terminal outcomes ({terminal_outcomes}) do not match move-family proposals ({})",
@@ -512,6 +1272,131 @@ impl ProposalStatistics {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
+
+    fn step_number(step: u32) -> NonZeroU32 {
+        NonZeroU32::new(step).expect("test step number should be nonzero")
+    }
+
+    fn assert_checkpoint_failure(
+        error: CdtError,
+        matches_failure: impl FnOnce(&CheckpointResumeFailure) -> bool,
+    ) {
+        match error {
+            CdtError::CheckpointResumeFailed { failure } => assert!(
+                matches_failure(&failure),
+                "unexpected checkpoint failure: {failure:?}"
+            ),
+            other => panic!("expected checkpoint resume failure, got {other:?}"),
+        }
+    }
+
+    fn assert_optional_actions_match(actual: Option<f64>, expected: Option<f64>) {
+        match (actual, expected) {
+            (Some(actual), Some(expected)) => assert!(
+                actions_match(actual, expected),
+                "expected {actual} to match {expected}"
+            ),
+            (None, None) => {}
+            (actual, expected) => panic!("expected {actual:?} to match {expected:?}"),
+        }
+    }
+
+    #[test]
+    fn monte_carlo_step_new_revalidates_outcome_against_action_before() {
+        let outcome = MonteCarloStepOutcome::accepted_transition(step_number(1), 4.0, 3.5, -0.5)
+            .expect("test outcome should satisfy its original action context");
+
+        let error = MonteCarloStep::new(step_number(1), MoveType::Move22, 10.0, outcome)
+            .expect_err("step constructor should reject outcome inconsistent with action_before");
+
+        assert_checkpoint_failure(error, |failure| {
+            matches!(
+                failure,
+                CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: 1 }
+            )
+        });
+    }
+
+    #[test]
+    fn monte_carlo_step_serde_round_trips_valid_outcome_variants() {
+        let steps = [
+            MonteCarloStep::accepted_step(step_number(1), MoveType::Move22, 4.0, 3.5, -0.5)
+                .expect("test accepted step should satisfy action invariants"),
+            MonteCarloStep::rejected_proposal(step_number(2), MoveType::Move13Add, 3.5, Some(0.25))
+                .expect("test rejected-proposal step should satisfy action invariants"),
+            MonteCarloStep::no_proposal(step_number(3), MoveType::EdgeFlip, 3.5)
+                .expect("test no-proposal step should satisfy action invariants"),
+        ];
+
+        for step in steps {
+            let value = serde_json::to_value(&step).expect("step telemetry should serialize");
+            let round_tripped: MonteCarloStep =
+                serde_json::from_value(value).expect("valid step telemetry should deserialize");
+
+            assert_eq!(round_tripped.step(), step.step());
+            assert_eq!(round_tripped.move_type(), step.move_type());
+            assert!(
+                actions_match(round_tripped.action_before(), step.action_before()),
+                "round-tripped action_before should match original"
+            );
+            assert_eq!(round_tripped.accepted(), step.accepted());
+            assert_optional_actions_match(round_tripped.action_after(), step.action_after());
+            assert_optional_actions_match(round_tripped.delta_action(), step.delta_action());
+        }
+    }
+
+    #[test]
+    fn monte_carlo_step_deserialization_rejects_accepted_delta_mismatch() {
+        let payload = r#"{
+            "step": 1,
+            "move_type": "Move22",
+            "action_before": 4.0,
+            "outcome": {
+                "Accepted": {
+                    "action_after": 3.5,
+                    "delta_action": 0.0
+                }
+            }
+        }"#;
+
+        let error = serde_json::from_str::<MonteCarloStep>(payload)
+            .expect_err("accepted action-after/delta mismatch should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("action_after does not match delta_action"),
+            "serde error should explain accepted-step action invariant, got {error}"
+        );
+    }
+
+    #[test]
+    fn monte_carlo_step_deserialization_preserves_rejected_proposal_kind() {
+        let payload = r#"{
+            "step": 2,
+            "move_type": "Move13Add",
+            "action_before": 3.5,
+            "outcome": {
+                "RejectedProposal": {
+                    "delta_action": null
+                }
+            }
+        }"#;
+
+        let step = serde_json::from_str::<MonteCarloStep>(payload)
+            .expect("rejected proposal without delta should deserialize");
+
+        assert_eq!(step.step().get(), 2);
+        assert_eq!(step.move_type(), MoveType::Move13Add);
+        assert_matches!(
+            step.outcome(),
+            MonteCarloStepOutcome::RejectedProposal(payload) if payload.delta_action().is_none()
+        );
+        assert!(!step.accepted());
+        assert_eq!(step.action_after(), None);
+        assert_eq!(step.delta_action(), None);
+    }
 
     #[test]
     fn proposal_statistics_deserialization_rejects_terminal_outcomes_above_proposals() {
@@ -583,7 +1468,7 @@ mod tests {
     }
 
     #[test]
-    fn proposal_statistics_extend_preserves_saturated_round_trip_invariant() {
+    fn proposal_statistics_deserialization_rejects_terminal_outcome_counter_overflow() {
         let mut stats = ProposalStatistics::from_validated_parts(
             u64::MAX,
             u64::MAX,
@@ -605,9 +1490,12 @@ mod tests {
 
         let serialized =
             serde_json::to_string(&stats).expect("saturated telemetry should serialize");
-        let round_tripped: ProposalStatistics = serde_json::from_str(&serialized)
-            .expect("saturated merged telemetry should deserialize");
+        let error = serde_json::from_str::<ProposalStatistics>(&serialized)
+            .expect_err("overflowed terminal outcome partition should be rejected");
 
-        assert_eq!(round_tripped, stats);
+        assert!(
+            error.to_string().contains("exceed u64::MAX"),
+            "serde error should explain terminal outcome counter overflow, got {error}"
+        );
     }
 }

--- a/src/cdt/results.rs
+++ b/src/cdt/results.rs
@@ -36,7 +36,7 @@ use std::time::Duration;
 /// Scalar measurement data collected during simulation.
 ///
 /// Use [`Self::new`] and builder-style methods such as
-/// [`Self::with_volume_profile`] rather than struct literals outside this
+/// [`Self::try_with_volume_profile`] rather than struct literals outside this
 /// crate; additional measurement fields may be added over time. Simplex counts
 /// are stored as [`NonZeroU32`] so serialized results cannot represent an empty
 /// measured triangulation. Use [`NonZeroU32::get`] when raw `u32` counts are
@@ -155,14 +155,19 @@ impl TryFrom<CdtScalarTraceRowWire> for CdtScalarTraceRow {
                 actual: wire.step,
             })
         })?;
+        let vertices = nonzero_scalar_trace_count(MeasurementCountField::Vertices, wire.vertices)?;
+        let edges = nonzero_scalar_trace_count(MeasurementCountField::Edges, wire.edges)?;
+        let triangles =
+            nonzero_scalar_trace_count(MeasurementCountField::Triangles, wire.triangles)?;
+        validate_scalar_trace_volume_profile(step, triangles, &wire.volume_profile)?;
         let row = Self {
             step,
             outcome: wire.outcome,
             log_prob: wire.log_prob,
             action: wire.action,
-            vertices: nonzero_measurement_count(MeasurementCountField::Vertices, wire.vertices)?,
-            edges: nonzero_measurement_count(MeasurementCountField::Edges, wire.edges)?,
-            triangles: nonzero_measurement_count(MeasurementCountField::Triangles, wire.triangles)?,
+            vertices,
+            edges,
+            triangles,
             move_type: wire.move_type,
             delta_action: wire.delta_action,
             action_before: wire.action_before,
@@ -279,7 +284,7 @@ impl Measurement {
     /// Creates a measurement with an empty volume profile from validated counts.
     ///
     /// This constructor records scalar simulation counts. Attach per-slice
-    /// volume data with [`Self::with_volume_profile`] when the measured
+    /// volume data with [`Self::try_with_volume_profile`] when the measured
     /// triangulation has a foliation.
     ///
     /// Use [`Self::try_new`] when converting raw counts from serialized data,
@@ -415,10 +420,18 @@ impl Measurement {
         &self.volume_profile
     }
 
-    /// Returns this measurement with a per-slice volume profile attached.
+    /// Returns this measurement with a validated per-slice volume profile attached.
     ///
     /// The profile entries are triangle counts `N₂(t)` by time slab, matching
     /// [`CdtTriangulation::volume_profile`](crate::cdt::triangulation::CdtTriangulation::volume_profile).
+    /// An empty profile represents a measurement whose triangulation has no
+    /// current foliation. Non-empty profiles may include zero-count slices, but
+    /// their total must not exceed [`Self::triangles`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidMeasurementVolumeProfile`] when the profile
+    /// total exceeds this measurement's stored triangle count.
     ///
     /// # Examples
     ///
@@ -426,22 +439,24 @@ impl Measurement {
     /// use causal_triangulations::prelude::simulation::Measurement;
     ///
     /// let measurement =
-    ///     Measurement::try_new(20, -10.0, 12, 26, 12)?.with_volume_profile(vec![6, 6, 0]);
+    ///     Measurement::try_new(20, -10.0, 12, 26, 12)?.try_with_volume_profile(vec![6, 6, 0])?;
     /// assert_eq!(measurement.volume_profile(), &[6, 6, 0]);
     /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
     /// ```
-    #[must_use]
-    pub fn with_volume_profile(mut self, volume_profile: Vec<u32>) -> Self {
+    pub fn try_with_volume_profile(mut self, volume_profile: Vec<u32>) -> CdtResult<Self> {
+        validate_measurement_volume_profile(self.step, self.triangles, &volume_profile)?;
         self.volume_profile = volume_profile;
-        self
+        Ok(self)
     }
 }
 
 /// Raw measurement shape used only while deserializing result and checkpoint payloads.
 ///
 /// Serialized measurements stay JSON-numeric for compatibility with analysis
-/// tools, while conversion through [`Measurement::try_new`] rejects zero counts
-/// and non-finite actions before the public [`Measurement`] stores them.
+/// tools, while conversion through [`Measurement::try_new`] and
+/// [`Measurement::try_with_volume_profile`] rejects zero counts, non-finite
+/// actions, and impossible volume-profile totals before the public
+/// [`Measurement`] stores them.
 #[derive(Deserialize)]
 struct MeasurementWire {
     step: u32,
@@ -456,14 +471,14 @@ impl TryFrom<MeasurementWire> for Measurement {
     type Error = CdtError;
 
     fn try_from(wire: MeasurementWire) -> Result<Self, Self::Error> {
-        Ok(Self::try_new(
+        Self::try_new(
             wire.step,
             wire.action,
             wire.vertices,
             wire.edges,
             wire.triangles,
         )?
-        .with_volume_profile(wire.volume_profile))
+        .try_with_volume_profile(wire.volume_profile)
     }
 }
 
@@ -480,14 +495,67 @@ impl<'de> Deserialize<'de> for Measurement {
 
 /// Parses a raw measurement count into its nonzero domain type.
 ///
-/// This is the single boundary for `Measurement` and scalar-trace count
-/// invariants, keeping JSON deserialization, live measurement capture, and CSV
-/// trace export aligned on the same strictly-positive rule.
 fn nonzero_measurement_count(field: MeasurementCountField, value: u32) -> CdtResult<NonZeroU32> {
     NonZeroU32::new(value).ok_or(CdtError::InvalidMeasurementCount {
         field,
         provided_value: value,
     })
+}
+
+/// Parses a raw scalar trace count into its nonzero domain type.
+fn nonzero_scalar_trace_count(field: MeasurementCountField, value: u32) -> CdtResult<NonZeroU32> {
+    NonZeroU32::new(value).ok_or(CdtError::InvalidScalarTraceCount {
+        field,
+        provided_value: value,
+    })
+}
+
+/// Rejects scalar trace profiles that cannot fit the stored triangle count.
+fn validate_scalar_trace_volume_profile(
+    step: NonZeroU32,
+    triangles: NonZeroU32,
+    volume_profile: &[u32],
+) -> CdtResult<()> {
+    let Some(profile_total) = volume_profile_total(volume_profile) else {
+        return Ok(());
+    };
+    if profile_total > u64::from(triangles.get()) {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceVolumeProfileExceedsTriangles {
+                step: step.get(),
+                profile_total,
+                triangles: triangles.get(),
+            },
+        ));
+    }
+    Ok(())
+}
+
+/// Rejects measurement profiles that cannot fit the stored triangle count.
+fn validate_measurement_volume_profile(
+    step: u32,
+    triangles: NonZeroU32,
+    volume_profile: &[u32],
+) -> CdtResult<()> {
+    let Some(profile_total) = volume_profile_total(volume_profile) else {
+        return Ok(());
+    };
+    if profile_total > u64::from(triangles.get()) {
+        return Err(CdtError::InvalidMeasurementVolumeProfile {
+            step,
+            profile_total,
+            triangles: triangles.get(),
+        });
+    }
+    Ok(())
+}
+
+/// Sums non-empty volume profiles in a wider type.
+fn volume_profile_total(volume_profile: &[u32]) -> Option<u64> {
+    if volume_profile.is_empty() {
+        return None;
+    }
+    Some(volume_profile.iter().map(|&volume| u64::from(volume)).sum())
 }
 
 fn nonzero_usize_measurement_count(
@@ -922,6 +990,15 @@ fn validate_scalar_trace_row(
                 step: step_number,
                 actual: row.outcome.accepted(),
                 expected: expected_outcome.accepted(),
+            },
+        ));
+    }
+    if row.seed != config.seed() {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceSeedMismatch {
+                step: step_number,
+                actual: row.seed,
+                expected: config.seed(),
             },
         ));
     }
@@ -2042,6 +2119,15 @@ mod tests {
         .expect("valid rejected result should construct")
     }
 
+    fn assert_checkpoint_resume_failure(error: &CdtError, expected: &CheckpointResumeFailure) {
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure
+            } if failure == expected
+        );
+    }
+
     /// Asserts two equal-length floating-point slices using relative tolerance.
     fn assert_slice_relative_eq(actual: &[f64], expected: &[f64]) {
         assert_eq!(actual.len(), expected.len());
@@ -2096,8 +2182,12 @@ mod tests {
         let proposal_stats = ProposalStatistics::from_validated_parts(1, 7, 0, 0, 0, 0, 0, 1, 0);
         let step = accepted_step(1, MoveType::Move22, 4.0, 3.5);
         let measurements = vec![
-            measurement(0, 4.0, 12, 26, 12).with_volume_profile(vec![4, 4, 4]),
-            measurement(1, 3.5, 12, 26, 12).with_volume_profile(vec![4, 4, 4]),
+            measurement(0, 4.0, 12, 26, 12)
+                .try_with_volume_profile(vec![4, 4, 4])
+                .expect("volume profile should fit triangle count"),
+            measurement(1, 3.5, 12, 26, 12)
+                .try_with_volume_profile(vec![4, 4, 4])
+                .expect("volume profile should fit triangle count"),
         ];
         let elapsed = Duration::from_millis(42);
         let triangulation =
@@ -2321,6 +2411,39 @@ mod tests {
     }
 
     #[test]
+    fn public_constructor_rejects_scalar_trace_length_mismatch() {
+        let config = metropolis_config(1.0, 1, 0, 1);
+        let mut move_stats = MoveStatistics::new();
+        move_stats.record_attempt(MoveType::Move22);
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+
+        let error = SimulationResultsBackend::new(
+            config,
+            ActionConfig::default(),
+            move_stats,
+            ProposalStatistics::from_validated_parts(1, 0, 1, 0, 0, 0, 0, 0, 0),
+            vec![no_proposal_step(1, MoveType::Move22, 0.0)],
+            vec![
+                measurement(0, 0.0, 12, 26, 12),
+                measurement(1, 0.0, 12, 26, 12),
+            ],
+            Vec::new(),
+            Duration::ZERO,
+            triangulation,
+        )
+        .expect_err("scalar trace rows must align with step telemetry");
+
+        assert_checkpoint_resume_failure(
+            &error,
+            &CheckpointResumeFailure::ScalarTraceLengthMismatch {
+                actual: 0,
+                expected: 1,
+            },
+        );
+    }
+
+    #[test]
     fn public_constructor_rejects_scalar_trace_acceptance_mismatch() {
         let config = metropolis_config(1.0, 1, 0, 1);
         let mut move_stats = MoveStatistics::new();
@@ -2368,6 +2491,384 @@ mod tests {
                     expected: false
                 }
             }
+        );
+    }
+
+    #[test]
+    fn public_constructor_rejects_scalar_trace_action_mismatches() {
+        let config = seeded_metropolis_config(1.5, 1, 0, 1, 23);
+        let step = accepted_step(1, MoveType::Move22, 4.0, 3.5);
+        let cases = [
+            (
+                -3.5 / config.temperature(),
+                3.5,
+                Some(-0.5),
+                4.25,
+                Some(3.5),
+                CheckpointResumeFailure::ScalarTraceActionBeforeMismatch { step: 1 },
+            ),
+            (
+                -3.5 / config.temperature(),
+                3.5,
+                Some(-0.25),
+                4.0,
+                Some(3.5),
+                CheckpointResumeFailure::ScalarTraceDeltaActionMismatch { step: 1 },
+            ),
+            (
+                -3.5 / config.temperature(),
+                3.5,
+                Some(-0.5),
+                4.0,
+                Some(3.25),
+                CheckpointResumeFailure::ScalarTraceActionAfterMismatch { step: 1 },
+            ),
+            (
+                -3.25 / config.temperature(),
+                3.25,
+                Some(-0.5),
+                4.0,
+                Some(3.5),
+                CheckpointResumeFailure::ScalarTraceActionMismatch { step: 1 },
+            ),
+            (
+                -4.0 / config.temperature(),
+                3.5,
+                Some(-0.5),
+                4.0,
+                Some(3.5),
+                CheckpointResumeFailure::ScalarTraceLogProbMismatch { step: 1 },
+            ),
+        ];
+
+        for (log_prob, action, delta_action, action_before, action_after, expected) in cases {
+            let mut move_stats = MoveStatistics::new();
+            move_stats.record_attempt(MoveType::Move22);
+            move_stats.record_success(MoveType::Move22);
+            let triangulation =
+                CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+            let scalar_trace_rows = vec![
+                CdtScalarTraceRow::new(
+                    step.step(),
+                    CdtScalarTraceOutcome::Accepted,
+                    log_prob,
+                    action,
+                    &triangulation,
+                    step.move_type(),
+                    delta_action,
+                    action_before,
+                    action_after,
+                    config.seed(),
+                )
+                .expect("finite scalar trace row should build before cross-telemetry validation"),
+            ];
+
+            let error = SimulationResultsBackend::new(
+                config.clone(),
+                ActionConfig::default(),
+                move_stats,
+                ProposalStatistics::from_validated_parts(1, 7, 0, 0, 0, 0, 0, 1, 0),
+                vec![step.clone()],
+                vec![
+                    measurement(0, 4.0, 12, 26, 12),
+                    measurement(1, 3.5, 12, 26, 12),
+                ],
+                scalar_trace_rows,
+                Duration::ZERO,
+                triangulation,
+            )
+            .expect_err("scalar trace action telemetry must match step telemetry");
+
+            assert_checkpoint_resume_failure(&error, &expected);
+        }
+    }
+
+    #[test]
+    fn public_constructor_rejects_scalar_trace_seed_mismatch() {
+        let config = seeded_metropolis_config(1.0, 1, 0, 1, 23);
+        let step = no_proposal_step(1, MoveType::Move22, 0.0);
+        let mut move_stats = MoveStatistics::new();
+        move_stats.record_attempt(MoveType::Move22);
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let scalar_trace_rows = vec![
+            CdtScalarTraceRow::new(
+                step.step(),
+                CdtScalarTraceOutcome::NoProposal,
+                -0.0 / config.temperature(),
+                0.0,
+                &triangulation,
+                step.move_type(),
+                None,
+                0.0,
+                None,
+                Some(99),
+            )
+            .expect("row should build before cross-telemetry validation"),
+        ];
+
+        let error = SimulationResultsBackend::new(
+            config,
+            ActionConfig::default(),
+            move_stats,
+            ProposalStatistics::from_validated_parts(1, 0, 1, 0, 0, 0, 0, 0, 0),
+            vec![step],
+            vec![
+                measurement(0, 0.0, 12, 26, 12),
+                measurement(1, 0.0, 12, 26, 12),
+            ],
+            scalar_trace_rows,
+            Duration::ZERO,
+            triangulation,
+        )
+        .expect_err("scalar trace seed must match simulation config");
+
+        assert_checkpoint_resume_failure(
+            &error,
+            &CheckpointResumeFailure::ScalarTraceSeedMismatch {
+                step: 1,
+                actual: Some(99),
+                expected: Some(23),
+            },
+        );
+    }
+
+    #[test]
+    fn scalar_trace_validation_rejects_step_and_move_mismatches() {
+        let config = metropolis_config(1.0, 1, 0, 1);
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let step = no_proposal_step(1, MoveType::Move22, 0.0);
+        let cases = [
+            (
+                CdtScalarTraceRow::new(
+                    step_number(2),
+                    CdtScalarTraceOutcome::NoProposal,
+                    -0.0 / config.temperature(),
+                    0.0,
+                    &triangulation,
+                    MoveType::Move22,
+                    None,
+                    0.0,
+                    None,
+                    config.seed(),
+                )
+                .expect("trace row should build"),
+                CheckpointResumeFailure::ScalarTraceStepMismatch {
+                    actual: 2,
+                    expected: 1,
+                },
+            ),
+            (
+                CdtScalarTraceRow::new(
+                    step.step(),
+                    CdtScalarTraceOutcome::NoProposal,
+                    -0.0 / config.temperature(),
+                    0.0,
+                    &triangulation,
+                    MoveType::EdgeFlip,
+                    None,
+                    0.0,
+                    None,
+                    config.seed(),
+                )
+                .expect("trace row should build"),
+                CheckpointResumeFailure::ScalarTraceMoveTypeMismatch {
+                    step: 1,
+                    actual: MoveType::EdgeFlip,
+                    expected: MoveType::Move22,
+                },
+            ),
+        ];
+
+        for (row, expected) in cases {
+            let error = validate_scalar_trace_rows(
+                &config,
+                &ProposalStatistics::from_validated_parts(1, 0, 1, 0, 0, 0, 0, 0, 0),
+                std::slice::from_ref(&step),
+                &[row],
+            )
+            .expect_err("scalar trace row identity must match step telemetry");
+
+            assert_checkpoint_resume_failure(&error, &expected);
+        }
+    }
+
+    #[test]
+    fn scalar_trace_validation_rejects_optional_delta_action_presence_mismatch() {
+        let config = metropolis_config(1.0, 1, 0, 1);
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let step = rejected_proposal_step(1, MoveType::Move22, 4.0, Some(0.5));
+        let row = CdtScalarTraceRow::new(
+            step.step(),
+            CdtScalarTraceOutcome::RejectedProposal,
+            -4.0 / config.temperature(),
+            4.0,
+            &triangulation,
+            step.move_type(),
+            None,
+            step.action_before(),
+            step.action_after(),
+            config.seed(),
+        )
+        .expect("row should build before cross-telemetry validation");
+
+        let error = validate_scalar_trace_rows(
+            &config,
+            &ProposalStatistics::from_validated_parts(1, 7, 0, 0, 0, 0, 0, 1, 0),
+            &[step],
+            &[row],
+        )
+        .expect_err("optional delta_action presence must match step telemetry");
+
+        assert_checkpoint_resume_failure(
+            &error,
+            &CheckpointResumeFailure::ScalarTraceDeltaActionMismatch { step: 1 },
+        );
+    }
+
+    #[test]
+    fn scalar_trace_validation_rejects_aggregate_counter_mismatches() {
+        let config = metropolis_config(1.0, 1, 0, 1);
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let accepted_step = accepted_step(1, MoveType::Move22, 4.0, 3.5);
+        let rejected_step = rejected_proposal_step(1, MoveType::Move22, 4.0, Some(0.5));
+        let no_proposal_step = no_proposal_step(1, MoveType::Move22, 4.0);
+        let accepted_row = CdtScalarTraceRow::new(
+            accepted_step.step(),
+            CdtScalarTraceOutcome::Accepted,
+            -3.5 / config.temperature(),
+            3.5,
+            &triangulation,
+            accepted_step.move_type(),
+            accepted_step.delta_action(),
+            accepted_step.action_before(),
+            accepted_step.action_after(),
+            config.seed(),
+        )
+        .expect("accepted scalar trace row should build");
+        let rejected_row = CdtScalarTraceRow::new(
+            rejected_step.step(),
+            CdtScalarTraceOutcome::RejectedProposal,
+            -4.0 / config.temperature(),
+            4.0,
+            &triangulation,
+            rejected_step.move_type(),
+            rejected_step.delta_action(),
+            rejected_step.action_before(),
+            rejected_step.action_after(),
+            config.seed(),
+        )
+        .expect("rejected scalar trace row should build");
+        let no_proposal_row = CdtScalarTraceRow::new(
+            no_proposal_step.step(),
+            CdtScalarTraceOutcome::NoProposal,
+            -4.0 / config.temperature(),
+            4.0,
+            &triangulation,
+            no_proposal_step.move_type(),
+            no_proposal_step.delta_action(),
+            no_proposal_step.action_before(),
+            no_proposal_step.action_after(),
+            config.seed(),
+        )
+        .expect("no-proposal scalar trace row should build");
+        let cases = [
+            (
+                accepted_step,
+                accepted_row,
+                ProposalStatistics::from_validated_parts(1, 7, 0, 0, 0, 0, 0, 0, 0),
+                CheckpointResumeFailure::ScalarTraceAcceptedCountMismatch {
+                    actual: 1,
+                    expected: 0,
+                },
+            ),
+            (
+                rejected_step,
+                rejected_row,
+                ProposalStatistics::from_validated_parts(1, 7, 0, 0, 0, 0, 0, 0, 0),
+                CheckpointResumeFailure::ScalarTraceRejectedProposalCountMismatch {
+                    actual: 1,
+                    expected: 0,
+                },
+            ),
+            (
+                no_proposal_step,
+                no_proposal_row,
+                ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 0),
+                CheckpointResumeFailure::ScalarTraceNoProposalCountMismatch {
+                    actual: 1,
+                    expected: 0,
+                },
+            ),
+        ];
+
+        for (step, row, proposal_stats, expected) in cases {
+            let error = validate_scalar_trace_rows(&config, &proposal_stats, &[step], &[row])
+                .expect_err("scalar trace aggregate counters must match proposal telemetry");
+
+            assert_checkpoint_resume_failure(&error, &expected);
+        }
+    }
+
+    #[test]
+    fn scalar_trace_export_encodes_rejected_rows_and_absent_seed_observables() {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let mut row = CdtScalarTraceRow::new(
+            step_number(1),
+            CdtScalarTraceOutcome::RejectedProposal,
+            -4.0,
+            4.0,
+            &triangulation,
+            MoveType::Move22,
+            Some(0.5),
+            4.0,
+            None,
+            None,
+        )
+        .expect("rejected trace row should build");
+        row.volume_profile = vec![2, 4];
+        let mut results = results_with(
+            metropolis_config(1.0, 1, 0, 1),
+            Vec::new(),
+            Vec::new(),
+            triangulation,
+        );
+        results.scalar_trace_rows = vec![row];
+
+        let trace = results.scalar_trace().expect("scalar trace should export");
+        assert_eq!(trace.len(), 1);
+        assert_eq!(
+            trace.observable_names(),
+            &[
+                "action",
+                "vertices",
+                "edges",
+                "triangles",
+                "move_family",
+                "delta_action",
+                "delta_action_present",
+                "action_before",
+                "action_after",
+                "action_after_present",
+                "seed_low_u32",
+                "seed_high_u32",
+                "seed_present",
+                "volume_profile_0",
+                "volume_profile_1",
+            ]
+        );
+        let record = &trace.records()[0];
+        assert_eq!(record.outcome(), TraceStepOutcome::rejected_proposal());
+        assert_relative_eq!(record.log_prob(), -4.0);
+        assert_eq!(
+            record.observable_values(),
+            &[
+                4.0, 12.0, 23.0, 12.0, 22.0, 0.5, 1.0, 4.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 4.0,
+            ]
         );
     }
 
@@ -2600,10 +3101,52 @@ mod tests {
                 .expect_err("zero scalar trace count should fail while parsing");
             let message = error.to_string();
             assert!(
-                message.contains("Invalid measurement count") && message.contains(field),
+                message.contains("Invalid scalar trace count") && message.contains(field),
                 "unexpected serde error for {field}: {message}"
             );
         }
+    }
+
+    #[test]
+    fn deserialization_rejects_scalar_trace_volume_profile_above_triangle_count() {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let results = valid_rejected_result(triangulation);
+        let mut payload = to_value(&results).expect("results should serialize");
+        payload["scalar_trace_rows"][0]["volume_profile"] =
+            to_value([13_u32]).expect("volume profile should serialize");
+
+        let error = from_str::<SimulationResultsBackend>(&payload.to_string())
+            .expect_err("scalar trace volume profile cannot exceed stored triangle count");
+
+        assert!(
+            error
+                .to_string()
+                .contains("scalar trace volume profile total 13")
+                && error.to_string().contains("triangle count 12"),
+            "unexpected serde error: {error}"
+        );
+    }
+
+    #[test]
+    fn deserialization_rejects_measurement_volume_profile_above_triangle_count() {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let results = valid_rejected_result(triangulation);
+        let mut payload = to_value(&results).expect("results should serialize");
+        payload["measurements"][0]["volume_profile"] =
+            to_value([13_u32]).expect("volume profile should serialize");
+
+        let error = from_str::<SimulationResultsBackend>(&payload.to_string())
+            .expect_err("measurement volume profile cannot exceed stored triangle count");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Invalid measurement volume profile at step 0: total 13")
+                && error.to_string().contains("triangle count 12"),
+            "unexpected serde error: {error}"
+        );
     }
 
     #[test]
@@ -2699,7 +3242,9 @@ mod tests {
 
     #[test]
     fn measurement_builders_preserve_scalar_counts_and_profile() {
-        let measurement = measurement(7, -3.5, 12, 26, 12).with_volume_profile(vec![6, 6, 0]);
+        let measurement = measurement(7, -3.5, 12, 26, 12)
+            .try_with_volume_profile(vec![6, 6, 0])
+            .expect("volume profile should fit triangle count");
 
         assert_eq!(measurement.step(), 7);
         assert_relative_eq!(measurement.action(), -3.5);
@@ -2707,6 +3252,22 @@ mod tests {
         assert_eq!(measurement.edges().get(), 26);
         assert_eq!(measurement.triangles().get(), 12);
         assert_eq!(measurement.volume_profile(), &[6, 6, 0]);
+    }
+
+    #[test]
+    fn measurement_builder_rejects_volume_profile_above_triangle_count() {
+        let error = measurement(7, -3.5, 12, 26, 12)
+            .try_with_volume_profile(vec![13])
+            .expect_err("volume profile cannot exceed stored triangle count");
+
+        assert_matches!(
+            error,
+            CdtError::InvalidMeasurementVolumeProfile {
+                step: 7,
+                profile_total: 13,
+                triangles: 12,
+            }
+        );
     }
 
     #[test]
@@ -2936,9 +3497,15 @@ mod tests {
             accepted_step(3, MoveType::Move31Remove, 2.5, 2.0),
         ];
         let measurements = vec![
-            measurement(0, 1.0, 3, 3, 1).with_volume_profile(vec![1, 0, 0]),
-            measurement(10, 2.0, 4, 5, 2).with_volume_profile(vec![1, 1, 0]),
-            measurement(15, 3.0, 5, 7, 3).with_volume_profile(vec![1, 2, 0]),
+            measurement(0, 1.0, 3, 3, 1)
+                .try_with_volume_profile(vec![1, 0, 0])
+                .expect("volume profile should fit triangle count"),
+            measurement(10, 2.0, 4, 5, 2)
+                .try_with_volume_profile(vec![1, 1, 0])
+                .expect("volume profile should fit triangle count"),
+            measurement(15, 3.0, 5, 7, 3)
+                .try_with_volume_profile(vec![1, 2, 0])
+                .expect("volume profile should fit triangle count"),
         ];
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
@@ -2963,8 +3530,12 @@ mod tests {
             metropolis_config(1.0, 20, 10, 5),
             vec![],
             vec![
-                measurement(10, 2.0, 4, 5, 2).with_volume_profile(vec![4, 8, 1]),
-                measurement(15, 3.0, 5, 7, 3).with_volume_profile(vec![6]),
+                measurement(10, 2.0, 4, 5, 13)
+                    .try_with_volume_profile(vec![4, 8, 1])
+                    .expect("volume profile should fit triangle count"),
+                measurement(15, 3.0, 5, 7, 6)
+                    .try_with_volume_profile(vec![6])
+                    .expect("volume profile should fit triangle count"),
             ],
             triangulation,
         );
@@ -2999,8 +3570,12 @@ mod tests {
             metropolis_config(1.0, 20, 10, 5),
             vec![],
             vec![
-                measurement(0, 1.0, 3, 3, 1).with_volume_profile(vec![1]),
-                measurement(10, 2.0, 4, 5, 2).with_volume_profile(vec![2]),
+                measurement(0, 1.0, 3, 3, 1)
+                    .try_with_volume_profile(vec![1])
+                    .expect("volume profile should fit triangle count"),
+                measurement(10, 2.0, 4, 5, 2)
+                    .try_with_volume_profile(vec![2])
+                    .expect("volume profile should fit triangle count"),
             ],
             triangulation,
         );

--- a/src/cdt/results.rs
+++ b/src/cdt/results.rs
@@ -7,83 +7,412 @@
 //! the final triangulation state.
 
 use crate::cdt::action::ActionConfig;
-use crate::cdt::ergodic_moves::MoveStatistics;
+use crate::cdt::ergodic_moves::{MoveStatistics, MoveType};
 use crate::cdt::metropolis::{
-    MetropolisConfig, MonteCarloStep, ProposalStatistics,
+    ChainId, MetropolisConfig, MonteCarloStep, MonteCarloStepOutcome, ProposalStatistics, Trace,
+    TraceError, TraceRecord, TraceStepOutcome,
     checkpoint::{chain_counters, checkpoint_resume_failed},
     helpers::{actions_match, expected_measurement_count, expected_measurement_step},
 };
 use crate::cdt::observables::{estimate_hausdorff_dimension, estimate_spectral_dimension};
+use crate::cdt::triangulation::CdtSimplexCounts;
 use crate::config::{CdtConfig, CdtTopology, ValidatedCdtConfig};
 use crate::errors::{
-    CdtError, CdtResult, CheckpointMoveCounter, CheckpointResumeFailure, OutputFormat,
-    ProposalTelemetryCounter,
+    CdtError, CdtResult, CheckpointMoveCounter, CheckpointResumeFailure, MeasurementCountField,
+    OutputFormat, ProposalTelemetryCounter, ScalarTraceField,
 };
 use crate::geometry::CdtTriangulation2D;
 use crate::util::usize_to_f64;
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::to_writer_pretty;
-use std::collections::HashMap;
 use std::fmt::Display;
 use std::fs::{File, create_dir_all};
 use std::io::{BufWriter, Write};
+use std::num::NonZeroU32;
 use std::path::Path;
 use std::time::Duration;
 
-/// Measurement data collected during simulation.
+/// Scalar measurement data collected during simulation.
 ///
 /// Use [`Self::new`] and builder-style methods such as
 /// [`Self::with_volume_profile`] rather than struct literals outside this
-/// crate; additional measurement fields may be added over time.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// crate; additional measurement fields may be added over time. Simplex counts
+/// are stored as [`NonZeroU32`] so serialized results cannot represent an empty
+/// measured triangulation. Use [`NonZeroU32::get`] when raw `u32` counts are
+/// needed for reporting or arithmetic.
+#[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct Measurement {
-    /// Monte Carlo step when measurement was taken
-    pub step: u32,
-    /// Current action value
-    pub action: f64,
-    /// Number of vertices
-    pub vertices: u32,
-    /// Number of edges
-    pub edges: u32,
-    /// Number of triangles
-    pub triangles: u32,
+    /// Monte Carlo step when measurement was taken.
+    step: u32,
+    /// Current action value.
+    action: f64,
+    /// Nonzero number of vertices.
+    vertices: NonZeroU32,
+    /// Nonzero number of edges.
+    edges: NonZeroU32,
+    /// Nonzero number of triangles.
+    triangles: NonZeroU32,
     /// Per-slice triangle counts `N₂(t)` from
     /// [`CdtTriangulation::volume_profile`](crate::cdt::triangulation::CdtTriangulation::volume_profile).
     ///
     /// Entry `t` counts classifiable CDT triangles assigned to time slab `t`;
     /// the vector is empty when the measured triangulation has no current
     /// foliation.
-    pub volume_profile: Vec<u32>,
+    volume_profile: Vec<u32>,
+}
+
+/// Base observable columns emitted by [`SimulationResultsBackend::scalar_trace`].
+const SCALAR_TRACE_BASE_OBSERVABLES: [&str; 13] = [
+    "action",
+    "vertices",
+    "edges",
+    "triangles",
+    "move_family",
+    "delta_action",
+    "delta_action_present",
+    "action_before",
+    "action_after",
+    "action_after_present",
+    "seed_low_u32",
+    "seed_high_u32",
+    "seed_present",
+];
+
+/// Single-chain identifier used by CDT result exports.
+const CDT_TRACE_CHAIN_ID: ChainId = ChainId::new(0);
+
+/// Invariant-bearing CDT trace outcome stored in serialized result/checkpoint rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum CdtScalarTraceOutcome {
+    /// A concrete proposal was accepted and committed.
+    Accepted,
+    /// A concrete proposal was rejected by Metropolis-Hastings.
+    RejectedProposal,
+    /// No concrete proposal was available or a local proposal check rejected it.
+    NoProposal,
+}
+
+impl CdtScalarTraceOutcome {
+    /// Converts the CDT-owned outcome into the upstream trace outcome type.
+    const fn into_trace_outcome(self) -> TraceStepOutcome {
+        match self {
+            Self::Accepted => TraceStepOutcome::accepted(),
+            Self::RejectedProposal => TraceStepOutcome::rejected_proposal(),
+            Self::NoProposal => TraceStepOutcome::no_proposal(),
+        }
+    }
+
+    /// Whether this row records an accepted proposal.
+    pub(crate) const fn accepted(self) -> bool {
+        matches!(self, Self::Accepted)
+    }
+}
+
+/// A rectangular scalar trace row captured from the upstream planned-step outcome.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CdtScalarTraceRow {
+    step: NonZeroU32,
+    outcome: CdtScalarTraceOutcome,
+    log_prob: f64,
+    action: f64,
+    vertices: NonZeroU32,
+    edges: NonZeroU32,
+    triangles: NonZeroU32,
+    move_type: MoveType,
+    delta_action: Option<f64>,
+    action_before: f64,
+    action_after: Option<f64>,
+    seed: Option<u64>,
+    volume_profile: Vec<u32>,
+}
+
+/// Raw scalar trace shape used only while deserializing result and checkpoint payloads.
+#[derive(Deserialize)]
+struct CdtScalarTraceRowWire {
+    step: u32,
+    outcome: CdtScalarTraceOutcome,
+    log_prob: f64,
+    action: f64,
+    vertices: u32,
+    edges: u32,
+    triangles: u32,
+    move_type: MoveType,
+    delta_action: Option<f64>,
+    action_before: f64,
+    action_after: Option<f64>,
+    seed: Option<u64>,
+    volume_profile: Vec<u32>,
+}
+
+impl TryFrom<CdtScalarTraceRowWire> for CdtScalarTraceRow {
+    type Error = CdtError;
+
+    fn try_from(wire: CdtScalarTraceRowWire) -> Result<Self, Self::Error> {
+        let step = NonZeroU32::new(wire.step).ok_or_else(|| {
+            checkpoint_resume_failed(CheckpointResumeFailure::ScalarTraceStepZero {
+                actual: wire.step,
+            })
+        })?;
+        let row = Self {
+            step,
+            outcome: wire.outcome,
+            log_prob: wire.log_prob,
+            action: wire.action,
+            vertices: nonzero_measurement_count(MeasurementCountField::Vertices, wire.vertices)?,
+            edges: nonzero_measurement_count(MeasurementCountField::Edges, wire.edges)?,
+            triangles: nonzero_measurement_count(MeasurementCountField::Triangles, wire.triangles)?,
+            move_type: wire.move_type,
+            delta_action: wire.delta_action,
+            action_before: wire.action_before,
+            action_after: wire.action_after,
+            seed: wire.seed,
+            volume_profile: wire.volume_profile,
+        };
+        validate_scalar_trace_finite_fields(&row)?;
+        Ok(row)
+    }
+}
+
+impl<'de> Deserialize<'de> for CdtScalarTraceRow {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        CdtScalarTraceRowWire::deserialize(deserializer)?
+            .try_into()
+            .map_err(DeError::custom)
+    }
+}
+
+impl CdtScalarTraceRow {
+    /// Captures one post-step CDT scalar trace row.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidSimplexCount`] if the triangulation reports zero
+    /// vertices, edges, or triangles at the completed step,
+    /// [`CdtError::MeasurementCountOverflow`] if any live count cannot fit the
+    /// compact trace storage type, or [`CdtError::CheckpointResumeFailed`] if a
+    /// scalar trace field is non-finite.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "trace rows mirror the upstream step outcome plus CDT scalar observables"
+    )]
+    pub(crate) fn new(
+        step: NonZeroU32,
+        outcome: CdtScalarTraceOutcome,
+        log_prob: f64,
+        action: f64,
+        triangulation: &CdtTriangulation2D,
+        move_type: MoveType,
+        delta_action: Option<f64>,
+        action_before: f64,
+        action_after: Option<f64>,
+        seed: Option<u64>,
+    ) -> CdtResult<Self> {
+        let counts = triangulation.simplex_counts()?;
+        let row = Self {
+            step,
+            outcome,
+            log_prob,
+            action,
+            vertices: nonzero_usize_measurement_count(
+                MeasurementCountField::Vertices,
+                counts.vertex_count(),
+            )?,
+            edges: nonzero_usize_measurement_count(
+                MeasurementCountField::Edges,
+                counts.edge_count(),
+            )?,
+            triangles: nonzero_usize_measurement_count(
+                MeasurementCountField::Triangles,
+                counts.triangle_count(),
+            )?,
+            move_type,
+            delta_action,
+            action_before,
+            action_after,
+            seed,
+            volume_profile: triangulation.volume_profile(),
+        };
+        validate_scalar_trace_finite_fields(&row)?;
+        Ok(row)
+    }
+
+    /// Converts the stored CDT outcome into the upstream trace outcome.
+    const fn outcome(&self) -> TraceStepOutcome {
+        self.outcome.into_trace_outcome()
+    }
+
+    /// Returns observable values in scalar trace observable order.
+    fn observable_values(&self, volume_profile_len: usize) -> Vec<f64> {
+        let (seed_low, seed_high, seed_present) = seed_observables(self.seed);
+        let mut values =
+            Vec::with_capacity(SCALAR_TRACE_BASE_OBSERVABLES.len() + volume_profile_len);
+        values.extend([
+            self.action,
+            f64::from(self.vertices.get()),
+            f64::from(self.edges.get()),
+            f64::from(self.triangles.get()),
+            f64::from(move_type_code(self.move_type)),
+            self.delta_action.unwrap_or(0.0),
+            option_presence(self.delta_action),
+            self.action_before,
+            self.action_after.unwrap_or(0.0),
+            option_presence(self.action_after),
+            seed_low,
+            seed_high,
+            seed_present,
+        ]);
+        values.extend((0..volume_profile_len).map(|index| {
+            self.volume_profile
+                .get(index)
+                .map_or(0.0, |&volume| f64::from(volume))
+        }));
+        values
+    }
 }
 
 impl Measurement {
-    /// Creates a measurement with an empty volume profile.
+    /// Creates a measurement with an empty volume profile from validated counts.
     ///
     /// This constructor records scalar simulation counts. Attach per-slice
     /// volume data with [`Self::with_volume_profile`] when the measured
     /// triangulation has a foliation.
     ///
+    /// Use [`Self::try_new`] when converting raw counts from serialized data,
+    /// test fixtures, or other boundary inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidMeasurementAction`] when `action` is not finite.
+    ///
     /// # Examples
     ///
     /// ```
     /// use causal_triangulations::prelude::simulation::Measurement;
+    /// use std::num::NonZeroU32;
     ///
-    /// let measurement = Measurement::new(10, -12.5, 64, 180, 117);
-    /// assert_eq!(measurement.step, 10);
-    /// assert!(measurement.volume_profile.is_empty());
+    /// let unit_count = NonZeroU32::MIN;
+    /// let measurement = Measurement::new(10, -12.5, unit_count, unit_count, unit_count)?;
+    /// assert_eq!(measurement.step(), 10);
+    /// assert_eq!(measurement.vertices().get(), 1);
+    /// assert!(measurement.volume_profile().is_empty());
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
     /// ```
-    #[must_use]
-    pub const fn new(step: u32, action: f64, vertices: u32, edges: u32, triangles: u32) -> Self {
-        Self {
+    pub fn new(
+        step: u32,
+        action: f64,
+        vertices: NonZeroU32,
+        edges: NonZeroU32,
+        triangles: NonZeroU32,
+    ) -> CdtResult<Self> {
+        validate_measurement_action(step, action)?;
+        Ok(Self {
             step,
             action,
             vertices,
             edges,
             triangles,
             volume_profile: Vec::new(),
-        }
+        })
+    }
+
+    /// Creates a measurement from raw scalar counts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidMeasurementCount`] when any count is zero, or
+    /// [`CdtError::InvalidMeasurementAction`] when `action` is not finite.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::Measurement;
+    ///
+    /// let measurement = Measurement::try_new(10, -12.5, 64, 180, 117)?;
+    /// assert_eq!(measurement.vertices().get(), 64);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
+    pub fn try_new(
+        step: u32,
+        action: f64,
+        vertices: u32,
+        edges: u32,
+        triangles: u32,
+    ) -> CdtResult<Self> {
+        Self::new(
+            step,
+            action,
+            nonzero_measurement_count(MeasurementCountField::Vertices, vertices)?,
+            nonzero_measurement_count(MeasurementCountField::Edges, edges)?,
+            nonzero_measurement_count(MeasurementCountField::Triangles, triangles)?,
+        )
+    }
+
+    /// Creates a measurement from a validated CDT simplex-count snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::MeasurementCountOverflow`] when any live count exceeds
+    /// `u32::MAX`, or [`CdtError::InvalidMeasurementAction`] when `action` is not
+    /// finite.
+    pub(crate) fn try_from_simplex_counts(
+        step: u32,
+        action: f64,
+        counts: CdtSimplexCounts,
+    ) -> CdtResult<Self> {
+        Self::new(
+            step,
+            action,
+            nonzero_usize_measurement_count(
+                MeasurementCountField::Vertices,
+                counts.vertex_count(),
+            )?,
+            nonzero_usize_measurement_count(MeasurementCountField::Edges, counts.edge_count())?,
+            nonzero_usize_measurement_count(
+                MeasurementCountField::Triangles,
+                counts.triangle_count(),
+            )?,
+        )
+    }
+
+    /// Returns the Monte Carlo step when this measurement was taken.
+    #[must_use]
+    pub const fn step(&self) -> u32 {
+        self.step
+    }
+
+    /// Returns the finite action value recorded at this measurement.
+    #[must_use]
+    pub const fn action(&self) -> f64 {
+        self.action
+    }
+
+    /// Returns the nonzero vertex count.
+    #[must_use]
+    pub const fn vertices(&self) -> NonZeroU32 {
+        self.vertices
+    }
+
+    /// Returns the nonzero edge count.
+    #[must_use]
+    pub const fn edges(&self) -> NonZeroU32 {
+        self.edges
+    }
+
+    /// Returns the nonzero triangle count.
+    #[must_use]
+    pub const fn triangles(&self) -> NonZeroU32 {
+        self.triangles
+    }
+
+    /// Returns per-slice triangle counts `N₂(t)` by time slab.
+    #[must_use]
+    pub fn volume_profile(&self) -> &[u32] {
+        &self.volume_profile
     }
 
     /// Returns this measurement with a per-slice volume profile attached.
@@ -97,13 +426,91 @@ impl Measurement {
     /// use causal_triangulations::prelude::simulation::Measurement;
     ///
     /// let measurement =
-    ///     Measurement::new(20, -10.0, 12, 26, 12).with_volume_profile(vec![6, 6, 0]);
-    /// assert_eq!(measurement.volume_profile, vec![6, 6, 0]);
+    ///     Measurement::try_new(20, -10.0, 12, 26, 12)?.with_volume_profile(vec![6, 6, 0]);
+    /// assert_eq!(measurement.volume_profile(), &[6, 6, 0]);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
     /// ```
     #[must_use]
     pub fn with_volume_profile(mut self, volume_profile: Vec<u32>) -> Self {
         self.volume_profile = volume_profile;
         self
+    }
+}
+
+/// Raw measurement shape used only while deserializing result and checkpoint payloads.
+///
+/// Serialized measurements stay JSON-numeric for compatibility with analysis
+/// tools, while conversion through [`Measurement::try_new`] rejects zero counts
+/// and non-finite actions before the public [`Measurement`] stores them.
+#[derive(Deserialize)]
+struct MeasurementWire {
+    step: u32,
+    action: f64,
+    vertices: u32,
+    edges: u32,
+    triangles: u32,
+    volume_profile: Vec<u32>,
+}
+
+impl TryFrom<MeasurementWire> for Measurement {
+    type Error = CdtError;
+
+    fn try_from(wire: MeasurementWire) -> Result<Self, Self::Error> {
+        Ok(Self::try_new(
+            wire.step,
+            wire.action,
+            wire.vertices,
+            wire.edges,
+            wire.triangles,
+        )?
+        .with_volume_profile(wire.volume_profile))
+    }
+}
+
+impl<'de> Deserialize<'de> for Measurement {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        MeasurementWire::deserialize(deserializer)?
+            .try_into()
+            .map_err(DeError::custom)
+    }
+}
+
+/// Parses a raw measurement count into its nonzero domain type.
+///
+/// This is the single boundary for `Measurement` and scalar-trace count
+/// invariants, keeping JSON deserialization, live measurement capture, and CSV
+/// trace export aligned on the same strictly-positive rule.
+fn nonzero_measurement_count(field: MeasurementCountField, value: u32) -> CdtResult<NonZeroU32> {
+    NonZeroU32::new(value).ok_or(CdtError::InvalidMeasurementCount {
+        field,
+        provided_value: value,
+    })
+}
+
+fn nonzero_usize_measurement_count(
+    field: MeasurementCountField,
+    value: usize,
+) -> CdtResult<NonZeroU32> {
+    let value = u32::try_from(value).map_err(|_| CdtError::MeasurementCountOverflow {
+        field,
+        provided_value: value,
+        max: u32::MAX,
+    })?;
+    nonzero_measurement_count(field, value)
+}
+
+/// Checks that a measurement action is finite before storage.
+const fn validate_measurement_action(step: u32, action: f64) -> CdtResult<()> {
+    if action.is_finite() {
+        Ok(())
+    } else {
+        Err(CdtError::InvalidMeasurementAction {
+            step,
+            provided_value: action,
+        })
     }
 }
 
@@ -134,6 +541,8 @@ pub struct SimulationResultsBackend {
     steps: Vec<MonteCarloStep>,
     /// Measurements taken during simulation
     measurements: Vec<Measurement>,
+    /// Upstream-compatible scalar trace rows for completed Metropolis steps
+    scalar_trace_rows: Vec<CdtScalarTraceRow>,
     /// Total simulation time
     elapsed_time: Duration,
     /// Final triangulation state
@@ -149,6 +558,7 @@ struct SimulationResultsBackendWire {
     proposal_stats: ProposalStatistics,
     steps: Vec<MonteCarloStep>,
     measurements: Vec<Measurement>,
+    scalar_trace_rows: Vec<CdtScalarTraceRow>,
     elapsed_time: Duration,
     triangulation: CdtTriangulation2D,
 }
@@ -161,6 +571,7 @@ pub(crate) struct SimulationResultsParts {
     pub(crate) proposal_stats: ProposalStatistics,
     pub(crate) steps: Vec<MonteCarloStep>,
     pub(crate) measurements: Vec<Measurement>,
+    pub(crate) scalar_trace_rows: Vec<CdtScalarTraceRow>,
     pub(crate) elapsed_time: Duration,
     pub(crate) triangulation: CdtTriangulation2D,
 }
@@ -179,6 +590,7 @@ impl TryFrom<SimulationResultsBackendWire> for SimulationResultsBackend {
             wire.proposal_stats,
             wire.steps,
             wire.measurements,
+            wire.scalar_trace_rows,
             wire.elapsed_time,
             wire.triangulation,
         )
@@ -209,8 +621,15 @@ fn validate_result_telemetry(
     proposal_stats: &ProposalStatistics,
     steps: &[MonteCarloStep],
     measurements: &[Measurement],
+    scalar_trace_rows: &[CdtScalarTraceRow],
 ) -> CdtResult<()> {
-    if is_initial_construction_snapshot(move_stats, proposal_stats, steps, measurements) {
+    if is_initial_construction_snapshot(
+        move_stats,
+        proposal_stats,
+        steps,
+        measurements,
+        scalar_trace_rows,
+    ) {
         return Ok(());
     }
 
@@ -241,7 +660,8 @@ fn validate_result_telemetry(
 
     validate_result_steps(steps, accepted)?;
     validate_result_measurements(config, steps, measurements)?;
-    validate_result_proposal_stats(proposal_stats, steps.len(), accepted, rejected)
+    validate_result_proposal_stats(proposal_stats, steps.len(), accepted, rejected)?;
+    validate_scalar_trace_rows(config, proposal_stats, steps, scalar_trace_rows)
 }
 
 /// Recognizes a construction-only result before Metropolis steps have run.
@@ -250,8 +670,10 @@ fn is_initial_construction_snapshot(
     proposal_stats: &ProposalStatistics,
     steps: &[MonteCarloStep],
     measurements: &[Measurement],
+    scalar_trace_rows: &[CdtScalarTraceRow],
 ) -> bool {
     steps.is_empty()
+        && scalar_trace_rows.is_empty()
         && move_stats.total_attempted() == 0
         && move_stats.total_accepted() == 0
         && move_stats.total_hard_failures() == 0
@@ -260,12 +682,12 @@ fn is_initial_construction_snapshot(
         && proposal_stats.rejected_transitions() == 0
         && proposal_stats.accepted_transitions() == 0
         && proposal_stats.hard_failures() == 0
-        && matches!(measurements, [measurement] if measurement.step == 0 && measurement.action.is_finite())
+        && matches!(measurements, [measurement] if measurement.step() == 0)
 }
 
 /// Checks per-step records against accepted-count and action-delta invariants.
 fn validate_result_steps(steps: &[MonteCarloStep], accepted: usize) -> CdtResult<()> {
-    let accepted_steps = steps.iter().filter(|step| step.accepted).count();
+    let accepted_steps = steps.iter().filter(|step| step.accepted()).count();
     if accepted_steps != accepted {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::StepTelemetryAcceptedCountMismatch {
@@ -279,7 +701,7 @@ fn validate_result_steps(steps: &[MonteCarloStep], accepted: usize) -> CdtResult
         let expected_step = u32::try_from(index + 1).map_err(|_| {
             checkpoint_resume_failed(CheckpointResumeFailure::StepTelemetryIndexOverflow)
         })?;
-        let step_number = step.step.get();
+        let step_number = step.step().get();
         if step_number != expected_step {
             return Err(checkpoint_resume_failed(
                 CheckpointResumeFailure::StepTelemetrySequenceMismatch {
@@ -287,50 +709,6 @@ fn validate_result_steps(steps: &[MonteCarloStep], accepted: usize) -> CdtResult
                     expected: expected_step,
                 },
             ));
-        }
-        if !step.action_before.is_finite() {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::NonFiniteStepActionBefore { step: step_number },
-            ));
-        }
-        if let Some(delta_action) = step.delta_action
-            && !delta_action.is_finite()
-        {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::NonFiniteStepDeltaAction { step: step_number },
-            ));
-        }
-        if step.accepted && step.delta_action.is_none() {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::AcceptedStepMissingDeltaAction { step: step_number },
-            ));
-        }
-        match (step.accepted, step.action_after) {
-            (true, Some(action_after)) if action_after.is_finite() => {
-                if let Some(delta_action) = step.delta_action
-                    && !actions_match(action_after, step.action_before + delta_action)
-                {
-                    return Err(checkpoint_resume_failed(
-                        CheckpointResumeFailure::StepActionAfterDeltaMismatch { step: step_number },
-                    ));
-                }
-            }
-            (true, Some(_)) => {
-                return Err(checkpoint_resume_failed(
-                    CheckpointResumeFailure::NonFiniteStepActionAfter { step: step_number },
-                ));
-            }
-            (true, None) => {
-                return Err(checkpoint_resume_failed(
-                    CheckpointResumeFailure::AcceptedStepMissingActionAfter { step: step_number },
-                ));
-            }
-            (false, Some(_)) => {
-                return Err(checkpoint_resume_failed(
-                    CheckpointResumeFailure::RejectedStepHasActionAfter { step: step_number },
-                ));
-            }
-            (false, None) => {}
         }
     }
     Ok(())
@@ -373,18 +751,11 @@ fn validate_result_measurements(
         .ok_or_else(|| {
             checkpoint_resume_failed(CheckpointResumeFailure::MeasurementStepOverflow)
         })?;
-        if measurement.step != expected_step {
+        if measurement.step() != expected_step {
             return Err(checkpoint_resume_failed(
                 CheckpointResumeFailure::MeasurementStepMismatch {
-                    actual: measurement.step,
+                    actual: measurement.step(),
                     expected: expected_step,
-                },
-            ));
-        }
-        if !measurement.action.is_finite() {
-            return Err(checkpoint_resume_failed(
-                CheckpointResumeFailure::NonFiniteMeasurementAction {
-                    step: measurement.step,
                 },
             ));
         }
@@ -454,6 +825,233 @@ fn validate_result_proposal_stats(
         ));
     }
     Ok(())
+}
+
+/// Checks scalar trace rows against step and proposal telemetry.
+///
+/// Trace rows are serialized result/checkpoint state, so they are validated at
+/// the same boundary as steps, measurements, and proposal counters before later
+/// code can trust them for CSV export.
+pub(crate) fn validate_scalar_trace_rows(
+    config: &MetropolisConfig,
+    proposal_stats: &ProposalStatistics,
+    steps: &[MonteCarloStep],
+    scalar_trace_rows: &[CdtScalarTraceRow],
+) -> CdtResult<()> {
+    if scalar_trace_rows.len() != steps.len() {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceLengthMismatch {
+                actual: scalar_trace_rows.len(),
+                expected: steps.len(),
+            },
+        ));
+    }
+
+    let mut accepted = 0_u64;
+    let mut rejected_proposal = 0_u64;
+    let mut no_proposal = 0_u64;
+    for (step, row) in steps.iter().zip(scalar_trace_rows) {
+        validate_scalar_trace_row(config, step, row)?;
+        match row.outcome {
+            CdtScalarTraceOutcome::Accepted => accepted = accepted.saturating_add(1),
+            CdtScalarTraceOutcome::RejectedProposal => {
+                rejected_proposal = rejected_proposal.saturating_add(1);
+            }
+            CdtScalarTraceOutcome::NoProposal => no_proposal = no_proposal.saturating_add(1),
+        }
+    }
+
+    if accepted != proposal_stats.accepted_transitions() {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceAcceptedCountMismatch {
+                actual: accepted,
+                expected: proposal_stats.accepted_transitions(),
+            },
+        ));
+    }
+    if rejected_proposal != proposal_stats.metropolis_rejections() {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceRejectedProposalCountMismatch {
+                actual: rejected_proposal,
+                expected: proposal_stats.metropolis_rejections(),
+            },
+        ));
+    }
+    let expected_no_proposal = scalar_trace_no_proposal_count(proposal_stats)?;
+    if no_proposal != expected_no_proposal {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceNoProposalCountMismatch {
+                actual: no_proposal,
+                expected: expected_no_proposal,
+            },
+        ));
+    }
+
+    Ok(())
+}
+
+/// Checks one scalar trace row against the corresponding step telemetry.
+fn validate_scalar_trace_row(
+    config: &MetropolisConfig,
+    step: &MonteCarloStep,
+    row: &CdtScalarTraceRow,
+) -> CdtResult<()> {
+    let step_number = step.step().get();
+    let row_step = row.step.get();
+    if row.step != step.step() {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceStepMismatch {
+                actual: row_step,
+                expected: step_number,
+            },
+        ));
+    }
+    if row.move_type != step.move_type() {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceMoveTypeMismatch {
+                step: step_number,
+                actual: row.move_type,
+                expected: step.move_type(),
+            },
+        ));
+    }
+    let expected_outcome = scalar_trace_outcome_from_step(step);
+    if row.outcome != expected_outcome {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceAcceptedMismatch {
+                step: step_number,
+                actual: row.outcome.accepted(),
+                expected: expected_outcome.accepted(),
+            },
+        ));
+    }
+    if !actions_match(row.action_before, step.action_before()) {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceActionBeforeMismatch { step: step_number },
+        ));
+    }
+    if !optional_actions_match(row.delta_action, step.delta_action()) {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceDeltaActionMismatch { step: step_number },
+        ));
+    }
+    if !optional_actions_match(row.action_after, step.action_after()) {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceActionAfterMismatch { step: step_number },
+        ));
+    }
+    let expected_action = step.action_after().unwrap_or_else(|| step.action_before());
+    if !actions_match(row.action, expected_action) {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceActionMismatch { step: step_number },
+        ));
+    }
+    let expected_log_prob = -row.action / config.temperature();
+    if !actions_match(row.log_prob, expected_log_prob) {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ScalarTraceLogProbMismatch { step: step_number },
+        ));
+    }
+    Ok(())
+}
+
+const fn scalar_trace_outcome_from_step(step: &MonteCarloStep) -> CdtScalarTraceOutcome {
+    match step.outcome() {
+        MonteCarloStepOutcome::Accepted(_) => CdtScalarTraceOutcome::Accepted,
+        MonteCarloStepOutcome::RejectedProposal(_) => CdtScalarTraceOutcome::RejectedProposal,
+        MonteCarloStepOutcome::NoProposal => CdtScalarTraceOutcome::NoProposal,
+    }
+}
+
+/// Checks finite scalar trace numeric fields.
+fn validate_scalar_trace_finite_fields(row: &CdtScalarTraceRow) -> CdtResult<()> {
+    validate_scalar_trace_finite(row.step, ScalarTraceField::LogProb, row.log_prob)?;
+    validate_scalar_trace_finite(row.step, ScalarTraceField::Action, row.action)?;
+    validate_scalar_trace_finite(row.step, ScalarTraceField::ActionBefore, row.action_before)?;
+    if let Some(delta_action) = row.delta_action {
+        validate_scalar_trace_finite(row.step, ScalarTraceField::DeltaAction, delta_action)?;
+    }
+    if let Some(action_after) = row.action_after {
+        validate_scalar_trace_finite(row.step, ScalarTraceField::ActionAfter, action_after)?;
+    }
+    Ok(())
+}
+
+/// Checks one finite scalar trace value.
+const fn validate_scalar_trace_finite(
+    step: NonZeroU32,
+    field: ScalarTraceField,
+    value: f64,
+) -> CdtResult<()> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::NonFiniteScalarTraceValue {
+                step: step.get(),
+                field,
+            },
+        ))
+    }
+}
+
+/// Compares optional action-like telemetry with the configured float tolerance.
+fn optional_actions_match(left: Option<f64>, right: Option<f64>) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => actions_match(left, right),
+        (None, None) => true,
+        (Some(_), None) | (None, Some(_)) => false,
+    }
+}
+
+/// Computes aggregate no-proposal trace outcomes from proposal telemetry.
+fn scalar_trace_no_proposal_count(proposal_stats: &ProposalStatistics) -> CdtResult<u64> {
+    [
+        proposal_stats.no_site_proposals(),
+        proposal_stats.site_causality_rejections(),
+        proposal_stats.site_geometric_rejections(),
+        proposal_stats.site_backend_rejections(),
+    ]
+    .into_iter()
+    .try_fold(0_u64, |total, count| {
+        total.checked_add(count).ok_or_else(|| {
+            checkpoint_resume_failed(CheckpointResumeFailure::ProposalCounterOverflow {
+                counter: ProposalTelemetryCounter::RejectedTransitions,
+            })
+        })
+    })
+}
+
+/// Converts a known CDT step number into an upstream trace row index.
+fn step_to_trace_index(step: NonZeroU32) -> usize {
+    usize::try_from(step.get()).unwrap_or(usize::MAX)
+}
+
+/// Stable numeric move-family codes used in scalar trace exports.
+const fn move_type_code(move_type: MoveType) -> u32 {
+    match move_type {
+        MoveType::Move22 => 22,
+        MoveType::Move13Add => 13,
+        MoveType::Move31Remove => 31,
+        MoveType::EdgeFlip => 1,
+    }
+}
+
+/// Encodes optional numeric fields without introducing blank cells into trace CSV.
+const fn option_presence(value: Option<f64>) -> f64 {
+    if value.is_some() { 1.0 } else { 0.0 }
+}
+
+/// Splits an optional seed into exactly representable numeric columns.
+fn seed_observables(seed: Option<u64>) -> (f64, f64, f64) {
+    let Some(seed) = seed else {
+        return (0.0, 0.0, 0.0);
+    };
+    let low = seed & u64::from(u32::MAX);
+    let high = seed >> 32;
+    let low = u32::try_from(low).unwrap_or(u32::MAX);
+    let high = u32::try_from(high).unwrap_or(u32::MAX);
+    (f64::from(low), f64::from(high), 1.0)
 }
 
 #[derive(Serialize)]
@@ -527,13 +1125,21 @@ impl SimulationResultsBackend {
         proposal_stats: ProposalStatistics,
         steps: Vec<MonteCarloStep>,
         measurements: Vec<Measurement>,
+        scalar_trace_rows: Vec<CdtScalarTraceRow>,
         elapsed_time: Duration,
         triangulation: CdtTriangulation2D,
     ) -> CdtResult<Self> {
         config.validate();
         action_config.validate();
         triangulation.validate_evolved_cdt()?;
-        validate_result_telemetry(&config, &move_stats, &proposal_stats, &steps, &measurements)?;
+        validate_result_telemetry(
+            &config,
+            &move_stats,
+            &proposal_stats,
+            &steps,
+            &measurements,
+            &scalar_trace_rows,
+        )?;
         Ok(Self::from_parts(SimulationResultsParts {
             config,
             action_config,
@@ -541,6 +1147,7 @@ impl SimulationResultsBackend {
             proposal_stats,
             steps,
             measurements,
+            scalar_trace_rows,
             elapsed_time,
             triangulation,
         }))
@@ -555,6 +1162,7 @@ impl SimulationResultsBackend {
             proposal_stats: parts.proposal_stats,
             steps: parts.steps,
             measurements: parts.measurements,
+            scalar_trace_rows: parts.scalar_trace_rows,
             elapsed_time: parts.elapsed_time,
             triangulation: parts.triangulation,
         }
@@ -679,7 +1287,7 @@ impl SimulationResultsBackend {
     ///     )
     ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
     ///     assert_eq!(results.steps().len(), 1);
-    ///     assert_eq!(results.steps()[0].step.get(), 1);
+    ///     assert_eq!(results.steps()[0].step().get(), 1);
     ///     Ok(())
     /// }
     /// ```
@@ -715,6 +1323,71 @@ impl SimulationResultsBackend {
     #[must_use]
     pub fn measurements(&self) -> &[Measurement] {
         &self.measurements
+    }
+
+    /// Builds an upstream scalar trace for every completed Metropolis step.
+    ///
+    /// The trace uses chain id `0` and stores upstream accept/proposal metadata in
+    /// the fixed trace columns. CDT observables are numeric and rectangular:
+    /// current action, vertex/edge/triangle counts, stable move-family code
+    /// (`22`, `13`, `31`, or `1` for edge flip), action-delta fields, the RNG
+    /// seed split into exactly representable `u32` halves when available, and
+    /// zero-filled `volume_profile_*` columns for per-slice triangle counts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TraceError`] if the upstream trace header or row widths are
+    /// rejected.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtError, CdtResult, CdtTriangulation, MetropolisAlgorithm,
+    ///     MetropolisConfig,
+    /// };
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let results = MetropolisAlgorithm::new(
+    ///         MetropolisConfig::new(1.0, 2, 0, 1)?.with_seed(7),
+    ///         ActionConfig::default(),
+    ///     )
+    ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
+    ///
+    ///     let trace = results.scalar_trace().map_err(|err| CdtError::OutputWriteFailed {
+    ///         path: "in-memory scalar trace".to_string(),
+    ///         format: causal_triangulations::prelude::errors::OutputFormat::Csv,
+    ///         detail: err.to_string(),
+    ///     })?;
+    ///     assert_eq!(trace.len(), results.steps().len());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn scalar_trace(&self) -> Result<Trace, TraceError> {
+        let mut observable_names = SCALAR_TRACE_BASE_OBSERVABLES
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let volume_profile_len = self
+            .scalar_trace_rows
+            .iter()
+            .map(|row| row.volume_profile.len())
+            .max()
+            .unwrap_or(0);
+        observable_names
+            .extend((0..volume_profile_len).map(|index| format!("volume_profile_{index}")));
+
+        let mut trace = Trace::new(observable_names)?;
+        for row in &self.scalar_trace_rows {
+            trace.push(TraceRecord::new(
+                CDT_TRACE_CHAIN_ID,
+                step_to_trace_index(row.step),
+                row.outcome(),
+                row.log_prob,
+                row.observable_values(volume_profile_len),
+            ))?;
+        }
+        Ok(trace)
     }
 
     /// Returns total wall-clock time recorded for the run.
@@ -790,7 +1463,7 @@ impl SimulationResultsBackend {
             return 0.0;
         }
 
-        let accepted_count = self.steps.iter().filter(|step| step.accepted).count();
+        let accepted_count = self.steps.iter().filter(|step| step.accepted()).count();
         let total_count = self.steps.len();
 
         let Some(accepted_f64) = usize_to_f64(accepted_count) else {
@@ -828,7 +1501,7 @@ impl SimulationResultsBackend {
             return 0.0;
         }
 
-        let sum: f64 = self.measurements.iter().map(|m| m.action).sum();
+        let sum: f64 = self.measurements.iter().map(Measurement::action).sum();
         let count = self.measurements.len();
 
         let Some(count_f64) = usize_to_f64(count) else {
@@ -870,7 +1543,7 @@ impl SimulationResultsBackend {
         let mut profile_len = 0_usize;
         for measurement in self.equilibrium_measurements_iter() {
             measurement_count += 1;
-            profile_len = profile_len.max(measurement.volume_profile.len());
+            profile_len = profile_len.max(measurement.volume_profile().len());
         }
         if measurement_count == 0 || profile_len == 0 {
             return Vec::new();
@@ -878,7 +1551,7 @@ impl SimulationResultsBackend {
 
         let mut sums = vec![0.0; profile_len];
         for measurement in self.equilibrium_measurements_iter() {
-            for (index, &volume) in measurement.volume_profile.iter().enumerate() {
+            for (index, &volume) in measurement.volume_profile().iter().enumerate() {
                 sums[index] += <f64 as From<u32>>::from(volume);
             }
         }
@@ -928,7 +1601,7 @@ impl SimulationResultsBackend {
         for measurement in self.equilibrium_measurements_iter() {
             for (index, mean) in means.iter().enumerate() {
                 let volume = measurement
-                    .volume_profile
+                    .volume_profile()
                     .get(index)
                     .map_or(0.0, |&volume| <f64 as From<u32>>::from(volume));
                 let delta = volume - mean;
@@ -1017,7 +1690,7 @@ impl SimulationResultsBackend {
     /// Metropolis runs record measurements only after the configured
     /// thermalization boundary, at completed-move counts divisible by
     /// [`MetropolisConfig::measurement_frequency`]. This accessor defines
-    /// equilibrium as `measurement.step >= thermalization_steps`, so a
+    /// equilibrium as `measurement.step() >= thermalization_steps`, so a
     /// measurement taken exactly on the thermalization boundary is included.
     ///
     /// # Examples
@@ -1047,21 +1720,19 @@ impl SimulationResultsBackend {
     fn equilibrium_measurements_iter(&self) -> impl Iterator<Item = &Measurement> {
         self.measurements
             .iter()
-            .filter(|measurement| measurement.step >= self.config.thermalization_steps())
+            .filter(|measurement| measurement.step() >= self.config.thermalization_steps())
     }
 
-    /// Writes one CSV row per recorded measurement.
+    /// Writes the upstream scalar trace CSV for every completed Metropolis step.
     ///
-    /// The CSV includes scalar measurement values plus accepted/delta-action
-    /// telemetry from the Monte Carlo step with the same step number when such a
-    /// step exists. Initial measurements at step 0 leave those telemetry columns
-    /// blank.
+    /// This uses [`Self::scalar_trace`] and therefore delegates the table shape
+    /// and CSV escaping rules to `markov-chain-monte-carlo`.
     ///
     /// # Errors
     ///
     /// Returns [`CdtError::OutputWriteFailed`] if the file or a parent directory
-    /// cannot be created, or if writing the CSV fails.
-    ///
+    /// cannot be created, if trace construction fails, or if writing the CSV
+    /// fails.
     /// # Examples
     ///
     /// ```no_run
@@ -1074,46 +1745,21 @@ impl SimulationResultsBackend {
     ///         ActionConfig::default(),
     ///     )
     ///     .run(tri)?;
-    ///     results.write_measurements_csv("measurements.csv")?;
+    ///     results.write_trace_csv("trace.csv")?;
     ///     Ok(())
     /// }
     /// ```
-    pub fn write_measurements_csv(&self, path: impl AsRef<Path>) -> CdtResult<()> {
+    pub fn write_trace_csv(&self, path: impl AsRef<Path>) -> CdtResult<()> {
         let path = path.as_ref();
         ensure_parent_directory(path, OutputFormat::Csv)?;
+        let trace = self
+            .scalar_trace()
+            .map_err(|err| output_error(path, OutputFormat::Csv, err))?;
         let file = File::create(path).map_err(|err| output_error(path, OutputFormat::Csv, err))?;
         let mut writer = BufWriter::new(file);
-        writeln!(
-            writer,
-            "step,action,vertices,edges,triangles,accepted,delta_action"
-        )
-        .map_err(|err| output_error(path, OutputFormat::Csv, err))?;
-
-        let steps_by_number: HashMap<_, _> = self
-            .steps
-            .iter()
-            .map(|step| (step.step.get(), step))
-            .collect();
-        for measurement in &self.measurements {
-            let step = steps_by_number.get(&measurement.step).copied();
-            let accepted = step.map_or(String::new(), |step| step.accepted.to_string());
-            let delta_action = step
-                .and_then(|step| step.delta_action)
-                .map_or_else(String::new, |delta| delta.to_string());
-            writeln!(
-                writer,
-                "{},{},{},{},{},{},{}",
-                measurement.step,
-                measurement.action,
-                measurement.vertices,
-                measurement.edges,
-                measurement.triangles,
-                accepted,
-                delta_action,
-            )
+        trace
+            .write_csv(&mut writer)
             .map_err(|err| output_error(path, OutputFormat::Csv, err))?;
-        }
-
         writer
             .flush()
             .map_err(|err| output_error(path, OutputFormat::Csv, err))
@@ -1205,7 +1851,7 @@ fn mean_measurement_action<'a>(measurements: impl IntoIterator<Item = &'a Measur
     let mut sum = 0.0;
     let mut count = 0_usize;
     for measurement in measurements {
-        sum += measurement.action;
+        sum += measurement.action();
         count += 1;
     }
 
@@ -1243,8 +1889,9 @@ mod tests {
     use super::*;
     use crate::cdt::ergodic_moves::MoveType;
     use crate::cdt::foliation::FoliationError;
+    use crate::cdt::metropolis::MetropolisAlgorithm;
     use crate::cdt::triangulation::CdtTriangulation;
-    use crate::errors::ConfigurationSetting;
+    use crate::errors::{ConfigurationSetting, MeasurementCountField};
     use crate::geometry::traits::TriangulationQuery;
     use approx::assert_relative_eq;
     use serde_json::{Value, from_str, to_value};
@@ -1297,6 +1944,48 @@ mod tests {
         NonZeroU32::new(step).expect("test step number should be nonzero")
     }
 
+    fn accepted_step(
+        step: u32,
+        move_type: MoveType,
+        action_before: f64,
+        action_after: f64,
+    ) -> MonteCarloStep {
+        MonteCarloStep::accepted_step(
+            step_number(step),
+            move_type,
+            action_before,
+            action_after,
+            action_after - action_before,
+        )
+        .expect("test accepted step should satisfy action invariants")
+    }
+
+    fn rejected_proposal_step(
+        step: u32,
+        move_type: MoveType,
+        action_before: f64,
+        delta_action: Option<f64>,
+    ) -> MonteCarloStep {
+        MonteCarloStep::rejected_proposal(step_number(step), move_type, action_before, delta_action)
+            .expect("test rejected step should satisfy action invariants")
+    }
+
+    fn no_proposal_step(step: u32, move_type: MoveType, action_before: f64) -> MonteCarloStep {
+        MonteCarloStep::no_proposal(step_number(step), move_type, action_before)
+            .expect("test no-proposal step should satisfy action invariants")
+    }
+
+    fn measurement(
+        step: u32,
+        action: f64,
+        vertices: u32,
+        edges: u32,
+        triangles: u32,
+    ) -> Measurement {
+        Measurement::try_new(step, action, vertices, edges, triangles)
+            .expect("test measurement should satisfy action and count invariants")
+    }
+
     /// Builds a result container around deterministic geometry for summary-method tests.
     fn results_with(
         config: MetropolisConfig,
@@ -1311,31 +2000,42 @@ mod tests {
             proposal_stats: ProposalStatistics::new(),
             steps,
             measurements,
+            scalar_trace_rows: Vec::new(),
             elapsed_time: Duration::from_millis(100),
             triangulation,
         }
     }
 
     fn valid_rejected_result(triangulation: CdtTriangulation2D) -> SimulationResultsBackend {
+        let config = metropolis_config(1.0, 1, 0, 1);
         let mut move_stats = MoveStatistics::new();
         move_stats.record_attempt(MoveType::Move22);
+        let scalar_trace_rows = vec![
+            CdtScalarTraceRow::new(
+                step_number(1),
+                CdtScalarTraceOutcome::NoProposal,
+                -0.0 / config.temperature(),
+                0.0,
+                &triangulation,
+                MoveType::Move22,
+                None,
+                0.0,
+                None,
+                config.seed(),
+            )
+            .expect("trace row should build"),
+        ];
         SimulationResultsBackend::new(
-            metropolis_config(1.0, 1, 0, 1),
+            config,
             ActionConfig::default(),
             move_stats,
             ProposalStatistics::from_validated_parts(1, 0, 1, 0, 0, 0, 0, 0, 0),
-            vec![MonteCarloStep {
-                step: step_number(1),
-                move_type: MoveType::Move22,
-                accepted: false,
-                action_before: 0.0,
-                action_after: None,
-                delta_action: None,
-            }],
+            vec![no_proposal_step(1, MoveType::Move22, 0.0)],
             vec![
-                Measurement::new(0, 0.0, 12, 26, 12),
-                Measurement::new(1, 0.0, 12, 26, 12),
+                measurement(0, 0.0, 12, 26, 12),
+                measurement(1, 0.0, 12, 26, 12),
             ],
+            scalar_trace_rows,
             Duration::ZERO,
             triangulation,
         )
@@ -1394,21 +2094,29 @@ mod tests {
         move_stats.record_attempt(MoveType::Move22);
         move_stats.record_success(MoveType::Move22);
         let proposal_stats = ProposalStatistics::from_validated_parts(1, 7, 0, 0, 0, 0, 0, 1, 0);
-        let step = MonteCarloStep {
-            step: step_number(1),
-            move_type: MoveType::Move22,
-            accepted: true,
-            action_before: 4.0,
-            action_after: Some(3.5),
-            delta_action: Some(-0.5),
-        };
+        let step = accepted_step(1, MoveType::Move22, 4.0, 3.5);
         let measurements = vec![
-            Measurement::new(0, 4.0, 12, 26, 12).with_volume_profile(vec![4, 4, 4]),
-            Measurement::new(1, 3.5, 12, 26, 12).with_volume_profile(vec![4, 4, 4]),
+            measurement(0, 4.0, 12, 26, 12).with_volume_profile(vec![4, 4, 4]),
+            measurement(1, 3.5, 12, 26, 12).with_volume_profile(vec![4, 4, 4]),
         ];
         let elapsed = Duration::from_millis(42);
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let scalar_trace_rows = vec![
+            CdtScalarTraceRow::new(
+                step.step(),
+                CdtScalarTraceOutcome::Accepted,
+                -3.5 / config.temperature(),
+                3.5,
+                &triangulation,
+                step.move_type(),
+                step.delta_action(),
+                step.action_before(),
+                step.action_after(),
+                config.seed(),
+            )
+            .expect("trace row should build"),
+        ];
 
         let results = SimulationResultsBackend::new(
             config.clone(),
@@ -1417,6 +2125,7 @@ mod tests {
             proposal_stats.clone(),
             vec![step],
             measurements,
+            scalar_trace_rows,
             elapsed,
             triangulation,
         )
@@ -1427,8 +2136,8 @@ mod tests {
         assert_eq!(results.move_stats().total_attempted(), 1);
         assert_eq!(results.move_stats().total_accepted(), 1);
         assert_eq!(results.proposal_stats(), &proposal_stats);
-        assert_eq!(results.steps()[0].step.get(), 1);
-        assert_eq!(results.measurements()[0].volume_profile, vec![4, 4, 4]);
+        assert_eq!(results.steps()[0].step().get(), 1);
+        assert_eq!(results.measurements()[0].volume_profile(), &[4, 4, 4]);
         assert_eq!(results.elapsed_time(), elapsed);
         assert_eq!(results.triangulation().slice_sizes(), &[4, 4, 4]);
     }
@@ -1441,18 +2150,11 @@ mod tests {
             move_stats.record_attempt(MoveType::Move22);
         }
         let steps = (1..=4)
-            .map(|step| MonteCarloStep {
-                step: step_number(step),
-                move_type: MoveType::Move22,
-                accepted: false,
-                action_before: f64::from(step),
-                action_after: None,
-                delta_action: None,
-            })
+            .map(|step| no_proposal_step(step, MoveType::Move22, f64::from(step)))
             .collect::<Vec<_>>();
         let measurements = vec![
-            Measurement::new(0, 0.0, 12, 26, 12),
-            Measurement::new(4, 4.0, 12, 26, 12),
+            measurement(0, 0.0, 12, 26, 12),
+            measurement(4, 4.0, 12, 26, 12),
         ];
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
@@ -1464,6 +2166,7 @@ mod tests {
             ProposalStatistics::from_validated_parts(4, 0, 4, 0, 0, 0, 0, 0, 0),
             steps,
             measurements,
+            Vec::new(),
             Duration::ZERO,
             triangulation,
         )
@@ -1488,14 +2191,7 @@ mod tests {
             move_stats.record_attempt(MoveType::Move22);
         }
         let steps = (1..=4)
-            .map(|step| MonteCarloStep {
-                step: step_number(step),
-                move_type: MoveType::Move22,
-                accepted: false,
-                action_before: f64::from(step),
-                action_after: None,
-                delta_action: None,
-            })
+            .map(|step| no_proposal_step(step, MoveType::Move22, f64::from(step)))
             .collect::<Vec<_>>();
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
@@ -1506,7 +2202,8 @@ mod tests {
             move_stats,
             ProposalStatistics::from_validated_parts(4, 0, 4, 0, 0, 0, 0, 0, 0),
             steps,
-            vec![Measurement::new(2, 2.0, 12, 26, 12)],
+            vec![measurement(2, 2.0, 12, 26, 12)],
+            Vec::new(),
             Duration::ZERO,
             triangulation,
         )
@@ -1535,18 +2232,12 @@ mod tests {
             ActionConfig::default(),
             move_stats,
             ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 1),
-            vec![MonteCarloStep {
-                step: step_number(1),
-                move_type: MoveType::Move22,
-                accepted: false,
-                action_before: 0.0,
-                action_after: None,
-                delta_action: None,
-            }],
+            vec![no_proposal_step(1, MoveType::Move22, 0.0)],
             vec![
-                Measurement::new(0, 0.0, 12, 26, 12),
-                Measurement::new(1, 0.0, 12, 26, 12),
+                measurement(0, 0.0, 12, 26, 12),
+                measurement(1, 0.0, 12, 26, 12),
             ],
+            Vec::new(),
             Duration::ZERO,
             triangulation,
         )
@@ -1573,18 +2264,12 @@ mod tests {
             ActionConfig::default(),
             move_stats,
             ProposalStatistics::from_validated_parts(1, 1, 1, 0, 0, 0, 0, 0, 0),
-            vec![MonteCarloStep {
-                step: step_number(1),
-                move_type: MoveType::Move22,
-                accepted: true,
-                action_before: 0.0,
-                action_after: Some(0.0),
-                delta_action: Some(0.0),
-            }],
+            vec![accepted_step(1, MoveType::Move22, 0.0, 0.0)],
             vec![
-                Measurement::new(0, 0.0, 12, 26, 12),
-                Measurement::new(1, 0.0, 12, 26, 12),
+                measurement(0, 0.0, 12, 26, 12),
+                measurement(1, 0.0, 12, 26, 12),
             ],
+            Vec::new(),
             Duration::ZERO,
             triangulation,
         )
@@ -1613,18 +2298,12 @@ mod tests {
             ActionConfig::default(),
             move_stats,
             ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 0),
-            vec![MonteCarloStep {
-                step: step_number(1),
-                move_type: MoveType::Move22,
-                accepted: false,
-                action_before: 0.0,
-                action_after: None,
-                delta_action: None,
-            }],
+            vec![no_proposal_step(1, MoveType::Move22, 0.0)],
             vec![
-                Measurement::new(0, 0.0, 12, 26, 12),
-                Measurement::new(1, 0.0, 12, 26, 12),
+                measurement(0, 0.0, 12, 26, 12),
+                measurement(1, 0.0, 12, 26, 12),
             ],
+            Vec::new(),
             Duration::ZERO,
             triangulation,
         )
@@ -1639,6 +2318,124 @@ mod tests {
                 }
             }
         );
+    }
+
+    #[test]
+    fn public_constructor_rejects_scalar_trace_acceptance_mismatch() {
+        let config = metropolis_config(1.0, 1, 0, 1);
+        let mut move_stats = MoveStatistics::new();
+        move_stats.record_attempt(MoveType::Move22);
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let scalar_trace_rows = vec![
+            CdtScalarTraceRow::new(
+                step_number(1),
+                CdtScalarTraceOutcome::Accepted,
+                -0.0 / config.temperature(),
+                0.0,
+                &triangulation,
+                MoveType::Move22,
+                None,
+                0.0,
+                None,
+                config.seed(),
+            )
+            .expect("trace row should build"),
+        ];
+
+        let error = SimulationResultsBackend::new(
+            config,
+            ActionConfig::default(),
+            move_stats,
+            ProposalStatistics::from_validated_parts(1, 0, 1, 0, 0, 0, 0, 0, 0),
+            vec![no_proposal_step(1, MoveType::Move22, 0.0)],
+            vec![
+                measurement(0, 0.0, 12, 26, 12),
+                measurement(1, 0.0, 12, 26, 12),
+            ],
+            scalar_trace_rows,
+            Duration::ZERO,
+            triangulation,
+        )
+        .expect_err("scalar trace outcomes must match step acceptance");
+
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::ScalarTraceAcceptedMismatch {
+                    step: 1,
+                    actual: true,
+                    expected: false
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn scalar_trace_row_rejects_nonfinite_numeric_fields_before_storage() {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let cases = [
+            (ScalarTraceField::LogProb, f64::NAN, 0.0, None, 0.0, None),
+            (
+                ScalarTraceField::Action,
+                -0.0,
+                f64::INFINITY,
+                None,
+                0.0,
+                None,
+            ),
+            (
+                ScalarTraceField::ActionBefore,
+                -0.0,
+                0.0,
+                None,
+                f64::NEG_INFINITY,
+                None,
+            ),
+            (
+                ScalarTraceField::DeltaAction,
+                -0.0,
+                0.0,
+                Some(f64::NAN),
+                0.0,
+                None,
+            ),
+            (
+                ScalarTraceField::ActionAfter,
+                -0.0,
+                0.0,
+                None,
+                0.0,
+                Some(f64::INFINITY),
+            ),
+        ];
+
+        for (expected_field, log_prob, action, delta_action, action_before, action_after) in cases {
+            let error = CdtScalarTraceRow::new(
+                step_number(1),
+                CdtScalarTraceOutcome::RejectedProposal,
+                log_prob,
+                action,
+                &triangulation,
+                MoveType::Move22,
+                delta_action,
+                action_before,
+                action_after,
+                None,
+            )
+            .expect_err("non-finite scalar trace fields should be rejected");
+
+            assert_matches!(
+                error,
+                CdtError::CheckpointResumeFailed {
+                    failure: CheckpointResumeFailure::NonFiniteScalarTraceValue {
+                        step: 1,
+                        field,
+                    }
+                } if field == expected_field
+            );
+        }
     }
 
     #[test]
@@ -1695,18 +2492,12 @@ mod tests {
             ActionConfig::default(),
             MoveStatistics::new(),
             ProposalStatistics::new(),
-            vec![MonteCarloStep {
-                step: step_number(1),
-                move_type: MoveType::Move22,
-                accepted: false,
-                action_before: 0.0,
-                action_after: None,
-                delta_action: None,
-            }],
+            vec![no_proposal_step(1, MoveType::Move22, 0.0)],
             vec![
-                Measurement::new(0, 0.0, 12, 26, 12),
-                Measurement::new(1, 0.0, 12, 26, 12),
+                measurement(0, 0.0, 12, 26, 12),
+                measurement(1, 0.0, 12, 26, 12),
             ],
+            Vec::new(),
             Duration::ZERO,
             triangulation,
         )
@@ -1757,6 +2548,65 @@ mod tests {
     }
 
     #[test]
+    fn deserialization_rejects_zero_scalar_trace_step() {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let results = valid_rejected_result(triangulation);
+        let mut payload = to_value(&results).expect("results should serialize");
+        payload["scalar_trace_rows"][0]["step"] = to_value(0_u32).expect("step should serialize");
+
+        let error = from_str::<SimulationResultsBackend>(&payload.to_string())
+            .expect_err("zero scalar trace step should fail while parsing");
+        assert!(
+            error
+                .to_string()
+                .contains("scalar trace step must be nonzero"),
+            "unexpected serde error: {error}"
+        );
+    }
+
+    #[test]
+    fn deserialization_rejects_zero_measurement_counts_by_field() {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let results = valid_rejected_result(triangulation);
+
+        for field in ["vertices", "edges", "triangles"] {
+            let mut payload = to_value(&results).expect("results should serialize");
+            payload["measurements"][0][field] = to_value(0_u32).expect("count should serialize");
+
+            let error = from_str::<SimulationResultsBackend>(&payload.to_string())
+                .expect_err("zero measurement count should fail while parsing");
+            let message = error.to_string();
+            assert!(
+                message.contains("Invalid measurement count") && message.contains(field),
+                "unexpected serde error for {field}: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn deserialization_rejects_zero_scalar_trace_counts_by_field() {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let results = valid_rejected_result(triangulation);
+
+        for field in ["vertices", "edges", "triangles"] {
+            let mut payload = to_value(&results).expect("results should serialize");
+            payload["scalar_trace_rows"][0][field] =
+                to_value(0_u32).expect("count should serialize");
+
+            let error = from_str::<SimulationResultsBackend>(&payload.to_string())
+                .expect_err("zero scalar trace count should fail while parsing");
+            let message = error.to_string();
+            assert!(
+                message.contains("Invalid measurement count") && message.contains(field),
+                "unexpected serde error for {field}: {message}"
+            );
+        }
+    }
+
+    #[test]
     fn deserialization_defaults_missing_proposal_stats() {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
@@ -1777,6 +2627,27 @@ mod tests {
     }
 
     #[test]
+    fn deserialization_rejects_missing_scalar_trace_rows() {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let results = valid_rejected_result(triangulation);
+        let mut payload = to_value(&results).expect("results should serialize");
+        payload
+            .as_object_mut()
+            .expect("results payload should be an object")
+            .remove("scalar_trace_rows");
+
+        let error = from_str::<SimulationResultsBackend>(&payload.to_string())
+            .expect_err("missing scalar trace rows should fail result deserialization");
+        assert!(
+            error
+                .to_string()
+                .contains("missing field `scalar_trace_rows`"),
+            "unexpected serde error: {error}"
+        );
+    }
+
+    #[test]
     fn result_wire_validation_rejects_invalid_metropolis_config() {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
@@ -1787,6 +2658,7 @@ mod tests {
             proposal_stats: ProposalStatistics::new(),
             steps: vec![],
             measurements: vec![],
+            scalar_trace_rows: vec![],
             elapsed_time: Duration::ZERO,
             triangulation,
         })
@@ -1811,6 +2683,7 @@ mod tests {
             proposal_stats: ProposalStatistics::new(),
             steps: vec![],
             measurements: vec![],
+            scalar_trace_rows: vec![],
             elapsed_time: Duration::ZERO,
             triangulation,
         })
@@ -1826,50 +2699,106 @@ mod tests {
 
     #[test]
     fn measurement_builders_preserve_scalar_counts_and_profile() {
-        let measurement = Measurement::new(7, -3.5, 12, 26, 12).with_volume_profile(vec![6, 6, 0]);
+        let measurement = measurement(7, -3.5, 12, 26, 12).with_volume_profile(vec![6, 6, 0]);
 
-        assert_eq!(measurement.step, 7);
-        assert_relative_eq!(measurement.action, -3.5);
-        assert_eq!(measurement.vertices, 12);
-        assert_eq!(measurement.edges, 26);
-        assert_eq!(measurement.triangles, 12);
-        assert_eq!(measurement.volume_profile, vec![6, 6, 0]);
+        assert_eq!(measurement.step(), 7);
+        assert_relative_eq!(measurement.action(), -3.5);
+        assert_eq!(measurement.vertices().get(), 12);
+        assert_eq!(measurement.edges().get(), 26);
+        assert_eq!(measurement.triangles().get(), 12);
+        assert_eq!(measurement.volume_profile(), &[6, 6, 0]);
     }
 
     #[test]
-    fn writes_measurements_csv_with_matching_step_telemetry() {
-        let triangulation =
-            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
-        let results = results_with(
-            metropolis_config(1.0, 2, 1, 1),
-            vec![MonteCarloStep {
-                step: step_number(1),
-                move_type: MoveType::Move22,
-                accepted: true,
-                action_before: 3.0,
-                action_after: Some(2.5),
-                delta_action: Some(-0.5),
-            }],
-            vec![
-                Measurement::new(0, 3.0, 12, 26, 12),
-                Measurement::new(1, 2.5, 12, 26, 12),
-            ],
-            triangulation,
+    fn measurement_try_new_rejects_each_zero_count_with_field_context() {
+        let cases = [
+            (0, 26, 12, MeasurementCountField::Vertices),
+            (12, 0, 12, MeasurementCountField::Edges),
+            (12, 26, 0, MeasurementCountField::Triangles),
+        ];
+
+        for (vertices, edges, triangles, expected_field) in cases {
+            let error = Measurement::try_new(7, -3.5, vertices, edges, triangles)
+                .expect_err("zero measurement counts should be rejected");
+
+            assert_matches!(
+                error,
+                CdtError::InvalidMeasurementCount {
+                    field,
+                    provided_value: 0,
+                } if field == expected_field
+            );
+        }
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn measurement_from_simplex_counts_rejects_count_overflow() {
+        let oversized = usize::try_from(u32::MAX).expect("u32::MAX should fit usize") + 1;
+        let counts = CdtSimplexCounts::try_new(oversized, 26, 12)
+            .expect("oversized live count should still be a positive CDT count");
+
+        let error = Measurement::try_from_simplex_counts(7, -3.5, counts)
+            .expect_err("measurement counts above u32::MAX should be rejected");
+
+        assert_matches!(
+            error,
+            CdtError::MeasurementCountOverflow {
+                field: MeasurementCountField::Vertices,
+                provided_value,
+                max: u32::MAX,
+            } if provided_value == oversized
         );
-        let path = temp_output_path("measurements.csv");
+    }
+
+    #[test]
+    fn measurement_try_new_rejects_nonfinite_action() {
+        for action in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let error = Measurement::try_new(7, action, 12, 26, 12)
+                .expect_err("non-finite measurement action should be rejected");
+
+            assert_matches!(
+                error,
+                CdtError::InvalidMeasurementAction {
+                    step: 7,
+                    provided_value,
+                } if provided_value.to_bits() == action.to_bits()
+            );
+        }
+    }
+
+    #[test]
+    fn writes_trace_csv_with_upstream_step_metadata() {
+        let results = MetropolisAlgorithm::new(
+            seeded_metropolis_config(1.0, 2, 0, 1, 7),
+            ActionConfig::default(),
+        )
+        .run(CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build"))
+        .expect("short Metropolis run should complete");
+        let trace = results
+            .scalar_trace()
+            .expect("CDT scalar trace columns should be valid");
+        let path = temp_output_path("trace.csv");
 
         results
-            .write_measurements_csv(&path)
-            .expect("CSV output should write");
+            .write_trace_csv(&path)
+            .expect("trace CSV output should write");
         let csv = fs::read_to_string(&path).expect("CSV output should be readable");
         fs::remove_file(&path).expect("temporary CSV should be removable");
 
-        assert_eq!(
-            csv,
-            "step,action,vertices,edges,triangles,accepted,delta_action\n\
-             0,3,12,26,12,,\n\
-             1,2.5,12,26,12,true,-0.5\n"
+        assert_eq!(trace.len(), results.steps().len());
+        assert_eq!(trace.records()[0].chain_id(), ChainId::new(0));
+        assert!(trace.records()[0].outcome().had_proposal());
+        assert!(
+            trace
+                .observable_names()
+                .iter()
+                .any(|name| name == "volume_profile_0")
         );
+        assert!(csv.starts_with(
+            "chain_id,step,accepted,proposed,log_prob,action,vertices,edges,triangles,move_family"
+        ));
+        assert_eq!(csv.lines().count().saturating_sub(1), results.steps().len());
     }
 
     #[test]
@@ -1878,15 +2807,8 @@ mod tests {
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let results = results_with(
             metropolis_config(1.0, 1, 0, 1),
-            vec![MonteCarloStep {
-                step: step_number(1),
-                move_type: MoveType::Move22,
-                accepted: true,
-                action_before: 3.0,
-                action_after: Some(2.5),
-                delta_action: Some(-0.5),
-            }],
-            vec![Measurement::new(1, 2.5, 12, 26, 12)],
+            vec![accepted_step(1, MoveType::Move22, 3.0, 2.5)],
+            vec![measurement(1, 2.5, 12, 26, 12)],
             triangulation,
         );
         let config = CdtConfig {
@@ -1927,9 +2849,9 @@ mod tests {
         let parent_file = temp_output_path("not-a-directory");
         fs::write(&parent_file, b"not a directory").expect("parent fixture file should write");
 
-        let csv_path = parent_file.join("measurements.csv");
+        let csv_path = parent_file.join("trace.csv");
         let csv_error = results
-            .write_measurements_csv(&csv_path)
+            .write_trace_csv(&csv_path)
             .expect_err("CSV writer should reject a parent path that is a file");
         let CdtError::OutputWriteFailed {
             path,
@@ -1973,9 +2895,9 @@ mod tests {
             metropolis_config(1.0, 2, 1, 1),
             vec![],
             vec![
-                Measurement::new(0, 100.0, 12, 26, 12),
-                Measurement::new(1, 4.0, 12, 26, 12),
-                Measurement::new(2, 6.0, 12, 26, 12),
+                measurement(0, 100.0, 12, 26, 12),
+                measurement(1, 4.0, 12, 26, 12),
+                measurement(2, 6.0, 12, 26, 12),
             ],
             triangulation,
         );
@@ -2009,35 +2931,14 @@ mod tests {
     fn summaries_use_post_thermalization_measurements() {
         let config = metropolis_config(1.0, 20, 10, 5);
         let steps = vec![
-            MonteCarloStep {
-                step: step_number(1),
-                move_type: MoveType::Move22,
-                accepted: true,
-                action_before: 3.0,
-                action_after: Some(2.5),
-                delta_action: Some(-0.5),
-            },
-            MonteCarloStep {
-                step: step_number(2),
-                move_type: MoveType::Move13Add,
-                accepted: false,
-                action_before: 2.5,
-                action_after: None,
-                delta_action: Some(0.8),
-            },
-            MonteCarloStep {
-                step: step_number(3),
-                move_type: MoveType::Move31Remove,
-                accepted: true,
-                action_before: 2.5,
-                action_after: Some(2.0),
-                delta_action: Some(-0.5),
-            },
+            accepted_step(1, MoveType::Move22, 3.0, 2.5),
+            rejected_proposal_step(2, MoveType::Move13Add, 2.5, Some(0.8)),
+            accepted_step(3, MoveType::Move31Remove, 2.5, 2.0),
         ];
         let measurements = vec![
-            Measurement::new(0, 1.0, 3, 3, 1).with_volume_profile(vec![1, 0, 0]),
-            Measurement::new(10, 2.0, 4, 5, 2).with_volume_profile(vec![1, 1, 0]),
-            Measurement::new(15, 3.0, 5, 7, 3).with_volume_profile(vec![1, 2, 0]),
+            measurement(0, 1.0, 3, 3, 1).with_volume_profile(vec![1, 0, 0]),
+            measurement(10, 2.0, 4, 5, 2).with_volume_profile(vec![1, 1, 0]),
+            measurement(15, 3.0, 5, 7, 3).with_volume_profile(vec![1, 2, 0]),
         ];
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
@@ -2050,8 +2951,8 @@ mod tests {
 
         let equilibrium = results.equilibrium_measurements();
         assert_eq!(equilibrium.len(), 2);
-        assert_eq!(equilibrium[0].step, 10);
-        assert_eq!(equilibrium[1].step, 15);
+        assert_eq!(equilibrium[0].step(), 10);
+        assert_eq!(equilibrium[1].step(), 15);
     }
 
     #[test]
@@ -2062,8 +2963,8 @@ mod tests {
             metropolis_config(1.0, 20, 10, 5),
             vec![],
             vec![
-                Measurement::new(10, 2.0, 4, 5, 2).with_volume_profile(vec![4, 8, 1]),
-                Measurement::new(15, 3.0, 5, 7, 3).with_volume_profile(vec![6]),
+                measurement(10, 2.0, 4, 5, 2).with_volume_profile(vec![4, 8, 1]),
+                measurement(15, 3.0, 5, 7, 3).with_volume_profile(vec![6]),
             ],
             triangulation,
         );
@@ -2082,10 +2983,7 @@ mod tests {
         let results = results_with(
             metropolis_config(1.0, 20, 10, 5),
             vec![],
-            vec![
-                Measurement::new(10, 2.0, 4, 5, 2),
-                Measurement::new(15, 3.0, 5, 7, 3),
-            ],
+            vec![measurement(10, 2.0, 4, 5, 2), measurement(15, 3.0, 5, 7, 3)],
             triangulation,
         );
 
@@ -2101,8 +2999,8 @@ mod tests {
             metropolis_config(1.0, 20, 10, 5),
             vec![],
             vec![
-                Measurement::new(0, 1.0, 3, 3, 1).with_volume_profile(vec![1]),
-                Measurement::new(10, 2.0, 4, 5, 2).with_volume_profile(vec![2]),
+                measurement(0, 1.0, 3, 3, 1).with_volume_profile(vec![1]),
+                measurement(10, 2.0, 4, 5, 2).with_volume_profile(vec![2]),
             ],
             triangulation,
         );

--- a/src/cdt/triangulation/state.rs
+++ b/src/cdt/triangulation/state.rs
@@ -9,13 +9,13 @@
 use crate::cdt::ergodic_moves::MoveType;
 use crate::cdt::foliation::{Foliation, FoliationError};
 use crate::config::CdtTopology;
-use crate::errors::{CdtError, CdtResult, TriangulationMetadataField};
+use crate::errors::{CdtError, CdtResult, SimplexCountField, TriangulationMetadataField};
 use crate::geometry::DelaunayBackend2D;
 use crate::geometry::traits::TriangulationQuery;
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
@@ -52,6 +52,115 @@ pub struct CdtTriangulation<B> {
     foliation: Option<Foliation>,
     /// Modification counter value when foliation bookkeeping was last synchronized.
     foliation_synced_at_modification: Option<u64>,
+}
+
+/// Strictly positive simplex counts for a CDT triangulation.
+///
+/// Generic geometry backends can be empty while they are being constructed,
+/// cleared, or used as test fixtures. A constructed CDT triangulation, however,
+/// must have positive vertex, edge, and triangle counts. This type carries that
+/// proof for CDT-domain code without imposing a `u32` cap on live geometry
+/// queries.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::triangulation::*;
+///
+/// fn main() -> CdtResult<()> {
+///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+///     let counts = tri.simplex_counts()?;
+///
+///     assert_eq!(counts.vertices().get(), tri.vertex_count());
+///     assert_eq!(counts.triangles().get(), tri.face_count());
+///     Ok(())
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CdtSimplexCounts {
+    vertices: NonZeroUsize,
+    edges: NonZeroUsize,
+    triangles: NonZeroUsize,
+}
+
+impl CdtSimplexCounts {
+    /// Parses raw `usize` counts into a strictly positive CDT count snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidSimplexCount`] when any count is zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::{
+    ///     CdtError, CdtSimplexCounts, SimplexCountField,
+    /// };
+    /// use std::assert_matches;
+    ///
+    /// let counts = CdtSimplexCounts::try_new(3, 3, 1)?;
+    /// assert_eq!(counts.edge_count(), 3);
+    ///
+    /// assert_matches!(
+    ///     CdtSimplexCounts::try_new(3, 0, 1),
+    ///     Err(CdtError::InvalidSimplexCount {
+    ///         field: SimplexCountField::Edges,
+    ///         ..
+    ///     })
+    /// );
+    /// # Ok::<(), CdtError>(())
+    /// ```
+    pub fn try_new(vertices: usize, edges: usize, triangles: usize) -> CdtResult<Self> {
+        Ok(Self {
+            vertices: nonzero_simplex_count(SimplexCountField::Vertices, vertices)?,
+            edges: nonzero_simplex_count(SimplexCountField::Edges, edges)?,
+            triangles: nonzero_simplex_count(SimplexCountField::Triangles, triangles)?,
+        })
+    }
+
+    /// Returns the nonzero vertex count.
+    #[must_use]
+    pub const fn vertices(&self) -> NonZeroUsize {
+        self.vertices
+    }
+
+    /// Returns the nonzero edge count.
+    #[must_use]
+    pub const fn edges(&self) -> NonZeroUsize {
+        self.edges
+    }
+
+    /// Returns the nonzero triangle count.
+    #[must_use]
+    pub const fn triangles(&self) -> NonZeroUsize {
+        self.triangles
+    }
+
+    /// Returns the vertex count as a raw `usize` for collection-style APIs.
+    #[must_use]
+    pub const fn vertex_count(&self) -> usize {
+        self.vertices.get()
+    }
+
+    /// Returns the edge count as a raw `usize` for collection-style APIs.
+    #[must_use]
+    pub const fn edge_count(&self) -> usize {
+        self.edges.get()
+    }
+
+    /// Returns the triangle count as a raw `usize` for collection-style APIs.
+    #[must_use]
+    pub const fn triangle_count(&self) -> usize {
+        self.triangles.get()
+    }
+}
+
+/// Parses one raw backend count into the nonzero proof used by [`CdtSimplexCounts`].
+fn nonzero_simplex_count(field: SimplexCountField, value: usize) -> CdtResult<NonZeroUsize> {
+    NonZeroUsize::new(value).ok_or(CdtError::InvalidSimplexCount {
+        field,
+        provided_value: value,
+    })
 }
 
 impl<B: fmt::Debug> fmt::Debug for CdtTriangulation<B> {
@@ -948,6 +1057,36 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
         self.geometry.edge_count()
     }
 
+    /// Returns strictly positive CDT simplex counts for the current state.
+    ///
+    /// This is the CDT-domain counterpart to the raw `usize` count accessors. Use
+    /// it when downstream code relies on a constructed triangulation having at
+    /// least one vertex, edge, and triangle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidSimplexCount`] if the underlying backend reports
+    /// a zero vertex, edge, or triangle count.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::*;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+    ///     let counts = tri.simplex_counts()?;
+    ///
+    ///     assert_eq!(counts.vertex_count(), 12);
+    ///     assert!(counts.edge_count() > 0);
+    ///     assert!(counts.triangle_count() > 0);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn simplex_counts(&self) -> CdtResult<CdtSimplexCounts> {
+        CdtSimplexCounts::try_new(self.vertex_count(), self.edge_count(), self.face_count())
+    }
+
     /// Force cache update.
     ///
     /// # Examples
@@ -1063,6 +1202,32 @@ mod tests {
         ])
         .expect("Should build labeled triangle");
         DelaunayBackend2D::from_triangulation(dt).expect("test Delaunay triangle should validate")
+    }
+
+    #[test]
+    fn simplex_counts_reject_zero_counts_before_storage() {
+        let error = CdtSimplexCounts::try_new(3, 0, 1)
+            .expect_err("zero edge count should not produce a CDT count snapshot");
+
+        assert_matches!(
+            error,
+            CdtError::InvalidSimplexCount {
+                field: SimplexCountField::Edges,
+                provided_value: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn triangulation_simplex_counts_preserve_nonzero_counts() {
+        let triangulation = CdtTriangulation::from_cdt_strip(4, 3).expect("CDT strip should build");
+        let counts = triangulation
+            .simplex_counts()
+            .expect("constructed CDT triangulation should have positive counts");
+
+        assert_eq!(counts.vertices().get(), triangulation.vertex_count());
+        assert_eq!(counts.edges().get(), triangulation.edge_count());
+        assert_eq!(counts.triangles().get(), triangulation.face_count());
     }
 
     #[test]
@@ -1970,10 +2135,11 @@ mod prop_tests {
             timeslices in 1u32..5
         ) {
             let triangulation = CdtTriangulation::from_random_points(vertices, timeslices, 2)?;
+            let counts = triangulation.simplex_counts()?;
 
-            prop_assert!(triangulation.vertex_count() >= 3, "Must have at least 3 vertices");
-            prop_assert!(triangulation.edge_count() >= 3, "Must have at least 3 edges");
-            prop_assert!(triangulation.face_count() >= 1, "Must have at least 1 face");
+            prop_assert!(counts.vertices().get() >= 3, "Must have at least 3 vertices");
+            prop_assert!(counts.edges().get() >= 3, "Must have at least 3 edges");
+            prop_assert!(counts.triangles().get() >= 1, "Must have at least 1 face");
         }
 
         #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -521,11 +521,11 @@ impl ValidatedCdtConfig {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let config = CdtConfig {
-    ///         output_csv: Some("measurements.csv".into()),
+    ///         output_csv: Some("trace.csv".into()),
     ///         ..CdtConfig::new(16, 4)
     ///     }
     ///     .into_validated()?;
-    ///     assert_eq!(config.output_csv(), Some(Path::new("measurements.csv")));
+    ///     assert_eq!(config.output_csv(), Some(Path::new("trace.csv")));
     ///     Ok(())
     /// }
     /// ```
@@ -1899,7 +1899,7 @@ mod tests {
         let raw = CdtConfig {
             topology: CdtTopology::Toroidal,
             simulate: false,
-            output_csv: Some(PathBuf::from("measurements.csv")),
+            output_csv: Some(PathBuf::from("trace.csv")),
             output_json: Some(PathBuf::from("summary.json")),
             ..CdtConfig::new(12, 3)
         };
@@ -1913,7 +1913,7 @@ mod tests {
         assert!(!validated.simulate());
         assert_eq!(
             validated.output_csv(),
-            Some(PathBuf::from("measurements.csv").as_path())
+            Some(PathBuf::from("trace.csv").as_path())
         );
         assert_eq!(
             validated.output_json(),
@@ -2485,7 +2485,7 @@ mod tests {
             cosmological_constant: Some(0.25),
             seed: Some(Some(99)),
             topology: Some(CdtTopology::Toroidal),
-            output_csv: Some(Some(PathBuf::from("measurements.csv"))),
+            output_csv: Some(Some(PathBuf::from("trace.csv"))),
             output_json: Some(Some(PathBuf::from("summary.json"))),
             ..CdtConfigOverrides::default()
         };
@@ -2506,7 +2506,7 @@ mod tests {
         assert_relative_eq!(merged.cosmological_constant, 0.25);
         assert_eq!(merged.seed, Some(99));
         assert_eq!(merged.topology, CdtTopology::Toroidal);
-        assert_eq!(merged.output_csv, Some(PathBuf::from("measurements.csv")));
+        assert_eq!(merged.output_csv, Some(PathBuf::from("trace.csv")));
         assert_eq!(merged.output_json, Some(PathBuf::from("summary.json")));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,7 +120,7 @@ pub struct CdtConfig {
     /// Topology and boundary conditions for triangulation generation.
     pub topology: CdtTopology,
 
-    /// Write per-measurement simulation data to a CSV file.
+    /// Write scalar trace rows to a CSV file.
     ///
     /// Relative paths are resolved from the current working directory with
     /// [`CdtConfig::resolve_path`]. Parent directories are created when output
@@ -128,7 +128,7 @@ pub struct CdtConfig {
     /// and JSON output paths resolve to the same file.
     pub output_csv: Option<PathBuf>,
 
-    /// Write simulation metadata and aggregate summary data to a JSON file.
+    /// Write simulation summary, metadata, and final triangulation data to a JSON file.
     ///
     /// Relative paths are resolved from the current working directory with
     /// [`CdtConfig::resolve_path`]. Parent directories are created when output
@@ -510,7 +510,7 @@ impl ValidatedCdtConfig {
         self.config.simulate
     }
 
-    /// Configured CSV output path, if any.
+    /// Configured trace CSV output path, if any.
     ///
     /// # Examples
     ///
@@ -534,7 +534,7 @@ impl ValidatedCdtConfig {
         self.config.output_csv.as_deref()
     }
 
-    /// Configured JSON output path, if any.
+    /// Configured summary/metadata JSON output path, if any.
     ///
     /// # Examples
     ///
@@ -619,7 +619,7 @@ impl TryFrom<CdtConfig> for ValidatedCdtConfig {
     author,
     version,
     about = "Run 1+1-dimensional Causal Dynamical Triangulations simulations",
-    long_about = "Run 1+1-dimensional Causal Dynamical Triangulations simulations.\n\nConstruct a foliated CDT triangulation, optionally run the Metropolis move loop, and write measurement summaries. Prefer --vertices-per-slice for regular initial data or --volume-profile for explicit nonuniform initial slice volumes; --vertices remains available when the total initial vertex count is already known.",
+    long_about = "Run 1+1-dimensional Causal Dynamical Triangulations simulations.\n\nConstruct a foliated CDT triangulation, optionally run the Metropolis move loop, and write CSV trace rows plus JSON summary metadata. Prefer --vertices-per-slice for regular initial data or --volume-profile for explicit nonuniform initial slice volumes; --vertices remains available when the total initial vertex count is already known.",
     group = ArgGroup::new("vertex_count")
         .required(true)
         .args(["vertices", "vertices_per_slice", "volume_profile"])
@@ -732,16 +732,16 @@ struct CdtCliArgs {
     #[arg(
         long,
         value_name = "PATH",
-        help = "Write per-measurement simulation data to a CSV file",
-        long_help = "Write per-measurement simulation data to a CSV file. Relative paths are resolved from the current working directory, and parent directories are created when output is written."
+        help = "Write scalar trace rows to a CSV file",
+        long_help = "Write scalar trace rows to a CSV file for external analysis workflows. Relative paths are resolved from the current working directory, and parent directories are created when output is written."
     )]
     output_csv: Option<PathBuf>,
 
     #[arg(
         long,
         value_name = "PATH",
-        help = "Write run metadata, aggregate summaries, and final triangulation data to JSON",
-        long_help = "Write run metadata, aggregate summaries, and final triangulation data to JSON. Relative paths are resolved from the current working directory, and parent directories are created when output is written."
+        help = "Write run summary, metadata, and final triangulation data to JSON",
+        long_help = "Write run summary, metadata, and final triangulation data to JSON. Relative paths are resolved from the current working directory, and parent directories are created when output is written."
     )]
     output_json: Option<PathBuf>,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -828,6 +828,28 @@ pub enum CheckpointResumeFailure {
         /// Step with invalid scalar trace telemetry.
         step: u32,
     },
+    /// Scalar trace RNG seed disagrees with the simulation configuration.
+    #[error("step {step} scalar trace seed mismatch: got {actual:?}, expected {expected:?}")]
+    ScalarTraceSeedMismatch {
+        /// Step with invalid scalar trace telemetry.
+        step: u32,
+        /// Seed stored in the scalar trace row.
+        actual: Option<u64>,
+        /// Seed from simulation configuration.
+        expected: Option<u64>,
+    },
+    /// Scalar trace volume profile exceeds the stored triangle count.
+    #[error(
+        "step {step} scalar trace volume profile total {profile_total} exceeds triangle count {triangles}"
+    )]
+    ScalarTraceVolumeProfileExceedsTriangles {
+        /// Step with invalid scalar trace telemetry.
+        step: u32,
+        /// Sum of the serialized volume profile entries.
+        profile_total: u64,
+        /// Stored scalar trace triangle count.
+        triangles: u32,
+    },
     /// Scalar trace contains a non-finite numeric value.
     #[error("step {step} scalar trace field {field} is non-finite")]
     NonFiniteScalarTraceValue {
@@ -1113,6 +1135,8 @@ impl From<CdtError> for MetropolisMoveApplicationFailure {
             | CdtError::InvalidSimplexCount { .. }
             | CdtError::InvalidMeasurementAction { .. }
             | CdtError::InvalidMeasurementCount { .. }
+            | CdtError::InvalidMeasurementVolumeProfile { .. }
+            | CdtError::InvalidScalarTraceCount { .. }
             | CdtError::MeasurementCountOverflow { .. }
             | CdtError::InvalidSimulationConfiguration { .. }
             | CdtError::PlannedProposalStepFailed { .. }
@@ -1215,6 +1239,29 @@ pub enum CdtError {
     )]
     InvalidMeasurementCount {
         /// Structured category for the invalid measurement count.
+        field: MeasurementCountField,
+        /// Value supplied for the count.
+        provided_value: u32,
+    },
+    /// [`Measurement`](crate::cdt::results::Measurement) construction failed
+    /// because a per-slice volume profile could not fit the stored triangle count.
+    #[error(
+        "Invalid measurement volume profile at step {step}: total {profile_total} exceeds triangle count {triangles}"
+    )]
+    InvalidMeasurementVolumeProfile {
+        /// Measurement step with invalid volume-profile telemetry.
+        step: u32,
+        /// Sum of the supplied volume profile entries.
+        profile_total: u64,
+        /// Stored measurement triangle count.
+        triangles: u32,
+    },
+    /// Scalar trace row construction failed because a count was not strictly positive.
+    #[error(
+        "Invalid scalar trace count: {field} (got: {provided_value}, expected: strictly positive)"
+    )]
+    InvalidScalarTraceCount {
+        /// Structured category for the invalid scalar trace count.
         field: MeasurementCountField,
         /// Value supplied for the count.
         provided_value: u32,
@@ -1743,6 +1790,34 @@ mod tests {
 
         for (counter, expected) in cases {
             assert_eq!(counter.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn scalar_trace_field_display_covers_all_fields() {
+        let cases = [
+            (ScalarTraceField::LogProb, "log_prob"),
+            (ScalarTraceField::Action, "action"),
+            (ScalarTraceField::DeltaAction, "delta_action"),
+            (ScalarTraceField::ActionBefore, "action_before"),
+            (ScalarTraceField::ActionAfter, "action_after"),
+        ];
+
+        for (field, expected) in cases {
+            assert_eq!(field.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn simplex_count_field_display_covers_all_fields() {
+        let cases = [
+            (SimplexCountField::Vertices, "vertices"),
+            (SimplexCountField::Edges, "edges"),
+            (SimplexCountField::Triangles, "triangles"),
+        ];
+
+        for (field, expected) in cases {
+            assert_eq!(field.to_string(), expected);
         }
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,7 @@
 use crate::cdt::ergodic_moves::MoveType;
 use crate::cdt::foliation::FoliationError;
 use crate::config::CdtTopology;
-use markov_chain_monte_carlo::McmcError;
+use markov_chain_monte_carlo::{McmcError, StepOutcome};
 use std::fmt;
 
 /// Highest cumulative upstream Delaunay validation level being enforced.
@@ -234,7 +234,7 @@ impl fmt::Display for TriangulationMetadataField {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum OutputFormat {
-    /// Comma-separated measurement output.
+    /// Comma-separated trace output.
     Csv,
     /// JSON simulation summary output.
     Json,
@@ -529,6 +529,105 @@ impl fmt::Display for ProposalTelemetryCounter {
     }
 }
 
+/// Scalar trace field category used in checkpoint/result diagnostics.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::errors::ScalarTraceField;
+///
+/// assert_eq!(ScalarTraceField::ActionBefore.to_string(), "action_before");
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ScalarTraceField {
+    /// Cached target log probability.
+    LogProb,
+    /// Current action observable.
+    Action,
+    /// Proposed or accepted action delta.
+    DeltaAction,
+    /// Action before the proposed move.
+    ActionBefore,
+    /// Action after an accepted move.
+    ActionAfter,
+}
+
+impl fmt::Display for ScalarTraceField {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LogProb => formatter.write_str("log_prob"),
+            Self::Action => formatter.write_str("action"),
+            Self::DeltaAction => formatter.write_str("delta_action"),
+            Self::ActionBefore => formatter.write_str("action_before"),
+            Self::ActionAfter => formatter.write_str("action_after"),
+        }
+    }
+}
+
+/// Measurement count column with a strictly positive invariant.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::errors::MeasurementCountField;
+///
+/// assert_eq!(MeasurementCountField::Vertices.to_string(), "vertices");
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum MeasurementCountField {
+    /// Vertex-count column.
+    Vertices,
+    /// Edge-count column.
+    Edges,
+    /// Triangle-count column.
+    Triangles,
+}
+
+impl fmt::Display for MeasurementCountField {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Vertices => formatter.write_str("vertices"),
+            Self::Edges => formatter.write_str("edges"),
+            Self::Triangles => formatter.write_str("triangles"),
+        }
+    }
+}
+
+/// CDT simplex-count field with a strictly positive triangulation-state invariant.
+///
+/// Use this with [`CdtError::InvalidSimplexCount`] when converting raw backend
+/// counts into an invariant-bearing CDT count snapshot.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::errors::SimplexCountField;
+///
+/// assert_eq!(SimplexCountField::Triangles.to_string(), "triangles");
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum SimplexCountField {
+    /// Vertex-count field.
+    Vertices,
+    /// Edge-count field.
+    Edges,
+    /// Triangle-count field.
+    Triangles,
+}
+
+impl fmt::Display for SimplexCountField {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Vertices => formatter.write_str("vertices"),
+            Self::Edges => formatter.write_str("edges"),
+            Self::Triangles => formatter.write_str("triangles"),
+        }
+    }
+}
+
 /// Structured reason a CDT checkpoint could not be resumed.
 ///
 /// [`CdtError::CheckpointResumeFailed`] wraps this enum for CDT-owned resume
@@ -645,12 +744,6 @@ pub enum CheckpointResumeFailure {
         /// Step with invalid telemetry.
         step: u32,
     },
-    /// Accepted step telemetry is missing the action delta.
-    #[error("accepted step {step} is missing delta_action")]
-    AcceptedStepMissingDeltaAction {
-        /// Step with invalid telemetry.
-        step: u32,
-    },
     /// Accepted step telemetry has an action-after value inconsistent with the delta.
     #[error("step {step} action_after does not match delta_action")]
     StepActionAfterDeltaMismatch {
@@ -663,17 +756,109 @@ pub enum CheckpointResumeFailure {
         /// Step with invalid telemetry.
         step: u32,
     },
-    /// Accepted step telemetry is missing the post-move action.
-    #[error("accepted step {step} is missing action_after")]
-    AcceptedStepMissingActionAfter {
-        /// Step with invalid telemetry.
+    /// Scalar trace row count disagrees with step telemetry.
+    #[error("scalar trace row count mismatch: got {actual}, expected {expected}")]
+    ScalarTraceLengthMismatch {
+        /// Number of scalar trace rows.
+        actual: usize,
+        /// Expected scalar trace rows from step telemetry.
+        expected: usize,
+    },
+    /// Scalar trace row step disagrees with step telemetry.
+    #[error("scalar trace step mismatch: got {actual}, expected {expected}")]
+    ScalarTraceStepMismatch {
+        /// Serialized scalar trace step.
+        actual: u32,
+        /// Expected step from step telemetry.
+        expected: u32,
+    },
+    /// Scalar trace row step was zero before it could be aligned with step telemetry.
+    #[error("scalar trace step must be nonzero: got {actual}")]
+    ScalarTraceStepZero {
+        /// Serialized scalar trace step.
+        actual: u32,
+    },
+    /// Scalar trace move family disagrees with step telemetry.
+    #[error("step {step} scalar trace move type mismatch: got {actual:?}, expected {expected:?}")]
+    ScalarTraceMoveTypeMismatch {
+        /// Step with invalid scalar trace telemetry.
+        step: u32,
+        /// Move type stored in the scalar trace row.
+        actual: MoveType,
+        /// Move type stored in step telemetry.
+        expected: MoveType,
+    },
+    /// Scalar trace accepted outcome disagrees with step telemetry.
+    #[error("step {step} scalar trace accepted mismatch: got {actual}, expected {expected}")]
+    ScalarTraceAcceptedMismatch {
+        /// Step with invalid scalar trace telemetry.
+        step: u32,
+        /// Accepted flag reconstructed from scalar trace outcome.
+        actual: bool,
+        /// Accepted flag stored in step telemetry.
+        expected: bool,
+    },
+    /// Scalar trace optional action delta disagrees with step telemetry.
+    #[error("step {step} scalar trace delta_action does not match step telemetry")]
+    ScalarTraceDeltaActionMismatch {
+        /// Step with invalid scalar trace telemetry.
         step: u32,
     },
-    /// Rejected step telemetry unexpectedly contains a post-move action.
-    #[error("rejected step {step} unexpectedly has action_after")]
-    RejectedStepHasActionAfter {
-        /// Step with invalid telemetry.
+    /// Scalar trace action-before value disagrees with step telemetry.
+    #[error("step {step} scalar trace action_before does not match step telemetry")]
+    ScalarTraceActionBeforeMismatch {
+        /// Step with invalid scalar trace telemetry.
         step: u32,
+    },
+    /// Scalar trace current action value disagrees with step telemetry.
+    #[error("step {step} scalar trace action does not match step telemetry")]
+    ScalarTraceActionMismatch {
+        /// Step with invalid scalar trace telemetry.
+        step: u32,
+    },
+    /// Scalar trace optional action-after value disagrees with step telemetry.
+    #[error("step {step} scalar trace action_after does not match step telemetry")]
+    ScalarTraceActionAfterMismatch {
+        /// Step with invalid scalar trace telemetry.
+        step: u32,
+    },
+    /// Scalar trace log probability disagrees with the stored action and temperature.
+    #[error("step {step} scalar trace log_prob does not match action and temperature")]
+    ScalarTraceLogProbMismatch {
+        /// Step with invalid scalar trace telemetry.
+        step: u32,
+    },
+    /// Scalar trace contains a non-finite numeric value.
+    #[error("step {step} scalar trace field {field} is non-finite")]
+    NonFiniteScalarTraceValue {
+        /// Step with invalid scalar trace telemetry.
+        step: u32,
+        /// Scalar trace field containing the invalid value.
+        field: ScalarTraceField,
+    },
+    /// Scalar trace accepted outcome count disagrees with proposal telemetry.
+    #[error("scalar trace accepted count mismatch: got {actual}, expected {expected}")]
+    ScalarTraceAcceptedCountMismatch {
+        /// Accepted outcomes recorded in scalar trace rows.
+        actual: u64,
+        /// Accepted outcomes recorded in proposal telemetry.
+        expected: u64,
+    },
+    /// Scalar trace rejected-proposal count disagrees with proposal telemetry.
+    #[error("scalar trace rejected-proposal count mismatch: got {actual}, expected {expected}")]
+    ScalarTraceRejectedProposalCountMismatch {
+        /// Rejected-proposal outcomes recorded in scalar trace rows.
+        actual: u64,
+        /// Metropolis rejection outcomes recorded in proposal telemetry.
+        expected: u64,
+    },
+    /// Scalar trace no-proposal count disagrees with proposal telemetry.
+    #[error("scalar trace no-proposal count mismatch: got {actual}, expected {expected}")]
+    ScalarTraceNoProposalCountMismatch {
+        /// No-proposal outcomes recorded in scalar trace rows.
+        actual: u64,
+        /// No-proposal outcomes recorded in proposal telemetry.
+        expected: u64,
     },
     /// Measurement count calculation overflowed.
     #[error("scheduled measurement count exceeds usize::MAX")]
@@ -696,12 +881,6 @@ pub enum CheckpointResumeFailure {
         actual: u32,
         /// Expected measurement step from the sampling schedule.
         expected: u32,
-    },
-    /// Measurement telemetry contains a non-finite action.
-    #[error("measurement at step {step} has non-finite action")]
-    NonFiniteMeasurementAction {
-        /// Measurement step with invalid telemetry.
-        step: u32,
     },
     /// A per-move counter sum overflowed.
     #[error("{counter} move count exceeds u64::MAX")]
@@ -931,8 +1110,13 @@ impl From<CdtError> for MetropolisMoveApplicationFailure {
             | CdtError::DelaunayGenerationFailed { .. }
             | CdtError::InvalidGenerationParameters { .. }
             | CdtError::InvalidConfiguration { .. }
+            | CdtError::InvalidSimplexCount { .. }
+            | CdtError::InvalidMeasurementAction { .. }
+            | CdtError::InvalidMeasurementCount { .. }
+            | CdtError::MeasurementCountOverflow { .. }
             | CdtError::InvalidSimulationConfiguration { .. }
             | CdtError::PlannedProposalStepFailed { .. }
+            | CdtError::UnexpectedPlannedStepOutcome { .. }
             | CdtError::PlannedProposalTelemetryMissing { .. }
             | CdtError::InvalidTriangulationMetadata { .. }
             | CdtError::VertexBuildFailed { .. }
@@ -1014,6 +1198,47 @@ pub enum CdtError {
         /// Expected constraint for the setting.
         expected: String,
     },
+    /// Live CDT simplex counts failed the strictly-positive triangulation-state invariant.
+    #[error(
+        "Invalid CDT simplex count: {field} (got: {provided_value}, expected: strictly positive)"
+    )]
+    InvalidSimplexCount {
+        /// Structured category for the invalid simplex count.
+        field: SimplexCountField,
+        /// Value observed for the count.
+        provided_value: usize,
+    },
+    /// [`Measurement`](crate::cdt::results::Measurement) construction failed
+    /// because a count was not strictly positive.
+    #[error(
+        "Invalid measurement count: {field} (got: {provided_value}, expected: strictly positive)"
+    )]
+    InvalidMeasurementCount {
+        /// Structured category for the invalid measurement count.
+        field: MeasurementCountField,
+        /// Value supplied for the count.
+        provided_value: u32,
+    },
+    /// [`Measurement`](crate::cdt::results::Measurement) construction failed
+    /// because a live triangulation count could not fit the serialized count type.
+    #[error("Measurement count overflow: {field} (got: {provided_value}, max: {max})")]
+    MeasurementCountOverflow {
+        /// Structured category for the overflowing measurement count.
+        field: MeasurementCountField,
+        /// Value supplied for the count.
+        provided_value: usize,
+        /// Maximum representable count for serialized telemetry.
+        max: u32,
+    },
+    /// [`Measurement`](crate::cdt::results::Measurement) construction failed
+    /// because the action value was not finite.
+    #[error("Invalid measurement action at step {step}: got {provided_value}, expected finite")]
+    InvalidMeasurementAction {
+        /// Monte Carlo step associated with the measurement.
+        step: u32,
+        /// Value supplied for the action.
+        provided_value: f64,
+    },
     /// Metropolis accepted a move, but a hard backend or invariant failure stopped application.
     ///
     /// The [`Self::MetropolisMoveApplicationFailed::source`] field keeps the
@@ -1056,6 +1281,14 @@ pub enum CdtError {
         step: u32,
         /// Upstream sampler diagnostic.
         detail: String,
+    },
+    /// A planned CDT proposal step returned an upstream outcome CDT does not support yet.
+    #[error("planned CDT proposal step {step} returned unsupported upstream outcome {outcome:?}")]
+    UnexpectedPlannedStepOutcome {
+        /// Monte Carlo step whose planned-proposal execution produced the outcome.
+        step: u32,
+        /// Upstream outcome variant that CDT does not support yet.
+        outcome: StepOutcome,
     },
     /// Constructed triangulation metadata is internally inconsistent.
     #[error(
@@ -2002,7 +2235,7 @@ mod tests {
     #[test]
     fn test_output_write_failed_error() {
         let error = CdtError::OutputWriteFailed {
-            path: "measurements.csv".to_string(),
+            path: "trace.csv".to_string(),
             format: OutputFormat::Csv,
             detail: "permission denied".to_string(),
         };
@@ -2014,13 +2247,13 @@ mod tests {
         else {
             panic!("expected OutputWriteFailed variant");
         };
-        assert_eq!(path, "measurements.csv");
+        assert_eq!(path, "trace.csv");
         assert_eq!(*format, OutputFormat::Csv);
         assert_eq!(detail, "permission denied");
         let display = format!("{error}");
         assert_eq!(
             display,
-            "Failed to write CSV output to measurements.csv: permission denied"
+            "Failed to write CSV output to trace.csv: permission denied"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -628,7 +628,7 @@ pub fn run_simulation(config: &ValidatedCdtConfig) -> CdtResult<SimulationResult
         );
 
         let measurement = Measurement::try_from_simplex_counts(0, initial_action, counts)?
-            .with_volume_profile(triangulation.volume_profile());
+            .try_with_volume_profile(triangulation.volume_profile())?;
 
         SimulationResultsBackend::from_parts(SimulationResultsParts {
             config: config.to_metropolis_config(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! - Metropolis-Hastings sampling over foliation-aware 2D ergodic moves
 //! - Volume-profile, Hausdorff-dimension, and spectral-dimension observables
 //!   for CDT analysis
-//! - CSV/JSON simulation output and resumable serde-backed CDT/MCMC checkpoints
+//! - Trace CSV/JSON simulation output and resumable serde-backed CDT/MCMC checkpoints
 //!
 //! The crate root re-exports the most common construction, simulation,
 //! observable, and error types. Focused preludes under [`prelude`] provide
@@ -157,8 +157,14 @@ pub mod cdt {
             CdtProposal, CdtProposalError, CdtProposalInfo, CdtProposalPlan, CdtTarget,
         };
         pub use checkpoint::CdtMcmcCheckpoint;
+        pub use markov_chain_monte_carlo::{
+            ChainId, StepOutcome, Trace, TraceError, TraceRecord, TraceStepOutcome,
+        };
         pub use runner::{MetropolisAlgorithm, MetropolisConfig};
-        pub use telemetry::{MonteCarloStep, ProposalStatistics};
+        pub use telemetry::{
+            AcceptedStepTelemetry, MonteCarloStep, MonteCarloStepOutcome, ProposalStatistics,
+            RejectedProposalStepTelemetry,
+        };
     }
     /// User-facing CDT observable estimators.
     pub mod observables;
@@ -177,11 +183,13 @@ pub use cdt::action::{
 pub use cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveStatistics, MoveType};
 pub use cdt::foliation::{EdgeType, Foliation, FoliationError, SimplexType};
 pub use cdt::metropolis::{
-    CdtMcmcCheckpoint, CdtProposal, CdtProposalError, CdtProposalInfo, CdtProposalPlan, CdtTarget,
-    MetropolisAlgorithm, MetropolisConfig, MonteCarloStep, ProposalStatistics,
+    AcceptedStepTelemetry, CdtMcmcCheckpoint, CdtProposal, CdtProposalError, CdtProposalInfo,
+    CdtProposalPlan, CdtTarget, MetropolisAlgorithm, MetropolisConfig, MonteCarloStep,
+    MonteCarloStepOutcome, ProposalStatistics, RejectedProposalStepTelemetry, StepOutcome,
 };
 pub use cdt::observables::{estimate_hausdorff_dimension, estimate_spectral_dimension};
 pub use cdt::results::{Measurement, SimulationResultsBackend};
+pub use cdt::triangulation::{CdtSimplexCounts, CdtTriangulation, SimulationEvent};
 pub use config::{
     CdtConfig, CdtConfigOverrides, CdtTopology, DimensionOverride, TestConfig, ValidatedCdtConfig,
     ValidatedInitialVolume,
@@ -189,19 +197,16 @@ pub use config::{
 pub use errors::{
     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
     CheckpointMoveCounter, CheckpointOperation, CheckpointResumeFailure, ConfigurationSetting,
-    DelaunayValidationLevel, GenerationParameterIssue, MetropolisMoveApplicationFailure,
-    OutputFormat, ProposalTelemetryCounter, TriangulationMetadataField,
+    DelaunayValidationLevel, GenerationParameterIssue, MeasurementCountField,
+    MetropolisMoveApplicationFailure, OutputFormat, ProposalTelemetryCounter, ScalarTraceField,
+    SimplexCountField, TriangulationMetadataField,
 };
+pub use geometry::traits::TriangulationQuery;
 
 use crate::cdt::results::SimulationResultsParts;
-use crate::util::saturating_usize_to_u32;
 use std::env;
 use std::path::PathBuf;
 use std::time::Duration;
-
-// Trait-based triangulation (recommended)
-pub use cdt::triangulation::{CdtTriangulation, SimulationEvent};
-pub use geometry::traits::TriangulationQuery;
 
 /// Prelude module for convenient imports.
 ///
@@ -223,9 +228,9 @@ pub use geometry::traits::TriangulationQuery;
 /// ```
 pub mod prelude {
     // Core CDT types
-    pub use crate::CdtTriangulation;
     pub use crate::geometry::CdtTriangulation2D;
     pub use crate::geometry::traits::TriangulationQuery;
+    pub use crate::{CdtSimplexCounts, CdtTriangulation};
 
     // Action and simulation setup
     pub use crate::cdt::action::ActionConfig;
@@ -269,8 +274,9 @@ pub mod prelude {
             BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck,
             CdtValidationFailure, CheckpointMoveCounter, CheckpointOperation,
             CheckpointResumeFailure, ConfigurationSetting, DelaunayValidationLevel,
-            GenerationParameterIssue, MetropolisMoveApplicationFailure, OutputFormat,
-            ProposalTelemetryCounter, TriangulationMetadataField,
+            GenerationParameterIssue, MeasurementCountField, MetropolisMoveApplicationFailure,
+            OutputFormat, ProposalTelemetryCounter, ScalarTraceField, SimplexCountField,
+            TriangulationMetadataField,
         };
     }
 
@@ -312,7 +318,7 @@ pub mod prelude {
         pub use crate::errors::{CdtError, CdtResult};
         pub use crate::geometry::CdtTriangulation2D;
         pub use crate::geometry::traits::TriangulationQuery;
-        pub use crate::{CdtTriangulation, SimulationEvent};
+        pub use crate::{CdtSimplexCounts, CdtTriangulation, SimulationEvent};
     }
 
     /// Focused exports for local CDT move kernels and move statistics.
@@ -338,11 +344,14 @@ pub mod prelude {
     /// configuration, the Metropolis runner, proposal-plan adapter, telemetry
     /// structs, result containers, and typed proposal errors needed by MCMC
     /// workflows. It also includes the triangulation query trait so callers can
-    /// inspect final or checkpointed states returned by simulation APIs. The
-    /// upstream MCMC traits are re-exported here because
+    /// inspect final or checkpointed states returned by simulation APIs.
+    /// Upstream MCMC traits, step outcomes, and trace/checkpoint types are
+    /// re-exported here because
     /// [`CdtProposal`](crate::cdt::metropolis::CdtProposal) and
     /// [`CdtTarget`](crate::cdt::metropolis::CdtTarget) expose their primary
-    /// behavior through those trait implementations.
+    /// behavior through those trait implementations, while
+    /// [`SimulationResultsBackend::scalar_trace`](crate::cdt::results::SimulationResultsBackend::scalar_trace)
+    /// returns an upstream [`Trace`](markov_chain_monte_carlo::Trace).
     /// Observable estimators live in [`crate::prelude::observables`].
     ///
     /// ```
@@ -371,8 +380,10 @@ pub mod prelude {
         pub use crate::cdt::action::{ActionConfig, compute_regge_action};
         pub use crate::cdt::ergodic_moves::MoveType;
         pub use crate::cdt::metropolis::{
-            CdtMcmcCheckpoint, CdtProposal, CdtProposalError, CdtProposalInfo, CdtProposalPlan,
-            CdtTarget, MetropolisAlgorithm, MetropolisConfig, MonteCarloStep, ProposalStatistics,
+            AcceptedStepTelemetry, CdtMcmcCheckpoint, CdtProposal, CdtProposalError,
+            CdtProposalInfo, CdtProposalPlan, CdtTarget, MetropolisAlgorithm, MetropolisConfig,
+            MonteCarloStep, MonteCarloStepOutcome, ProposalStatistics,
+            RejectedProposalStepTelemetry,
         };
         pub use crate::cdt::results::{Measurement, SimulationResultsBackend};
         pub use crate::cdt::triangulation::SimulationEvent;
@@ -380,8 +391,11 @@ pub mod prelude {
         pub use crate::errors::{CdtError, CdtResult};
         pub use crate::geometry::CdtTriangulation2D;
         pub use crate::geometry::traits::TriangulationQuery;
-        pub use crate::{CdtTriangulation, run_simulation};
-        pub use markov_chain_monte_carlo::{ChainCheckpoint, DelayedProposal, Target};
+        pub use crate::{CdtSimplexCounts, CdtTriangulation, run_simulation};
+        pub use markov_chain_monte_carlo::{
+            ChainCheckpoint, ChainId, DelayedProposal, StepOutcome, Target, Trace, TraceError,
+            TraceRecord, TraceStepOutcome,
+        };
     }
 
     /// Focused exports for CDT observables and post-simulation analysis.
@@ -605,11 +619,16 @@ pub fn run_simulation(config: &ValidatedCdtConfig) -> CdtResult<SimulationResult
         results
     } else {
         // Just return basic simulation results with the triangulation
-        let vertices = saturating_usize_to_u32(triangulation.vertex_count());
-        let edges = saturating_usize_to_u32(triangulation.edge_count());
-        let triangles = saturating_usize_to_u32(triangulation.face_count());
+        let counts = triangulation.simplex_counts()?;
         let action_config = config.to_action_config();
-        let initial_action = action_config.calculate_action(vertices, edges, triangles);
+        let initial_action = action_config.calculate_action(
+            counts.vertex_count(),
+            counts.edge_count(),
+            counts.triangle_count(),
+        );
+
+        let measurement = Measurement::try_from_simplex_counts(0, initial_action, counts)?
+            .with_volume_profile(triangulation.volume_profile());
 
         SimulationResultsBackend::from_parts(SimulationResultsParts {
             config: config.to_metropolis_config(),
@@ -617,14 +636,8 @@ pub fn run_simulation(config: &ValidatedCdtConfig) -> CdtResult<SimulationResult
             move_stats: MoveStatistics::new(),
             proposal_stats: ProposalStatistics::new(),
             steps: vec![],
-            measurements: vec![Measurement {
-                step: 0,
-                action: initial_action,
-                vertices,
-                edges,
-                triangles,
-                volume_profile: triangulation.volume_profile(),
-            }],
+            measurements: vec![measurement],
+            scalar_trace_rows: vec![],
             elapsed_time: Duration::from_millis(0),
             triangulation,
         })
@@ -684,8 +697,8 @@ fn write_configured_outputs(
     output_paths: &ResolvedOutputPaths,
 ) -> CdtResult<()> {
     if let Some(resolved) = &output_paths.csv {
-        results.write_measurements_csv(resolved)?;
-        log::info!("Wrote measurement CSV to {}", resolved.display());
+        results.write_trace_csv(resolved)?;
+        log::info!("Wrote trace CSV to {}", resolved.display());
     }
 
     if let Some(resolved) = &output_paths.json {
@@ -790,10 +803,7 @@ mod tests {
         let results = run_simulation(&config).expect("construction-only run should succeed");
         assert!(results.steps().is_empty());
         assert_eq!(
-            results
-                .measurements()
-                .first()
-                .map(|measurement| measurement.step),
+            results.measurements().first().map(Measurement::step),
             Some(0)
         );
 
@@ -803,10 +813,7 @@ mod tests {
 
         assert!(roundtrip.steps().is_empty());
         assert_eq!(
-            roundtrip
-                .measurements()
-                .first()
-                .map(|measurement| measurement.step),
+            roundtrip.measurements().first().map(Measurement::step),
             Some(0)
         );
         assert_eq!(roundtrip.triangulation().slice_sizes(), &[12, 12, 12]);
@@ -822,7 +829,7 @@ mod tests {
 
     #[test]
     fn run_simulation_writes_configured_outputs() {
-        let csv_path = temp_output_path("measurements.csv");
+        let csv_path = temp_output_path("trace.csv");
         let json_path = temp_output_path("summary.json");
         let mut config = create_test_config();
         config.output_csv = Some(csv_path.clone());
@@ -837,7 +844,9 @@ mod tests {
         fs::remove_file(&json_path).expect("temporary JSON output should be removable");
         let parsed: Value = from_str(&json).expect("JSON output should parse");
 
-        assert!(csv.starts_with("step,action,vertices,edges,triangles,accepted,delta_action\n"));
+        assert!(csv.starts_with(
+            "chain_id,step,accepted,proposed,log_prob,action,vertices,edges,triangles,move_family"
+        ));
         assert_eq!(parsed["config"]["vertices"], config.vertices().get());
         assert_eq!(
             parsed["final_triangulation"]["time_slices"],
@@ -1065,7 +1074,7 @@ mod tests {
 
         assert_eq!(results.triangulation().vertex_count(), 15);
         assert_eq!(results.triangulation().slice_sizes(), &[4, 6, 5]);
-        assert_eq!(results.measurements()[0].volume_profile.len(), 3);
+        assert_eq!(results.measurements()[0].volume_profile().len(), 3);
         results
             .triangulation()
             .validate()

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,16 +5,6 @@
 use num_traits::cast::NumCast;
 use rand::random;
 
-// ---------------------------------------------------------------------------
-// Safe numeric conversions
-// ---------------------------------------------------------------------------
-
-/// Converts a `usize` to `u32`, saturating at `u32::MAX`.
-#[must_use]
-pub(crate) fn saturating_usize_to_u32(n: usize) -> u32 {
-    u32::try_from(n).unwrap_or(u32::MAX)
-}
-
 /// Converts a `usize` to `f64`, preserving the checked conversion boundary.
 #[must_use]
 pub(crate) fn usize_to_f64(n: usize) -> Option<f64> {
@@ -107,29 +97,6 @@ mod tests {
             .iter()
             .all(|&x| abs_diff_eq!(x, first, epsilon = f64::EPSILON));
         assert!(!all_same, "All random values should not be identical");
-    }
-
-    // =========================================================================
-    // Safe numeric conversion tests
-    // =========================================================================
-
-    #[test]
-    fn test_saturating_usize_to_u32_normal() {
-        assert_eq!(saturating_usize_to_u32(0), 0);
-        assert_eq!(saturating_usize_to_u32(1), 1);
-        assert_eq!(saturating_usize_to_u32(42), 42);
-    }
-
-    #[test]
-    fn test_saturating_usize_to_u32_boundary() {
-        assert_eq!(saturating_usize_to_u32(u32::MAX as usize), u32::MAX);
-    }
-
-    #[test]
-    fn test_saturating_usize_to_u32_overflow() {
-        #[cfg(target_pointer_width = "64")]
-        assert_eq!(saturating_usize_to_u32(u32::MAX as usize + 1), u32::MAX);
-        assert_eq!(saturating_usize_to_u32(usize::MAX), u32::MAX);
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -193,7 +193,7 @@ fn cdt_cli_runs_simulation_with_real_moves() {
 #[test]
 fn cdt_cli_writes_configured_outputs() {
     let output_dir = temp_output_dir("outputs");
-    let csv_path = output_dir.join("measurements.csv");
+    let csv_path = output_dir.join("trace.csv");
     let json_path = output_dir.join("summary.json");
     let mut cmd = cdt_command();
 
@@ -215,7 +215,9 @@ fn cdt_cli_writes_configured_outputs() {
     let parsed: Value = from_str(&json).expect("summary should parse");
     fs::remove_dir_all(&output_dir).expect("temporary output directory should be removable");
 
-    assert!(csv.starts_with("step,action,vertices,edges,triangles,accepted,delta_action\n"));
+    assert!(csv.starts_with(
+        "chain_id,step,accepted,proposed,log_prob,action,vertices,edges,triangles,move_family"
+    ));
     assert_eq!(parsed["config"]["vertices"], 12);
     assert_eq!(parsed["final_triangulation"]["time_slices"], 3);
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -50,8 +50,8 @@ mod integration_tests {
         assert!(results.average_action().is_finite());
         assert!(
             results.steps().iter().any(|step| {
-                step.action_after.is_some_and(|action_after| {
-                    !abs_diff_eq!(action_after, step.action_before, epsilon = f64::EPSILON)
+                step.action_after().is_some_and(|action_after| {
+                    !abs_diff_eq!(action_after, step.action_before(), epsilon = f64::EPSILON)
                 })
             }),
             "accepted moves should change the action over time"
@@ -254,9 +254,9 @@ mod integration_tests {
             CdtTriangulation::from_random_points(4, 1, 2).expect("Failed to create triangulation");
 
         let config = ActionConfig::default();
-        let vertices = u32::try_from(triangulation.vertex_count()).unwrap_or_default();
-        let edges = u32::try_from(triangulation.edge_count()).unwrap_or_default();
-        let faces = u32::try_from(triangulation.face_count()).unwrap_or_default();
+        let vertices = triangulation.vertex_count();
+        let edges = triangulation.edge_count();
+        let faces = triangulation.face_count();
 
         let action = config.calculate_action(vertices, edges, faces);
 
@@ -267,7 +267,9 @@ mod integration_tests {
         );
 
         // Defaults map the edge-count lambda convention to the critical 1+1 CDT triangle coupling.
-        let expected = DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT * f64::from(edges);
+        let expected_edges: f64 =
+            num_traits::cast::NumCast::from(edges).expect("edge count should fit f64");
+        let expected = DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT * expected_edges;
         assert_relative_eq!(action, expected, epsilon = f64::EPSILON);
     }
 
@@ -296,8 +298,8 @@ mod integration_tests {
 
         assert_eq!(results1.steps().len(), results2.steps().len());
         for (left, right) in results1.steps().iter().zip(results2.steps().iter()) {
-            assert_eq!(left.move_type, right.move_type);
-            assert_eq!(left.accepted, right.accepted);
+            assert_eq!(left.move_type(), right.move_type());
+            assert_eq!(left.accepted(), right.accepted());
         }
     }
 

--- a/tests/physics_integration.rs
+++ b/tests/physics_integration.rs
@@ -34,12 +34,12 @@ fn assert_physics_pipeline(config: CdtConfig) {
         .measurements()
         .first()
         .expect("simulation should record measurements")
-        .action;
+        .action();
     assert!(
         results
             .measurements()
             .iter()
-            .any(|measurement| (measurement.action - first_action).abs() > 1e-6),
+            .any(|measurement| (measurement.action() - first_action).abs() > 1e-6),
         "action never changed"
     );
 

--- a/tests/proptest_metropolis.rs
+++ b/tests/proptest_metropolis.rs
@@ -39,9 +39,9 @@ proptest! {
         );
 
         // Must equal -action / T
-        let v = u32::try_from(tri.vertex_count()).unwrap();
-        let e = u32::try_from(tri.edge_count()).unwrap();
-        let f = u32::try_from(tri.face_count()).unwrap();
+        let v = tri.vertex_count();
+        let e = tri.edge_count();
+        let f = tri.face_count();
         let action = action_config.calculate_action(v, e, f);
         let expected = -action / temperature;
 

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -5,7 +5,7 @@
 use approx::assert_relative_eq;
 use causal_triangulations::{
     ActionConfig, CdtTriangulation, ErgodicsSystem, MetropolisAlgorithm, MetropolisConfig,
-    MoveResult, SimulationEvent,
+    MonteCarloStep, MoveResult, SimulationEvent,
 };
 use std::assert_matches;
 
@@ -31,7 +31,7 @@ fn toroidal_observables_run_accepts_periodic_moves_after_offset_support() {
         "periodic toroidal runs should accept moves after delaunay offset-aware flips"
     );
     assert!(
-        results.steps().iter().any(|step| step.accepted),
+        results.steps().iter().any(MonteCarloStep::accepted),
         "observables workflow should expose at least one accepted periodic move"
     );
     assert!(
@@ -113,22 +113,22 @@ fn accepted_step_telemetry_keeps_action_delta_consistent_after_planned_proposal_
 
     let mut accepted_steps = 0_u64;
     for step in results.steps() {
-        if step.accepted {
+        if step.accepted() {
             accepted_steps = accepted_steps.saturating_add(1);
             let action_after = step
-                .action_after
+                .action_after()
                 .expect("accepted steps should expose action_after");
             let delta_action = step
-                .delta_action
+                .delta_action()
                 .expect("accepted steps should expose delta_action");
             assert_relative_eq!(
                 delta_action,
-                action_after - step.action_before,
+                action_after - step.action_before(),
                 epsilon = 1e-12
             );
         } else {
             assert!(
-                step.action_after.is_none(),
+                step.action_after().is_none(),
                 "rejected steps should not expose action_after"
             );
         }

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -174,3 +174,52 @@ fn proposal_site_cache_does_not_reuse_sites_for_replaced_triangulation_instances
         .validate()
         .expect("fresh strip move should preserve CDT invariants");
 }
+
+#[test]
+fn resumed_scalar_trace_keeps_checkpoint_seed_not_fresh_resume_seed() {
+    // Regression for causal-triangulations#164: checkpoint continuation ignores
+    // the fresh algorithm seed and resumes from serialized RNG state. Scalar
+    // trace metadata must therefore keep the checkpoint/run seed, not the seed
+    // on the temporary resume driver.
+    let action_config = ActionConfig::default();
+    let prefix_config = MetropolisConfig::new(1.0, 4, 0, 1)
+        .expect("prefix Metropolis config should be valid")
+        .with_seed(19);
+    let resume_config = MetropolisConfig::new(1.0, 6, 0, 1)
+        .expect("resume Metropolis config should be valid")
+        .with_seed(999);
+    let prefix = MetropolisAlgorithm::new(prefix_config, action_config.clone())
+        .run_to_checkpoint(
+            CdtTriangulation::from_cdt_strip(4, 3).expect("strip fixture should build"),
+        )
+        .expect("prefix checkpoint should build");
+
+    let checkpoint = MetropolisAlgorithm::new(resume_config, action_config)
+        .resume_to_checkpoint(prefix)
+        .expect("resume with a different fresh seed should still validate");
+    let results = checkpoint.into_results();
+    let trace = results.scalar_trace().expect("scalar trace should export");
+    let seed_low_index = trace
+        .observable_names()
+        .iter()
+        .position(|name| name == "seed_low_u32")
+        .expect("trace should include seed_low_u32");
+    let seed_high_index = trace
+        .observable_names()
+        .iter()
+        .position(|name| name == "seed_high_u32")
+        .expect("trace should include seed_high_u32");
+    let seed_present_index = trace
+        .observable_names()
+        .iter()
+        .position(|name| name == "seed_present")
+        .expect("trace should include seed_present");
+
+    assert_eq!(trace.len(), 10);
+    for record in trace.records() {
+        let values = record.observable_values();
+        assert_relative_eq!(values[seed_low_index], 19.0);
+        assert_relative_eq!(values[seed_high_index], 0.0);
+        assert_relative_eq!(values[seed_present_index], 1.0);
+    }
+}


### PR DESCRIPTION
- Represent constructed CDT simplex counts with invariant-bearing nonzero types while keeping raw backend geometry counts as usize.
- Replace public measurement and Metropolis step fields with typed accessors and outcome-specific telemetry payloads.
- Export simulation diagnostics through upstream scalar trace CSV rows instead of legacy measurement CSV rows.
- Remove saturating telemetry downcasts in favor of checked conversions and structured count/trace error variants.
- Update docs, examples, preludes, and tooling guidance for the new trace and count contracts.

BREAKING CHANGE: Measurement, MonteCarloStep, action count, checkpoint, and CSV output APIs now use typed/nonzero count and trace representations instead of the previous public fields and measurement CSV schema.

Closes #164