### PR TITLE
ci(release): finalize v0.1.0 validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enforce simulation state invariants [#174](https://github.com/acgetchell/causal-triangulations/pull/174)
 - Encode nonzero CDT invariants
 - Run continuation through planned proposals [#153](https://github.com/acgetchell/causal-triangulations/pull/153)
+- Encode trace and count invariants [#164](https://github.com/acgetchell/causal-triangulations/pull/164)
+- Enforce trace profile invariants [#164](https://github.com/acgetchell/causal-triangulations/pull/164)
 - Enforce CDT and backend invariants
 - Harden CDT telemetry and profiled initialization
 - Reject volume-profile override overflows
@@ -32,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Merged Pull Requests
 
 - Enforce simulation state invariants [#174](https://github.com/acgetchell/causal-triangulations/pull/174)
+- Encode trace and count invariants [#164](https://github.com/acgetchell/causal-triangulations/pull/164)
+- Enforce trace profile invariants [#164](https://github.com/acgetchell/causal-triangulations/pull/164)
 - Require validated CDT runtime configs [#163](https://github.com/acgetchell/causal-triangulations/pull/163)
 - Tighten coverage and doctest assertion checks [#163](https://github.com/acgetchell/causal-triangulations/pull/163)
 - Tighten Semgrep fixture coverage [#162](https://github.com/acgetchell/causal-triangulations/pull/162)
@@ -535,6 +539,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     history.
   - Carry validated config, volume, and foliation counts as NonZeroU32 so downstream construction can rely on nonzero invariants.
   - Add Semgrep guardrails around planned-step telemetry and sampler-state synchronization.
+
+- [**breaking**] Encode trace and count invariants [#164](https://github.com/acgetchell/causal-triangulations/pull/164)
+  [`d843d16`](https://github.com/acgetchell/causal-triangulations/commit/d843d165d0392ad1e179e3d43a7984491faa5a18)
+
+  - Represent constructed CDT simplex counts with invariant-bearing nonzero types while keeping raw backend geometry counts as usize.
+  - Replace public measurement and Metropolis step fields with typed accessors and outcome-specific telemetry payloads.
+  - Export simulation diagnostics through upstream scalar trace CSV rows instead of legacy measurement CSV rows.
+  - Remove saturating telemetry downcasts in favor of checked conversions and structured count/trace error variants.
+  - Update docs, examples, preludes, and tooling guidance for the new trace and count contracts.
+
+- [**breaking**] Enforce trace profile invariants [#164](https://github.com/acgetchell/causal-triangulations/pull/164)
+  [`f481bc2`](https://github.com/acgetchell/causal-triangulations/commit/f481bc2bdf9d1ad727a90b12e4c35f67a7c8bf9c)
+
+  - Reject measurement and scalar trace volume profiles whose totals exceed the stored triangle count.
+  - Preserve checkpoint seed metadata across resumed scalar trace rows and reject mismatched trace seeds during validation.
+  - Clarify that CSV output carries trace rows while JSON output carries summary metadata and final triangulation data.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## 🚧 Project Status
 
-🚧 **Pre-release (0.0.x)** — The 1+1 CDT foundation is implemented and tested, but this crate is still under active development and
-**not yet ready for production use**. APIs, data structures, and module boundaries may change before v0.1.0.
+🚧 **v0.1.0 release-readiness** — The validated 1+1 CDT foundation is in place, including toroidal volume-changing moves, nonuniform initial volume
+profiles, upstream-backed MCMC sampler mechanics, and CI-aligned validation tooling. The crate remains unreleased at v0.1.0 until the release PR merges and the
+v0.1.0 package and tag are cut.
 
-The library currently supports validated 1+1 CDT construction, foliation checks, Metropolis sampling, and core observables. Higher-dimensional CDT support, full
-move-kernel maturity, visualization/export workflows, and advanced ensemble-analysis helpers remain roadmap work.
+The library currently supports validated 1+1 CDT construction, foliation checks, Metropolis sampling, resumable checkpoints, and core observables.
+Higher-dimensional CDT support, visualization/export workflows, and advanced ensemble-analysis helpers remain roadmap work.
 
 See [`docs/roadmap.md`](docs/roadmap.md) for current direction, near-term candidates, and non-goals.
 

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -117,7 +117,8 @@ For heavier stabilization work, run the slow-test wrapper:
 just ci-slow
 ```
 
-This runs the normal CI command and then feature-gated slow/stress tests.
+This runs the normal CI command and then feature-gated slow/stress tests through the repository `perf` Cargo profile. The slow suite includes large-scale
+toroidal debug probes, so optimized builds are part of the validation contract rather than an optional speed tweak.
 
 ## Semgrep
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -176,6 +176,9 @@ Run feature-gated slow integration tests:
 just test-slow
 ```
 
+Slow tests run through the repository `perf` Cargo profile and set a wall-clock cap for large-scale debug runs. This keeps stress probes aligned with
+release/debug recipes and prevents default test-profile runtime from dominating slow validation.
+
 Run all tests:
 
 ```bash

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -47,7 +47,8 @@ Some differences remain because CDT has different workflows and project invarian
 - CDT keeps `archive-changelog` so completed release series move under `docs/archive/changelog/`; MCMC does not yet archive old changelog sections.
 - CDT keeps a dedicated `performance.yml` workflow and local `perf-*` recipes. MCMC does not have matching CDT benchmark-baseline tooling.
 - CDT exposes feature-gated long-running Rust checks through the `slow-tests` Cargo feature and the `just test-slow` recipe, keeping normal CI fast while giving
-  stabilization work a named path for heavier integration coverage.
+  stabilization work a named path for heavier integration coverage. Issue #140 release validation runs those slow tests through CDT's local `perf` profile,
+  matching the dedicated large-scale debug recipes instead of measuring default test-profile overhead.
 - CDT has a repository rule SARIF workflow for the local Semgrep rules. A Codacy workflow was not ported because it depends on project-specific
   `CODACY_PROJECT_TOKEN` setup and would duplicate the existing repository-rule SARIF signal until Codacy is configured for this repository.
 - CDT Semgrep rules include geometry-backend isolation, foliation/topology validation, focused prelude imports, doctest assertion-idiom enforcement,
@@ -90,7 +91,8 @@ The useful Semgrep updates ported from the sibling `delaunay` repository are:
 
 The useful `justfile` updates ported from `delaunay` are:
 
-- `ci-slow`, a named CI-plus-slow-tests workflow using CDT's existing `slow-tests` feature gate;
+- `ci-slow`, a named CI-plus-slow-tests workflow using CDT's existing `slow-tests` feature gate and local `perf` profile so large-scale toroidal probes validate
+  release-relevant behavior within a bounded runtime;
 - `cargo nextest` for runnable Rust unit, integration, CLI, slow, example, and release test recipes, while keeping rustdoc doctests on `cargo test --doc`
   because nextest does not execute doctests;
 - single-pass release example builds in `scripts/run_all_examples.sh`, which preserve semantic output validation while avoiding repeated `cargo run --example`

--- a/docs/moves.md
+++ b/docs/moves.md
@@ -85,10 +85,11 @@ non-success `MoveResult`. Toroidal post-move topology or closed-ring foliation f
 site was geometrically editable but would break the periodic CDT contract.
 
 The Metropolis loop first selects an explicit local proposal site, clones the current triangulation, and applies that exact site on the cloned proposed state;
-see `src/cdt/metropolis/runner.rs` and `src/cdt/metropolis/adapter.rs`. It then performs the accept/reject decision from the proposed move metadata; see
-`docs/metropolis.md`. Only accepted proposals
-swap the cloned, mutated state into the live simulation. Ordinary causal, geometric, or backend edit failures on the cloned state are self-loop proposal
-outcomes recorded in `ProposalStatistics`; hard backend mutation or invariant-refresh failures still return `CdtError::MetropolisMoveApplicationFailed`.
+see `src/cdt/metropolis/runner.rs` and `src/cdt/metropolis/adapter.rs`. The CDT proposal adapter scores the planned move with its action change and
+forward/reverse local-site ratio, then the upstream `markov-chain-monte-carlo` sampler owns the Metropolis-Hastings accept/reject draw and generic chain
+counters; see `docs/metropolis.md`. Only accepted proposals swap the cloned, mutated state into the live simulation. Ordinary causal, geometric, or backend
+edit failures on the cloned state are self-loop proposal outcomes recorded in `ProposalStatistics`; hard backend mutation or invariant-refresh failures still
+return `CdtError::MetropolisMoveApplicationFailed`.
 
 ## Ensemble And Volume Fixing
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,16 +13,21 @@ The v0.1.0 foundation work focuses on making the crate a usable, validated 1+1 C
 - [x] Explicit toroidal S¹×S¹ CDT construction with χ = 0 validation
 - [x] Per-vertex foliation labels, causality checks, and strict Up/Down simplex classification
 - [x] Real 2D ergodic move kernels over Delaunay backend edit operations
-- [x] Concrete planned-proposal Metropolis-Hastings loop with forward/reverse local-site weighting
+- [x] Planned-proposal Metropolis execution through the upstream `markov-chain-monte-carlo` sampler with forward/reverse local-site weighting
 - [x] Toroidal Metropolis regression coverage requiring accepted periodic moves while preserving topology and foliation
 - [x] CLI and configuration support for open-boundary and toroidal topology selection
 - [x] Volume-profile, Hausdorff-dimension, and spectral-dimension observables on the combinatorial dual graph
 - [x] Repository validation loop covering Rust, Python support scripts, Semgrep rules, documentation, examples, and benchmarks
-- [ ] Support variable spatial volume profiles for 1+1 CDT initial geometries
-  ([#141](https://github.com/acgetchell/causal-triangulations/issues/141))
-- [ ] Track release-readiness gates for the first public release
+- [x] Support variable spatial volume profiles for 1+1 CDT initial geometries
+  ([#141](https://github.com/acgetchell/causal-triangulations/issues/141)). Open-boundary and toroidal constructors now accept explicit per-slice `N(t)`
+  profiles, while regular constructors remain the equal-slice initial-data path.
+- [x] Align CI and security tooling with the shared Rust workflow
+  ([#162](https://github.com/acgetchell/causal-triangulations/issues/162))
+- [x] Upgrade to Rust 1.96.0 and the released `markov-chain-monte-carlo` v0.4.0 baseline
+  ([#163](https://github.com/acgetchell/causal-triangulations/issues/163))
+- [x] Track release-readiness gates for the first public release
   ([#140](https://github.com/acgetchell/causal-triangulations/issues/140))
-- [ ] Audit public doctests for fallible error handling
+- [x] Audit public doctests for fallible error handling
   ([#151](https://github.com/acgetchell/causal-triangulations/issues/151))
 - [x] Use chunked Metropolis sweeps in large-scale 1+1 CDT debug runs
   ([#152](https://github.com/acgetchell/causal-triangulations/issues/152)). The v0.1.0 scientific-utility bar requires the large-scale debug path to exercise
@@ -30,12 +35,10 @@ The v0.1.0 foundation work focuses on making the crate a usable, validated 1+1 C
 - [x] Align chunked Metropolis continuation with the upstream resumable sampler pattern
   ([#153](https://github.com/acgetchell/causal-triangulations/issues/153)). CDT chunk execution now drives the proposal-plan adapter through
   `markov-chain-monte-carlo` v0.4 sampler continuation while preserving CDT-owned measurements, proposal telemetry, and current-volume sweep sizing.
-- [ ] Enforce the MCMC backend boundary
-  ([#155](https://github.com/acgetchell/causal-triangulations/issues/155)). Because GitHub releases are archived by Zenodo, the DOI-backed `v0.1.0` release
-  should not ship with generic Metropolis-Hastings mechanics duplicated in CDT-local code. Complete this after an updated `markov-chain-monte-carlo` release
-  provides the needed upstream resumable-sampler and planned-step telemetry APIs
-  ([markov-chain-monte-carlo#60](https://github.com/acgetchell/markov-chain-monte-carlo/issues/60),
-  [markov-chain-monte-carlo#61](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61)).
+- [x] Enforce the MCMC backend boundary
+  ([#155](https://github.com/acgetchell/causal-triangulations/issues/155)). The production runner delegates generic acceptance/rejection,
+  proposal-ratio application, planned-proposal commit ordering, and chain-counter mechanics to `markov-chain-monte-carlo` through thin CDT adapters, with
+  repository rules guarding against accidental CDT-local reintroduction.
 
 ## 1+1 Maturity
 

--- a/justfile
+++ b/justfile
@@ -905,7 +905,7 @@ test-release: _ensure-cargo-nextest
     cargo test --doc --release
 
 test-slow: _ensure-cargo-nextest
-    cargo nextest run --tests --features slow-tests --verbose
+    CDT_LARGE_DEBUG_MAX_RUNTIME_SECS=1800 cargo nextest run --cargo-profile perf --tests --features slow-tests --verbose
 
 toml-check: toml-fmt-check toml-lint
 

--- a/src/cdt/metropolis/checkpoint.rs
+++ b/src/cdt/metropolis/checkpoint.rs
@@ -19,7 +19,9 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::num::NonZeroU32;
 use std::time::Duration;
 
-use super::helpers::{actions_match, expected_measurement_count, expected_measurement_step};
+use super::helpers::{
+    action_for, actions_match, expected_measurement_count, expected_measurement_step,
+};
 use super::runner::{MetropolisAlgorithm, MetropolisConfig};
 use super::telemetry::{MonteCarloStep, ProposalStatistics};
 
@@ -41,6 +43,28 @@ pub(crate) struct CdtMcmcCheckpointParts {
     pub(crate) ergodics: ErgodicsSystem,
 }
 
+/// Finite action value stored in resumable checkpoint state.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+struct CheckpointAction(f64);
+
+impl CheckpointAction {
+    /// Parses a raw checkpoint action into a finite stored action value.
+    const fn new(value: f64) -> CdtResult<Self> {
+        if value.is_finite() {
+            Ok(Self(value))
+        } else {
+            Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::NonFiniteCheckpointAction { stored: value },
+            ))
+        }
+    }
+
+    /// Returns the finite action value.
+    const fn get(self) -> f64 {
+        self.0
+    }
+}
+
 /// Resumable checkpoint for a CDT Metropolis-Hastings run.
 ///
 /// The embedded [`ChainCheckpoint`] stores the current triangulation and
@@ -53,6 +77,8 @@ pub(crate) struct CdtMcmcCheckpointParts {
 /// Metropolis step. Their current step is therefore stored and exposed as a
 /// [`NonZeroU32`]; initial step-0 samples are measurement telemetry, not a
 /// checkpoint position.
+/// Deserialized checkpoints also validate that their stored action is finite
+/// and matches the action recomputed from the restored triangulation.
 ///
 /// # Examples
 ///
@@ -80,7 +106,7 @@ pub struct CdtMcmcCheckpoint {
     pub(crate) config: MetropolisConfig,
     pub(crate) action_config: ActionConfig,
     pub(crate) current_step: NonZeroU32,
-    pub(crate) current_action: f64,
+    current_action: CheckpointAction,
     pub(crate) move_stats: MoveStatistics,
     #[serde(default)]
     pub(crate) proposal_stats: ProposalStatistics,
@@ -118,12 +144,13 @@ impl<'de> Deserialize<'de> for CdtMcmcCheckpoint {
         let wire = CdtMcmcCheckpointWire::deserialize(deserializer)?;
         let current_step = NonZeroU32::new(wire.current_step)
             .ok_or_else(|| DeError::custom("checkpoint current_step must be nonzero"))?;
+        let current_action = CheckpointAction::new(wire.current_action).map_err(DeError::custom)?;
         let checkpoint = Self {
             chain: wire.chain,
             config: wire.config,
             action_config: wire.action_config,
             current_step,
-            current_action: wire.current_action,
+            current_action,
             move_stats: wire.move_stats,
             proposal_stats: wire.proposal_stats,
             steps: wire.steps,
@@ -140,12 +167,13 @@ impl<'de> Deserialize<'de> for CdtMcmcCheckpoint {
 
 impl CdtMcmcCheckpoint {
     pub(crate) fn from_parts(parts: CdtMcmcCheckpointParts) -> CdtResult<Self> {
+        let current_action = CheckpointAction::new(parts.current_action)?;
         let checkpoint = Self {
             chain: ChainCheckpoint::new(parts.triangulation, parts.accepted, parts.rejected),
             config: parts.config,
             action_config: parts.action_config,
             current_step: parts.current_step,
-            current_action: parts.current_action,
+            current_action,
             move_stats: parts.move_stats,
             proposal_stats: parts.proposal_stats,
             steps: parts.steps,
@@ -316,7 +344,7 @@ impl CdtMcmcCheckpoint {
     /// ```
     #[must_use]
     pub const fn current_action(&self) -> f64 {
-        self.current_action
+        self.current_action.get()
     }
 
     /// Returns accumulated move statistics through the checkpoint step.
@@ -539,11 +567,12 @@ fn action_configs_match(left: &ActionConfig, right: &ActionConfig) -> bool {
 /// Returns [`CdtError::InvalidSimulationConfiguration`] for invalid
 /// Metropolis settings, [`CdtError::InvalidConfiguration`] for invalid action
 /// couplings, or [`CdtError::CheckpointResumeFailed`] when serialized chain
-/// counters, step telemetry, or measurements do not match the configured
-/// sampling schedule.
+/// counters, step telemetry, measurements, or stored action do not match the
+/// configured sampling schedule and restored triangulation state.
 pub(crate) fn validate_checkpoint_counters(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
     checkpoint.config.validate();
     checkpoint.action_config.validate();
+    validate_checkpoint_current_action(checkpoint)?;
 
     let (accepted, rejected) = chain_counters(&checkpoint.move_stats)?;
     if checkpoint.chain.accepted() != accepted || checkpoint.chain.rejected() != rejected {
@@ -583,6 +612,18 @@ pub(crate) fn validate_checkpoint_counters(checkpoint: &CdtMcmcCheckpoint) -> Cd
         &checkpoint.steps,
         &checkpoint.scalar_trace_rows,
     )?;
+    Ok(())
+}
+
+/// Verifies that the stored checkpoint action is finite and matches the restored state.
+fn validate_checkpoint_current_action(checkpoint: &CdtMcmcCheckpoint) -> CdtResult<()> {
+    let recomputed = action_for(&checkpoint.action_config, checkpoint.triangulation());
+    let stored = checkpoint.current_action.get();
+    if !actions_match(stored, recomputed) {
+        return Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::ActionMismatch { stored, recomputed },
+        ));
+    }
     Ok(())
 }
 

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -821,6 +821,7 @@ impl MetropolisRunState {
     /// from the invariant-checked triangulation payload.
     fn from_checkpoint(checkpoint: CdtMcmcCheckpoint) -> CdtResult<Self> {
         validate_checkpoint_counters(&checkpoint)?;
+        let stored_action = checkpoint.current_action();
         let target = CdtTarget::new(
             checkpoint.action_config.clone(),
             checkpoint.config.temperature(),
@@ -828,10 +829,10 @@ impl MetropolisRunState {
         let triangulation = restore_checkpoint_state(checkpoint.chain, &target)?;
         triangulation.validate_evolved_cdt()?;
         let actual_action = action_for(&checkpoint.action_config, &triangulation);
-        if !actions_match(actual_action, checkpoint.current_action) {
+        if !actions_match(actual_action, stored_action) {
             return Err(checkpoint_resume_failed(
                 CheckpointResumeFailure::ActionMismatch {
-                    stored: checkpoint.current_action,
+                    stored: stored_action,
                     recomputed: actual_action,
                 },
             ));
@@ -840,7 +841,7 @@ impl MetropolisRunState {
         Ok(Self {
             triangulation,
             current_step: checkpoint.current_step.get(),
-            current_action: checkpoint.current_action,
+            current_action: stored_action,
             trace_seed: checkpoint.config.seed(),
             acceptance_rng: checkpoint.acceptance_rng,
             ergodics: checkpoint.ergodics,
@@ -1445,7 +1446,7 @@ mod tests {
             .expect("synthetic rejected checkpoint should validate")
     }
 
-    fn synthetic_one_step_checkpoint(accepted: bool) -> CdtMcmcCheckpoint {
+    fn synthetic_one_step_checkpoint_parts(accepted: bool) -> CdtMcmcCheckpointParts {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let config = seeded_metropolis_config(1.0, 1, 0, 1, 13);
@@ -1465,7 +1466,7 @@ mod tests {
             CdtScalarTraceOutcome::RejectedProposal
         };
 
-        CdtMcmcCheckpoint::from_parts(CdtMcmcCheckpointParts {
+        CdtMcmcCheckpointParts {
             triangulation: triangulation.clone(),
             accepted: usize::from(accepted),
             rejected: usize::from(!accepted),
@@ -1508,8 +1509,12 @@ mod tests {
             elapsed_time: Duration::ZERO,
             acceptance_rng: simulation_rng(Some(1)),
             ergodics: ErgodicsSystem::with_seed(2),
-        })
-        .expect("synthetic checkpoint should validate")
+        }
+    }
+
+    fn synthetic_one_step_checkpoint(accepted: bool) -> CdtMcmcCheckpoint {
+        CdtMcmcCheckpoint::from_parts(synthetic_one_step_checkpoint_parts(accepted))
+            .expect("synthetic checkpoint should validate")
     }
 
     fn empty_run_state(triangulation: CdtTriangulation2D) -> MetropolisRunState {
@@ -1961,6 +1966,42 @@ mod tests {
     }
 
     #[test]
+    fn serialized_checkpoint_rejects_mismatched_current_action() {
+        let checkpoint = serializable_rejected_checkpoint(ActionConfig::default());
+        let mut payload = to_value(&checkpoint).expect("checkpoint should serialize");
+        payload["current_action"] =
+            to_value(checkpoint.current_action() + 1.0).expect("action should serialize");
+
+        let Err(error) = from_str::<CdtMcmcCheckpoint>(&payload.to_string()) else {
+            panic!("checkpoint action mismatch should fail while parsing");
+        };
+
+        assert!(
+            error.to_string().contains("checkpoint action mismatch"),
+            "unexpected serde error: {error}"
+        );
+    }
+
+    #[test]
+    fn checkpoint_validation_rejects_nonfinite_current_action() {
+        for current_action in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let mut parts = synthetic_one_step_checkpoint_parts(false);
+            parts.current_action = current_action;
+
+            assert_checkpoint_resume_failed(
+                CdtMcmcCheckpoint::from_parts(parts),
+                |failure| match failure {
+                    CheckpointResumeFailure::NonFiniteCheckpointAction { stored } => {
+                        stored.to_bits() == current_action.to_bits()
+                    }
+                    _ => false,
+                },
+                "checkpoint action is non-finite",
+            );
+        }
+    }
+
+    #[test]
     fn serialized_checkpoint_rejects_zero_step_telemetry() {
         let checkpoint = serializable_rejected_checkpoint(ActionConfig::default());
         let mut payload = to_value(&checkpoint).expect("checkpoint should serialize");
@@ -2270,7 +2311,7 @@ mod tests {
         checkpoint.steps[0] = rejected_proposal_step(
             1,
             checkpoint.steps[0].move_type(),
-            checkpoint.current_action,
+            checkpoint.current_action(),
             None,
         );
         let algorithm = MetropolisAlgorithm::new(
@@ -2452,16 +2493,12 @@ mod tests {
     }
 
     #[test]
-    fn resume_rejects_checkpoint_action_mismatch() {
-        let mut checkpoint = short_checkpoint();
-        checkpoint.current_action += 1.0;
-        let algorithm = MetropolisAlgorithm::new(
-            seeded_metropolis_config(1.0, 2, 0, 1, 999),
-            ActionConfig::default(),
-        );
+    fn checkpoint_from_parts_rejects_action_mismatch() {
+        let mut parts = synthetic_one_step_checkpoint_parts(false);
+        parts.current_action += 1.0;
 
         assert_checkpoint_resume_failed(
-            algorithm.resume_from_checkpoint(checkpoint),
+            CdtMcmcCheckpoint::from_parts(parts),
             |failure| matches!(failure, CheckpointResumeFailure::ActionMismatch { .. }),
             "checkpoint action mismatch",
         );

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -669,6 +669,12 @@ pub enum CheckpointResumeFailure {
         /// Action recomputed from the restored triangulation.
         recomputed: f64,
     },
+    /// Stored checkpoint action is NaN or infinite.
+    #[error("checkpoint action is non-finite: stored {stored}")]
+    NonFiniteCheckpointAction {
+        /// Serialized action stored in the checkpoint.
+        stored: f64,
+    },
     /// Action configuration differs from the checkpoint.
     #[error("action configuration differs from checkpoint")]
     IncompatibleActionConfiguration,
@@ -1833,6 +1839,13 @@ mod tests {
         assert_eq!(
             failure.to_string(),
             "chain counters do not match move statistics: chain accepted=1, rejected=2; move accepted=3, rejected=4"
+        );
+
+        let action_failure =
+            CheckpointResumeFailure::NonFiniteCheckpointAction { stored: f64::NAN };
+        assert_eq!(
+            action_failure.to_string(),
+            "checkpoint action is non-finite: stored NaN"
         );
     }
 


### PR DESCRIPTION
- Store resumable checkpoint actions behind a finite-action boundary before exposing checkpoint state.
- Reject non-finite and mismatched checkpoint actions during checkpoint construction and deserialization.
- Run slow release validation through the perf profile with a bounded large-scale debug harness.
- Align v0.1.0 release-readiness docs with upstream-backed Metropolis continuation and completed validation gates.

Closes #140