### PR TITLE
refactor(cdt)!: enforce fallible observable and trace invariants

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,6 +3,7 @@ message: "If you use this software, please cite it as below."
 type: software
 title: "causal-triangulations: A Causal Dynamical Triangulation library for quantum gravity research"
 version: 0.1.0
+doi: 10.5281/zenodo.20513228
 url: "https://github.com/acgetchell/causal-triangulations"
 repository-code: "https://github.com/acgetchell/causal-triangulations"
 authors:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bit-set"
@@ -138,9 +138,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bstr"
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cast"
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -212,7 +212,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -412,15 +412,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -487,6 +487,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -520,7 +544,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -547,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -565,12 +589,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -598,9 +622,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
@@ -611,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -622,10 +646,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -649,15 +675,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -670,9 +696,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "markov-chain-monte-carlo"
@@ -686,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "normalize-line-endings"
@@ -766,7 +792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -822,9 +848,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -897,7 +923,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -935,9 +961,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
  "serde",
@@ -945,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -961,7 +987,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "serde",
 ]
 
@@ -995,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -1010,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1116,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1165,9 +1191,15 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slotmap"
@@ -1299,9 +1331,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -1343,11 +1375,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1356,14 +1388,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1374,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1384,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1397,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -1440,9 +1472,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1502,6 +1534,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -1584,18 +1622,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # causal-triangulations
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20513229.svg)](https://doi.org/10.5281/zenodo.20513228)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20513229.svg)](https://doi.org/10.5281/zenodo.20513229)
 [![Crates.io](https://img.shields.io/crates/v/causal-triangulations.svg)](https://crates.io/crates/causal-triangulations)
 [![Downloads](https://img.shields.io/crates/d/causal-triangulations.svg)](https://crates.io/crates/causal-triangulations)
 [![Docs.rs](https://docs.rs/causal-triangulations/badge.svg)](https://docs.rs/causal-triangulations)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # causal-triangulations
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20513229.svg)](https://doi.org/10.5281/zenodo.20513228)
 [![Crates.io](https://img.shields.io/crates/v/causal-triangulations.svg)](https://crates.io/crates/causal-triangulations)
 [![Downloads](https://img.shields.io/crates/d/causal-triangulations.svg)](https://crates.io/crates/causal-triangulations)
 [![Docs.rs](https://docs.rs/causal-triangulations/badge.svg)](https://docs.rs/causal-triangulations)

--- a/benches/cdt_benchmarks.rs
+++ b/benches/cdt_benchmarks.rs
@@ -43,7 +43,7 @@ impl Display for SetupOperation {
 }
 
 /// Fails fast when benchmark fixture setup cannot satisfy its invariant.
-fn require_result<T, E: Display>(result: Result<T, E>, operation: SetupOperation) -> T {
+fn require_result<T>(result: Result<T, impl Display>, operation: SetupOperation) -> T {
     match result {
         Ok(value) => value,
         Err(error) => panic!("{operation}: {error}"),
@@ -372,14 +372,24 @@ fn bench_simulation_analysis(c: &mut Criterion) {
 
     group.bench_function("hausdorff_dimension_estimate", |b| {
         b.iter(|| {
-            let estimate = results.hausdorff_dimension_estimate();
+            let estimate = match results.hausdorff_dimension_estimate() {
+                Ok(estimate) => estimate,
+                Err(error) => {
+                    panic!("benchmark triangulation adjacency should be readable: {error}")
+                }
+            };
             black_box(estimate)
         });
     });
 
     group.bench_function("spectral_dimension_estimate", |b| {
         b.iter(|| {
-            let estimate = results.spectral_dimension_estimate();
+            let estimate = match results.spectral_dimension_estimate() {
+                Ok(estimate) => estimate,
+                Err(error) => {
+                    panic!("benchmark triangulation adjacency should be readable: {error}")
+                }
+            };
             black_box(estimate)
         });
     });

--- a/benches/ci_performance_suite.rs
+++ b/benches/ci_performance_suite.rs
@@ -159,7 +159,7 @@ const PROPOSAL_FIXTURES: &[CdtFixture] = &[
 ];
 
 /// Fails fast when benchmark fixture setup cannot satisfy its invariant.
-fn require_result<T, E: Display>(result: Result<T, E>, operation: SetupOperation) -> T {
+fn require_result<T>(result: Result<T, impl Display>, operation: SetupOperation) -> T {
     match result {
         Ok(value) => value,
         Err(error) => panic!("{operation}: {error}"),

--- a/examples/observables.rs
+++ b/examples/observables.rs
@@ -15,16 +15,16 @@ use causal_triangulations::prelude::simulation::{
 fn main() -> CdtResult<()> {
     let triangulation = CdtTriangulation::from_toroidal_cdt(8, 8)?;
 
-    let initial_profile = triangulation.volume_profile();
+    let initial_profile = triangulation.volume_profile()?;
     println!("Initial volume profile N2(t): {initial_profile:?}");
 
-    let hausdorff = estimate_hausdorff_dimension(&triangulation).map_or_else(
+    let hausdorff = estimate_hausdorff_dimension(&triangulation)?.map_or_else(
         || "not enough dual-graph data".to_string(),
         |dimension| format!("{dimension:.3}"),
     );
     println!("Initial Hausdorff-dimension estimate: {hausdorff}");
 
-    let spectral = estimate_spectral_dimension(&triangulation).map_or_else(
+    let spectral = estimate_spectral_dimension(&triangulation)?.map_or_else(
         || "not enough dual-graph diffusion data".to_string(),
         |dimension| format!("{dimension:.3}"),
     );
@@ -43,13 +43,13 @@ fn main() -> CdtResult<()> {
         results.volume_fluctuations()
     );
 
-    let final_hausdorff = results.hausdorff_dimension_estimate().map_or_else(
+    let final_hausdorff = results.hausdorff_dimension_estimate()?.map_or_else(
         || "not enough dual-graph data".to_string(),
         |dimension| format!("{dimension:.3}"),
     );
     println!("Final Hausdorff-dimension estimate: {final_hausdorff}");
 
-    let final_spectral = results.spectral_dimension_estimate().map_or_else(
+    let final_spectral = results.spectral_dimension_estimate()?.map_or_else(
         || "not enough dual-graph diffusion data".to_string(),
         |dimension| format!("{dimension:.3}"),
     );

--- a/src/cdt/action.rs
+++ b/src/cdt/action.rs
@@ -8,13 +8,14 @@
 use crate::errors::{CdtError, CdtResult, ConfigurationSetting};
 use num_traits::cast::NumCast;
 use serde::{Deserialize, Deserializer, Serialize};
+use std::f64::consts::LN_2;
 
 /// Critical cosmological coupling for pure 1+1 CDT in the triangle-volume convention.
 ///
 /// The exactly solved 2D CDT transfer matrix has critical point `λ_c = ln 2`
 /// when triangulations are weighted by `exp(-λ N2)`, where `N2` is the number
 /// of triangles.
-pub const CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT: f64 = std::f64::consts::LN_2;
+pub const CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT: f64 = LN_2;
 
 /// Default edge-count cosmological coupling for toroidal 1+1 CDT runs.
 ///

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -9,7 +9,7 @@
 //! - edge flips: retained as an API-compatible alias for the 2D (2,2) move
 
 use crate::config::CdtTopology;
-use crate::errors::{BackendMutationOperation, CdtError};
+use crate::errors::{BackendMutationOperation, CdtError, CdtResult, CheckpointResumeFailure};
 use crate::geometry::CdtTriangulation2D;
 use crate::geometry::backends::delaunay::{
     DelaunayEdgeHandle, DelaunayFaceHandle, DelaunayVertexHandle,
@@ -177,7 +177,7 @@ impl MoveStatistics {
     /// Deserialization rejects impossible counters such as accepted moves plus
     /// hard failures exceeding attempts, so public accessors can treat stored
     /// move-family counters as coherent telemetry.
-    fn from_wire(wire: &MoveStatisticsWire) -> Result<Self, String> {
+    fn from_wire(wire: &MoveStatisticsWire) -> CdtResult<Self> {
         validate_move_counter(
             MoveType::Move22,
             wire.moves_22_attempted,
@@ -578,14 +578,20 @@ fn validate_move_counter(
     attempted: u64,
     accepted: u64,
     hard_failed: u64,
-) -> Result<(), String> {
-    let terminal = accepted.checked_add(hard_failed).ok_or_else(|| {
-        format!("{move_type:?} accepted plus hard-failure counters exceed u64::MAX")
-    })?;
+) -> CdtResult<()> {
+    let terminal = accepted
+        .checked_add(hard_failed)
+        .ok_or(CdtError::CheckpointResumeFailed {
+            failure: CheckpointResumeFailure::MoveTerminalCounterOverflow { move_type },
+        })?;
     if terminal > attempted {
-        Err(format!(
-            "{move_type:?} accepted plus hard-failure counters ({terminal}) exceed attempted counter ({attempted})"
-        ))
+        Err(CdtError::CheckpointResumeFailed {
+            failure: CheckpointResumeFailure::MoveTerminalOutcomesExceedAttempted {
+                move_type,
+                terminal,
+                attempted,
+            },
+        })
     } else {
         Ok(())
     }
@@ -2089,15 +2095,17 @@ fn toroidal_insertion_sites(
 /// and unfoliated states use direct degree-3 vertex collapses.
 fn removal_sites(triangulation: &CdtTriangulation2D, visit: &mut impl FnMut(ProposalSite)) -> bool {
     if is_toroidal_foliated(triangulation) {
+        let mut geometric_candidate_seen = false;
         for vertex in triangulation.geometry().vertices() {
             let Some(remove) = toroidal_removal_candidate(triangulation, vertex) else {
                 continue;
             };
+            geometric_candidate_seen = true;
             if toroidal_removal_candidate_is_sampleable(triangulation, &remove) {
                 visit(ProposalSite::ToroidalRemoval(remove));
             }
         }
-        return true;
+        return geometric_candidate_seen;
     }
 
     let mut geometric_candidate_seen = false;
@@ -2343,27 +2351,64 @@ mod tests {
     }
 
     #[test]
-    fn move_statistics_deserialization_rejects_impossible_counters() {
-        let error = serde_json::from_str::<MoveStatistics>(
-            r#"{
-                "moves_22_attempted": 1,
-                "moves_22_accepted": 1,
-                "moves_22_hard_failed": 1,
-                "moves_13_attempted": 0,
-                "moves_13_accepted": 0,
-                "moves_31_attempted": 0,
-                "moves_31_accepted": 0,
-                "edge_flips_attempted": 0,
-                "edge_flips_accepted": 0
-            }"#,
-        )
-        .expect_err("accepted plus hard failures above attempts should be rejected");
+    fn move_statistics_from_wire_rejects_terminal_outcomes_above_attempts() {
+        let wire = MoveStatisticsWire {
+            moves_22_attempted: 1,
+            moves_22_accepted: 1,
+            moves_22_hard_failed: 1,
+            moves_13_attempted: 0,
+            moves_13_accepted: 0,
+            moves_13_hard_failed: 0,
+            moves_31_attempted: 0,
+            moves_31_accepted: 0,
+            moves_31_hard_failed: 0,
+            edge_flips_attempted: 0,
+            edge_flips_accepted: 0,
+            edge_flips_hard_failed: 0,
+        };
 
-        assert!(
-            error
-                .to_string()
-                .contains("accepted plus hard-failure counters"),
-            "serde error should explain move-counter invariant, got {error}"
+        let error = MoveStatistics::from_wire(&wire)
+            .expect_err("accepted plus hard failures above attempts should be rejected");
+
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::MoveTerminalOutcomesExceedAttempted {
+                    move_type: MoveType::Move22,
+                    terminal: 2,
+                    attempted: 1,
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn move_statistics_from_wire_rejects_terminal_counter_overflow() {
+        let wire = MoveStatisticsWire {
+            moves_22_attempted: u64::MAX,
+            moves_22_accepted: u64::MAX,
+            moves_22_hard_failed: 1,
+            moves_13_attempted: 0,
+            moves_13_accepted: 0,
+            moves_13_hard_failed: 0,
+            moves_31_attempted: 0,
+            moves_31_accepted: 0,
+            moves_31_hard_failed: 0,
+            edge_flips_attempted: 0,
+            edge_flips_accepted: 0,
+            edge_flips_hard_failed: 0,
+        };
+
+        let error = MoveStatistics::from_wire(&wire)
+            .expect_err("overflowed accepted plus hard-failure counters should be rejected");
+
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::MoveTerminalCounterOverflow {
+                    move_type: MoveType::Move22
+                }
+            }
         );
     }
 
@@ -3052,6 +3097,7 @@ mod tests {
         assert!(
             triangulation
                 .volume_profile()
+                .expect("accepted toroidal removal profile should be valid")
                 .iter()
                 .all(|&count| count >= 3),
             "accepted periodic toroidal removal must preserve nonempty closed spatial slices"
@@ -3115,7 +3161,7 @@ mod tests {
     }
 
     #[test]
-    fn periodic_toroidal_move_31_rejects_minimal_slice_removal() {
+    fn periodic_toroidal_move_31_rejects_minimal_slice_without_inverse_site() {
         let mut system = ErgodicsSystem::with_seed(7);
         let mut triangulation =
             CdtTriangulation2D::from_toroidal_cdt(3, 3).expect("build minimal toroidal CDT");
@@ -3124,14 +3170,16 @@ mod tests {
             triangulation.edge_count(),
             triangulation.face_count(),
         );
-        let profile_before = triangulation.volume_profile();
+        let profile_before = triangulation
+            .volume_profile()
+            .expect("initial minimal toroidal profile should be valid");
 
         let result = system.attempt_31_move(&mut triangulation);
 
         assert_matches!(
             result,
-            MoveResult::CausalityViolation,
-            "minimal periodic toroidal slices should reject volume removal causally"
+            MoveResult::GeometricViolation,
+            "minimal periodic toroidal slices should reject volume removal without an inverse site"
         );
         assert_eq!(system.stats.moves_31_attempted, 1);
         assert_eq!(system.stats.moves_31_accepted, 0);
@@ -3145,7 +3193,9 @@ mod tests {
             "rejected minimal toroidal removal must preserve simplex counts"
         );
         assert_eq!(
-            triangulation.volume_profile(),
+            triangulation
+                .volume_profile()
+                .expect("rejected minimal toroidal profile should be valid"),
             profile_before,
             "rejected minimal toroidal removal must preserve closed spatial slices"
         );

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -573,17 +573,13 @@ impl MoveStatistics {
 }
 
 /// Checks one move family's serialized counters before they become invariant-bearing telemetry.
-fn validate_move_counter(
+const fn validate_move_counter(
     move_type: MoveType,
     attempted: u64,
     accepted: u64,
     hard_failed: u64,
 ) -> CdtResult<()> {
-    let terminal = accepted
-        .checked_add(hard_failed)
-        .ok_or(CdtError::CheckpointResumeFailed {
-            failure: CheckpointResumeFailure::MoveTerminalCounterOverflow { move_type },
-        })?;
+    let terminal = accepted.saturating_add(hard_failed);
     if terminal > attempted {
         Err(CdtError::CheckpointResumeFailed {
             failure: CheckpointResumeFailure::MoveTerminalOutcomesExceedAttempted {
@@ -2100,8 +2096,8 @@ fn removal_sites(triangulation: &CdtTriangulation2D, visit: &mut impl FnMut(Prop
             let Some(remove) = toroidal_removal_candidate(triangulation, vertex) else {
                 continue;
             };
-            geometric_candidate_seen = true;
             if toroidal_removal_candidate_is_sampleable(triangulation, &remove) {
+                geometric_candidate_seen = true;
                 visit(ProposalSite::ToroidalRemoval(remove));
             }
         }
@@ -2383,7 +2379,7 @@ mod tests {
     }
 
     #[test]
-    fn move_statistics_from_wire_rejects_terminal_counter_overflow() {
+    fn move_statistics_from_wire_accepts_saturated_terminal_counters() {
         let wire = MoveStatisticsWire {
             moves_22_attempted: u64::MAX,
             moves_22_accepted: u64::MAX,
@@ -2399,17 +2395,12 @@ mod tests {
             edge_flips_hard_failed: 0,
         };
 
-        let error = MoveStatistics::from_wire(&wire)
-            .expect_err("overflowed accepted plus hard-failure counters should be rejected");
+        let stats = MoveStatistics::from_wire(&wire)
+            .expect("saturated terminal counters should deserialize");
 
-        assert_matches!(
-            error,
-            CdtError::CheckpointResumeFailed {
-                failure: CheckpointResumeFailure::MoveTerminalCounterOverflow {
-                    move_type: MoveType::Move22
-                }
-            }
-        );
+        assert_eq!(stats.attempted(MoveType::Move22), u64::MAX);
+        assert_eq!(stats.accepted(MoveType::Move22), u64::MAX);
+        assert_eq!(stats.hard_failed(MoveType::Move22), 1);
     }
 
     #[test]

--- a/src/cdt/foliation.rs
+++ b/src/cdt/foliation.rs
@@ -91,7 +91,7 @@ impl SimplexType {
 /// # Examples
 ///
 /// ```
-/// use causal_triangulations::cdt::foliation::{classify_edge, EdgeType};
+/// use causal_triangulations::prelude::triangulation::{EdgeType, classify_edge};
 ///
 /// assert_eq!(classify_edge(Some(2), Some(2)), Some(EdgeType::Spacelike));
 /// assert_eq!(classify_edge(Some(2), Some(3)), Some(EdgeType::Timelike));
@@ -118,7 +118,7 @@ pub fn classify_edge(t0: Option<u32>, t1: Option<u32>) -> Option<EdgeType> {
 /// # Examples
 ///
 /// ```
-/// use causal_triangulations::cdt::foliation::{classify_simplex, SimplexType};
+/// use causal_triangulations::prelude::triangulation::{SimplexType, classify_simplex};
 ///
 /// assert_eq!(classify_simplex(Some(0), Some(0), Some(1)), Some(SimplexType::Up));
 /// assert_eq!(classify_simplex(Some(0), Some(1), Some(1)), Some(SimplexType::Down));

--- a/src/cdt/metropolis/adapter.rs
+++ b/src/cdt/metropolis/adapter.rs
@@ -2,6 +2,8 @@
 
 //! Adapter boundary between CDT state and `markov-chain-monte-carlo`.
 
+use super::helpers::{action_for, proposed_delta_action, simplex_counts, validate_temperature};
+use super::telemetry::{CdtProposalSiteRejection, ProposalStatistics};
 use crate::cdt::action::ActionConfig;
 use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveType, proposal_site_count};
 use crate::errors::{CdtError, CdtResult, MetropolisMoveApplicationFailure};
@@ -13,9 +15,6 @@ use rand::Rng;
 use std::error::Error;
 use std::fmt;
 use std::hint::cold_path;
-
-use super::helpers::{action_for, proposed_delta_action, simplex_counts, validate_temperature};
-use super::telemetry::{CdtProposalSiteRejection, ProposalStatistics};
 
 /// Target distribution for CDT: log-probability from the Regge action.
 ///
@@ -95,13 +94,11 @@ impl Target<CdtTriangulation2D> for CdtTarget {
 ///     MoveType::Move22 | MoveType::Move13Add | MoveType::Move31Remove | MoveType::EdgeFlip
 /// );
 /// assert!(plan.action_before().is_finite());
-/// if let (Some(delta), Some(action_after)) = (plan.delta_action(), plan.action_after()) {
-///     approx::assert_relative_eq!(
-///         action_after,
-///         plan.action_before() + delta,
-///         epsilon = 1e-12
-///     );
-/// }
+/// approx::assert_relative_eq!(
+///     plan.action_after(),
+///     plan.action_before() + plan.delta_action(),
+///     epsilon = 1e-12
+/// );
 /// # Ok(())
 /// # }
 /// ```
@@ -109,8 +106,8 @@ impl Target<CdtTriangulation2D> for CdtTarget {
 pub struct CdtProposalPlan {
     pub(crate) move_type: MoveType,
     pub(crate) action_before: f64,
-    pub(crate) action_after: Option<f64>,
-    pub(crate) delta_action: Option<f64>,
+    pub(crate) action_after: f64,
+    pub(crate) delta_action: f64,
     pub(crate) forward_site_count: usize,
     /// Reverse proposal-site denominator for the realized proposed state.
     ///
@@ -179,11 +176,10 @@ impl CdtProposalPlan {
         self.action_before
     }
 
-    /// Returns the action of the concrete proposed state, if one was realized.
+    /// Returns the action of the concrete proposed state.
     ///
-    /// A value of `None` means the selected move could not be scored or
-    /// realized, so [`DelayedProposal::proposed_log_prob`] treats the plan as
-    /// impossible.
+    /// Concrete plans are only constructed after a selected move has been
+    /// realized and scored.
     ///
     /// # Examples
     ///
@@ -200,16 +196,16 @@ impl CdtProposalPlan {
     /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
     ///     return Ok(());
     /// };
-    /// assert_eq!(plan.action_after().is_some(), plan.delta_action().is_some());
+    /// assert!(plan.action_after().is_finite());
     /// # Ok(())
     /// # }
     /// ```
     #[must_use]
-    pub const fn action_after(&self) -> Option<f64> {
+    pub const fn action_after(&self) -> f64 {
         self.action_after
     }
 
-    /// Returns the concrete proposal action change, if it can be evaluated.
+    /// Returns the concrete proposal action change.
     ///
     /// # Examples
     ///
@@ -226,18 +222,12 @@ impl CdtProposalPlan {
     /// let Some(plan) = proposal.propose_plan(&tri, &mut rng)? else {
     ///     return Ok(());
     /// };
-    /// if let (Some(delta), Some(action_after)) = (plan.delta_action(), plan.action_after()) {
-    ///     approx::assert_relative_eq!(
-    ///         action_after,
-    ///         plan.action_before() + delta,
-    ///         epsilon = 1e-12
-    ///     );
-    /// }
+    /// approx::assert_relative_eq!(plan.action_after(), plan.action_before() + plan.delta_action());
     /// # Ok(())
     /// # }
     /// ```
     #[must_use]
-    pub const fn delta_action(&self) -> Option<f64> {
+    pub const fn delta_action(&self) -> f64 {
         self.delta_action
     }
 }
@@ -266,9 +256,9 @@ impl CdtProposalPlan {
 ///
 /// let info = proposal.info(&plan);
 /// assert_eq!(info.move_type, plan.move_type());
-/// assert_eq!(info.delta_action.is_some(), plan.delta_action().is_some());
-/// if let (Some(info_delta), Some(plan_delta)) = (info.delta_action, plan.delta_action()) {
-///     approx::assert_relative_eq!(info_delta, plan_delta, epsilon = 1e-12);
+/// assert!(info.delta_action.is_some());
+/// if let Some(delta_action) = info.delta_action {
+///     approx::assert_relative_eq!(delta_action, plan.delta_action(), epsilon = 1e-12);
 /// }
 /// # Ok(())
 /// # }
@@ -546,8 +536,8 @@ impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
         self.last_step_info = Some(CdtProposalInfo {
             move_type: plan.move_type,
             action_before: plan.action_before,
-            action_after: plan.action_after,
-            delta_action: plan.delta_action,
+            action_after: Some(plan.action_after),
+            delta_action: Some(plan.delta_action),
         });
         self.last_no_plan_info = None;
         self.last_proposal_stats = proposal_stats;
@@ -564,9 +554,7 @@ impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
         plan: &Self::Plan,
         target: &T,
     ) -> Result<f64, Self::Error> {
-        Ok(plan
-            .action_after
-            .map_or(f64::NEG_INFINITY, |_| target.log_prob(&plan.proposed_state)))
+        Ok(target.log_prob(&plan.proposed_state))
     }
 
     fn log_q_ratio(
@@ -581,8 +569,8 @@ impl DelayedProposal<CdtTriangulation2D> for CdtProposal {
         CdtProposalInfo {
             move_type: plan.move_type,
             action_before: plan.action_before,
-            action_after: plan.action_after,
-            delta_action: plan.delta_action,
+            action_after: Some(plan.action_after),
+            delta_action: Some(plan.delta_action),
         }
     }
 
@@ -667,8 +655,8 @@ pub(crate) fn propose_concrete_plan(
     Ok(Some(CdtProposalPlan {
         move_type,
         action_before,
-        action_after: Some(action_after),
-        delta_action: Some(delta_action),
+        action_after,
+        delta_action,
         forward_site_count,
         reverse_site_count,
         proposed_state,

--- a/src/cdt/metropolis/checkpoint.rs
+++ b/src/cdt/metropolis/checkpoint.rs
@@ -2,6 +2,11 @@
 
 //! Checkpoint and resume validation for CDT Metropolis sampling.
 
+use super::helpers::{
+    action_for, actions_match, expected_measurement_count, expected_measurement_step,
+};
+use super::runner::{MetropolisAlgorithm, MetropolisConfig};
+use super::telemetry::{MonteCarloStep, ProposalStatistics};
 use crate::cdt::action::ActionConfig;
 use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveStatistics, MoveType};
 use crate::cdt::results::{
@@ -18,12 +23,6 @@ use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::num::NonZeroU32;
 use std::time::Duration;
-
-use super::helpers::{
-    action_for, actions_match, expected_measurement_count, expected_measurement_step,
-};
-use super::runner::{MetropolisAlgorithm, MetropolisConfig};
-use super::telemetry::{MonteCarloStep, ProposalStatistics};
 
 pub(crate) struct CdtMcmcCheckpointParts {
     pub(crate) triangulation: CdtTriangulation2D,
@@ -142,8 +141,7 @@ impl<'de> Deserialize<'de> for CdtMcmcCheckpoint {
         D: Deserializer<'de>,
     {
         let wire = CdtMcmcCheckpointWire::deserialize(deserializer)?;
-        let current_step = NonZeroU32::new(wire.current_step)
-            .ok_or_else(|| DeError::custom("checkpoint current_step must be nonzero"))?;
+        let current_step = checkpoint_current_step(wire.current_step).map_err(DeError::custom)?;
         let current_action = CheckpointAction::new(wire.current_action).map_err(DeError::custom)?;
         let checkpoint = Self {
             chain: wire.chain,
@@ -470,6 +468,12 @@ impl CdtMcmcCheckpoint {
     /// measurements, move statistics, proposal statistics, elapsed time, and the
     /// checkpointed triangulation in the returned [`SimulationResultsBackend`].
     ///
+    /// # Panics
+    ///
+    /// Panics if this validated checkpoint's private telemetry invariants no
+    /// longer satisfy the result-snapshot invariants. Constructors and
+    /// deserialization validate those invariants before a checkpoint can exist.
+    ///
     /// # Examples
     ///
     /// ```
@@ -492,23 +496,35 @@ impl CdtMcmcCheckpoint {
     #[must_use]
     pub fn into_results(self) -> SimulationResultsBackend {
         let (triangulation, _, _) = self.chain.into_parts();
-        SimulationResultsBackend::from_parts(SimulationResultsParts {
-            config: self.config,
-            action_config: self.action_config,
-            move_stats: self.move_stats,
-            proposal_stats: self.proposal_stats,
-            steps: self.steps,
-            measurements: self.measurements,
-            scalar_trace_rows: self.scalar_trace_rows,
-            elapsed_time: self.elapsed_time,
+        let parts = SimulationResultsParts::new(
+            self.config,
+            self.action_config,
+            self.move_stats,
+            self.proposal_stats,
+            self.steps,
+            self.measurements,
+            self.scalar_trace_rows,
+            self.elapsed_time,
             triangulation,
-        })
+        )
+        .expect("validated CDT checkpoint components should remain valid result components");
+        SimulationResultsBackend::from_parts(parts)
     }
 }
 
 /// Builds the public checkpoint-resume error wrapper for CDT-owned resume invariants.
 pub(crate) const fn checkpoint_resume_failed(failure: CheckpointResumeFailure) -> CdtError {
     CdtError::CheckpointResumeFailed { failure }
+}
+
+/// Parses a raw checkpoint step into the nonzero resumable-step invariant.
+const fn checkpoint_current_step(step: u32) -> CdtResult<NonZeroU32> {
+    match NonZeroU32::new(step) {
+        Some(step) => Ok(step),
+        None => Err(checkpoint_resume_failed(
+            CheckpointResumeFailure::CheckpointCurrentStepZero { actual: step },
+        )),
+    }
 }
 
 /// Verifies that a checkpoint can be resumed by the requested algorithm.
@@ -526,11 +542,7 @@ pub(crate) fn validate_resume_compatible(
     algorithm: &MetropolisAlgorithm,
     checkpoint: &CdtMcmcCheckpoint,
 ) -> CdtResult<()> {
-    if !action_configs_match(algorithm.action_config(), &checkpoint.action_config) {
-        return Err(checkpoint_resume_failed(
-            CheckpointResumeFailure::IncompatibleActionConfiguration,
-        ));
-    }
+    ResumeCompatibleActionConfig::new(algorithm.action_config(), &checkpoint.action_config)?;
     if algorithm.config().temperature().to_bits() != checkpoint.config.temperature().to_bits() {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::IncompatibleTemperature,
@@ -549,11 +561,45 @@ pub(crate) fn validate_resume_compatible(
     validate_checkpoint_counters(checkpoint)
 }
 
-/// Compares action couplings with the same tolerance used for persisted action values.
-fn action_configs_match(left: &ActionConfig, right: &ActionConfig) -> bool {
-    actions_match(left.coupling_0(), right.coupling_0())
-        && actions_match(left.coupling_2(), right.coupling_2())
-        && actions_match(left.cosmological_constant(), right.cosmological_constant())
+/// Proof that requested and checkpointed action couplings describe the same resume target.
+struct ResumeCompatibleActionConfig;
+
+impl ResumeCompatibleActionConfig {
+    /// Parses two action configurations into resume-compatible physics evidence.
+    const fn new(requested: &ActionConfig, checkpointed: &ActionConfig) -> CdtResult<Self> {
+        if action_configs_match(requested, checkpointed) {
+            Ok(Self)
+        } else {
+            Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::IncompatibleActionConfiguration,
+            ))
+        }
+    }
+}
+
+/// Compares action couplings by exact value or one-ULP serde JSON round-trip drift.
+const fn action_configs_match(left: &ActionConfig, right: &ActionConfig) -> bool {
+    resume_couplings_match(left.coupling_0(), right.coupling_0())
+        && resume_couplings_match(left.coupling_2(), right.coupling_2())
+        && resume_couplings_match(left.cosmological_constant(), right.cosmological_constant())
+}
+
+/// Accepts exact couplings plus adjacent finite values introduced by JSON round trips.
+const fn resume_couplings_match(left: f64, right: f64) -> bool {
+    left.is_finite()
+        && right.is_finite()
+        && ordered_f64_bits(left).abs_diff(ordered_f64_bits(right)) <= 1
+}
+
+/// Maps finite `f64` values into a monotonic bit ordering for ULP distance checks.
+const fn ordered_f64_bits(value: f64) -> u64 {
+    const SIGN_MASK: u64 = 1 << 63;
+    let bits = value.to_bits();
+    if bits & SIGN_MASK == 0 {
+        bits | SIGN_MASK
+    } else {
+        !bits
+    }
 }
 
 /// Checks that serialized chain counters and CDT telemetry agree.
@@ -864,4 +910,23 @@ pub(crate) fn chain_counters(move_stats: &MoveStatistics) -> CdtResult<(usize, u
             })
         })?,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::assert_matches;
+
+    #[test]
+    fn checkpoint_current_step_rejects_zero_with_typed_failure() {
+        let error = checkpoint_current_step(0)
+            .expect_err("zero checkpoint step should not become a resumable position");
+
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::CheckpointCurrentStepZero { actual: 0 }
+            }
+        );
+    }
 }

--- a/src/cdt/metropolis/checkpoint.rs
+++ b/src/cdt/metropolis/checkpoint.rs
@@ -468,11 +468,10 @@ impl CdtMcmcCheckpoint {
     /// measurements, move statistics, proposal statistics, elapsed time, and the
     /// checkpointed triangulation in the returned [`SimulationResultsBackend`].
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if this validated checkpoint's private telemetry invariants no
-    /// longer satisfy the result-snapshot invariants. Constructors and
-    /// deserialization validate those invariants before a checkpoint can exist.
+    /// Returns [`CdtError`] if this checkpoint's components no longer satisfy
+    /// the result-snapshot invariants.
     ///
     /// # Examples
     ///
@@ -488,13 +487,12 @@ impl CdtMcmcCheckpoint {
     ///     )
     ///     .run_to_checkpoint(CdtTriangulation::from_cdt_strip(4, 3)?)?;
     ///
-    ///     let results = checkpoint.into_results();
+    ///     let results = checkpoint.into_results()?;
     ///     assert_eq!(results.steps().len(), 1);
     ///     Ok(())
     /// }
     /// ```
-    #[must_use]
-    pub fn into_results(self) -> SimulationResultsBackend {
+    pub fn into_results(self) -> CdtResult<SimulationResultsBackend> {
         let (triangulation, _, _) = self.chain.into_parts();
         let parts = SimulationResultsParts::new(
             self.config,
@@ -506,9 +504,8 @@ impl CdtMcmcCheckpoint {
             self.scalar_trace_rows,
             self.elapsed_time,
             triangulation,
-        )
-        .expect("validated CDT checkpoint components should remain valid result components");
-        SimulationResultsBackend::from_parts(parts)
+        )?;
+        Ok(SimulationResultsBackend::from_parts(parts))
     }
 }
 

--- a/src/cdt/metropolis/helpers.rs
+++ b/src/cdt/metropolis/helpers.rs
@@ -123,7 +123,7 @@ pub fn measurement_for(
 ) -> CdtResult<Measurement> {
     let counts = triangulation.simplex_counts()?;
     Measurement::try_from_simplex_counts(step, action, counts)?
-        .try_with_volume_profile(triangulation.volume_profile())
+        .try_with_volume_profile(triangulation.volume_profile()?)
 }
 
 /// Returns true when a completed step is on the post-thermalization measurement cadence.

--- a/src/cdt/metropolis/helpers.rs
+++ b/src/cdt/metropolis/helpers.rs
@@ -114,8 +114,9 @@ pub fn action_for(action_config: &ActionConfig, triangulation: &CdtTriangulation
 /// Returns [`CdtError::InvalidSimplexCount`] if the live triangulation reports
 /// zero vertices, edges, or triangles,
 /// [`CdtError::MeasurementCountOverflow`] if any live count cannot fit compact
-/// measurement storage, or [`CdtError::InvalidMeasurementAction`] if `action` is
-/// not finite.
+/// measurement storage, [`CdtError::InvalidMeasurementAction`] if `action` is
+/// not finite, or the validation error reported by
+/// [`CdtTriangulation2D::volume_profile`].
 pub fn measurement_for(
     step: u32,
     action: f64,

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -454,7 +454,7 @@ impl MetropolisAlgorithm {
     /// }
     /// ```
     pub fn run(&self, triangulation: CdtTriangulation2D) -> CdtResult<SimulationResultsBackend> {
-        Ok(self.run_to_checkpoint(triangulation)?.into_results())
+        self.run_to_checkpoint(triangulation)?.into_results()
     }
 
     /// Run the simulation and return both the final results and checkpoint.
@@ -507,7 +507,7 @@ impl MetropolisAlgorithm {
         triangulation: CdtTriangulation2D,
     ) -> CdtResult<(SimulationResultsBackend, CdtMcmcCheckpoint)> {
         let checkpoint = self.run_to_checkpoint(triangulation)?;
-        let results = checkpoint.clone().into_results();
+        let results = checkpoint.clone().into_results()?;
         Ok((results, checkpoint))
     }
 
@@ -625,7 +625,7 @@ impl MetropolisAlgorithm {
         checkpoint: CdtMcmcCheckpoint,
     ) -> CdtResult<SimulationResultsBackend> {
         self.resume_to_checkpoint(checkpoint)
-            .map(CdtMcmcCheckpoint::into_results)
+            .and_then(CdtMcmcCheckpoint::into_results)
     }
 
     /// Continue a checkpoint for this algorithm's configured step count.
@@ -1837,7 +1837,9 @@ mod tests {
         assert_eq!(checkpoint.current_step().get(), 3);
         assert_eq!(results.steps().len(), checkpoint.steps().len());
         assert_eq!(results.config(), checkpoint.config());
-        let checkpoint_results = checkpoint.into_results();
+        let checkpoint_results = checkpoint
+            .into_results()
+            .expect("checkpoint results should validate");
         assert_eq!(
             results.triangulation().vertex_count(),
             checkpoint_results.triangulation().vertex_count()
@@ -1984,7 +1986,9 @@ mod tests {
             MetropolisAlgorithm::new(seeded_metropolis_config(1.0, 6, 0, 1, 999), action_config)
                 .resume_to_checkpoint(prefix)
                 .expect("chunked checkpoint resume should complete");
-        let chunked = chunked_checkpoint.into_results();
+        let chunked = chunked_checkpoint
+            .into_results()
+            .expect("chunked checkpoint results should validate");
 
         assert_eq!(chunked.config().steps().get(), 10);
         assert_eq!(

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -19,6 +19,7 @@ use super::checkpoint::{
 };
 use super::helpers::{
     action_for, actions_match, measurement_for, measurement_is_due, validate_metropolis_schedule,
+    validate_temperature,
 };
 use super::telemetry::{MonteCarloStep, MonteCarloStepOutcome, ProposalStatistics};
 use crate::cdt::action::ActionConfig;
@@ -321,11 +322,16 @@ impl MetropolisConfig {
         1.0 / self.temperature
     }
 
-    /// Confirms that stored simulation-specific configuration values are valid.
+    /// Rechecks the stored simulation-specific configuration invariants.
     ///
-    /// This method is kept for code that wants a common validation hook across
-    /// configuration-like types. Because [`MetropolisConfig`] validates before
-    /// storage, it is an infallible debug assertion of the stored invariant.
+    /// Constructors and deserialization already run the same validation before a
+    /// [`MetropolisConfig`] can be observed. This method exists for callers that
+    /// want an explicit runtime validation hook when handling a stored config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidSimulationConfiguration`] if stored values no
+    /// longer satisfy the Metropolis temperature or sampling-schedule contract.
     ///
     /// # Examples
     ///
@@ -333,7 +339,34 @@ impl MetropolisConfig {
     /// use causal_triangulations::MetropolisConfig;
     ///
     /// let config = MetropolisConfig::new(1.0, 100, 10, 5)?;
-    /// config.validate();
+    /// config.try_validate()?;
+    /// # Ok::<(), causal_triangulations::CdtError>(())
+    /// ```
+    pub fn try_validate(&self) -> CdtResult<()> {
+        validate_temperature(self.temperature)?;
+        validate_metropolis_schedule(
+            self.temperature,
+            self.steps.get(),
+            self.thermalization_steps,
+            self.measurement_frequency.get(),
+        )
+    }
+
+    /// Debug-checks that stored simulation-specific configuration values are valid.
+    ///
+    /// This method is kept for code that wants a common validation hook across
+    /// configuration-like types. Because [`MetropolisConfig`] validates before
+    /// storage, it is an infallible debug assertion of the stored invariant; use
+    /// [`Self::try_validate`] when a fallible runtime check is needed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::MetropolisConfig;
+    ///
+    /// let config = MetropolisConfig::new(1.0, 100, 10, 5)?;
+    /// config.validate(); // debug-only invariant check
+    /// config.try_validate()?;
     /// # Ok::<(), causal_triangulations::CdtError>(())
     /// ```
     pub fn validate(&self) {
@@ -562,7 +595,7 @@ impl MetropolisAlgorithm {
         &self,
         triangulation: CdtTriangulation2D,
     ) -> CdtResult<CdtMcmcCheckpoint> {
-        self.config.validate();
+        self.config.try_validate()?;
         self.action_config.validate();
 
         let mut state = self.initial_state(triangulation)?;
@@ -683,7 +716,7 @@ impl MetropolisAlgorithm {
         &self,
         checkpoint: CdtMcmcCheckpoint,
     ) -> CdtResult<CdtMcmcCheckpoint> {
-        self.config.validate();
+        self.config.try_validate()?;
         self.action_config.validate();
         validate_resume_compatible(self, &checkpoint)?;
 
@@ -840,7 +873,7 @@ impl MetropolisRunState {
         Ok(Self {
             triangulation,
             current_step: checkpoint.current_step.get(),
-            current_action: stored_action,
+            current_action: actual_action,
             trace_seed: checkpoint.config.seed(),
             acceptance_rng: checkpoint.acceptance_rng,
             ergodics: checkpoint.ergodics,
@@ -2279,6 +2312,21 @@ mod tests {
             },
             "action configuration",
         );
+    }
+
+    #[test]
+    fn resume_state_normalizes_tolerant_checkpoint_action() {
+        let mut parts = synthetic_one_step_checkpoint_parts(false);
+        let actual_action = parts.current_action;
+        let scale = actual_action.abs().max(1.0);
+        parts.current_action = (f64::EPSILON * scale).mul_add(4.0, actual_action);
+        let checkpoint = CdtMcmcCheckpoint::from_parts(parts)
+            .expect("tolerant checkpoint action should validate");
+
+        let state = MetropolisRunState::from_checkpoint(checkpoint)
+            .expect("tolerant checkpoint action should resume");
+
+        assert_eq!(state.current_action.to_bits(), actual_action.to_bits());
     }
 
     #[test]

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -10,6 +10,17 @@
 //! Metropolis-Hastings acceptance. Ordinary site failures are self-loop
 //! proposal outcomes tracked in [`crate::cdt::metropolis::ProposalStatistics`].
 
+use super::adapter::{
+    CdtProposal, CdtProposalError, CdtProposalInfo, CdtTarget, restore_checkpoint_state,
+};
+use super::checkpoint::{
+    CdtMcmcCheckpoint, CdtMcmcCheckpointParts, chain_counters, checkpoint_resume_failed,
+    validate_checkpoint_counters, validate_resume_compatible,
+};
+use super::helpers::{
+    action_for, actions_match, measurement_for, measurement_is_due, validate_metropolis_schedule,
+};
+use super::telemetry::{MonteCarloStep, MonteCarloStepOutcome, ProposalStatistics};
 use crate::cdt::action::ActionConfig;
 use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveStatistics, MoveType};
 use crate::cdt::results::{
@@ -28,18 +39,6 @@ use rand::{SeedableRng, rngs::Xoshiro256PlusPlus};
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroU32;
 use std::time::{Duration, Instant};
-
-use super::adapter::{
-    CdtProposal, CdtProposalError, CdtProposalInfo, CdtTarget, restore_checkpoint_state,
-};
-use super::checkpoint::{
-    CdtMcmcCheckpoint, CdtMcmcCheckpointParts, chain_counters, checkpoint_resume_failed,
-    validate_checkpoint_counters, validate_resume_compatible,
-};
-use super::helpers::{
-    action_for, actions_match, measurement_for, measurement_is_due, validate_metropolis_schedule,
-};
-use super::telemetry::{MonteCarloStep, MonteCarloStepOutcome, ProposalStatistics};
 
 /// Validated configuration for the Metropolis-Hastings algorithm.
 ///
@@ -1013,30 +1012,58 @@ fn record_planned_step_parts(
     let action_after = step_outcome.action_after();
     let delta_action = step_outcome.delta_action();
 
-    state.move_stats.record_attempt(move_type);
-    if let Some(applied_action) = action_after {
-        state.triangulation = triangulation.clone();
-        state.current_action = applied_action;
+    let mut next_move_stats = state.move_stats.clone();
+    next_move_stats.record_attempt(move_type);
+    let mut accepted_candidate = action_after.map(|applied_action| {
+        next_move_stats.record_success(move_type);
+        AcceptedCandidate::new(
+            step,
+            move_type,
+            action_before,
+            applied_action,
+            triangulation,
+        )
+    });
+    if let Some(candidate) = &accepted_candidate {
+        candidate.validate_if_due(next_move_stats.total_accepted())?;
     }
 
-    state
-        .triangulation
-        .record_event(SimulationEvent::MoveAttempted {
-            move_type,
-            step: step.get().into(),
-        });
+    let trace_action = accepted_candidate
+        .as_ref()
+        .map_or(state.current_action, AcceptedCandidate::action_after);
+    let trace_triangulation = accepted_candidate
+        .as_ref()
+        .map_or(&state.triangulation, AcceptedCandidate::triangulation);
+    let step_entry = MonteCarloStep::new(step, move_type, action_before, step_outcome)?;
+    let scalar_trace_row = CdtScalarTraceRow::new(
+        step,
+        trace_outcome,
+        -trace_action / algorithm.config.temperature(),
+        trace_action,
+        trace_triangulation,
+        move_type,
+        delta_action,
+        action_before,
+        action_after,
+        state.trace_seed,
+    )?;
+    let measurement =
+        staged_measurement_for_step(algorithm, step, trace_action, trace_triangulation)?;
 
-    if let Some(applied_action) = action_after {
-        state.move_stats.record_success(move_type);
+    state.move_stats = next_move_stats;
+    if let Some(candidate) = accepted_candidate.take() {
+        let (applied_action, triangulation) = candidate.into_parts();
+        state.current_action = applied_action;
+        state.triangulation = triangulation;
+    } else {
         state
             .triangulation
-            .record_event(SimulationEvent::MoveAccepted {
+            .record_event(SimulationEvent::MoveAttempted {
                 move_type,
                 step: step.get().into(),
-                action_change: applied_action - action_before,
             });
-        validate_evolved_cdt_if_due(state)?;
     }
+
     state.proposal_stats.extend(proposal_stats);
     match trace_outcome {
         CdtScalarTraceOutcome::Accepted => state.proposal_stats.record_accepted_transition(),
@@ -1046,35 +1073,11 @@ fn record_planned_step_parts(
         CdtScalarTraceOutcome::NoProposal => {}
     }
 
-    state.steps.push(MonteCarloStep::new(
-        step,
-        move_type,
-        action_before,
-        step_outcome,
-    )?);
-    state.scalar_trace_rows.push(CdtScalarTraceRow::new(
-        step,
-        trace_outcome,
-        -state.current_action / algorithm.config.temperature(),
-        state.current_action,
-        &state.triangulation,
-        move_type,
-        delta_action,
-        action_before,
-        action_after,
-        state.trace_seed,
-    )?);
+    state.steps.push(step_entry);
+    state.scalar_trace_rows.push(scalar_trace_row);
 
-    if measurement_is_due(
-        step.get(),
-        algorithm.config.thermalization_steps(),
-        algorithm.config.measurement_frequency(),
-    ) {
-        state.measurements.push(measurement_for(
-            step.get(),
-            state.current_action,
-            &state.triangulation,
-        )?);
+    if let Some(measurement) = measurement {
+        state.measurements.push(measurement);
         state
             .triangulation
             .record_event(SimulationEvent::MeasurementTaken {
@@ -1084,6 +1087,76 @@ fn record_planned_step_parts(
     }
 
     Ok(())
+}
+
+/// Staged accepted proposal state that has its action and triangulation together.
+struct AcceptedCandidate {
+    action_after: f64,
+    triangulation: CdtTriangulation2D,
+}
+
+impl AcceptedCandidate {
+    /// Builds the accepted-state candidate before it is committed to live run state.
+    fn new(
+        step: NonZeroU32,
+        move_type: MoveType,
+        action_before: f64,
+        action_after: f64,
+        triangulation: &CdtTriangulation2D,
+    ) -> Self {
+        let mut triangulation = triangulation.clone();
+        triangulation.record_event(SimulationEvent::MoveAttempted {
+            move_type,
+            step: step.get().into(),
+        });
+        triangulation.record_event(SimulationEvent::MoveAccepted {
+            move_type,
+            step: step.get().into(),
+            action_change: action_after - action_before,
+        });
+        Self {
+            action_after,
+            triangulation,
+        }
+    }
+
+    /// Returns the accepted action carried with the staged triangulation.
+    const fn action_after(&self) -> f64 {
+        self.action_after
+    }
+
+    /// Borrows the staged accepted triangulation.
+    const fn triangulation(&self) -> &CdtTriangulation2D {
+        &self.triangulation
+    }
+
+    /// Validates the staged triangulation at the configured backend cadence.
+    fn validate_if_due(&self, accepted_moves: u64) -> CdtResult<()> {
+        validate_evolved_cdt_candidate_if_due(&self.triangulation, accepted_moves)
+    }
+
+    /// Splits the validated accepted candidate for commitment to run state.
+    fn into_parts(self) -> (f64, CdtTriangulation2D) {
+        (self.action_after, self.triangulation)
+    }
+}
+
+/// Builds a measurement for a planned step only when the configured cadence is due.
+fn staged_measurement_for_step(
+    algorithm: &MetropolisAlgorithm,
+    step: NonZeroU32,
+    action: f64,
+    triangulation: &CdtTriangulation2D,
+) -> CdtResult<Option<Measurement>> {
+    if measurement_is_due(
+        step.get(),
+        algorithm.config.thermalization_steps(),
+        algorithm.config.measurement_frequency(),
+    ) {
+        measurement_for(step.get(), action, triangulation).map(Some)
+    } else {
+        Ok(None)
+    }
 }
 
 /// Maps upstream planned-proposal failures into CDT runner errors.
@@ -1126,13 +1199,21 @@ const fn missing_planned_step_info(step: u32) -> CdtError {
 }
 
 /// Runs the expensive full evolved-state validation only when the backend policy is due.
+#[cfg(test)]
 fn validate_evolved_cdt_if_due(state: &MetropolisRunState) -> CdtResult<()> {
-    if state
-        .triangulation
+    validate_evolved_cdt_candidate_if_due(&state.triangulation, state.move_stats.total_accepted())
+}
+
+/// Runs expensive evolved-state validation for a staged accepted triangulation.
+fn validate_evolved_cdt_candidate_if_due(
+    triangulation: &CdtTriangulation2D,
+    accepted_moves: u64,
+) -> CdtResult<()> {
+    if triangulation
         .geometry()
-        .should_check_delaunay_after(state.move_stats.total_accepted())
+        .should_check_delaunay_after(accepted_moves)
     {
-        state.triangulation.validate_evolved_cdt()?;
+        triangulation.validate_evolved_cdt()?;
     }
     Ok(())
 }
@@ -1174,6 +1255,7 @@ mod tests {
     use super::*;
     use crate::cdt::action::CDT_1P1_CRITICAL_TRIANGLE_COSMOLOGICAL_CONSTANT;
     use crate::cdt::ergodic_moves::proposal_site_count;
+    use crate::cdt::foliation::FoliationError;
     use crate::cdt::triangulation::CdtTriangulation;
     use crate::errors::{BackendMutationOperation, CheckpointMoveCounter, ConfigurationSetting};
     use crate::geometry::traits::TriangulationQuery;
@@ -1312,7 +1394,13 @@ mod tests {
         assert_eq!(left.edge_count(), right.edge_count());
         assert_eq!(left.face_count(), right.face_count());
         assert_eq!(left.slice_sizes(), right.slice_sizes());
-        assert_eq!(left.volume_profile(), right.volume_profile());
+        assert_eq!(
+            left.volume_profile()
+                .expect("left canonical profile should be valid"),
+            right
+                .volume_profile()
+                .expect("right canonical profile should be valid")
+        );
         assert_eq!(
             left.metadata().time_slices(),
             right.metadata().time_slices()
@@ -1917,8 +2005,14 @@ mod tests {
         );
         assert_canonical_triangulations_match(one_shot.triangulation(), chunked.triangulation());
         assert_eq!(
-            one_shot.triangulation().volume_profile(),
-            chunked.triangulation().volume_profile()
+            one_shot
+                .triangulation()
+                .volume_profile()
+                .expect("one-shot profile should be valid"),
+            chunked
+                .triangulation()
+                .volume_profile()
+                .expect("chunked profile should be valid")
         );
     }
 
@@ -2148,6 +2242,31 @@ mod tests {
 
         assert_checkpoint_resume_failed(
             algorithm.resume_to_checkpoint(checkpoint),
+            |failure| {
+                matches!(
+                    failure,
+                    CheckpointResumeFailure::IncompatibleActionConfiguration
+                )
+            },
+            "action configuration",
+        );
+    }
+
+    #[test]
+    fn resume_rejects_action_config_within_action_value_tolerance() {
+        let checkpoint = short_checkpoint();
+        let checkpoint_action = checkpoint.action_config();
+        let algorithm = MetropolisAlgorithm::new(
+            seeded_metropolis_config(1.0, 2, 0, 1, 999),
+            action_config(
+                checkpoint_action.coupling_0() + f64::EPSILON,
+                checkpoint_action.coupling_2(),
+                checkpoint_action.cosmological_constant(),
+            ),
+        );
+
+        assert_checkpoint_resume_failed(
+            algorithm.resume_from_checkpoint(checkpoint),
             |failure| {
                 matches!(
                     failure,
@@ -2572,10 +2691,20 @@ mod tests {
     #[test]
     fn explicit_cdt_volume_profiles_count_time_slabs() {
         let strip = CdtTriangulation::from_cdt_strip(4, 3).expect("create Delaunay strip");
-        assert_eq!(strip.volume_profile(), vec![6, 6, 0]);
+        assert_eq!(
+            strip
+                .volume_profile()
+                .expect("strip profile should be valid"),
+            vec![6, 6, 0]
+        );
 
         let torus = CdtTriangulation::from_toroidal_cdt(3, 3).expect("create periodic torus");
-        assert_eq!(torus.volume_profile(), vec![6, 6, 6]);
+        assert_eq!(
+            torus
+                .volume_profile()
+                .expect("torus profile should be valid"),
+            vec![6, 6, 6]
+        );
     }
 
     #[test]
@@ -2599,7 +2728,12 @@ mod tests {
             measurement_for(0, 1.0, &triangulation).expect("measurement should build");
 
         assert!(!triangulation.has_foliation());
-        assert!(triangulation.volume_profile().is_empty());
+        assert!(
+            triangulation
+                .volume_profile()
+                .expect("unfoliated triangulation should report an empty profile")
+                .is_empty()
+        );
         assert!(measurement.volume_profile().is_empty());
     }
 
@@ -2996,6 +3130,66 @@ mod tests {
     }
 
     #[test]
+    fn accepted_planned_step_validation_failure_does_not_mutate_state() {
+        let config = seeded_metropolis_config(1.0, 1, 0, 1, 2);
+        let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
+        let triangulation =
+            CdtTriangulation::from_toroidal_cdt(4, 3).expect("Delaunay torus should build");
+        let mut invalid_candidate = triangulation.clone();
+        invalid_candidate.set_delaunay_check_interval(NonZeroUsize::new(1));
+        let vertex = invalid_candidate
+            .geometry()
+            .vertices()
+            .find(|vertex| invalid_candidate.time_label(vertex) == Some(1))
+            .expect("fixture has a slice-1 vertex");
+        invalid_candidate
+            .set_vertex_data(&vertex, Some(0))
+            .expect("fixture vertex label can be edited");
+        let mut state = algorithm
+            .initial_state(triangulation)
+            .expect("initial state should build");
+        let triangulation_before = state.triangulation.clone();
+        let action_before = state.current_action;
+        let steps_before = state.steps.len();
+        let measurements_before = state.measurements.len();
+        let attempted_before = state.move_stats.total_attempted();
+        let accepted_before = state.move_stats.total_accepted();
+        let proposal_stats_before = state.proposal_stats.clone();
+        let proposal_stats = ProposalStatistics::from_validated_parts(1, 0, 0, 0, 0, 0, 0, 0, 0);
+
+        let error = record_planned_step_parts(
+            &algorithm,
+            &mut state,
+            step_number(1),
+            PlannedStepRecord {
+                outcome: StepOutcome::Accepted,
+                log_prob_after: Some(-action_before),
+                info: CdtProposalInfo {
+                    move_type: MoveType::Move22,
+                    action_before,
+                    action_after: Some(action_before),
+                    delta_action: Some(0.0),
+                },
+                proposal_stats: &proposal_stats,
+                triangulation: &invalid_candidate,
+            },
+        )
+        .expect_err("accepted invalid triangulation should fail staged validation");
+
+        assert_matches!(
+            error,
+            CdtError::Foliation(FoliationError::StaleBookkeeping { .. })
+        );
+        assert_canonical_triangulations_match(&state.triangulation, &triangulation_before);
+        assert_relative_eq!(state.current_action, action_before, epsilon = 1e-12);
+        assert_eq!(state.steps.len(), steps_before);
+        assert_eq!(state.measurements.len(), measurements_before);
+        assert_eq!(state.move_stats.total_attempted(), attempted_before);
+        assert_eq!(state.move_stats.total_accepted(), accepted_before);
+        assert_eq!(state.proposal_stats, proposal_stats_before);
+    }
+
+    #[test]
     fn run_steps_rejects_step_count_overflow_before_planned_sampler_step() {
         let config = seeded_metropolis_config(1.0, 1, 0, 1, 2);
         let algorithm = MetropolisAlgorithm::new(config, ActionConfig::default());
@@ -3291,12 +3485,13 @@ mod tests {
             .expect("scoring should not fail");
 
         assert_eq!(info.move_type, plan.move_type());
-        assert_optional_relative_eq(info.delta_action, plan.delta_action());
-        if let Some(action_after) = plan.action_after() {
-            assert_relative_eq!(proposed_log_prob, -action_after, epsilon = 1e-12);
-        } else {
-            assert!(proposed_log_prob.is_infinite() && proposed_log_prob.is_sign_negative());
-        }
+        assert_relative_eq!(
+            info.delta_action
+                .expect("concrete plan info should include action delta"),
+            plan.delta_action(),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(proposed_log_prob, -plan.action_after(), epsilon = 1e-12);
     }
 
     #[test]
@@ -3368,17 +3563,18 @@ mod tests {
     }
 
     #[test]
-    fn cdt_proposal_scores_impossible_plan_as_negative_infinity() {
+    fn cdt_proposal_scores_concrete_plan_from_proposed_state() {
         let action_config = ActionConfig::default();
         let target =
             CdtTarget::new(action_config.clone(), 1.0).expect("valid target configuration");
         let proposal = CdtProposal::with_seed(action_config, 7);
         let triangulation = CdtTriangulation::from_seeded_points(5, 1, 2, 53).expect("Failed");
+        let action_before = action_for(&ActionConfig::default(), &triangulation);
         let plan = CdtProposalPlan {
             move_type: MoveType::Move31Remove,
-            action_before: 1.0,
-            action_after: None,
-            delta_action: None,
+            action_before,
+            action_after: action_before,
+            delta_action: 0.0,
             forward_site_count: 0,
             reverse_site_count: 0,
             proposed_state: triangulation.clone(),
@@ -3386,9 +3582,9 @@ mod tests {
 
         let proposed_log_prob = proposal
             .proposed_log_prob(&triangulation, &plan, &target)
-            .expect("scoring an impossible count delta should not fail");
+            .expect("scoring a concrete plan should not fail");
 
-        assert!(proposed_log_prob.is_infinite() && proposed_log_prob.is_sign_negative());
+        assert_relative_eq!(proposed_log_prob, -action_before, epsilon = 1e-12);
     }
 
     #[test]
@@ -3430,8 +3626,8 @@ mod tests {
         let plan = CdtProposalPlan {
             move_type: MoveType::Move13Add,
             action_before,
-            action_after: Some(action_after),
-            delta_action: Some(action_after - action_before),
+            action_after,
+            delta_action: action_after - action_before,
             forward_site_count: proposal_site_count(&triangulation, MoveType::Move13Add),
             reverse_site_count: proposal_site_count(&proposed_state, MoveType::Move31Remove),
             proposed_state,

--- a/src/cdt/metropolis/telemetry.rs
+++ b/src/cdt/metropolis/telemetry.rs
@@ -982,8 +982,9 @@ impl ProposalStatistics {
     /// The wire form is rejected when terminal outcomes do not exactly account
     /// for selected move families, or when forward-site observations exist
     /// without any selected move family. Saturated terminal counters are accepted
-    /// because merging telemetry uses saturating arithmetic and can no longer
-    /// preserve an exact terminal-outcome partition.
+    /// only when move-family proposals also saturated, because merging telemetry
+    /// uses saturating arithmetic and can no longer preserve an exact
+    /// terminal-outcome partition.
     fn from_wire(wire: &ProposalStatisticsWire) -> CdtResult<Self> {
         let terminal_counters = [
             wire.no_site_proposals,
@@ -1001,8 +1002,16 @@ impl ProposalStatistics {
         let mut terminal_overflowed = false;
         let terminal_outcomes = terminal_outcomes.unwrap_or_else(|| {
             terminal_overflowed = true;
-            wire.move_family_proposals
+            u64::MAX
         });
+        if (terminal_saturated || terminal_overflowed) && wire.move_family_proposals != u64::MAX {
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::ProposalTerminalOutcomeCountMismatch {
+                    terminal_outcomes,
+                    move_family_proposals: wire.move_family_proposals,
+                },
+            ));
+        }
         if !terminal_saturated
             && !terminal_overflowed
             && terminal_outcomes != wire.move_family_proposals
@@ -1509,5 +1518,61 @@ mod tests {
         assert_eq!(stats.move_family_proposals(), u64::MAX);
         assert_eq!(stats.no_site_proposals(), u64::MAX);
         assert_eq!(stats.site_causality_rejections(), 1);
+    }
+
+    #[test]
+    fn proposal_statistics_from_wire_rejects_saturated_terminals_without_saturated_proposals() {
+        let wire = ProposalStatisticsWire {
+            move_family_proposals: 1,
+            observed_forward_sites: 1,
+            no_site_proposals: u64::MAX,
+            site_causality_rejections: 0,
+            site_geometric_rejections: 0,
+            site_backend_rejections: 0,
+            metropolis_rejections: 0,
+            accepted_transitions: 0,
+            hard_failures: 0,
+        };
+
+        let error = ProposalStatistics::from_wire(&wire)
+            .expect_err("saturated terminal counters require saturated move-family proposals");
+
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::ProposalTerminalOutcomeCountMismatch {
+                    terminal_outcomes: u64::MAX,
+                    move_family_proposals: 1,
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn proposal_statistics_from_wire_rejects_overflowed_terminals_without_saturated_proposals() {
+        let wire = ProposalStatisticsWire {
+            move_family_proposals: 3,
+            observed_forward_sites: 3,
+            no_site_proposals: u64::MAX - 1,
+            site_causality_rejections: 2,
+            site_geometric_rejections: 0,
+            site_backend_rejections: 0,
+            metropolis_rejections: 0,
+            accepted_transitions: 0,
+            hard_failures: 0,
+        };
+
+        let error = ProposalStatistics::from_wire(&wire)
+            .expect_err("overflowed terminal counters require saturated move-family proposals");
+
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::ProposalTerminalOutcomeCountMismatch {
+                    terminal_outcomes: u64::MAX,
+                    move_family_proposals: 3,
+                }
+            }
+        );
     }
 }

--- a/src/cdt/metropolis/telemetry.rs
+++ b/src/cdt/metropolis/telemetry.rs
@@ -861,9 +861,12 @@ impl Error for CdtProposalSiteRejection {
 /// references returned by
 /// [`checkpoint proposal stats`][super::CdtMcmcCheckpoint::proposal_stats] or
 /// [`result proposal stats`][crate::cdt::results::SimulationResultsBackend::proposal_stats].
-/// Deserialization requires exactly one terminal outcome for every selected
-/// move-family proposal, and counters saturate at `u64::MAX` instead of
-/// wrapping.
+/// Deserialization normally requires exactly one terminal outcome for every
+/// selected move-family proposal, and counters saturate at `u64::MAX` instead
+/// of wrapping. When telemetry merges saturate a terminal counter or terminal
+/// sum, the exact terminal-outcome partition is no longer recoverable; in that
+/// case deserialization accepts the relaxed partition only when move-family
+/// proposals also saturated.
 ///
 /// # Examples
 ///

--- a/src/cdt/metropolis/telemetry.rs
+++ b/src/cdt/metropolis/telemetry.rs
@@ -2,6 +2,7 @@
 
 //! Proposal and step telemetry for CDT Metropolis sampling.
 
+use super::helpers::actions_match;
 use crate::cdt::ergodic_moves::MoveType;
 use crate::errors::{CdtError, CdtResult, CheckpointResumeFailure};
 use serde::de::Error as DeError;
@@ -9,8 +10,6 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::error::Error;
 use std::fmt;
 use std::num::NonZeroU32;
-
-use super::helpers::actions_match;
 
 /// Telemetry for one completed Monte Carlo step.
 ///
@@ -985,7 +984,7 @@ impl ProposalStatistics {
     /// forward-site observations exist without any selected move family. That
     /// keeps deserialized result and checkpoint telemetry coherent before public
     /// accessors expose the counters.
-    fn from_wire(wire: &ProposalStatisticsWire) -> Result<Self, String> {
+    fn from_wire(wire: &ProposalStatisticsWire) -> CdtResult<Self> {
         let terminal_outcomes = [
             wire.no_site_proposals,
             wire.site_causality_rejections,
@@ -997,21 +996,24 @@ impl ProposalStatistics {
         ]
         .into_iter()
         .try_fold(0_u64, |total, count| {
-            total
-                .checked_add(count)
-                .ok_or_else(|| "proposal terminal outcome counters exceed u64::MAX".to_string())
+            total.checked_add(count).ok_or_else(|| {
+                checkpoint_resume_failed(CheckpointResumeFailure::ProposalTerminalCounterOverflow)
+            })
         })?;
         if terminal_outcomes != wire.move_family_proposals {
-            return Err(format!(
-                "proposal terminal outcomes ({terminal_outcomes}) do not match move-family proposals ({})",
-                wire.move_family_proposals
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::ProposalTerminalOutcomeCountMismatch {
+                    terminal_outcomes,
+                    move_family_proposals: wire.move_family_proposals,
+                },
             ));
         }
         if wire.move_family_proposals == 0 && wire.observed_forward_sites != 0 {
-            return Err(
-                "observed forward-site count must be zero when no move families were proposed"
-                    .to_string(),
-            );
+            return Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::ProposalForwardSitesWithoutMoveFamily {
+                    observed_forward_sites: wire.observed_forward_sites,
+                },
+            ));
         }
         Ok(Self {
             move_family_proposals: wire.move_family_proposals,
@@ -1399,103 +1401,110 @@ mod tests {
     }
 
     #[test]
-    fn proposal_statistics_deserialization_rejects_terminal_outcomes_above_proposals() {
-        let payload = r#"{
-            "move_family_proposals": 1,
-            "observed_forward_sites": 1,
-            "no_site_proposals": 1,
-            "site_causality_rejections": 0,
-            "site_geometric_rejections": 0,
-            "site_backend_rejections": 0,
-            "metropolis_rejections": 0,
-            "accepted_transitions": 1,
-            "hard_failures": 0
-        }"#;
+    fn proposal_statistics_from_wire_rejects_terminal_outcomes_above_proposals() {
+        let wire = ProposalStatisticsWire {
+            move_family_proposals: 1,
+            observed_forward_sites: 1,
+            no_site_proposals: 1,
+            site_causality_rejections: 0,
+            site_geometric_rejections: 0,
+            site_backend_rejections: 0,
+            metropolis_rejections: 0,
+            accepted_transitions: 1,
+            hard_failures: 0,
+        };
 
-        let error = serde_json::from_str::<ProposalStatistics>(payload)
+        let error = ProposalStatistics::from_wire(&wire)
             .expect_err("terminal outcomes above move-family proposals should be rejected");
 
-        assert!(
-            error.to_string().contains("terminal outcomes"),
-            "serde error should explain proposal telemetry invariant, got {error}"
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::ProposalTerminalOutcomeCountMismatch {
+                    terminal_outcomes: 2,
+                    move_family_proposals: 1,
+                }
+            }
         );
     }
 
     #[test]
-    fn proposal_statistics_deserialization_rejects_under_classified_proposals() {
-        let payload = r#"{
-            "move_family_proposals": 2,
-            "observed_forward_sites": 1,
-            "no_site_proposals": 1,
-            "site_causality_rejections": 0,
-            "site_geometric_rejections": 0,
-            "site_backend_rejections": 0,
-            "metropolis_rejections": 0,
-            "accepted_transitions": 0,
-            "hard_failures": 0
-        }"#;
+    fn proposal_statistics_from_wire_rejects_under_classified_proposals() {
+        let wire = ProposalStatisticsWire {
+            move_family_proposals: 2,
+            observed_forward_sites: 1,
+            no_site_proposals: 1,
+            site_causality_rejections: 0,
+            site_geometric_rejections: 0,
+            site_backend_rejections: 0,
+            metropolis_rejections: 0,
+            accepted_transitions: 0,
+            hard_failures: 0,
+        };
 
-        let error = serde_json::from_str::<ProposalStatistics>(payload)
+        let error = ProposalStatistics::from_wire(&wire)
             .expect_err("under-classified move-family proposals should be rejected");
 
-        assert!(
-            error.to_string().contains("do not match"),
-            "serde error should explain exact proposal telemetry invariant, got {error}"
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::ProposalTerminalOutcomeCountMismatch {
+                    terminal_outcomes: 1,
+                    move_family_proposals: 2,
+                }
+            }
         );
     }
 
     #[test]
-    fn proposal_statistics_deserialization_rejects_forward_sites_without_proposals() {
-        let payload = r#"{
-            "move_family_proposals": 0,
-            "observed_forward_sites": 1,
-            "no_site_proposals": 0,
-            "site_causality_rejections": 0,
-            "site_geometric_rejections": 0,
-            "site_backend_rejections": 0,
-            "metropolis_rejections": 0,
-            "accepted_transitions": 0,
-            "hard_failures": 0
-        }"#;
+    fn proposal_statistics_from_wire_rejects_forward_sites_without_proposals() {
+        let wire = ProposalStatisticsWire {
+            move_family_proposals: 0,
+            observed_forward_sites: 1,
+            no_site_proposals: 0,
+            site_causality_rejections: 0,
+            site_geometric_rejections: 0,
+            site_backend_rejections: 0,
+            metropolis_rejections: 0,
+            accepted_transitions: 0,
+            hard_failures: 0,
+        };
 
-        let error = serde_json::from_str::<ProposalStatistics>(payload)
+        let error = ProposalStatistics::from_wire(&wire)
             .expect_err("forward sites without proposals should be rejected");
 
-        assert!(
-            error.to_string().contains("forward-site"),
-            "serde error should explain forward-site invariant, got {error}"
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::ProposalForwardSitesWithoutMoveFamily {
+                    observed_forward_sites: 1
+                }
+            }
         );
     }
 
     #[test]
-    fn proposal_statistics_deserialization_rejects_terminal_outcome_counter_overflow() {
-        let mut stats = ProposalStatistics::from_validated_parts(
-            u64::MAX,
-            u64::MAX,
-            u64::MAX,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        );
-        let other = ProposalStatistics::from_validated_parts(1, 1, 0, 0, 0, 0, 0, 1, 0);
+    fn proposal_statistics_from_wire_rejects_terminal_outcome_counter_overflow() {
+        let wire = ProposalStatisticsWire {
+            move_family_proposals: u64::MAX,
+            observed_forward_sites: u64::MAX,
+            no_site_proposals: u64::MAX,
+            site_causality_rejections: 1,
+            site_geometric_rejections: 0,
+            site_backend_rejections: 0,
+            metropolis_rejections: 0,
+            accepted_transitions: 0,
+            hard_failures: 0,
+        };
 
-        stats.extend(&other);
-
-        assert_eq!(stats.move_family_proposals(), u64::MAX);
-        assert_eq!(stats.no_site_proposals(), u64::MAX);
-        assert_eq!(stats.accepted_transitions(), 1);
-
-        let serialized =
-            serde_json::to_string(&stats).expect("saturated telemetry should serialize");
-        let error = serde_json::from_str::<ProposalStatistics>(&serialized)
+        let error = ProposalStatistics::from_wire(&wire)
             .expect_err("overflowed terminal outcome partition should be rejected");
 
-        assert!(
-            error.to_string().contains("exceed u64::MAX"),
-            "serde error should explain terminal outcome counter overflow, got {error}"
+        assert_matches!(
+            error,
+            CdtError::CheckpointResumeFailed {
+                failure: CheckpointResumeFailure::ProposalTerminalCounterOverflow
+            }
         );
     }
 }

--- a/src/cdt/metropolis/telemetry.rs
+++ b/src/cdt/metropolis/telemetry.rs
@@ -979,13 +979,13 @@ impl ProposalStatistics {
 
     /// Rebuilds proposal telemetry from the serialized wire shape.
     ///
-    /// The wire form is rejected when terminal outcomes cannot be summed without
-    /// overflow, do not exactly account for selected move families, or when
-    /// forward-site observations exist without any selected move family. That
-    /// keeps deserialized result and checkpoint telemetry coherent before public
-    /// accessors expose the counters.
+    /// The wire form is rejected when terminal outcomes do not exactly account
+    /// for selected move families, or when forward-site observations exist
+    /// without any selected move family. Saturated terminal counters are accepted
+    /// because merging telemetry uses saturating arithmetic and can no longer
+    /// preserve an exact terminal-outcome partition.
     fn from_wire(wire: &ProposalStatisticsWire) -> CdtResult<Self> {
-        let terminal_outcomes = [
+        let terminal_counters = [
             wire.no_site_proposals,
             wire.site_causality_rejections,
             wire.site_geometric_rejections,
@@ -993,14 +993,20 @@ impl ProposalStatistics {
             wire.metropolis_rejections,
             wire.accepted_transitions,
             wire.hard_failures,
-        ]
-        .into_iter()
-        .try_fold(0_u64, |total, count| {
-            total.checked_add(count).ok_or_else(|| {
-                checkpoint_resume_failed(CheckpointResumeFailure::ProposalTerminalCounterOverflow)
-            })
-        })?;
-        if terminal_outcomes != wire.move_family_proposals {
+        ];
+        let terminal_saturated = terminal_counters.contains(&u64::MAX);
+        let terminal_outcomes = terminal_counters
+            .into_iter()
+            .try_fold(0_u64, u64::checked_add);
+        let mut terminal_overflowed = false;
+        let terminal_outcomes = terminal_outcomes.unwrap_or_else(|| {
+            terminal_overflowed = true;
+            wire.move_family_proposals
+        });
+        if !terminal_saturated
+            && !terminal_overflowed
+            && terminal_outcomes != wire.move_family_proposals
+        {
             return Err(checkpoint_resume_failed(
                 CheckpointResumeFailure::ProposalTerminalOutcomeCountMismatch {
                     terminal_outcomes,
@@ -1484,7 +1490,7 @@ mod tests {
     }
 
     #[test]
-    fn proposal_statistics_from_wire_rejects_terminal_outcome_counter_overflow() {
+    fn proposal_statistics_from_wire_accepts_saturated_terminal_outcome_counter_overflow() {
         let wire = ProposalStatisticsWire {
             move_family_proposals: u64::MAX,
             observed_forward_sites: u64::MAX,
@@ -1497,14 +1503,11 @@ mod tests {
             hard_failures: 0,
         };
 
-        let error = ProposalStatistics::from_wire(&wire)
-            .expect_err("overflowed terminal outcome partition should be rejected");
+        let stats = ProposalStatistics::from_wire(&wire)
+            .expect("saturated terminal outcome partition should deserialize");
 
-        assert_matches!(
-            error,
-            CdtError::CheckpointResumeFailed {
-                failure: CheckpointResumeFailure::ProposalTerminalCounterOverflow
-            }
-        );
+        assert_eq!(stats.move_family_proposals(), u64::MAX);
+        assert_eq!(stats.no_site_proposals(), u64::MAX);
+        assert_eq!(stats.site_causality_rejections(), 1);
     }
 }

--- a/src/cdt/observables.rs
+++ b/src/cdt/observables.rs
@@ -462,6 +462,28 @@ mod tests {
     }
 
     #[test]
+    fn dual_ball_averages_are_empty_for_too_small_graphs() {
+        assert!(
+            average_dual_ball_volumes_from_adjacency(&[])
+                .expect("empty adjacency should not fail numerically")
+                .is_empty()
+        );
+        assert!(
+            average_dual_ball_volumes_from_adjacency(&[vec![]])
+                .expect("single-node adjacency should not fail numerically")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn return_probabilities_are_empty_for_empty_graph() {
+        let probabilities = average_return_probabilities(&[], 4)
+            .expect("empty adjacency should not fail numerically");
+
+        assert!(probabilities.is_empty());
+    }
+
+    #[test]
     fn spectral_fit_recovers_power_law_return_probability() {
         let probabilities = vec![1.0, 0.75, 0.5, 1.0 / 3.0, 0.25, 0.2];
 
@@ -470,6 +492,17 @@ mod tests {
             .expect("decreasing power-law return probabilities should fit");
 
         assert_relative_eq!(estimate, 2.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn spectral_fit_returns_none_for_non_positive_dimension() {
+        let increasing_return_probabilities = vec![1.0, 0.1, 0.2, 0.3, 0.4];
+
+        assert_eq!(
+            fit_spectral_dimension(&increasing_return_probabilities)
+                .expect("finite return probabilities should not fail numerically"),
+            None
+        );
     }
 
     #[test]

--- a/src/cdt/observables.rs
+++ b/src/cdt/observables.rs
@@ -5,6 +5,7 @@
 //! This module contains user-facing analysis routines that measure fixed
 //! triangulations or simulation outputs without owning the simulation loop.
 
+use crate::errors::{CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure};
 use crate::geometry::CdtTriangulation2D;
 use crate::geometry::traits::TriangulationQuery;
 use crate::util::usize_to_f64;
@@ -29,8 +30,14 @@ const SPECTRAL_SELF_LOOP_PROBABILITY: f64 = 0.5;
 /// breadth-first search from every face, so its time complexity is
 /// `O(F * (F + E_d))` for `F` faces and `E_d` dual edges.
 ///
-/// Returns `None` when the triangulation is too small, disconnected data leaves
-/// fewer than two usable radii, or live face adjacency cannot be resolved.
+/// Returns `Ok(None)` when the triangulation is too small or disconnected data
+/// leaves fewer than two usable radii.
+///
+/// # Errors
+///
+/// Returns [`CdtError::ValidationFailed`] if backend face adjacency cannot be
+/// resolved or if observable counters cannot be represented as finite fitting
+/// inputs.
 ///
 /// # References
 ///
@@ -54,12 +61,11 @@ const SPECTRAL_SELF_LOOP_PROBABILITY: f64 = 0.5;
 ///
 /// fn main() -> CdtResult<()> {
 ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-///     assert!(estimate_hausdorff_dimension(&tri).is_some_and(f64::is_finite));
+///     assert!(estimate_hausdorff_dimension(&tri)?.is_some_and(f64::is_finite));
 ///     Ok(())
 /// }
 /// ```
-#[must_use]
-pub fn estimate_hausdorff_dimension(triangulation: &CdtTriangulation2D) -> Option<f64> {
+pub fn estimate_hausdorff_dimension(triangulation: &CdtTriangulation2D) -> CdtResult<Option<f64>> {
     let ball_volumes = average_dual_ball_volumes(triangulation)?;
     fit_log_log_slope(&ball_volumes)
 }
@@ -79,9 +85,15 @@ pub fn estimate_hausdorff_dimension(triangulation: &CdtTriangulation2D) -> Optio
 /// complexity is `O(S * F * (F + E_d))` for `S` diffusion steps, `F` faces, and
 /// `E_d` dual edges.
 ///
-/// Returns `None` when the triangulation is too small, fewer than two positive
-/// return-probability samples are available for the fit, the fitted dimension is
-/// not positive, or live face adjacency cannot be resolved.
+/// Returns `Ok(None)` when the triangulation is too small, fewer than two
+/// positive return-probability samples are available for the fit, or the fitted
+/// dimension is not positive.
+///
+/// # Errors
+///
+/// Returns [`CdtError::ValidationFailed`] if backend face adjacency cannot be
+/// resolved or if observable counters cannot be represented as finite fitting
+/// inputs.
 ///
 /// # References
 ///
@@ -101,21 +113,20 @@ pub fn estimate_hausdorff_dimension(triangulation: &CdtTriangulation2D) -> Optio
 ///
 /// fn main() -> CdtResult<()> {
 ///     let tri = CdtTriangulation::from_toroidal_cdt(6, 6)?;
-///     assert!(estimate_spectral_dimension(&tri).is_some_and(f64::is_finite));
+///     assert!(estimate_spectral_dimension(&tri)?.is_some_and(f64::is_finite));
 ///     Ok(())
 /// }
 /// ```
-#[must_use]
-pub fn estimate_spectral_dimension(triangulation: &CdtTriangulation2D) -> Option<f64> {
+pub fn estimate_spectral_dimension(triangulation: &CdtTriangulation2D) -> CdtResult<Option<f64>> {
     let adjacency = dual_adjacency(triangulation)?;
     estimate_spectral_dimension_from_adjacency(&adjacency)
 }
 
 /// Builds the combinatorial face-adjacency graph for CDT dual observables.
-fn dual_adjacency(triangulation: &CdtTriangulation2D) -> Option<Vec<Vec<usize>>> {
+fn dual_adjacency(triangulation: &CdtTriangulation2D) -> CdtResult<Vec<Vec<usize>>> {
     let faces: Vec<_> = triangulation.geometry().faces().collect();
     if faces.len() < 2 {
-        return Some(Vec::new());
+        return Ok(Vec::new());
     }
 
     let face_indices: HashMap<_, _> = faces
@@ -128,28 +139,34 @@ fn dual_adjacency(triangulation: &CdtTriangulation2D) -> Option<Vec<Vec<usize>>>
     faces
         .iter()
         .map(|face| {
-            let neighbors = triangulation.geometry().face_neighbors(face).ok()?;
-            Some(
-                neighbors
-                    .into_iter()
-                    .filter_map(|neighbor| face_indices.get(&neighbor).copied())
-                    .collect(),
-            )
+            let neighbors = triangulation
+                .geometry()
+                .face_neighbors(face)
+                .map_err(|err| CdtError::ValidationFailed {
+                    check: CdtValidationCheck::Geometry,
+                    failure: CdtValidationFailure::FaceVerticesUnavailable {
+                        face: format!("{:?}", face.simplex_key()),
+                        detail: err.to_string(),
+                    },
+                })?;
+            Ok(neighbors
+                .into_iter()
+                .filter_map(|neighbor| face_indices.get(&neighbor).copied())
+                .collect())
         })
         .collect()
 }
 
 /// Computes average dual-graph ball volumes for each reachable graph radius.
-fn average_dual_ball_volumes(triangulation: &CdtTriangulation2D) -> Option<Vec<f64>> {
-    dual_adjacency(triangulation)
-        .as_deref()
-        .and_then(average_dual_ball_volumes_from_adjacency)
+fn average_dual_ball_volumes(triangulation: &CdtTriangulation2D) -> CdtResult<Vec<f64>> {
+    let adjacency = dual_adjacency(triangulation)?;
+    average_dual_ball_volumes_from_adjacency(&adjacency)
 }
 
 /// Computes reachable-radius average ball volumes from a dual adjacency list.
-fn average_dual_ball_volumes_from_adjacency(adjacency: &[Vec<usize>]) -> Option<Vec<f64>> {
+fn average_dual_ball_volumes_from_adjacency(adjacency: &[Vec<usize>]) -> CdtResult<Vec<f64>> {
     if adjacency.len() < 2 {
-        return Some(Vec::new());
+        return Ok(Vec::new());
     }
 
     let mut sums = Vec::new();
@@ -185,14 +202,22 @@ fn average_dual_ball_volumes_from_adjacency(adjacency: &[Vec<usize>]) -> Option<
             .take(max_radius + 1)
         {
             ball_volume += shell_count;
-            sums[radius] += usize_to_f64(ball_volume)?;
+            sums[radius] += usize_to_f64(ball_volume).ok_or_else(|| {
+                observable_numeric_error("dual ball volume cannot be represented as f64")
+            })?;
             counts[radius] += 1;
         }
     }
 
     sums.into_iter()
         .zip(counts)
-        .map(|(sum, count)| usize_to_f64(count).map(|count_f64| sum / count_f64))
+        .map(|(sum, count)| {
+            usize_to_f64(count)
+                .map(|count_f64| sum / count_f64)
+                .ok_or_else(|| {
+                    observable_numeric_error("dual ball sample count cannot be represented as f64")
+                })
+        })
         .collect()
 }
 
@@ -230,44 +255,40 @@ fn dual_graph_distances(
 }
 
 /// Fits the slope of `log(volume)` against `log(radius)`.
-fn fit_log_log_slope(ball_volumes: &[f64]) -> Option<f64> {
-    fit_linear_slope(
-        ball_volumes
-            .iter()
-            .enumerate()
-            .skip(1)
-            .filter_map(|(radius, &volume)| {
-                // Exclude root-only samples: ln(1.0) = 0 biases the slope toward zero.
-                if volume > 1.0 && volume.is_finite() {
-                    let radius_f64 = usize_to_f64(radius)?;
-                    Some((radius_f64.ln(), volume.ln()))
-                } else {
-                    None
-                }
-            }),
-    )
+fn fit_log_log_slope(ball_volumes: &[f64]) -> CdtResult<Option<f64>> {
+    let mut samples = Vec::new();
+    for (radius, &volume) in ball_volumes.iter().enumerate().skip(1) {
+        // Exclude root-only samples: ln(1.0) = 0 biases the slope toward zero.
+        if volume > 1.0 && volume.is_finite() {
+            let radius_f64 = usize_to_f64(radius).ok_or_else(|| {
+                observable_numeric_error("dual graph radius cannot be represented as f64")
+            })?;
+            samples.push((radius_f64.ln(), volume.ln()));
+        }
+    }
+    Ok(fit_linear_slope(samples))
 }
 
 /// Estimates spectral dimension from a precomputed dual adjacency list.
-fn estimate_spectral_dimension_from_adjacency(adjacency: &[Vec<usize>]) -> Option<f64> {
+fn estimate_spectral_dimension_from_adjacency(adjacency: &[Vec<usize>]) -> CdtResult<Option<f64>> {
     if adjacency.len() < 3 {
-        return None;
+        return Ok(None);
     }
 
     let max_step = MAX_SPECTRAL_DIFFUSION_STEP.min(adjacency.len().saturating_sub(1));
     if max_step < MIN_SPECTRAL_DIFFUSION_STEP {
-        return None;
+        return Ok(None);
     }
 
-    let return_probabilities = average_return_probabilities(adjacency, max_step);
+    let return_probabilities = average_return_probabilities(adjacency, max_step)?;
     fit_spectral_dimension(&return_probabilities)
 }
 
 /// Computes average random-walk return probabilities for diffusion steps.
-fn average_return_probabilities(adjacency: &[Vec<usize>], max_step: usize) -> Vec<f64> {
+fn average_return_probabilities(adjacency: &[Vec<usize>], max_step: usize) -> CdtResult<Vec<f64>> {
     let node_count = adjacency.len();
     if node_count == 0 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     let mut sums = vec![0.0; max_step + 1];
@@ -300,9 +321,11 @@ fn average_return_probabilities(adjacency: &[Vec<usize>], max_step: usize) -> Ve
                     continue;
                 }
 
-                let Some(neighbor_count) = usize_to_f64(live_neighbor_count) else {
-                    return Vec::new();
-                };
+                let neighbor_count = usize_to_f64(live_neighbor_count).ok_or_else(|| {
+                    observable_numeric_error(
+                        "live dual-neighbor count cannot be represented as f64",
+                    )
+                })?;
                 let share = move_probability / neighbor_count;
                 for neighbor in adjacency[index]
                     .iter()
@@ -318,31 +341,34 @@ fn average_return_probabilities(adjacency: &[Vec<usize>], max_step: usize) -> Ve
         }
     }
 
-    let Some(node_count_f64) = usize_to_f64(node_count) else {
-        return Vec::new();
-    };
-    sums.into_iter().map(|sum| sum / node_count_f64).collect()
+    let node_count_f64 = usize_to_f64(node_count).ok_or_else(|| {
+        observable_numeric_error("dual graph node count cannot be represented as f64")
+    })?;
+    Ok(sums.into_iter().map(|sum| sum / node_count_f64).collect())
 }
 
 /// Fits `d_s = -2 d log(P(sigma)) / d log(sigma)` from return probabilities.
-fn fit_spectral_dimension(return_probabilities: &[f64]) -> Option<f64> {
-    let slope = fit_linear_slope(
-        return_probabilities
-            .iter()
-            .enumerate()
-            .skip(MIN_SPECTRAL_DIFFUSION_STEP)
-            .filter_map(|(step, &probability)| {
-                if probability > 0.0 && probability < 1.0 && probability.is_finite() {
-                    let step_f64 = usize_to_f64(step)?;
-                    Some((step_f64.ln(), probability.ln()))
-                } else {
-                    None
-                }
-            }),
-    )?;
+fn fit_spectral_dimension(return_probabilities: &[f64]) -> CdtResult<Option<f64>> {
+    let mut samples = Vec::new();
+    for (step, &probability) in return_probabilities
+        .iter()
+        .enumerate()
+        .skip(MIN_SPECTRAL_DIFFUSION_STEP)
+    {
+        if probability > 0.0 && probability < 1.0 && probability.is_finite() {
+            let step_f64 = usize_to_f64(step).ok_or_else(|| {
+                observable_numeric_error("diffusion step cannot be represented as f64")
+            })?;
+            samples.push((step_f64.ln(), probability.ln()));
+        }
+    }
+
+    let Some(slope) = fit_linear_slope(samples) else {
+        return Ok(None);
+    };
 
     let dimension = -2.0 * slope;
-    (dimension.is_finite() && dimension > 0.0).then_some(dimension)
+    Ok((dimension.is_finite() && dimension > 0.0).then_some(dimension))
 }
 
 /// Fits the slope of `y = a + bx` from streaming `(x, y)` samples.
@@ -373,6 +399,16 @@ fn fit_linear_slope(samples: impl IntoIterator<Item = (f64, f64)>) -> Option<f64
     Some(count_f64.mul_add(product_total, -x_total * y_total) / denominator)
 }
 
+/// Maps impossible-sized observable counters into the public validation error contract.
+fn observable_numeric_error(detail: &'static str) -> CdtError {
+    CdtError::ValidationFailed {
+        check: CdtValidationCheck::Geometry,
+        failure: CdtValidationFailure::BackendGeometry {
+            detail: detail.to_string(),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -383,6 +419,7 @@ mod tests {
     fn hausdorff_estimate_uses_dual_graph_ball_growth() {
         let triangulation = CdtTriangulation::from_cdt_strip(4, 3).expect("create Delaunay strip");
         let estimate = estimate_hausdorff_dimension(&triangulation)
+            .expect("strip dual graph adjacency should be readable")
             .expect("strip dual graph should have enough radii for a fit");
 
         assert!(estimate.is_finite());
@@ -394,7 +431,11 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_random_points(3, 1, 2).expect("create minimal triangulation");
 
-        assert_eq!(estimate_hausdorff_dimension(&triangulation), None);
+        assert_eq!(
+            estimate_hausdorff_dimension(&triangulation)
+                .expect("minimal triangulation adjacency should be readable"),
+            None
+        );
     }
 
     #[test]
@@ -402,6 +443,7 @@ mod tests {
         let triangulation =
             CdtTriangulation::from_toroidal_cdt(6, 6).expect("create periodic torus");
         let estimate = estimate_spectral_dimension(&triangulation)
+            .expect("torus dual graph adjacency should be readable")
             .expect("torus dual graph should have enough diffusion data");
 
         assert!(estimate.is_finite());
@@ -412,7 +454,11 @@ mod tests {
     fn spectral_estimate_returns_none_for_too_little_diffusion_data() {
         let adjacency = vec![vec![1], vec![0]];
 
-        assert_eq!(estimate_spectral_dimension_from_adjacency(&adjacency), None);
+        assert_eq!(
+            estimate_spectral_dimension_from_adjacency(&adjacency)
+                .expect("small adjacency should not fail numerically"),
+            None
+        );
     }
 
     #[test]
@@ -420,6 +466,7 @@ mod tests {
         let probabilities = vec![1.0, 0.75, 0.5, 1.0 / 3.0, 0.25, 0.2];
 
         let estimate = fit_spectral_dimension(&probabilities)
+            .expect("small probability vector should not fail numerically")
             .expect("decreasing power-law return probabilities should fit");
 
         assert_relative_eq!(estimate, 2.0, epsilon = 1e-12);
@@ -429,12 +476,17 @@ mod tests {
     fn spectral_estimate_returns_none_for_stationary_isolated_graph() {
         let adjacency = vec![vec![], vec![], vec![]];
 
-        let probabilities = average_return_probabilities(&adjacency, 4);
+        let probabilities = average_return_probabilities(&adjacency, 4)
+            .expect("small isolated graph should not fail numerically");
 
         for probability in probabilities {
             assert_relative_eq!(probability, 1.0);
         }
-        assert_eq!(estimate_spectral_dimension_from_adjacency(&adjacency), None);
+        assert_eq!(
+            estimate_spectral_dimension_from_adjacency(&adjacency)
+                .expect("isolated graph should not fail numerically"),
+            None
+        );
     }
 
     #[test]
@@ -478,7 +530,8 @@ mod tests {
     fn return_probabilities_follow_two_node_walk() {
         let adjacency = vec![vec![1], vec![0]];
 
-        let probabilities = average_return_probabilities(&adjacency, 4);
+        let probabilities = average_return_probabilities(&adjacency, 4)
+            .expect("small two-node graph should not fail numerically");
 
         assert_relative_eq!(probabilities[0], 1.0);
         assert_relative_eq!(probabilities[1], 0.5);

--- a/src/cdt/results.rs
+++ b/src/cdt/results.rs
@@ -24,6 +24,7 @@ use crate::errors::{
 use crate::geometry::CdtTriangulation2D;
 use crate::util::usize_to_f64;
 use serde::de::Error as DeError;
+use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::to_writer_pretty;
 use std::fmt::Display;
@@ -111,21 +112,87 @@ impl CdtScalarTraceOutcome {
 }
 
 /// A rectangular scalar trace row captured from the upstream planned-step outcome.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 pub(crate) struct CdtScalarTraceRow {
     step: NonZeroU32,
-    outcome: CdtScalarTraceOutcome,
+    payload: CdtScalarTracePayload,
     log_prob: f64,
     action: f64,
     vertices: NonZeroU32,
     edges: NonZeroU32,
     triangles: NonZeroU32,
     move_type: MoveType,
-    delta_action: Option<f64>,
     action_before: f64,
-    action_after: Option<f64>,
     seed: Option<u64>,
     volume_profile: Vec<u32>,
+}
+
+/// Outcome-specific scalar trace action evidence.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum CdtScalarTracePayload {
+    /// Accepted proposals must carry both post-move action and action delta.
+    Accepted {
+        delta_action: f64,
+        action_after: f64,
+    },
+    /// Rejected concrete proposals may carry a scored proposal delta.
+    RejectedProposal { delta_action: Option<f64> },
+    /// Local proposal absence carries no concrete action evidence.
+    NoProposal,
+}
+
+impl CdtScalarTracePayload {
+    const fn from_parts(
+        step: NonZeroU32,
+        outcome: CdtScalarTraceOutcome,
+        delta_action: Option<f64>,
+        action_after: Option<f64>,
+    ) -> CdtResult<Self> {
+        match (outcome, delta_action, action_after) {
+            (CdtScalarTraceOutcome::Accepted, Some(delta_action), Some(action_after)) => {
+                Ok(Self::Accepted {
+                    delta_action,
+                    action_after,
+                })
+            }
+            (CdtScalarTraceOutcome::Accepted, None, _)
+            | (CdtScalarTraceOutcome::NoProposal, Some(_), _) => Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::ScalarTraceDeltaActionMismatch { step: step.get() },
+            )),
+            (CdtScalarTraceOutcome::Accepted, Some(_), None)
+            | (CdtScalarTraceOutcome::RejectedProposal, _, Some(_))
+            | (CdtScalarTraceOutcome::NoProposal, None, Some(_)) => Err(checkpoint_resume_failed(
+                CheckpointResumeFailure::ScalarTraceActionAfterMismatch { step: step.get() },
+            )),
+            (CdtScalarTraceOutcome::RejectedProposal, delta_action, None) => {
+                Ok(Self::RejectedProposal { delta_action })
+            }
+            (CdtScalarTraceOutcome::NoProposal, None, None) => Ok(Self::NoProposal),
+        }
+    }
+
+    const fn outcome(self) -> CdtScalarTraceOutcome {
+        match self {
+            Self::Accepted { .. } => CdtScalarTraceOutcome::Accepted,
+            Self::RejectedProposal { .. } => CdtScalarTraceOutcome::RejectedProposal,
+            Self::NoProposal => CdtScalarTraceOutcome::NoProposal,
+        }
+    }
+
+    const fn delta_action(self) -> Option<f64> {
+        match self {
+            Self::Accepted { delta_action, .. } => Some(delta_action),
+            Self::RejectedProposal { delta_action } => delta_action,
+            Self::NoProposal => None,
+        }
+    }
+
+    const fn action_after(self) -> Option<f64> {
+        match self {
+            Self::Accepted { action_after, .. } => Some(action_after),
+            Self::RejectedProposal { .. } | Self::NoProposal => None,
+        }
+    }
 }
 
 /// Raw scalar trace shape used only while deserializing result and checkpoint payloads.
@@ -159,19 +226,23 @@ impl TryFrom<CdtScalarTraceRowWire> for CdtScalarTraceRow {
         let edges = nonzero_scalar_trace_count(MeasurementCountField::Edges, wire.edges)?;
         let triangles =
             nonzero_scalar_trace_count(MeasurementCountField::Triangles, wire.triangles)?;
+        let payload = CdtScalarTracePayload::from_parts(
+            step,
+            wire.outcome,
+            wire.delta_action,
+            wire.action_after,
+        )?;
         validate_scalar_trace_volume_profile(step, triangles, &wire.volume_profile)?;
         let row = Self {
             step,
-            outcome: wire.outcome,
+            payload,
             log_prob: wire.log_prob,
             action: wire.action,
             vertices,
             edges,
             triangles,
             move_type: wire.move_type,
-            delta_action: wire.delta_action,
             action_before: wire.action_before,
-            action_after: wire.action_after,
             seed: wire.seed,
             volume_profile: wire.volume_profile,
         };
@@ -188,6 +259,29 @@ impl<'de> Deserialize<'de> for CdtScalarTraceRow {
         CdtScalarTraceRowWire::deserialize(deserializer)?
             .try_into()
             .map_err(DeError::custom)
+    }
+}
+
+impl Serialize for CdtScalarTraceRow {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("CdtScalarTraceRow", 13)?;
+        state.serialize_field("step", &self.step)?;
+        state.serialize_field("outcome", &self.payload.outcome())?;
+        state.serialize_field("log_prob", &self.log_prob)?;
+        state.serialize_field("action", &self.action)?;
+        state.serialize_field("vertices", &self.vertices)?;
+        state.serialize_field("edges", &self.edges)?;
+        state.serialize_field("triangles", &self.triangles)?;
+        state.serialize_field("move_type", &self.move_type)?;
+        state.serialize_field("delta_action", &self.payload.delta_action())?;
+        state.serialize_field("action_before", &self.action_before)?;
+        state.serialize_field("action_after", &self.payload.action_after())?;
+        state.serialize_field("seed", &self.seed)?;
+        state.serialize_field("volume_profile", &self.volume_profile)?;
+        state.end()
     }
 }
 
@@ -218,9 +312,10 @@ impl CdtScalarTraceRow {
         seed: Option<u64>,
     ) -> CdtResult<Self> {
         let counts = triangulation.simplex_counts()?;
+        let payload = CdtScalarTracePayload::from_parts(step, outcome, delta_action, action_after)?;
         let row = Self {
             step,
-            outcome,
+            payload,
             log_prob,
             action,
             vertices: nonzero_usize_measurement_count(
@@ -236,11 +331,9 @@ impl CdtScalarTraceRow {
                 counts.triangle_count(),
             )?,
             move_type,
-            delta_action,
             action_before,
-            action_after,
             seed,
-            volume_profile: triangulation.volume_profile(),
+            volume_profile: triangulation.volume_profile()?,
         };
         validate_scalar_trace_finite_fields(&row)?;
         Ok(row)
@@ -248,12 +341,14 @@ impl CdtScalarTraceRow {
 
     /// Converts the stored CDT outcome into the upstream trace outcome.
     const fn outcome(&self) -> TraceStepOutcome {
-        self.outcome.into_trace_outcome()
+        self.payload.outcome().into_trace_outcome()
     }
 
     /// Returns observable values in scalar trace observable order.
     fn observable_values(&self, volume_profile_len: usize) -> Vec<f64> {
         let (seed_low, seed_high, seed_present) = seed_observables(self.seed);
+        let delta_action = self.payload.delta_action();
+        let action_after = self.payload.action_after();
         let mut values =
             Vec::with_capacity(SCALAR_TRACE_BASE_OBSERVABLES.len() + volume_profile_len);
         values.extend([
@@ -262,11 +357,11 @@ impl CdtScalarTraceRow {
             f64::from(self.edges.get()),
             f64::from(self.triangles.get()),
             f64::from(move_type_code(self.move_type)),
-            self.delta_action.unwrap_or(0.0),
-            option_presence(self.delta_action),
+            delta_action.unwrap_or(0.0),
+            option_presence(delta_action),
             self.action_before,
-            self.action_after.unwrap_or(0.0),
-            option_presence(self.action_after),
+            action_after.unwrap_or(0.0),
+            option_presence(action_after),
             seed_low,
             seed_high,
             seed_present,
@@ -385,36 +480,98 @@ impl Measurement {
     }
 
     /// Returns the Monte Carlo step when this measurement was taken.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::Measurement;
+    ///
+    /// let measurement = Measurement::try_new(10, -12.5, 64, 180, 117)?;
+    /// assert_eq!(measurement.step(), 10);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
     #[must_use]
     pub const fn step(&self) -> u32 {
         self.step
     }
 
     /// Returns the finite action value recorded at this measurement.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use causal_triangulations::prelude::simulation::Measurement;
+    ///
+    /// let measurement = Measurement::try_new(10, -12.5, 64, 180, 117)?;
+    /// assert_relative_eq!(measurement.action(), -12.5);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
     #[must_use]
     pub const fn action(&self) -> f64 {
         self.action
     }
 
     /// Returns the nonzero vertex count.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::Measurement;
+    ///
+    /// let measurement = Measurement::try_new(10, -12.5, 64, 180, 117)?;
+    /// assert_eq!(measurement.vertices().get(), 64);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
     #[must_use]
     pub const fn vertices(&self) -> NonZeroU32 {
         self.vertices
     }
 
     /// Returns the nonzero edge count.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::Measurement;
+    ///
+    /// let measurement = Measurement::try_new(10, -12.5, 64, 180, 117)?;
+    /// assert_eq!(measurement.edges().get(), 180);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
     #[must_use]
     pub const fn edges(&self) -> NonZeroU32 {
         self.edges
     }
 
     /// Returns the nonzero triangle count.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::Measurement;
+    ///
+    /// let measurement = Measurement::try_new(10, -12.5, 64, 180, 117)?;
+    /// assert_eq!(measurement.triangles().get(), 117);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
     #[must_use]
     pub const fn triangles(&self) -> NonZeroU32 {
         self.triangles
     }
 
     /// Returns per-slice triangle counts `N₂(t)` by time slab.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::Measurement;
+    ///
+    /// let measurement =
+    ///     Measurement::try_new(10, -12.5, 64, 180, 117)?.try_with_volume_profile(vec![39, 39, 39])?;
+    /// assert_eq!(measurement.volume_profile(), &[39, 39, 39]);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
     #[must_use]
     pub fn volume_profile(&self) -> &[u32] {
         &self.volume_profile
@@ -633,15 +790,57 @@ struct SimulationResultsBackendWire {
 
 /// Validated components for constructing a simulation result snapshot.
 pub(crate) struct SimulationResultsParts {
-    pub(crate) config: MetropolisConfig,
-    pub(crate) action_config: ActionConfig,
-    pub(crate) move_stats: MoveStatistics,
-    pub(crate) proposal_stats: ProposalStatistics,
-    pub(crate) steps: Vec<MonteCarloStep>,
-    pub(crate) measurements: Vec<Measurement>,
-    pub(crate) scalar_trace_rows: Vec<CdtScalarTraceRow>,
-    pub(crate) elapsed_time: Duration,
-    pub(crate) triangulation: CdtTriangulation2D,
+    config: MetropolisConfig,
+    action_config: ActionConfig,
+    move_stats: MoveStatistics,
+    proposal_stats: ProposalStatistics,
+    steps: Vec<MonteCarloStep>,
+    measurements: Vec<Measurement>,
+    scalar_trace_rows: Vec<CdtScalarTraceRow>,
+    elapsed_time: Duration,
+    triangulation: CdtTriangulation2D,
+}
+
+impl SimulationResultsParts {
+    /// Parses raw result components into a validated result-parts proof.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "result snapshots are assembled from independent telemetry streams"
+    )]
+    pub(crate) fn new(
+        config: MetropolisConfig,
+        action_config: ActionConfig,
+        move_stats: MoveStatistics,
+        proposal_stats: ProposalStatistics,
+        steps: Vec<MonteCarloStep>,
+        measurements: Vec<Measurement>,
+        scalar_trace_rows: Vec<CdtScalarTraceRow>,
+        elapsed_time: Duration,
+        triangulation: CdtTriangulation2D,
+    ) -> CdtResult<Self> {
+        config.validate();
+        action_config.validate();
+        triangulation.validate_evolved_cdt()?;
+        validate_result_telemetry(
+            &config,
+            &move_stats,
+            &proposal_stats,
+            &steps,
+            &measurements,
+            &scalar_trace_rows,
+        )?;
+        Ok(Self {
+            config,
+            action_config,
+            move_stats,
+            proposal_stats,
+            steps,
+            measurements,
+            scalar_trace_rows,
+            elapsed_time,
+            triangulation,
+        })
+    }
 }
 
 impl TryFrom<SimulationResultsBackendWire> for SimulationResultsBackend {
@@ -920,7 +1119,7 @@ pub(crate) fn validate_scalar_trace_rows(
     let mut no_proposal = 0_u64;
     for (step, row) in steps.iter().zip(scalar_trace_rows) {
         validate_scalar_trace_row(config, step, row)?;
-        match row.outcome {
+        match row.payload.outcome() {
             CdtScalarTraceOutcome::Accepted => accepted = accepted.saturating_add(1),
             CdtScalarTraceOutcome::RejectedProposal => {
                 rejected_proposal = rejected_proposal.saturating_add(1);
@@ -984,11 +1183,11 @@ fn validate_scalar_trace_row(
         ));
     }
     let expected_outcome = scalar_trace_outcome_from_step(step);
-    if row.outcome != expected_outcome {
+    if row.payload.outcome() != expected_outcome {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::ScalarTraceAcceptedMismatch {
                 step: step_number,
-                actual: row.outcome.accepted(),
+                actual: row.payload.outcome().accepted(),
                 expected: expected_outcome.accepted(),
             },
         ));
@@ -1007,12 +1206,12 @@ fn validate_scalar_trace_row(
             CheckpointResumeFailure::ScalarTraceActionBeforeMismatch { step: step_number },
         ));
     }
-    if !optional_actions_match(row.delta_action, step.delta_action()) {
+    if !optional_actions_match(row.payload.delta_action(), step.delta_action()) {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::ScalarTraceDeltaActionMismatch { step: step_number },
         ));
     }
-    if !optional_actions_match(row.action_after, step.action_after()) {
+    if !optional_actions_match(row.payload.action_after(), step.action_after()) {
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::ScalarTraceActionAfterMismatch { step: step_number },
         ));
@@ -1045,10 +1244,10 @@ fn validate_scalar_trace_finite_fields(row: &CdtScalarTraceRow) -> CdtResult<()>
     validate_scalar_trace_finite(row.step, ScalarTraceField::LogProb, row.log_prob)?;
     validate_scalar_trace_finite(row.step, ScalarTraceField::Action, row.action)?;
     validate_scalar_trace_finite(row.step, ScalarTraceField::ActionBefore, row.action_before)?;
-    if let Some(delta_action) = row.delta_action {
+    if let Some(delta_action) = row.payload.delta_action() {
         validate_scalar_trace_finite(row.step, ScalarTraceField::DeltaAction, delta_action)?;
     }
-    if let Some(action_after) = row.action_after {
+    if let Some(action_after) = row.payload.action_after() {
         validate_scalar_trace_finite(row.step, ScalarTraceField::ActionAfter, action_after)?;
     }
     Ok(())
@@ -1206,18 +1405,7 @@ impl SimulationResultsBackend {
         elapsed_time: Duration,
         triangulation: CdtTriangulation2D,
     ) -> CdtResult<Self> {
-        config.validate();
-        action_config.validate();
-        triangulation.validate_evolved_cdt()?;
-        validate_result_telemetry(
-            &config,
-            &move_stats,
-            &proposal_stats,
-            &steps,
-            &measurements,
-            &scalar_trace_rows,
-        )?;
-        Ok(Self::from_parts(SimulationResultsParts {
+        Ok(Self::from_parts(SimulationResultsParts::new(
             config,
             action_config,
             move_stats,
@@ -1227,7 +1415,7 @@ impl SimulationResultsBackend {
             scalar_trace_rows,
             elapsed_time,
             triangulation,
-        }))
+        )?))
     }
 
     /// Creates a result snapshot from components that were already validated by this crate.
@@ -1704,6 +1892,12 @@ impl SimulationResultsBackend {
     /// triangulation snapshots in [`Measurement`] or rerunning the chain.
     /// For ensemble-style recorded data, see [`Self::average_volume_profile`].
     ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::ValidationFailed`] if the final triangulation's
+    /// backend face adjacency cannot be resolved or if observable counters cannot
+    /// be represented as finite fitting inputs.
+    ///
     /// # Examples
     ///
     /// ```
@@ -1718,13 +1912,12 @@ impl SimulationResultsBackend {
     ///     )
     ///     .run(CdtTriangulation::from_cdt_strip(4, 3)?)?;
     ///     assert!(results
-    ///         .hausdorff_dimension_estimate()
+    ///         .hausdorff_dimension_estimate()?
     ///         .is_some_and(f64::is_finite));
     ///     Ok(())
     /// }
     /// ```
-    #[must_use]
-    pub fn hausdorff_dimension_estimate(&self) -> Option<f64> {
+    pub fn hausdorff_dimension_estimate(&self) -> CdtResult<Option<f64>> {
         estimate_hausdorff_dimension(&self.triangulation)
     }
 
@@ -1737,6 +1930,12 @@ impl SimulationResultsBackend {
     /// require storing triangulation snapshots in [`Measurement`] or rerunning
     /// the chain. For ensemble-style recorded data, see
     /// [`Self::average_volume_profile`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::ValidationFailed`] if the final triangulation's
+    /// backend face adjacency cannot be resolved or if observable counters cannot
+    /// be represented as finite fitting inputs.
     ///
     /// # Examples
     ///
@@ -1752,13 +1951,12 @@ impl SimulationResultsBackend {
     ///     )
     ///     .run(CdtTriangulation::from_toroidal_cdt(6, 6)?)?;
     ///     assert!(results
-    ///         .spectral_dimension_estimate()
+    ///         .spectral_dimension_estimate()?
     ///         .is_some_and(f64::is_finite));
     ///     Ok(())
     /// }
     /// ```
-    #[must_use]
-    pub fn spectral_dimension_estimate(&self) -> Option<f64> {
+    pub fn spectral_dimension_estimate(&self) -> CdtResult<Option<f64>> {
         estimate_spectral_dimension(&self.triangulation)
     }
 
@@ -2458,9 +2656,9 @@ mod tests {
                 0.0,
                 &triangulation,
                 MoveType::Move22,
-                None,
+                Some(0.0),
                 0.0,
-                None,
+                Some(0.0),
                 config.seed(),
             )
             .expect("trace row should build"),
@@ -2873,13 +3071,78 @@ mod tests {
     }
 
     #[test]
+    fn scalar_trace_row_rejects_outcome_payload_mismatch_before_storage() {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
+        let cases = [
+            (
+                CdtScalarTraceOutcome::Accepted,
+                None,
+                Some(4.0),
+                CheckpointResumeFailure::ScalarTraceDeltaActionMismatch { step: 1 },
+            ),
+            (
+                CdtScalarTraceOutcome::Accepted,
+                Some(0.0),
+                None,
+                CheckpointResumeFailure::ScalarTraceActionAfterMismatch { step: 1 },
+            ),
+            (
+                CdtScalarTraceOutcome::RejectedProposal,
+                Some(0.0),
+                Some(4.0),
+                CheckpointResumeFailure::ScalarTraceActionAfterMismatch { step: 1 },
+            ),
+            (
+                CdtScalarTraceOutcome::NoProposal,
+                Some(0.0),
+                None,
+                CheckpointResumeFailure::ScalarTraceDeltaActionMismatch { step: 1 },
+            ),
+            (
+                CdtScalarTraceOutcome::NoProposal,
+                None,
+                Some(4.0),
+                CheckpointResumeFailure::ScalarTraceActionAfterMismatch { step: 1 },
+            ),
+        ];
+
+        for (outcome, delta_action, action_after, expected) in cases {
+            let error = CdtScalarTraceRow::new(
+                step_number(1),
+                outcome,
+                -4.0,
+                4.0,
+                &triangulation,
+                MoveType::Move22,
+                delta_action,
+                4.0,
+                action_after,
+                None,
+            )
+            .expect_err("scalar trace rows should reject mismatched outcome payloads");
+
+            assert_checkpoint_resume_failure(&error, &expected);
+        }
+    }
+
+    #[test]
     fn scalar_trace_row_rejects_nonfinite_numeric_fields_before_storage() {
         let triangulation =
             CdtTriangulation::from_cdt_strip(4, 3).expect("Delaunay strip should build");
         let cases = [
-            (ScalarTraceField::LogProb, f64::NAN, 0.0, None, 0.0, None),
+            (
+                ScalarTraceField::LogProb,
+                CdtScalarTraceOutcome::RejectedProposal,
+                f64::NAN,
+                0.0,
+                None,
+                0.0,
+                None,
+            ),
             (
                 ScalarTraceField::Action,
+                CdtScalarTraceOutcome::RejectedProposal,
                 -0.0,
                 f64::INFINITY,
                 None,
@@ -2888,6 +3151,7 @@ mod tests {
             ),
             (
                 ScalarTraceField::ActionBefore,
+                CdtScalarTraceOutcome::RejectedProposal,
                 -0.0,
                 0.0,
                 None,
@@ -2896,6 +3160,7 @@ mod tests {
             ),
             (
                 ScalarTraceField::DeltaAction,
+                CdtScalarTraceOutcome::RejectedProposal,
                 -0.0,
                 0.0,
                 Some(f64::NAN),
@@ -2904,18 +3169,28 @@ mod tests {
             ),
             (
                 ScalarTraceField::ActionAfter,
+                CdtScalarTraceOutcome::Accepted,
                 -0.0,
                 0.0,
-                None,
+                Some(0.0),
                 0.0,
                 Some(f64::INFINITY),
             ),
         ];
 
-        for (expected_field, log_prob, action, delta_action, action_before, action_after) in cases {
+        for (
+            expected_field,
+            outcome,
+            log_prob,
+            action,
+            delta_action,
+            action_before,
+            action_after,
+        ) in cases
+        {
             let error = CdtScalarTraceRow::new(
                 step_number(1),
-                CdtScalarTraceOutcome::RejectedProposal,
+                outcome,
                 log_prob,
                 action,
                 &triangulation,
@@ -3614,12 +3889,18 @@ mod tests {
         );
 
         assert_optional_relative_eq(
-            results.hausdorff_dimension_estimate(),
-            estimate_hausdorff_dimension(results.triangulation()),
+            results
+                .hausdorff_dimension_estimate()
+                .expect("result triangulation adjacency should be readable"),
+            estimate_hausdorff_dimension(results.triangulation())
+                .expect("result triangulation adjacency should be readable"),
         );
         assert_optional_relative_eq(
-            results.spectral_dimension_estimate(),
-            estimate_spectral_dimension(results.triangulation()),
+            results
+                .spectral_dimension_estimate()
+                .expect("result triangulation adjacency should be readable"),
+            estimate_spectral_dimension(results.triangulation())
+                .expect("result triangulation adjacency should be readable"),
         );
     }
 
@@ -3634,7 +3915,17 @@ mod tests {
             triangulation,
         );
 
-        assert!(results.hausdorff_dimension_estimate().is_none());
-        assert!(results.spectral_dimension_estimate().is_none());
+        assert!(
+            results
+                .hausdorff_dimension_estimate()
+                .expect("tiny triangulation adjacency should be readable")
+                .is_none()
+        );
+        assert!(
+            results
+                .spectral_dimension_estimate()
+                .expect("tiny triangulation adjacency should be readable")
+                .is_none()
+        );
     }
 }

--- a/src/cdt/results.rs
+++ b/src/cdt/results.rs
@@ -86,7 +86,7 @@ const CDT_TRACE_CHAIN_ID: ChainId = ChainId::new(0);
 
 /// Invariant-bearing CDT trace outcome stored in serialized result/checkpoint rows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum CdtScalarTraceOutcome {
+pub enum CdtScalarTraceOutcome {
     /// A concrete proposal was accepted and committed.
     Accepted,
     /// A concrete proposal was rejected by Metropolis-Hastings.
@@ -103,11 +103,6 @@ impl CdtScalarTraceOutcome {
             Self::RejectedProposal => TraceStepOutcome::rejected_proposal(),
             Self::NoProposal => TraceStepOutcome::no_proposal(),
         }
-    }
-
-    /// Whether this row records an accepted proposal.
-    pub(crate) const fn accepted(self) -> bool {
-        matches!(self, Self::Accepted)
     }
 }
 
@@ -1187,8 +1182,8 @@ fn validate_scalar_trace_row(
         return Err(checkpoint_resume_failed(
             CheckpointResumeFailure::ScalarTraceAcceptedMismatch {
                 step: step_number,
-                actual: row.payload.outcome().accepted(),
-                expected: expected_outcome.accepted(),
+                actual: row.payload.outcome(),
+                expected: expected_outcome,
             },
         ));
     }
@@ -2685,8 +2680,8 @@ mod tests {
             CdtError::CheckpointResumeFailed {
                 failure: CheckpointResumeFailure::ScalarTraceAcceptedMismatch {
                     step: 1,
-                    actual: true,
-                    expected: false
+                    actual: CdtScalarTraceOutcome::Accepted,
+                    expected: CdtScalarTraceOutcome::NoProposal
                 }
             }
         );

--- a/src/cdt/triangulation/builders.rs
+++ b/src/cdt/triangulation/builders.rs
@@ -1562,7 +1562,12 @@ mod tests {
         assert_eq!(tri.vertex_count(), 15);
         assert_eq!(tri.face_count(), 17);
         assert_eq!(tri.slice_sizes(), &[4, 6, 5]);
-        assert_eq!(tri.volume_profile().len(), 3);
+        assert_eq!(
+            tri.volume_profile()
+                .expect("nonuniform strip profile should be valid")
+                .len(),
+            3
+        );
         assert!(tri.validate_topology().is_ok());
         assert!(tri.validate_foliation().is_ok());
         assert!(tri.validate_causality_delaunay().is_ok());

--- a/src/cdt/triangulation/foliation.rs
+++ b/src/cdt/triangulation/foliation.rs
@@ -1473,4 +1473,38 @@ mod tests {
         assert_eq!(profile, vec![8, 8, 8]);
         assert_eq!(profile.iter().sum::<u32>(), 24);
     }
+
+    #[test]
+    fn volume_profile_is_empty_without_current_foliation() {
+        let triangulation =
+            CdtTriangulation::from_random_points(5, 3, 2).expect("create unfoliated triangulation");
+
+        assert!(
+            triangulation
+                .volume_profile()
+                .expect("missing foliation should not fail")
+                .is_empty()
+        );
+
+        let mut triangulation = strict_strip(4, 2);
+        let vertex = triangulation
+            .geometry()
+            .vertices()
+            .next()
+            .expect("strip should contain vertices");
+        let label = triangulation
+            .geometry()
+            .vertex_data_by_key(vertex.vertex_key())
+            .expect("strip vertices should be labeled");
+        triangulation
+            .set_vertex_data(&vertex, Some(label))
+            .expect("label rewrite should stale foliation bookkeeping");
+
+        assert!(
+            triangulation
+                .volume_profile()
+                .expect("stale foliation should not fail")
+                .is_empty()
+        );
+    }
 }

--- a/src/cdt/triangulation/foliation.rs
+++ b/src/cdt/triangulation/foliation.rs
@@ -7,7 +7,7 @@ use crate::cdt::foliation::{EdgeType, Foliation, FoliationError, SimplexType, cl
 use crate::config::CdtTopology;
 use crate::errors::{
     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
-    TriangulationMetadataField,
+    MeasurementCountField, TriangulationMetadataField,
 };
 use crate::geometry::DelaunayBackend2D;
 use crate::geometry::backends::delaunay::{
@@ -576,6 +576,12 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// future slice exists; toroidal triangulations wrap the last slab back to
     /// slice zero.
     ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::MeasurementCountOverflow`] if any per-slice triangle
+    /// count exceeds the compact `u32` storage used by measurements and scalar
+    /// traces.
+    ///
     /// # Examples
     ///
     /// ```
@@ -583,18 +589,17 @@ impl CdtTriangulation<DelaunayBackend2D> {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    ///     assert_eq!(tri.volume_profile(), vec![6, 6, 0]);
+    ///     assert_eq!(tri.volume_profile()?, vec![6, 6, 0]);
     ///     Ok(())
     /// }
     /// ```
-    #[must_use]
-    pub fn volume_profile(&self) -> Vec<u32> {
+    pub fn volume_profile(&self) -> CdtResult<Vec<u32>> {
         if !self.has_current_foliation() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
         let Ok(slice_count) = usize::try_from(self.metadata.time_slices.get()) else {
-            return Vec::new();
+            return Ok(Vec::new());
         };
         let mut profile = vec![0_u32; slice_count];
 
@@ -606,11 +611,13 @@ impl CdtTriangulation<DelaunayBackend2D> {
                 continue;
             };
             if let Some(count) = profile.get_mut(index) {
-                *count = count.saturating_add(1);
+                *count = count
+                    .checked_add(1)
+                    .ok_or_else(volume_profile_count_overflow)?;
             }
         }
 
-        profile
+        Ok(profile)
     }
 
     /// Computes the temporal step distance between two time labels.
@@ -1027,6 +1034,15 @@ impl CdtTriangulation<DelaunayBackend2D> {
                 Err(err)
             }
         }
+    }
+}
+
+/// Builds the typed measurement overflow reported by [`CdtTriangulation::volume_profile`].
+fn volume_profile_count_overflow() -> CdtError {
+    CdtError::MeasurementCountOverflow {
+        field: MeasurementCountField::Triangles,
+        provided_value: usize::try_from(u32::MAX).map_or(usize::MAX, |max| max.saturating_add(1)),
+        max: u32::MAX,
     }
 }
 
@@ -1450,7 +1466,9 @@ mod tests {
     fn volume_profile_counts_temporal_wrap_slab() {
         let tri = CdtTriangulation::from_toroidal_cdt(4, 3).expect("build toroidal CDT");
 
-        let profile = tri.volume_profile();
+        let profile = tri
+            .volume_profile()
+            .expect("toroidal CDT should have a valid volume profile");
 
         assert_eq!(profile, vec![8, 8, 8]);
         assert_eq!(profile.iter().sum::<u32>(), 24);

--- a/src/cdt/triangulation/state.rs
+++ b/src/cdt/triangulation/state.rs
@@ -797,8 +797,10 @@ impl<B> CdtTriangulation<B> {
         self.invalidate_foliation_bookkeeping();
         self.metadata.last_modified = Instant::now();
         // Deserialized checkpoints can carry arbitrary counters; avoid wraparound
-        // so cache keys such as MoveSiteCache never see a stale version as fresh.
+        // and rotate the instance epoch so external caches keyed by
+        // `(instance_id, modification_count)` cannot see a stale version as fresh.
         if self.metadata.modification_count == u64::MAX {
+            self.instance_id = next_triangulation_instance_id();
             self.metadata.modification_count = 1;
         } else {
             self.metadata.modification_count += 1;
@@ -1736,8 +1738,14 @@ mod tests {
         assert_eq!(triangulation.metadata().modification_count, 2);
 
         triangulation.metadata.modification_count = u64::MAX;
+        let saturated_instance_id = triangulation.instance_id();
         triangulation.bump_modification_count();
         assert_eq!(triangulation.metadata().modification_count, 1);
+        assert_ne!(
+            triangulation.instance_id(),
+            saturated_instance_id,
+            "saturated modification counters must rotate instance epochs so external caches cannot collide"
+        );
     }
 
     #[test]

--- a/src/cdt/triangulation/state.rs
+++ b/src/cdt/triangulation/state.rs
@@ -119,36 +119,96 @@ impl CdtSimplexCounts {
     }
 
     /// Returns the nonzero vertex count.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::CdtSimplexCounts;
+    ///
+    /// let counts = CdtSimplexCounts::try_new(3, 3, 1)?;
+    /// assert_eq!(counts.vertices().get(), 3);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
     #[must_use]
     pub const fn vertices(&self) -> NonZeroUsize {
         self.vertices
     }
 
     /// Returns the nonzero edge count.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::CdtSimplexCounts;
+    ///
+    /// let counts = CdtSimplexCounts::try_new(3, 3, 1)?;
+    /// assert_eq!(counts.edges().get(), 3);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
     #[must_use]
     pub const fn edges(&self) -> NonZeroUsize {
         self.edges
     }
 
     /// Returns the nonzero triangle count.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::CdtSimplexCounts;
+    ///
+    /// let counts = CdtSimplexCounts::try_new(3, 3, 1)?;
+    /// assert_eq!(counts.triangles().get(), 1);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
     #[must_use]
     pub const fn triangles(&self) -> NonZeroUsize {
         self.triangles
     }
 
     /// Returns the vertex count as a raw `usize` for collection-style APIs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::CdtSimplexCounts;
+    ///
+    /// let counts = CdtSimplexCounts::try_new(3, 3, 1)?;
+    /// assert_eq!(counts.vertex_count(), 3);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
     #[must_use]
     pub const fn vertex_count(&self) -> usize {
         self.vertices.get()
     }
 
     /// Returns the edge count as a raw `usize` for collection-style APIs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::CdtSimplexCounts;
+    ///
+    /// let counts = CdtSimplexCounts::try_new(3, 3, 1)?;
+    /// assert_eq!(counts.edge_count(), 3);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
     #[must_use]
     pub const fn edge_count(&self) -> usize {
         self.edges.get()
     }
 
     /// Returns the triangle count as a raw `usize` for collection-style APIs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::CdtSimplexCounts;
+    ///
+    /// let counts = CdtSimplexCounts::try_new(3, 3, 1)?;
+    /// assert_eq!(counts.triangle_count(), 1);
+    /// # Ok::<(), causal_triangulations::prelude::errors::CdtError>(())
+    /// ```
     #[must_use]
     pub const fn triangle_count(&self) -> usize {
         self.triangles.get()
@@ -218,9 +278,8 @@ impl CdtMetadata {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
-    /// use causal_triangulations::geometry::backends::mock::MockBackend;
-    /// use causal_triangulations::prelude::errors::CdtResult;
+    /// use causal_triangulations::prelude::testing::*;
+    /// use causal_triangulations::prelude::triangulation::*;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
@@ -238,9 +297,8 @@ impl CdtMetadata {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
-    /// use causal_triangulations::geometry::backends::mock::MockBackend;
-    /// use causal_triangulations::prelude::errors::CdtResult;
+    /// use causal_triangulations::prelude::testing::*;
+    /// use causal_triangulations::prelude::triangulation::*;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
@@ -258,10 +316,8 @@ impl CdtMetadata {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
-    /// use causal_triangulations::config::CdtTopology;
-    /// use causal_triangulations::geometry::backends::mock::MockBackend;
-    /// use causal_triangulations::prelude::errors::CdtResult;
+    /// use causal_triangulations::prelude::testing::*;
+    /// use causal_triangulations::prelude::triangulation::*;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
@@ -279,9 +335,8 @@ impl CdtMetadata {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
-    /// use causal_triangulations::geometry::backends::mock::MockBackend;
-    /// use causal_triangulations::prelude::errors::CdtResult;
+    /// use causal_triangulations::prelude::testing::*;
+    /// use causal_triangulations::prelude::triangulation::*;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
@@ -299,9 +354,8 @@ impl CdtMetadata {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
-    /// use causal_triangulations::geometry::backends::mock::MockBackend;
-    /// use causal_triangulations::prelude::errors::CdtResult;
+    /// use causal_triangulations::prelude::testing::*;
+    /// use causal_triangulations::prelude::triangulation::*;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
@@ -319,9 +373,8 @@ impl CdtMetadata {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
-    /// use causal_triangulations::geometry::backends::mock::MockBackend;
-    /// use causal_triangulations::prelude::errors::CdtResult;
+    /// use causal_triangulations::prelude::testing::*;
+    /// use causal_triangulations::prelude::triangulation::*;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
@@ -339,9 +392,8 @@ impl CdtMetadata {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::cdt::triangulation::CdtTriangulation;
-    /// use causal_triangulations::geometry::backends::mock::MockBackend;
-    /// use causal_triangulations::prelude::errors::CdtResult;
+    /// use causal_triangulations::prelude::testing::*;
+    /// use causal_triangulations::prelude::triangulation::*;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::try_new(MockBackend::create_triangle(), 2, 2)?;
@@ -825,9 +877,9 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use causal_triangulations::{CdtError, CdtResult};
     /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
@@ -852,10 +904,10 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// ```
     ///
     /// ```rust
-    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::errors::TriangulationMetadataField;
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use causal_triangulations::{CdtError, CdtResult};
     /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
@@ -890,10 +942,10 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     /// ```
     ///
     /// ```rust
-    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::errors::TriangulationMetadataField;
     /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::prelude::triangulation::*;
+    /// use causal_triangulations::{CdtError, CdtResult};
     /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -991,16 +991,16 @@ impl CdtConfig {
                     total.checked_add(vertices).ok_or_else(|| {
                         invalid_config(
                             ConfigurationSetting::Vertices,
-                            &format!("{profile:?}"),
-                            &"volume profile sum <= u32::MAX",
+                            format!("{profile:?}"),
+                            "volume profile sum <= u32::MAX",
                         )
                     })
                 })?;
                 let profile_timeslices = u32::try_from(profile.len()).map_err(|err| {
                     invalid_config(
                         ConfigurationSetting::Timeslices,
-                        &profile.len(),
-                        &format!("volume profile length must fit in u32: {err}"),
+                        profile.len(),
+                        format!("volume profile length must fit in u32: {err}"),
                     )
                 })?;
 
@@ -1160,8 +1160,8 @@ fn normalize_components(path: &Path) -> PathBuf {
 /// Builds a typed configuration error from displayable values without duplicating field names.
 fn invalid_config(
     setting: ConfigurationSetting,
-    provided_value: &impl Display,
-    expected: &impl Display,
+    provided_value: impl Display,
+    expected: impl Display,
 ) -> CdtError {
     invalid_config_parts(setting, provided_value.to_string(), expected.to_string())
 }
@@ -1197,7 +1197,7 @@ fn validate_coupling(setting: ConfigurationSetting, value: f64) -> CdtResult<()>
     if value.is_finite() {
         Ok(())
     } else {
-        Err(invalid_config(setting, &value, &"finite"))
+        Err(invalid_config(setting, value, "finite"))
     }
 }
 
@@ -1207,7 +1207,7 @@ fn validate_coupling(setting: ConfigurationSetting, value: f64) -> CdtResult<()>
 /// downstream callers can preserve nonzero proof instead of rechecking raw
 /// counts.
 fn nonzero_config_count(setting: ConfigurationSetting, value: u32) -> CdtResult<NonZeroU32> {
-    NonZeroU32::new(value).ok_or_else(|| invalid_config(setting, &value, &"≥ 1"))
+    NonZeroU32::new(value).ok_or_else(|| invalid_config(setting, value, "≥ 1"))
 }
 
 /// Parses a comma-separated spatial volume profile from the CLI.
@@ -1466,23 +1466,23 @@ impl CdtConfig {
         if self.vertices < 3 {
             return Err(invalid_config(
                 ConfigurationSetting::Vertices,
-                &self.vertices,
-                &"≥ 3",
+                self.vertices,
+                "≥ 3",
             ));
         }
 
         if self.timeslices == 0 {
             return Err(invalid_config(
                 ConfigurationSetting::Timeslices,
-                &self.timeslices,
-                &"≥ 1",
+                self.timeslices,
+                "≥ 1",
             ));
         }
 
         if let Some(dim) = self.dimension
             && dim != 2
         {
-            return Err(invalid_config(ConfigurationSetting::Dimension, &dim, &"2"));
+            return Err(invalid_config(ConfigurationSetting::Dimension, dim, "2"));
         }
 
         validate_coupling(ConfigurationSetting::Coupling0, self.coupling_0)?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -916,6 +916,24 @@ pub enum CheckpointResumeFailure {
         /// Counter category that overflowed.
         counter: CheckpointMoveCounter,
     },
+    /// Serialized terminal move counters overflowed before they could be compared to attempts.
+    #[error("{move_type:?} accepted plus hard-failure counters exceed u64::MAX")]
+    MoveTerminalCounterOverflow {
+        /// Move type with overflowing terminal outcome telemetry.
+        move_type: MoveType,
+    },
+    /// Serialized accepted plus hard-failure move counters exceed attempted moves.
+    #[error(
+        "{move_type:?} accepted plus hard-failure counters ({terminal}) exceed attempted counter ({attempted})"
+    )]
+    MoveTerminalOutcomesExceedAttempted {
+        /// Move type with impossible terminal outcome telemetry.
+        move_type: MoveType,
+        /// Sum of accepted and hard-failure counters.
+        terminal: u64,
+        /// Attempted move counter.
+        attempted: u64,
+    },
     /// Resumable checkpoints cannot contain hard-failure move counters.
     #[error("{move_type:?} hard-failure move count must be zero in resumable checkpoints")]
     MoveHardFailures {
@@ -942,6 +960,27 @@ pub enum CheckpointResumeFailure {
     ProposalCounterOverflow {
         /// Proposal telemetry counter that could not fit in the target type.
         counter: ProposalTelemetryCounter,
+    },
+    /// Serialized terminal proposal outcome counters overflowed before validation.
+    #[error("proposal terminal outcome counters exceed u64::MAX")]
+    ProposalTerminalCounterOverflow,
+    /// Serialized proposal terminal outcomes do not partition selected move families.
+    #[error(
+        "proposal terminal outcomes ({terminal_outcomes}) do not match move-family proposals ({move_family_proposals})"
+    )]
+    ProposalTerminalOutcomeCountMismatch {
+        /// Sum of terminal proposal outcomes.
+        terminal_outcomes: u64,
+        /// Number of selected move-family proposals.
+        move_family_proposals: u64,
+    },
+    /// Serialized forward-site observations exist without any proposed move family.
+    #[error(
+        "observed forward-site count must be zero when no move families were proposed: got {observed_forward_sites}"
+    )]
+    ProposalForwardSitesWithoutMoveFamily {
+        /// Forward-site observations recorded in proposal telemetry.
+        observed_forward_sites: u64,
     },
     /// Resume-validated proposal telemetry cannot contain hard failures.
     #[error("proposal telemetry has {actual} hard failures; expected 0")]
@@ -972,6 +1011,12 @@ pub enum CheckpointResumeFailure {
         actual: u64,
         /// Expected rejected count from step telemetry.
         expected: u64,
+    },
+    /// Deserialized checkpoint step was zero before it could become a resumable position.
+    #[error("checkpoint current_step must be nonzero: got {actual}")]
+    CheckpointCurrentStepZero {
+        /// Raw checkpoint step value.
+        actual: u32,
     },
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,7 @@
 
 use crate::cdt::ergodic_moves::MoveType;
 use crate::cdt::foliation::FoliationError;
+use crate::cdt::results::CdtScalarTraceOutcome;
 use crate::config::CdtTopology;
 use markov_chain_monte_carlo::{McmcError, StepOutcome};
 use std::fmt;
@@ -794,15 +795,15 @@ pub enum CheckpointResumeFailure {
         /// Move type stored in step telemetry.
         expected: MoveType,
     },
-    /// Scalar trace accepted outcome disagrees with step telemetry.
-    #[error("step {step} scalar trace accepted mismatch: got {actual}, expected {expected}")]
+    /// Scalar trace outcome disagrees with step telemetry.
+    #[error("step {step} scalar trace outcome mismatch: got {actual:?}, expected {expected:?}")]
     ScalarTraceAcceptedMismatch {
         /// Step with invalid scalar trace telemetry.
         step: u32,
-        /// Accepted flag reconstructed from scalar trace outcome.
-        actual: bool,
-        /// Accepted flag stored in step telemetry.
-        expected: bool,
+        /// Outcome reconstructed from scalar trace telemetry.
+        actual: CdtScalarTraceOutcome,
+        /// Outcome reconstructed from step telemetry.
+        expected: CdtScalarTraceOutcome,
     },
     /// Scalar trace optional action delta disagrees with step telemetry.
     #[error("step {step} scalar trace delta_action does not match step telemetry")]

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -18,6 +18,7 @@ use delaunay::flips::BistellarFlips;
 use delaunay::geometry::kernel::AdaptiveKernel;
 use delaunay::geometry::point::Point;
 use delaunay::geometry::traits::coordinate::Coordinate;
+use delaunay::prelude::query::AdjacencyIndex;
 use delaunay::prelude::{DataType, VertexBuilder};
 use delaunay::tds::{EdgeKey, FacetHandle, SimplexKey, Tds, Vertex, VertexKey};
 use delaunay::topology::traits::{GlobalTopology, TopologyKind, ToroidalConstructionMode};
@@ -27,6 +28,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
 use std::fmt::{self, Display};
 use std::num::NonZeroUsize;
+use std::sync::RwLock;
 
 type DelaunayKernel = AdaptiveKernel<f64>;
 type RawTriangulation<VertexData, SimplexData, const D: usize> =
@@ -47,15 +49,35 @@ type RawVertex<VertexData, const D: usize> = Vertex<f64, VertexData, D>;
 /// Serde checkpoints store the upstream triangulation data structure plus its
 /// global topology and topology-guarantee metadata. Deserialization rebuilds
 /// transient backend caches, including the interior-facet lookup used for local
-/// 2D edge queries. Toroidal topology checkpoints must contain finite,
-/// strictly positive periods; invalid domains are rejected during
-/// deserialization before a backend can observe them.
-#[derive(Debug, Clone)]
+/// 2D edge queries. Vertex-adjacency caches are not serialized; they are rebuilt
+/// lazily by read-only adjacency queries and invalidated after topology
+/// mutations. Toroidal topology checkpoints must contain finite, strictly
+/// positive periods; invalid domains are rejected during deserialization before
+/// a backend can observe them.
+#[derive(Debug)]
 pub struct DelaunayBackend<VertexData, SimplexData, const D: usize> {
     /// The underlying Delaunay triangulation from the delaunay crate
     dt: RawTriangulation<VertexData, SimplexData, D>,
     /// Interior 2D edge to one incident facet suitable for k=2 local queries.
     interior_facets_by_edge: HashMap<EdgeKey, FacetHandle>,
+    /// Lazily built vertex/simplex adjacency for repeated read-only local queries.
+    adjacency_index: RwLock<Option<AdjacencyIndex>>,
+}
+
+impl<VertexData: DataType, SimplexData: DataType, const D: usize> Clone
+    for DelaunayBackend<VertexData, SimplexData, D>
+{
+    fn clone(&self) -> Self {
+        let adjacency_index = self
+            .adjacency_index
+            .read()
+            .map_or_else(|_| None, |index| index.clone());
+        Self {
+            dt: self.dt.clone(),
+            interior_facets_by_edge: self.interior_facets_by_edge.clone(),
+            adjacency_index: RwLock::new(adjacency_index),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -554,6 +576,60 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
         self.interior_facets_by_edge = Self::build_interior_facets_by_edge(&self.dt);
     }
 
+    /// Drops query caches tied to the current raw triangulation snapshot.
+    fn invalidate_query_caches(&mut self) {
+        match self.adjacency_index.get_mut() {
+            Ok(index) => *index = None,
+            Err(poisoned) => *poisoned.into_inner() = None,
+        }
+    }
+
+    /// Restores the raw triangulation and all caches to a saved snapshot.
+    fn restore_mutation_snapshot(
+        &mut self,
+        dt_before: RawTriangulation<VertexData, SimplexData, D>,
+        facets_before: HashMap<EdgeKey, FacetHandle>,
+    ) {
+        self.dt = dt_before;
+        self.interior_facets_by_edge = facets_before;
+        self.invalidate_query_caches();
+    }
+
+    /// Returns simplex keys adjacent to `vertex`, rebuilding adjacency at most once per snapshot.
+    fn adjacent_simplex_keys(&self, vertex: VertexKey) -> Result<Vec<SimplexKey>, DelaunayError> {
+        {
+            let index =
+                self.adjacency_index
+                    .read()
+                    .map_err(|err| DelaunayError::ValidationFailed {
+                        level: DelaunayValidationLevel::Three,
+                        detail: format!("adjacency index cache read lock poisoned: {err}"),
+                    })?;
+            if let Some(index) = index.as_ref() {
+                return Ok(index.adjacent_simplices(vertex).collect());
+            }
+        }
+
+        let index =
+            self.dt
+                .build_adjacency_index()
+                .map_err(|err| DelaunayError::ValidationFailed {
+                    level: DelaunayValidationLevel::Three,
+                    detail: err.to_string(),
+                })?;
+        let adjacent = index.adjacent_simplices(vertex).collect();
+        let mut cached =
+            self.adjacency_index
+                .write()
+                .map_err(|err| DelaunayError::ValidationFailed {
+                    level: DelaunayValidationLevel::Three,
+                    detail: format!("adjacency index cache write lock poisoned: {err}"),
+                })?;
+        *cached = Some(index);
+        drop(cached);
+        Ok(adjacent)
+    }
+
     /// Validates a completed backend mutation and restores the previous snapshot on failure.
     ///
     /// This keeps local edit APIs from publishing geometry that violates the evolved-state
@@ -566,8 +642,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
         target: impl Display,
     ) -> Result<(), DelaunayError> {
         if let Err(err) = self.validate_structural() {
-            self.dt = dt_before;
-            self.interior_facets_by_edge = facets_before;
+            self.restore_mutation_snapshot(dt_before, facets_before);
             return Err(match err {
                 DelaunayError::ValidationFailed { level, detail } => {
                     DelaunayError::ValidationFailed {
@@ -639,6 +714,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
         let backend = Self {
             dt,
             interior_facets_by_edge,
+            adjacency_index: RwLock::new(None),
         };
         backend.validate_delaunay()?;
         Ok(backend)
@@ -1308,13 +1384,8 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationQ
             return Err(DelaunayError::InvalidVertex { key: vertex.key });
         }
         Ok(self
-            .dt
-            .build_adjacency_index()
-            .map_err(|err| DelaunayError::ValidationFailed {
-                level: DelaunayValidationLevel::Three,
-                detail: err.to_string(),
-            })?
-            .adjacent_simplices(vertex.key)
+            .adjacent_simplex_keys(vertex.key)?
+            .into_iter()
             .map(|key| DelaunayFaceHandle { key })
             .collect())
     }
@@ -1374,8 +1445,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
         let key = match self.dt.insert(vertex) {
             Ok(key) => key,
             Err(err) => {
-                self.dt = dt_before;
-                self.interior_facets_by_edge = facets_before;
+                self.restore_mutation_snapshot(dt_before, facets_before);
                 return Err(DelaunayError::InsertionFailed {
                     operation: DelaunayOperation::InsertVertex,
                     coordinates: coords.to_vec(),
@@ -1384,6 +1454,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
             }
         };
         self.rebuild_interior_facet_index();
+        self.invalidate_query_caches();
         self.validate_mutation_or_restore(
             dt_before,
             facets_before,
@@ -1406,8 +1477,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
         let info = match self.dt.flip_k1_remove(vertex.key) {
             Ok(info) => info,
             Err(err) => {
-                self.dt = dt_before;
-                self.interior_facets_by_edge = facets_before;
+                self.restore_mutation_snapshot(dt_before, facets_before);
                 return Err(DelaunayError::FlipFailed {
                     operation: DelaunayOperation::FlipK1Remove,
                     target: format!("vertex {:?}", vertex.key),
@@ -1416,6 +1486,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
             }
         };
         self.rebuild_interior_facet_index();
+        self.invalidate_query_caches();
         self.validate_mutation_or_restore(
             dt_before,
             facets_before,
@@ -1464,8 +1535,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
         let info = match self.dt.flip_k2(facet) {
             Ok(info) => info,
             Err(err) => {
-                self.dt = dt_before;
-                self.interior_facets_by_edge = facets_before;
+                self.restore_mutation_snapshot(dt_before, facets_before);
                 return Err(DelaunayError::FlipFailed {
                     operation: DelaunayOperation::FlipK2,
                     target: format!(
@@ -1480,8 +1550,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
         };
         let mut inserted = info.inserted_face_vertices.iter().copied();
         let Some(v0) = inserted.next() else {
-            self.dt = dt_before;
-            self.interior_facets_by_edge = facets_before;
+            self.restore_mutation_snapshot(dt_before, facets_before);
             return Err(DelaunayError::UnexpectedFlipOutput {
                 operation: DelaunayOperation::FlipK2,
                 target: format!("edge {:?} -- {:?}", edge.key.v0(), edge.key.v1()),
@@ -1490,8 +1559,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
             });
         };
         let Some(v1) = inserted.next() else {
-            self.dt = dt_before;
-            self.interior_facets_by_edge = facets_before;
+            self.restore_mutation_snapshot(dt_before, facets_before);
             return Err(DelaunayError::UnexpectedFlipOutput {
                 operation: DelaunayOperation::FlipK2,
                 target: format!("edge {:?} -- {:?}", edge.key.v0(), edge.key.v1()),
@@ -1500,8 +1568,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
             });
         };
         if let Some(extra) = inserted.next() {
-            self.dt = dt_before;
-            self.interior_facets_by_edge = facets_before;
+            self.restore_mutation_snapshot(dt_before, facets_before);
             let actual = 3 + inserted.count();
             return Err(DelaunayError::UnexpectedFlipOutput {
                 operation: DelaunayOperation::FlipK2,
@@ -1511,6 +1578,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
             });
         }
         self.rebuild_interior_facet_index();
+        self.invalidate_query_caches();
         self.validate_mutation_or_restore(
             dt_before,
             facets_before,
@@ -1550,8 +1618,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
         let info = match self.dt.flip_k1_insert(face.key, vertex) {
             Ok(info) => info,
             Err(err) => {
-                self.dt = dt_before;
-                self.interior_facets_by_edge = facets_before;
+                self.restore_mutation_snapshot(dt_before, facets_before);
                 return Err(DelaunayError::FlipFailed {
                     operation: DelaunayOperation::FlipK1Insert,
                     target: format!("face {:?} at point {:?}", face.key, point),
@@ -1561,8 +1628,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
         };
         let mut inserted = info.inserted_face_vertices.iter().copied();
         let Some(new_vertex) = inserted.next() else {
-            self.dt = dt_before;
-            self.interior_facets_by_edge = facets_before;
+            self.restore_mutation_snapshot(dt_before, facets_before);
             return Err(DelaunayError::UnexpectedFlipOutput {
                 operation: DelaunayOperation::FlipK1Insert,
                 target: format!("face {:?} at point {:?}", face.key, point),
@@ -1571,8 +1637,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
             });
         };
         if let Some(extra) = inserted.next() {
-            self.dt = dt_before;
-            self.interior_facets_by_edge = facets_before;
+            self.restore_mutation_snapshot(dt_before, facets_before);
             let actual = 2 + inserted.count();
             return Err(DelaunayError::UnexpectedFlipOutput {
                 operation: DelaunayOperation::FlipK1Insert,
@@ -1582,6 +1647,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
             });
         }
         self.rebuild_interior_facet_index();
+        self.invalidate_query_caches();
         self.validate_mutation_or_restore(
             dt_before,
             facets_before,
@@ -2182,6 +2248,68 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn adjacent_faces_cache_reuses_and_invalidates_on_mutation() {
+        let dt = build_delaunay2_with_data(&[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.0, 1.0], 1)])
+            .expect("triangle fixture should build");
+        let mut backend = validated_backend(dt);
+        let vertex = backend
+            .vertices()
+            .next()
+            .expect("triangle fixture should contain a vertex");
+
+        assert!(
+            backend
+                .adjacency_index
+                .read()
+                .expect("adjacency cache lock should be readable")
+                .is_none()
+        );
+        let first = backend
+            .adjacent_faces(&vertex)
+            .expect("first adjacency query should build the cache");
+        assert!(
+            backend
+                .adjacency_index
+                .read()
+                .expect("adjacency cache lock should be readable")
+                .is_some()
+        );
+        let second = backend
+            .adjacent_faces(&vertex)
+            .expect("second adjacency query should reuse the cache");
+        assert_eq!(first, second);
+
+        let face = backend
+            .faces()
+            .next()
+            .expect("triangle fixture should contain a face");
+        backend
+            .subdivide_face(face, &[0.25, 0.25])
+            .expect("subdivision should invalidate cached adjacency");
+        assert!(
+            backend
+                .adjacency_index
+                .read()
+                .expect("adjacency cache lock should be readable")
+                .is_none()
+        );
+        assert!(
+            backend
+                .adjacent_faces(&vertex)
+                .expect("adjacency query after mutation should rebuild the cache")
+                .len()
+                >= first.len()
+        );
+        assert!(
+            backend
+                .adjacency_index
+                .read()
+                .expect("adjacency cache lock should be readable")
+                .is_some()
+        );
     }
 
     #[test]

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -614,10 +614,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::geometry::backends::delaunay::{DelaunayBackend, DelaunayError};
-    /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
-    /// use causal_triangulations::geometry::traits::TriangulationQuery;
-    /// use causal_triangulations::DelaunayValidationLevel;
+    /// use causal_triangulations::prelude::geometry::*;
     ///
     /// fn main() -> Result<(), DelaunayError> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -652,10 +649,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::geometry::DelaunayBackend2D;
-    /// use causal_triangulations::geometry::backends::delaunay::DelaunayError;
-    /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
-    /// use causal_triangulations::DelaunayValidationLevel;
+    /// use causal_triangulations::prelude::geometry::*;
     ///
     /// fn main() -> Result<(), DelaunayError> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -688,10 +682,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::geometry::DelaunayBackend2D;
-    /// use causal_triangulations::geometry::backends::delaunay::DelaunayError;
-    /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
-    /// use causal_triangulations::DelaunayValidationLevel;
+    /// use causal_triangulations::prelude::geometry::*;
     ///
     /// fn main() -> Result<(), DelaunayError> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -728,10 +719,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::geometry::DelaunayBackend2D;
-    /// use causal_triangulations::geometry::backends::delaunay::DelaunayError;
-    /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
-    /// use causal_triangulations::DelaunayValidationLevel;
+    /// use causal_triangulations::prelude::geometry::*;
     ///
     /// fn main() -> Result<(), DelaunayError> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -776,9 +764,8 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
-    /// use causal_triangulations::geometry::DelaunayBackend2D;
-    /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
+    /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::{CdtError, CdtResult};
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -817,9 +804,8 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
-    /// use causal_triangulations::geometry::DelaunayBackend2D;
-    /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
+    /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::{CdtError, CdtResult};
     /// use std::num::NonZeroUsize;
     ///
     /// fn main() -> CdtResult<()> {
@@ -865,9 +851,8 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
-    /// use causal_triangulations::geometry::DelaunayBackend2D;
-    /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
+    /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::{CdtError, CdtResult};
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -919,11 +904,8 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{
-    ///     CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure, DelaunayValidationLevel,
-    /// };
-    /// use causal_triangulations::geometry::DelaunayBackend2D;
-    /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
+    /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::{CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure};
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -962,11 +944,8 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::{
-    ///     CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure, DelaunayValidationLevel,
-    /// };
-    /// use causal_triangulations::geometry::DelaunayBackend2D;
-    /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
+    /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::{CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure};
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -1011,12 +990,10 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::{
-    ///     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck,
-    ///     CdtValidationFailure, DelaunayValidationLevel,
+    ///     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
     /// };
-    /// use causal_triangulations::geometry::DelaunayBackend2D;
-    /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[
@@ -1074,12 +1051,10 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// # Examples
     ///
     /// ```
+    /// use causal_triangulations::prelude::geometry::*;
     /// use causal_triangulations::{
-    ///     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck,
-    ///     CdtValidationFailure, DelaunayValidationLevel,
+    ///     BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
     /// };
-    /// use causal_triangulations::geometry::DelaunayBackend2D;
-    /// use causal_triangulations::geometry::generators::build_delaunay2_with_data;
     ///
     /// fn main() -> CdtResult<()> {
     ///     let dt = build_delaunay2_with_data(&[

--- a/src/geometry/backends/mock.rs
+++ b/src/geometry/backends/mock.rs
@@ -188,8 +188,7 @@ impl MockBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::geometry::backends::mock::MockBackend;
-    /// use causal_triangulations::geometry::traits::TriangulationQuery;
+    /// use causal_triangulations::prelude::testing::*;
     /// use std::num::NonZeroUsize;
     ///
     /// let n = 2;
@@ -218,8 +217,7 @@ impl MockBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::geometry::backends::mock::MockBackend;
-    /// use causal_triangulations::geometry::traits::TriangulationQuery;
+    /// use causal_triangulations::prelude::testing::*;
     ///
     /// let backend = MockBackend::new_2d();
     /// assert_eq!(backend.dimension(), 2);
@@ -242,8 +240,7 @@ impl MockBackend {
     /// # Examples
     ///
     /// ```
-    /// use causal_triangulations::geometry::backends::mock::MockBackend;
-    /// use causal_triangulations::geometry::traits::TriangulationQuery;
+    /// use causal_triangulations::prelude::testing::*;
     ///
     /// let backend = MockBackend::create_triangle();
     /// assert_eq!(backend.vertex_count(), 3);

--- a/src/geometry/generators.rs
+++ b/src/geometry/generators.rs
@@ -862,52 +862,39 @@ mod tests {
     #[test]
     fn test_generate_delaunay2_insufficient_vertices() {
         let result = generate_delaunay2(2, (0.0, 10.0), None);
-        assert!(result.is_err(), "Should fail with insufficient vertices");
-
-        match result.unwrap_err() {
-            CdtError::InvalidGenerationParameters {
-                issue,
-                provided_value,
-                expected_range,
-            } => {
-                assert_eq!(issue, GenerationParameterIssue::InsufficientVertexCount);
-                assert_eq!(provided_value, "2");
-                assert_eq!(expected_range, "≥ 3");
-            }
-            _ => panic!("Expected InvalidGenerationParameters error"),
-        }
+        assert_matches!(
+            result,
+            Err(CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::InsufficientVertexCount,
+                ref provided_value,
+                ref expected_range,
+            }) if provided_value == "2" && expected_range == "≥ 3"
+        );
     }
 
     #[test]
     fn test_generate_delaunay2_invalid_range() {
         let result = generate_delaunay2(4, (10.0, 5.0), None);
-        assert!(result.is_err(), "Should fail with invalid coordinate range");
-
-        match result.unwrap_err() {
-            CdtError::InvalidGenerationParameters {
-                issue,
-                provided_value,
-                expected_range,
-            } => {
-                assert_eq!(issue, GenerationParameterIssue::InvalidCoordinateRange);
-                assert_eq!(provided_value, "[10, 5]");
-                assert_eq!(expected_range, "finite min < max");
-            }
-            _ => panic!("Expected InvalidGenerationParameters error"),
-        }
+        assert_matches!(
+            result,
+            Err(CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::InvalidCoordinateRange,
+                ref provided_value,
+                ref expected_range,
+            }) if provided_value == "[10, 5]" && expected_range == "finite min < max"
+        );
     }
 
     #[test]
     fn test_generate_delaunay2_equal_range() {
         let result = generate_delaunay2(4, (5.0, 5.0), None);
-        assert!(result.is_err(), "Should fail with equal coordinate range");
-
-        match result.unwrap_err() {
-            CdtError::InvalidGenerationParameters { issue, .. } => {
-                assert_eq!(issue, GenerationParameterIssue::InvalidCoordinateRange);
-            }
-            _ => panic!("Expected InvalidGenerationParameters error"),
-        }
+        assert_matches!(
+            result,
+            Err(CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::InvalidCoordinateRange,
+                ..
+            })
+        );
     }
 
     #[test]

--- a/src/geometry/generators.rs
+++ b/src/geometry/generators.rs
@@ -892,8 +892,9 @@ mod tests {
             result,
             Err(CdtError::InvalidGenerationParameters {
                 issue: GenerationParameterIssue::InvalidCoordinateRange,
-                ..
-            })
+                ref provided_value,
+                ref expected_range,
+            }) if provided_value == "[5, 5]" && expected_range == "finite min < max"
         );
     }
 

--- a/src/geometry/operations.rs
+++ b/src/geometry/operations.rs
@@ -53,16 +53,20 @@ impl<V: Hash> Hash for UnorderedPair<V> {
 #[derive(Clone, Debug)]
 struct UnorderedSet<V>(Vec<V>);
 
-impl<V: Eq + Hash> PartialEq for UnorderedSet<V> {
+impl<V: Eq> PartialEq for UnorderedSet<V> {
     fn eq(&self, other: &Self) -> bool {
         // Compare as sets (order-independent and duplicate-robust).
-        let self_set: HashSet<_> = self.0.iter().collect();
-        let other_set: HashSet<_> = other.0.iter().collect();
-        self_set == other_set
+        self.0
+            .iter()
+            .all(|value| other.0.iter().any(|candidate| candidate == value))
+            && other
+                .0
+                .iter()
+                .all(|value| self.0.iter().any(|candidate| candidate == value))
     }
 }
 
-impl<V: Eq + Hash> Eq for UnorderedSet<V> {}
+impl<V: Eq> Eq for UnorderedSet<V> {}
 
 impl<V: Hash> Hash for UnorderedSet<V> {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/src/geometry/traits.rs
+++ b/src/geometry/traits.rs
@@ -133,8 +133,9 @@ pub trait TriangulationQuery: GeometryBackend {
     /// Get all faces adjacent to a vertex.
     ///
     /// Backend implementations may build an adjacency index for this query.
-    /// The Delaunay backend currently rebuilds that index per call, so callers
-    /// should treat it as `O(F)` in the number of finite faces.
+    /// The Delaunay backend caches that index between topology mutations, so the
+    /// first query after a mutation is `O(F)` in the number of finite faces and
+    /// later queries reuse the same snapshot.
     ///
     /// # Errors
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,10 @@ use std::fmt::Display;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+
+static NEXT_TEMP_OUTPUT_ID: AtomicU64 = AtomicU64::new(0);
 
 /// Prelude module for convenient imports.
 ///
@@ -849,10 +852,16 @@ fn sibling_temp_output_path(path: &Path, format: OutputFormat) -> PathBuf {
         OutputFormat::Csv => "csv",
         OutputFormat::Json => "json",
     };
+    let token = NEXT_TEMP_OUTPUT_ID.fetch_add(1, Ordering::Relaxed);
     let file_name = path
         .file_name()
         .map_or_else(|| "output".into(), |name| name.to_string_lossy());
-    path.with_file_name(format!(".{file_name}.{}.{}.tmp", process::id(), suffix))
+    path.with_file_name(format!(
+        ".{file_name}.{}.{}.{}.tmp",
+        process::id(),
+        token,
+        suffix
+    ))
 }
 
 /// Builds a typed output write error for crate-root persistence helpers.
@@ -1052,20 +1061,41 @@ mod tests {
     }
 
     #[test]
+    fn sibling_temp_output_path_is_unique_per_call() {
+        let output_path = temp_output_path("unique-trace.csv");
+
+        let first = sibling_temp_output_path(&output_path, OutputFormat::Csv);
+        let second = sibling_temp_output_path(&output_path, OutputFormat::Csv);
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
     fn staged_outputs_roll_back_published_csv_when_json_persist_fails() {
         let csv_path = temp_output_path("rollback-trace.csv");
         let json_path = temp_output_path("rollback-summary.json");
-        let csv_temp = sibling_temp_output_path(&csv_path, OutputFormat::Csv);
-        let json_temp = sibling_temp_output_path(&json_path, OutputFormat::Json);
-        fs::write(&csv_temp, "trace").expect("staged CSV fixture should write");
-        fs::write(&json_temp, "{}").expect("staged JSON fixture should write");
-        fs::create_dir(&json_path).expect("JSON final path directory should block rename");
         let output_paths = ResolvedOutputPaths {
             csv: Some(csv_path.clone()),
             json: Some(json_path.clone()),
         };
+        let staged_outputs = StagedOutputs::new(&output_paths);
+        let csv_temp = staged_outputs
+            .csv
+            .as_ref()
+            .expect("CSV output should be staged")
+            .temp_path
+            .clone();
+        let json_temp = staged_outputs
+            .json
+            .as_ref()
+            .expect("JSON output should be staged")
+            .temp_path
+            .clone();
+        fs::write(&csv_temp, "trace").expect("staged CSV fixture should write");
+        fs::write(&json_temp, "{}").expect("staged JSON fixture should write");
+        fs::create_dir(&json_path).expect("JSON final path directory should block rename");
 
-        let error = StagedOutputs::new(&output_paths)
+        let error = staged_outputs
             .commit()
             .expect_err("JSON persist failure should roll back already-published CSV");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,9 @@ pub mod geometry {
     /// Convenient alias for CDT triangulations using the default backend
     pub type CdtTriangulation2D = crate::cdt::triangulation::CdtTriangulation<DefaultBackend>;
 
-    pub use generators::{GlobalTopology, TopologyGuarantee, ToroidalConstructionMode};
+    pub use generators::{
+        DelaunayTriangulation2D, GlobalTopology, TopologyGuarantee, ToroidalConstructionMode,
+    };
 }
 
 /// Causal Dynamical Triangulations implementation modules.
@@ -181,7 +183,9 @@ pub use cdt::action::{
     DEFAULT_CDT_1P1_EDGE_COSMOLOGICAL_CONSTANT, compute_regge_action,
 };
 pub use cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveStatistics, MoveType};
-pub use cdt::foliation::{EdgeType, Foliation, FoliationError, SimplexType};
+pub use cdt::foliation::{
+    EdgeType, Foliation, FoliationError, SimplexType, classify_edge, classify_simplex,
+};
 pub use cdt::metropolis::{
     AcceptedStepTelemetry, CdtMcmcCheckpoint, CdtProposal, CdtProposalError, CdtProposalInfo,
     CdtProposalPlan, CdtTarget, MetropolisAlgorithm, MetropolisConfig, MonteCarloStep,
@@ -189,7 +193,7 @@ pub use cdt::metropolis::{
 };
 pub use cdt::observables::{estimate_hausdorff_dimension, estimate_spectral_dimension};
 pub use cdt::results::{Measurement, SimulationResultsBackend};
-pub use cdt::triangulation::{CdtSimplexCounts, CdtTriangulation, SimulationEvent};
+pub use cdt::triangulation::{CdtMetadata, CdtSimplexCounts, CdtTriangulation, SimulationEvent};
 pub use config::{
     CdtConfig, CdtConfigOverrides, CdtTopology, DimensionOverride, TestConfig, ValidatedCdtConfig,
     ValidatedInitialVolume,
@@ -205,7 +209,10 @@ pub use geometry::traits::TriangulationQuery;
 
 use crate::cdt::results::SimulationResultsParts;
 use std::env;
-use std::path::PathBuf;
+use std::fmt::Display;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process;
 use std::time::Duration;
 
 /// Prelude module for convenient imports.
@@ -230,7 +237,7 @@ pub mod prelude {
     // Core CDT types
     pub use crate::geometry::CdtTriangulation2D;
     pub use crate::geometry::traits::TriangulationQuery;
-    pub use crate::{CdtSimplexCounts, CdtTriangulation};
+    pub use crate::{CdtMetadata, CdtSimplexCounts, CdtTriangulation};
 
     // Action and simulation setup
     pub use crate::cdt::action::ActionConfig;
@@ -298,7 +305,7 @@ pub mod prelude {
         };
     }
 
-    /// Focused exports for CDT triangulation construction, queries, and history events.
+    /// Focused exports for CDT triangulation construction, queries, classification, and history events.
     ///
     /// Lighter than `prelude::*` — just the types needed for building and
     /// inspecting triangulations (the most common doctest pattern).
@@ -313,12 +320,14 @@ pub mod prelude {
     /// }
     /// ```
     pub mod triangulation {
-        pub use crate::cdt::foliation::{EdgeType, Foliation, FoliationError, SimplexType};
+        pub use crate::cdt::foliation::{
+            EdgeType, Foliation, FoliationError, SimplexType, classify_edge, classify_simplex,
+        };
         pub use crate::config::CdtTopology;
         pub use crate::errors::{CdtError, CdtResult};
         pub use crate::geometry::CdtTriangulation2D;
         pub use crate::geometry::traits::TriangulationQuery;
-        pub use crate::{CdtSimplexCounts, CdtTriangulation, SimulationEvent};
+        pub use crate::{CdtMetadata, CdtSimplexCounts, CdtTriangulation, SimulationEvent};
     }
 
     /// Focused exports for local CDT move kernels and move statistics.
@@ -413,11 +422,11 @@ pub mod prelude {
     ///
     /// fn main() -> CdtResult<()> {
     ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
-    ///     let profile = tri.volume_profile();
+    ///     let profile = tri.volume_profile()?;
     ///
     ///     assert_eq!(profile.len(), 3);
-    ///     assert!(estimate_hausdorff_dimension(&tri).is_some_and(f64::is_finite));
-    ///     assert!(estimate_spectral_dimension(&tri).is_some_and(f64::is_finite));
+    ///     assert!(estimate_hausdorff_dimension(&tri)?.is_some_and(f64::is_finite));
+    ///     assert!(estimate_spectral_dimension(&tri)?.is_some_and(f64::is_finite));
     ///     Ok(())
     /// }
     /// ```
@@ -436,8 +445,8 @@ pub mod prelude {
     /// queries), without pulling in simulation-specific symbols.
     ///
     /// ```
-    /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
     /// use causal_triangulations::prelude::geometry::*;
+    /// use causal_triangulations::{CdtError, CdtResult};
     /// use std::assert_matches;
     ///
     /// fn main() -> CdtResult<()> {
@@ -467,7 +476,7 @@ pub mod prelude {
     /// }
     /// ```
     pub mod geometry {
-        pub use crate::geometry::DelaunayBackend2D;
+        pub use crate::errors::DelaunayValidationLevel;
         pub use crate::geometry::backends::delaunay::{
             DelaunayBackend, DelaunayError, DelaunayOperation, NonFlippableEdgeReason,
         };
@@ -482,6 +491,7 @@ pub mod prelude {
             EdgeAdjacentFaces, EdgeAdjacentFacesResult, FlipResult, GeometryBackend,
             SubdivisionResult, TriangulationMut, TriangulationQuery,
         };
+        pub use crate::geometry::{DelaunayBackend2D, DelaunayTriangulation2D};
     }
 
     /// Focused exports for tests and documentation fixtures.
@@ -628,19 +638,19 @@ pub fn run_simulation(config: &ValidatedCdtConfig) -> CdtResult<SimulationResult
         );
 
         let measurement = Measurement::try_from_simplex_counts(0, initial_action, counts)?
-            .try_with_volume_profile(triangulation.volume_profile())?;
+            .try_with_volume_profile(triangulation.volume_profile()?)?;
 
-        SimulationResultsBackend::from_parts(SimulationResultsParts {
-            config: config.to_metropolis_config(),
+        SimulationResultsBackend::from_parts(SimulationResultsParts::new(
+            config.to_metropolis_config(),
             action_config,
-            move_stats: MoveStatistics::new(),
-            proposal_stats: ProposalStatistics::new(),
-            steps: vec![],
-            measurements: vec![measurement],
-            scalar_trace_rows: vec![],
-            elapsed_time: Duration::from_millis(0),
+            MoveStatistics::new(),
+            ProposalStatistics::new(),
+            vec![],
+            vec![measurement],
+            vec![],
+            Duration::from_millis(0),
             triangulation,
-        })
+        )?)
     };
 
     write_configured_outputs(config, &results, &output_paths)?;
@@ -696,17 +706,162 @@ fn write_configured_outputs(
     results: &SimulationResultsBackend,
     output_paths: &ResolvedOutputPaths,
 ) -> CdtResult<()> {
+    let staged_outputs = StagedOutputs::new(output_paths);
+    staged_outputs.write_trace_csv(results)?;
+    staged_outputs.write_summary_json(validated_config, results)?;
+    staged_outputs.commit()?;
+
     if let Some(resolved) = &output_paths.csv {
-        results.write_trace_csv(resolved)?;
         log::info!("Wrote trace CSV to {}", resolved.display());
     }
 
     if let Some(resolved) = &output_paths.json {
-        results.write_summary_json(validated_config, resolved)?;
         log::info!("Wrote simulation JSON summary to {}", resolved.display());
     }
 
     Ok(())
+}
+
+/// Owns staged simulation outputs until they are committed or cleaned up.
+struct StagedOutputs<'a> {
+    csv: Option<StagedOutput<'a>>,
+    json: Option<StagedOutput<'a>>,
+}
+
+impl<'a> StagedOutputs<'a> {
+    /// Builds staged output paths next to their configured final destinations.
+    fn new(output_paths: &'a ResolvedOutputPaths) -> Self {
+        Self {
+            csv: output_paths
+                .csv
+                .as_deref()
+                .map(|path| StagedOutput::new(path, OutputFormat::Csv)),
+            json: output_paths
+                .json
+                .as_deref()
+                .map(|path| StagedOutput::new(path, OutputFormat::Json)),
+        }
+    }
+
+    /// Writes the CSV output to its staged file when configured.
+    fn write_trace_csv(&self, results: &SimulationResultsBackend) -> CdtResult<()> {
+        if let Some(output) = &self.csv {
+            results
+                .write_trace_csv(&output.temp_path)
+                .map_err(|err| output.remap_error(err))?;
+        }
+        Ok(())
+    }
+
+    /// Writes the JSON output to its staged file when configured.
+    fn write_summary_json(
+        &self,
+        validated_config: &ValidatedCdtConfig,
+        results: &SimulationResultsBackend,
+    ) -> CdtResult<()> {
+        if let Some(output) = &self.json {
+            results
+                .write_summary_json(validated_config, &output.temp_path)
+                .map_err(|err| output.remap_error(err))?;
+        }
+        Ok(())
+    }
+
+    /// Publishes every staged output, rolling back an earlier CSV publish on JSON failure.
+    fn commit(mut self) -> CdtResult<()> {
+        let published_csv = if let Some(output) = &self.csv {
+            output.persist()?;
+            let final_path = output.final_path.to_path_buf();
+            self.csv = None;
+            Some(final_path)
+        } else {
+            None
+        };
+
+        if let Some(output) = &self.json
+            && let Err(err) = output.persist()
+        {
+            if let Some(path) = &published_csv {
+                let _ignored = fs::remove_file(path);
+            }
+            return Err(err);
+        }
+        self.json = None;
+        Ok(())
+    }
+}
+
+impl Drop for StagedOutputs<'_> {
+    fn drop(&mut self) {
+        if let Some(output) = &self.csv {
+            output.cleanup();
+        }
+        if let Some(output) = &self.json {
+            output.cleanup();
+        }
+    }
+}
+
+/// One configured output file staged through a sibling temporary path.
+struct StagedOutput<'a> {
+    final_path: &'a Path,
+    temp_path: PathBuf,
+    format: OutputFormat,
+}
+
+impl<'a> StagedOutput<'a> {
+    /// Builds one same-directory temporary output path.
+    fn new(final_path: &'a Path, format: OutputFormat) -> Self {
+        Self {
+            final_path,
+            temp_path: sibling_temp_output_path(final_path, format),
+            format,
+        }
+    }
+
+    /// Renames the staged output into its final path.
+    fn persist(&self) -> CdtResult<()> {
+        fs::rename(&self.temp_path, self.final_path)
+            .map_err(|err| output_write_failed(self.final_path, self.format, err))
+    }
+
+    /// Removes the staged temporary file if it still exists.
+    fn cleanup(&self) {
+        let _ignored = fs::remove_file(&self.temp_path);
+    }
+
+    /// Reports a staged write failure against the configured final path.
+    fn remap_error(&self, error: CdtError) -> CdtError {
+        match error {
+            CdtError::OutputWriteFailed { detail, .. } => CdtError::OutputWriteFailed {
+                path: self.final_path.display().to_string(),
+                format: self.format,
+                detail,
+            },
+            error => error,
+        }
+    }
+}
+
+/// Builds a same-directory temporary output path for later atomic rename.
+fn sibling_temp_output_path(path: &Path, format: OutputFormat) -> PathBuf {
+    let suffix = match format {
+        OutputFormat::Csv => "csv",
+        OutputFormat::Json => "json",
+    };
+    let file_name = path
+        .file_name()
+        .map_or_else(|| "output".into(), |name| name.to_string_lossy());
+    path.with_file_name(format!(".{file_name}.{}.{}.tmp", process::id(), suffix))
+}
+
+/// Builds a typed output write error for crate-root persistence helpers.
+fn output_write_failed(path: &Path, format: OutputFormat, err: impl Display) -> CdtError {
+    CdtError::OutputWriteFailed {
+        path: path.display().to_string(),
+        format,
+        detail: err.to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -781,7 +936,13 @@ mod tests {
         assert!(results.triangulation().face_count() > 0);
         assert!(results.triangulation().has_foliation());
         assert_eq!(results.triangulation().slice_sizes(), &[12, 12, 12]);
-        assert!(!results.triangulation().volume_profile().is_empty());
+        assert!(
+            !results
+                .triangulation()
+                .volume_profile()
+                .expect("run triangulation should have a valid volume profile")
+                .is_empty()
+        );
         results
             .triangulation()
             .validate_foliation()
@@ -852,6 +1013,79 @@ mod tests {
             parsed["final_triangulation"]["time_slices"],
             config.timeslices().get()
         );
+    }
+
+    #[test]
+    fn run_simulation_cleans_staged_csv_when_json_write_fails() {
+        let csv_path = temp_output_path("atomic-trace.csv");
+        let blocked_parent = temp_output_path("blocked-output-parent");
+        fs::write(&blocked_parent, "not a directory").expect("blocked parent fixture should write");
+        let json_path = blocked_parent.join("summary.json");
+        let csv_temp = sibling_temp_output_path(&csv_path, OutputFormat::Csv);
+        let json_temp = sibling_temp_output_path(&json_path, OutputFormat::Json);
+        let mut config = create_test_config();
+        config.output_csv = Some(csv_path.clone());
+        config.output_json = Some(json_path.clone());
+        let config = validated(config);
+
+        let error =
+            run_simulation(&config).expect_err("JSON output with a missing parent should fail");
+
+        assert_matches!(
+            error,
+            CdtError::OutputWriteFailed {
+                format: OutputFormat::Json,
+                ..
+            }
+        );
+        assert!(
+            !csv_path.exists(),
+            "CSV final output should not be published"
+        );
+        assert!(
+            !json_path.exists(),
+            "JSON final output should not be published"
+        );
+        assert!(!csv_temp.exists(), "staged CSV output should be cleaned");
+        assert!(!json_temp.exists(), "staged JSON output should be absent");
+        fs::remove_file(&blocked_parent).expect("blocked parent fixture should be removable");
+    }
+
+    #[test]
+    fn staged_outputs_roll_back_published_csv_when_json_persist_fails() {
+        let csv_path = temp_output_path("rollback-trace.csv");
+        let json_path = temp_output_path("rollback-summary.json");
+        let csv_temp = sibling_temp_output_path(&csv_path, OutputFormat::Csv);
+        let json_temp = sibling_temp_output_path(&json_path, OutputFormat::Json);
+        fs::write(&csv_temp, "trace").expect("staged CSV fixture should write");
+        fs::write(&json_temp, "{}").expect("staged JSON fixture should write");
+        fs::create_dir(&json_path).expect("JSON final path directory should block rename");
+        let output_paths = ResolvedOutputPaths {
+            csv: Some(csv_path.clone()),
+            json: Some(json_path.clone()),
+        };
+
+        let error = StagedOutputs::new(&output_paths)
+            .commit()
+            .expect_err("JSON persist failure should roll back already-published CSV");
+
+        assert_matches!(
+            error,
+            CdtError::OutputWriteFailed {
+                format: OutputFormat::Json,
+                ..
+            }
+        );
+        assert!(
+            !csv_path.exists(),
+            "CSV final output should be removed after JSON publish failure"
+        );
+        assert!(!csv_temp.exists(), "staged CSV should have been renamed");
+        assert!(
+            !json_temp.exists(),
+            "staged JSON should be cleaned when commit fails"
+        );
+        fs::remove_dir(&json_path).expect("blocking JSON directory should be removable");
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -75,7 +75,9 @@ mod integration_tests {
         let triangulation = CdtTriangulation::from_toroidal_cdt(4, 3).expect("build toroidal CDT");
         assert_eq!(triangulation.metadata().topology(), CdtTopology::Toroidal);
         assert_eq!(triangulation.geometry().euler_characteristic(), 0);
-        let initial_profile = triangulation.volume_profile();
+        let initial_profile = triangulation
+            .volume_profile()
+            .expect("initial toroidal profile should be valid");
         triangulation
             .validate_topology()
             .expect("initial toroidal topology is valid");
@@ -102,7 +104,10 @@ mod integration_tests {
             "periodic toroidal simulation should accept at least one volume-increasing move"
         );
         assert_ne!(
-            results.triangulation().volume_profile(),
+            results
+                .triangulation()
+                .volume_profile()
+                .expect("final toroidal profile should be valid"),
             initial_profile,
             "periodic toroidal volume moves should change the final volume profile"
         );

--- a/tests/large_scale_debug.rs
+++ b/tests/large_scale_debug.rs
@@ -267,7 +267,9 @@ fn debug_large_scale_1p1() {
     let started_at = Instant::now();
     let triangulation = CdtTriangulation2D::from_toroidal_cdt(vertices_per_slice, timeslices)
         .expect("large-scale toroidal CDT fixture should build");
-    let initial_profile = triangulation.volume_profile();
+    let initial_profile = triangulation
+        .volume_profile()
+        .expect("initial toroidal profile should be valid");
     let mut expected_attempts = 0_u64;
     let mut previous_acceptance = MoveAcceptanceCounts::default();
     let mut previous_proposals = ProposalOutcomeCounts::default();
@@ -333,7 +335,9 @@ fn debug_large_scale_1p1() {
             triangulation.vertex_count(),
             triangulation.edge_count(),
             triangulation.face_count(),
-            triangulation.volume_profile(),
+            triangulation
+                .volume_profile()
+                .expect("checkpoint toroidal profile should be valid"),
             sweep_acceptance.total,
             sweep_acceptance.move_22,
             sweep_acceptance.move_13,
@@ -382,7 +386,9 @@ fn debug_large_scale_1p1() {
         "large-scale Metropolis sweeps should exercise toroidal Move31Remove"
     );
     assert_ne!(
-        triangulation.volume_profile(),
+        triangulation
+            .volume_profile()
+            .expect("final toroidal profile should be valid"),
         initial_profile,
         "large-scale Metropolis sweeps should change the toroidal volume profile"
     );

--- a/tests/proptest_metropolis.rs
+++ b/tests/proptest_metropolis.rs
@@ -3,6 +3,7 @@
 
 use approx::relative_eq;
 use causal_triangulations::prelude::action::ActionConfig;
+use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveResult};
 use causal_triangulations::prelude::simulation::{CdtTarget, Target};
 use causal_triangulations::prelude::triangulation::{CdtTriangulation, CdtTriangulation2D};
 use proptest::prelude::*;
@@ -50,5 +51,38 @@ proptest! {
             "log_prob {:.15} != -action/T {:.15}",
             log_prob, expected,
         );
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(8))]
+
+    /// Random local-move sequences must preserve the full evolved CDT invariant
+    /// contract for representative open-boundary and toroidal fixtures.
+    #[test]
+    fn random_move_sequences_preserve_cdt_invariants(
+        seed in 0_u64..10_000,
+        attempts in 1_usize..16,
+        toroidal in any::<bool>(),
+    ) {
+        let mut triangulation = if toroidal {
+            CdtTriangulation::from_toroidal_cdt(4, 3)
+                .expect("valid toroidal property-test fixture should build")
+        } else {
+            CdtTriangulation::from_cdt_strip(4, 3)
+                .expect("valid strip property-test fixture should build")
+        };
+        let mut moves = ErgodicsSystem::with_seed(seed);
+
+        for attempt in 0..attempts {
+            let result = moves.attempt_random_move(&mut triangulation);
+            prop_assert!(
+                !matches!(result, MoveResult::HardFailure(_)),
+                "attempt {attempt} produced a hard move failure: {result:?}",
+            );
+            triangulation
+                .validate()
+                .unwrap_or_else(|err| panic!("attempt {attempt} left invalid CDT state after {result:?}: {err}"));
+        }
     }
 }

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -203,7 +203,9 @@ fn resumed_scalar_trace_keeps_checkpoint_seed_not_fresh_resume_seed() {
     let checkpoint = MetropolisAlgorithm::new(resume_config, action_config)
         .resume_to_checkpoint(prefix)
         .expect("resume with a different fresh seed should still validate");
-    let results = checkpoint.into_results();
+    let results = checkpoint
+        .into_results()
+        .expect("checkpoint results should validate");
     let trace = results.scalar_trace().expect("scalar trace should export");
     let seed_low_index = trace
         .observable_names()

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -43,11 +43,17 @@ fn toroidal_observables_run_accepts_periodic_moves_after_offset_support() {
         .validate()
         .expect("accepted periodic moves should preserve evolved toroidal CDT invariants");
     assert!(
-        results.hausdorff_dimension_estimate().is_some(),
+        results
+            .hausdorff_dimension_estimate()
+            .expect("final triangulation adjacency should be readable")
+            .is_some(),
         "observables workflow should still report a Hausdorff estimate"
     );
     assert!(
-        results.spectral_dimension_estimate().is_some(),
+        results
+            .spectral_dimension_estimate()
+            .expect("final triangulation adjacency should be readable")
+            .is_some(),
         "observables workflow should still report a spectral estimate"
     );
 }


### PR DESCRIPTION
- Make CDT observable estimators and volume-profile APIs return typed errors instead of silently collapsing backend or overflow failures.
- Store Metropolis proposal plans and scalar trace rows with invariant-bearing action and count evidence before serialization.
- Validate checkpoint, result, move-statistics, and measurement reconstruction through typed CDT error paths.
- Carry API docs, examples, benchmarks, citation metadata, and the lockfile through the stricter contracts.

BREAKING CHANGE: `estimate_hausdorff_dimension`, `estimate_spectral_dimension`, `CdtTriangulation::volume_profile`, and final-dimension accessors on `SimulationResultsBackend` now return `CdtResult`; `CdtProposalPlan::action_after` and `delta_action` now return concrete `f64` values.