### PR TITLE
docs: add physicist quickstart and streamline guides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ env:
   CARGO_NEXTEST_VERSION: "0.9.137"
   DPRINT_VERSION: "0.54.0"
   JUST_VERSION: "1.51.0"
-  RUMDL_VERSION: "0.2.4"
+  RUMDL_VERSION: "0.2.10"
   TAPLO_VERSION: "0.10.0"
-  TYPOS_VERSION: "1.47.0"
+  TYPOS_VERSION: "1.47.2"
   UV_VERSION: "0.11.17"
   ZIZMOR_VERSION: "1.25.2"
 
@@ -92,7 +92,7 @@ jobs:
         with:
           tool: cargo-nextest@${{ env.CARGO_NEXTEST_VERSION }}
 
-      - name: Install typos-cli
+      - name: Install typos
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: typos-cli@${{ env.TYPOS_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ⚠️ Breaking Changes
+
+- Enforce fallible observable and trace invariants
+- Propagate checkpoint result invariant failures
+
+### Changed
+
+- [**breaking**] Enforce fallible observable and trace invariants
+  [`513140f`](https://github.com/acgetchell/causal-triangulations/commit/513140f1d2a22e505c212389c981c8fefacbc3d1)
+
+  - Make CDT observable estimators and volume-profile APIs return typed errors instead of silently collapsing backend or overflow failures.
+  - Store Metropolis proposal plans and scalar trace rows with invariant-bearing action and count evidence before serialization.
+  - Validate checkpoint, result, move-statistics, and measurement reconstruction through typed CDT error paths.
+  - Carry API docs, examples, benchmarks, citation metadata, and the lockfile through the stricter contracts.
+
+### Documentation
+
+- Clarify saturated proposal telemetry deserialization
+  [`e5a3efb`](https://github.com/acgetchell/causal-triangulations/commit/e5a3efb7adb25c53e7c5e11a325ded64d8ad2f77)
+
+  - Document that ProposalStatistics deserialization only relaxes exact terminal-outcome partitioning after saturated telemetry merges when move-family
+    proposals also saturated.
+
+### Fixed
+
+- [**breaking**] Propagate checkpoint result invariant failures
+  [`faf5ece`](https://github.com/acgetchell/causal-triangulations/commit/faf5ecedf8f80566c6241b952edf2f2ca944fa97)
+
+  - Return CdtResult from CdtMcmcCheckpoint::into_results so result snapshot invariant failures propagate instead of panicking.
+  - Preserve saturated move and proposal telemetry, and report concrete scalar trace outcomes during resume validation.
+  - Avoid same-process staged output temp-file collisions and keep toroidal removal selection limited to sampleable inverse sites.
+  - Align the Zenodo DOI badge and cover empty observable/profile boundaries.
+- Harden checkpoint and adjacency invariants [`1795533`](https://github.com/acgetchell/causal-triangulations/commit/17955336be720cd3533db644af287f10e252db71)
+
+  - Recompute resumed checkpoint actions into live state after tolerant validation so telemetry starts from the canonical action value.
+  - Reject saturated or overflowed proposal-terminal counters unless the selected move-family counter saturated too.
+  - Rotate triangulation instance epochs when modification counters saturate so proposal-site caches cannot collide with stale versions.
+  - Cache Delaunay vertex-adjacency indexes between topology mutations while keeping mutation rollback and serialization cache boundaries explicit.
+  - Add fallible MetropolisConfig runtime validation for runner entry points.
+
 ## [0.1.0] - 2026-06-02
 
 ### ⚠️ Breaking Changes
@@ -1033,4 +1075,5 @@ Older releases are archived by minor series:
 
 - [0.0.x](docs/archive/changelog/0.0.md)
 
+[Unreleased]: https://github.com/acgetchell/causal-triangulations/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/acgetchell/causal-triangulations/compare/v0.0.1...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Document that ProposalStatistics deserialization only relaxes exact terminal-outcome partitioning after saturated telemetry merges when move-family
     proposals also saturated.
 
+- Add physicist quickstart and streamline guides
+  [`34b86f9`](https://github.com/acgetchell/causal-triangulations/commit/34b86f995cb5ef128e87a62d21ef9fd6a923b54b)
+
+  - Add a non-programmer quickstart for running 1+1 CDT simulations, interpreting CSV/JSON output, and tuning the main physics knobs.
+  - Refocus README around current 1+1 scope, grand-canonical volume behavior, the crate ecosystem, and reviewer-facing documentation entry points.
+  - Streamline CLI, script, contributing, benchmark, and performance docs so each guide has a distinct maintenance role.
+  - Document how Delaunay bistellar k-flips map onto foliation-preserving CDT/Pachner moves, including the planned interface revisit after delaunay#252.
+  - Align Markdown and spelling tool pins with sibling repositories.
+
 ### Fixed
 
 - [**breaking**] Propagate checkpoint result invariant failures

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,505 +1,160 @@
 # Contributing to Causal Dynamical Triangulations
 
-Thank you for your interest in contributing to the [**causal-triangulations**][cdt-lib] library! This document provides comprehensive guidelines for
-contributors, from first-time contributors to experienced developers looking to contribute significant features.
-
-## Table of Contents
-
-- [Code of Conduct](#code-of-conduct)
-- [Getting Started](#getting-started)
-- [Development Environment Setup](#development-environment-setup)
-- [Code Organization](#code-organization)
-- [Development Workflow](#development-workflow)
-- [Just Command Runner](#just-command-runner)
-- [Code Style and Standards](#code-style-and-standards)
-- [Testing](#testing)
-- [Documentation](#documentation)
-- [Performance and Benchmarking](#performance-and-benchmarking)
-- [Submitting Changes](#submitting-changes)
-- [Types of Contributions](#types-of-contributions)
-- [Release Process](#release-process)
-- [Getting Help](#getting-help)
+Thank you for your interest in contributing to [**causal-triangulations**][cdt-lib]. This project is a Rust library and command-line tool for validated
+1+1 CDT simulations, with a strong emphasis on correctness, reproducibility, performance, and clear physics documentation.
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by our commitment to creating an inclusive and welcoming environment for quantum gravity research and
-computational physics development.
-
-Our community is built on the principles of:
-
-- **Respectful collaboration** in quantum gravity research and computational physics
-- **Inclusive participation** regardless of background or experience level
-- **Excellence in scientific computing** and algorithm implementation
-- **Open knowledge sharing** about CDT and discrete approaches to quantum gravity
+Please keep discussion respectful and focused on advancing computational quantum-gravity research. Good contributions make the project easier to understand,
+verify, reproduce, or extend.
 
 ## Getting Started
 
-### Prerequisites
+Prerequisites:
 
-Before you begin, ensure you have:
+- Rust 1.96.0 or newer, managed by `rust-toolchain.toml`
+- Git
+- [Just] command runner: `cargo install just`
+- `uv` for Python support tooling
 
-1. **Rust 1.96.0** (pinned via `rust-toolchain.toml` - automatically handled by rustup)
-2. **Git** for version control
-3. **Just** (command runner): `cargo install just`
+Recommended setup:
 
-### Quick Start
-
-1. **Fork and clone** the repository:
-   - Fork this repository to your GitHub account using the "Fork" button
-   - Clone your fork locally:
-
-   ```bash
-   git clone https://github.com/yourusername/causal-triangulations.git
-   cd causal-triangulations
-   ```
-
-2. **Setup development environment**:
-
-   ```bash
-   # Comprehensive setup (recommended)
-   just setup           # Installs tools and builds project
-
-   # Manual setup
-   cargo build
-   ```
-
-3. **Run tests**:
-
-   ```bash
-   # Basic tests
-   cargo test            # Library tests
-   cargo test --test cli # CLI tests
-   cargo test --test integration_tests  # Integration tests
-
-   # Or use convenient workflows:
-   just check           # Run non-mutating checks
-   just fix             # Apply formatters/auto-fixes when needed
-   just test-all        # All tests
-   ```
-
-4. **Try the examples**:
-
-   ```bash
-   cargo run --example basic_cdt
-   ./examples/scripts/basic_simulation.sh
-   ```
-
-5. **Run benchmarks** (optional):
-
-   ```bash
-   # Compile benchmarks without running
-   cargo bench --no-run
-
-   # Run all benchmarks
-   cargo bench
-   ```
-
-6. **Code quality checks**:
-
-   ```bash
-   cargo fmt            # Format code
-   cargo clippy --all-targets -- -D warnings  # Linting
-   just check           # Run all non-mutating checks
-   just fix             # Apply formatters/auto-fixes when needed
-   just lint            # Lint code, docs, and config (checks only)
-   ```
-
-7. **Use Just for comprehensive workflows** (recommended):
-
-   ```bash
-   # See all available commands
-   just --list
-
-   # Common workflows
-   just check           # Run all linters/validators
-   just fix             # Apply formatters/auto-fixes when needed
-   just commit-check    # Full pre-commit validation
-   just ci              # CI parity (mirrors .github/workflows/ci.yml)
-   ```
-
-## Development Environment Setup
-
-### Automatic Toolchain Management
-
-**🔧 This project uses automatic Rust toolchain management via `rust-toolchain.toml`**
-
-When you enter the project directory, `rustup` will automatically:
-
-- **Install the correct Rust version** (1.96.0) if you don't have it
-- **Switch to the pinned version** for this project
-- **Install required components** (clippy, rustfmt, rust-docs, rust-src, rust-analyzer)
-- **Add cross-compilation targets** for supported platforms
-
-**What this means for contributors:**
-
-1. **No manual setup needed** - Just have `rustup` installed ([rustup.rs][rustup])
-2. **Consistent environment** - Everyone uses the same Rust version automatically
-3. **Reproducible builds** - Eliminates "works on my machine" issues
-4. **CI compatibility** - Your local environment matches our CI exactly
-
-**First time in the project?** You'll see:
-
-```text
-info: syncing channel updates for '1.96.0-<your-platform>'
-info: downloading component 'cargo'
-info: downloading component 'clippy'
-...
+```bash
+git clone https://github.com/acgetchell/causal-triangulations.git
+cd causal-triangulations
+just setup
+just check
 ```
 
-This is normal and only happens once.
+Useful entry points:
 
-## Code Organization
-
-The source/module layout and architecture-sensitive boundaries live in [docs/code_organization.md](docs/code_organization.md). Keep that file current when
-adding, removing, or moving source files, examples, or architecture-significant modules.
+- [README.md](README.md) — project overview and top-level documentation map
+- [docs/QUICKSTART.md](docs/QUICKSTART.md) — first local CDT run
+- [docs/code_organization.md](docs/code_organization.md) — module layout and architecture boundaries
+- [docs/dev/commands.md](docs/dev/commands.md) — authoritative local command guide
+- [docs/dev/rust.md](docs/dev/rust.md) — Rust API, error, prelude, backend, and MCMC boundary rules
+- [docs/dev/python.md](docs/dev/python.md) — Python support-script rules
+- [docs/dev/testing.md](docs/dev/testing.md) — test expectations and validation workflow
+- [docs/dev/tooling-alignment.md](docs/dev/tooling-alignment.md) — rationale for repository tooling choices
 
 ## Development Workflow
 
-### Just Command Runner
-
-This project uses [Just] as the primary task automation tool. Just provides better workflow organization than traditional shell scripts or cargo aliases.
-
-**Essential Just Commands:**
+Common commands:
 
 ```bash
-just setup          # Complete environment setup
-just check          # Run linters/validators (non-mutating)
-just fix            # Apply formatters/auto-fixes (mutating)
-just ci             # CI parity (mirrors .github/workflows/ci.yml)
-just commit-check   # Comprehensive pre-commit validation (recommended before pushing)
-just lint           # Lint code, docs, and config (checks only)
-just test-all       # All test suites
-just bench          # Run performance benchmarks
-just clean          # Clean build artifacts
+just --list          # Show available recipes
+just check           # Non-mutating validation
+just fix             # Formatters and auto-fixes
+just ci              # CI parity
+just commit-check    # Full pre-commit validation
+just bench-ci        # CI benchmark contract
+just perf-check      # Local performance regression check
 ```
 
-**Workflow Help:**
-
-```bash
-just --list          # Show all available commands
-just help-workflows  # Detailed workflow guidance
-```
-
-### Repository Tooling Map
+Prefer small focused branches. Branch names should follow `{type}/{issue}-descriptor-or-two`, for example:
 
 ```text
-.github/workflows/codeql.yml # CodeQL analysis for Actions and Rust
-.github/workflows/semgrep-sarif.yml # Repository Semgrep rule SARIF upload
-rustfmt.toml           # Stable Rust formatting settings
-cliff.toml             # git-cliff changelog template and commit grouping
-semgrep.yaml           # Repository-owned Semgrep rules
-docs/dev/python.md     # Python script style and validation guidance
-docs/dev/tooling-alignment.md # Tooling comparison and issue #112 decisions
-docs/roadmap.md        # High-level release direction and non-goals
-tests/semgrep/         # Semgrep rule fixtures run by `just semgrep-test`
-scripts/archive_changelog.py # Split completed changelog minor series into archive files
-scripts/coverage_report.py # Cobertura coverage summary helper
-scripts/postprocess_changelog.py # Markdown hygiene for git-cliff changelogs
-scripts/tag_release.py # Annotated release tags from root or archived changelog sections
+fix/307-topology-validation
+perf/315-bench-profile
+docs/187-quickstart
 ```
 
-### Typical Development Cycle
+Before opening a PR:
 
-1. **Start working on a feature/fix**:
+- run the appropriate `just` checks;
+- update tests and docs with the code change;
+- update `docs/code_organization.md` when files or architecture-significant modules move;
+- update `docs/dev/tooling-alignment.md` before changing repository tooling, workflows, or config policy;
+- do not edit `CHANGELOG.md` directly; it is generated from commits.
 
-   ```bash
-   git checkout -b fix/307-topology-validation
-   ```
+## Code Style
 
-   Branch names should follow `{type}/{issue}-descriptor-or-two`, such as `fix/307-topology-validation` or `perf/315-bench-profile`.
+Rust code uses:
 
-2. **Development cycle**:
+- Rust 2024 edition
+- MSRV 1.96.0
+- `#![forbid(unsafe_code)]`
+- `rustfmt` and strict Clippy
+- narrow `CdtError` variants and `CdtResult<T>` for production errors
 
-   ```bash
-   # Make changes to code
-   just test            # Run fast tests (lib + doc)
-   just fix             # Apply formatters/auto-fixes when needed
-   # Repeat until satisfied
-   ```
+Architectural boundaries matter:
 
-3. **Pre-commit validation**:
+- `src/geometry/` is the backend interface layer over `delaunay`.
+- `src/cdt/` owns CDT domain logic: foliation, topology, moves, action, observables, simulation, and results.
+- `src/cdt/metropolis/` contains the thin adapters and runner code that consume `markov-chain-monte-carlo`.
+- Direct `delaunay::` imports are restricted to the geometry layer and documented exceptions.
 
-   ```bash
-   just commit-check    # Full validation including all tests
-   ```
-
-4. **Submit**:
-
-   ```bash
-   git commit -m "Your descriptive commit message"
-   git push origin feature/your-feature-name
-   # Create pull request
-   ```
-
-## Code Style and Standards
-
-### Rust Code Style
-
-- **Edition**: Rust 2024
-- **MSRV**: Rust 1.96.0 (pinned in `rust-toolchain.toml`)
-- **Formatting**: Use `rustfmt` (configured in `rustfmt.toml`)
-- **Linting**: Strict clippy with warnings as errors
-
-### Linting Configuration
-
-The project uses comprehensive linting rules:
-
-```bash
-cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo
-```
-
-Key areas of focus:
-
-- **Performance**: Zero-cost abstractions, avoid unnecessary allocations
-- **Safety**: Leverage Rust's type system for mathematical correctness
-- **Documentation**: All public APIs must be documented
-- **Testing**: Comprehensive test coverage including property-based tests
-
-### Code Organization
-
-- **Separation of concerns**: Geometry backends decoupled from CDT algorithms
-- **Type safety**: Use strong types for mathematical concepts (e.g., time vs space coordinates)
-- **Error handling**: Comprehensive error types with context
-- **Performance**: Profile-guided optimization for hot paths
+See [docs/dev/rust.md](docs/dev/rust.md) for the detailed rules.
 
 ## Testing
 
-### Test Categories
+Use focused tests for narrow changes and broader validation for shared behavior. Common commands:
 
-1. **Unit Tests**: Test individual functions and methods
-
-   ```bash
-   cargo test --lib
-   ```
-
-2. **Integration Tests**: Test component interactions
-
-   ```bash
-   cargo test --test integration_tests
-   ```
-
-3. **CLI Tests**: Test command-line interface
-
-   ```bash
-   cargo test --test cli
-   ```
-
-4. **Documentation Tests**: Ensure examples in docs compile
-
-   ```bash
-   cargo test --doc
-   ```
-
-5. **Benchmark Tests**: Verify benchmarks compile
-
-   ```bash
-   cargo bench --no-run
-   ```
-
-### Property-Based Testing
-
-For mathematical algorithms, use property-based testing:
-
-```rust
-use proptest::prelude::*;
-
-proptest! {
-    #[test]
-    fn test_triangulation_invariant(vertices in 3u32..100) {
-        let triangulation = create_test_triangulation(vertices);
-        // Test Euler characteristic invariant
-        prop_assert!(triangulation.satisfies_euler_formula());
-    }
-}
+```bash
+cargo test --lib
+cargo test --test integration_tests
+cargo test --test cli
+cargo test --doc
+cargo bench --no-run
+just check
+just ci
 ```
 
-### Test Data and Fixtures
-
-- Use deterministic test data when possible
-- For randomized tests, use seeded generators for reproducibility
-- Keep test execution time reasonable (< 1 second for unit tests)
+Testing expectations live in [docs/dev/testing.md](docs/dev/testing.md). Benchmarks and performance regression workflows live in
+[benches/README.md](benches/README.md) and [docs/PERFORMANCE_TESTING.md](docs/PERFORMANCE_TESTING.md).
 
 ## Documentation
 
-### Documentation Standards
+Documentation changes are first-class contributions. Keep prose accurate for both CDT specialists and readers who know physics or AI but not Rust.
 
-- **Public APIs**: All public functions, structs, and traits must have rustdoc comments
-- **Examples**: Include usage examples in documentation
-- **Mathematical Context**: Explain the physics/mathematics behind algorithms
-- **Performance Notes**: Document time/space complexity where relevant
+When editing docs:
 
-### Documentation Generation
+- keep README high-level and link to deeper docs;
+- keep [docs/QUICKSTART.md](docs/QUICKSTART.md) beginner-oriented;
+- keep [docs/CLI_EXAMPLES.md](docs/CLI_EXAMPLES.md) focused on advanced CLI patterns;
+- keep technical move/sampler details in [docs/moves.md](docs/moves.md) and [docs/metropolis.md](docs/metropolis.md);
+- add or update citations in [REFERENCES.md](REFERENCES.md) when scientific claims depend on literature.
 
-```bash
-# Generate documentation
-cargo doc --no-deps --open
+## Performance
 
-# Check documentation builds without warnings
-RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
-```
+Performance is part of the scientific contract for this project. Use:
 
-### Contributing to Docs
+- [benches/README.md](benches/README.md) for benchmark inventory, Criterion usage, and adding new benchmarks;
+- [docs/PERFORMANCE_TESTING.md](docs/PERFORMANCE_TESTING.md) for regression checks, baselines, CI behavior, and reporting.
 
-- Update `docs/` directory for comprehensive guides
-- Ensure examples in documentation actually compile
-- Link to relevant papers in [REFERENCES.md](REFERENCES.md)
-
-## Performance and Benchmarking
-
-### Benchmark Organization
-
-Benchmarks are organized in `benches/` directory:
-
-- **Triangulation creation**: `triangulation_creation`
-- **Geometry operations**: `edge_counting`, `geometry_queries`
-- **Monte Carlo simulation**: `metropolis_simulation`
-- **Action calculations**: `action_calculations`
-
-### Running Benchmarks
+Before large algorithmic changes, save or inspect a baseline:
 
 ```bash
-# Run all benchmarks
-cargo bench
-
-# Run specific benchmark group
-cargo bench triangulation_creation
-
-# HTML reports are automatically generated at target/criterion/report/index.html
-# Open the report in your browser
-open target/criterion/report/index.html
+just bench-ci
+just perf-baseline pre-change
+just perf-check
 ```
 
-### Performance Guidelines
+## Pull Requests
 
-- Profile before optimizing
-- Use criterion for statistical analysis
-- Consider memory allocation patterns
-- Document performance characteristics
+Pull requests should be small enough to review. Include:
 
-### Memory Management
+- what changed;
+- why it changed;
+- validation commands run;
+- performance impact when relevant;
+- links to issues or literature when the change is scientific or architectural.
 
-- Prefer stack allocation for small, fixed-size data
-- Use arena allocation for temporary geometry data
-- Profile memory usage for large simulations
-- Consider cache-friendly data layouts
-
-## Submitting Changes
-
-### Pull Request Process
-
-1. **Fork and create feature branch**
-2. **Make changes following coding standards**
-3. **Add tests for new functionality**
-4. **Run full validation**: `just commit-check`
-5. **Update documentation** if needed
-6. **Create descriptive pull request**
-
-### Commit Message Guidelines
-
-Use conventional commit format:
+Use conventional commit subjects when possible:
 
 ```text
-type(scope): description
-
-Longer description if needed.
-
-- List specific changes
-- Reference issues: Closes #123
+docs: streamline cli documentation
+fix: reject invalid toroidal profile metadata
+perf: reduce proposal-site allocation
 ```
-
-Types: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `ci`
-
-### Pull Request Checklist
-
-- [ ] Tests pass (`just test-all`)
-- [ ] Code is formatted (`cargo fmt`)
-- [ ] No clippy warnings (`cargo clippy`)
-- [ ] Documentation updated
-- [ ] Benchmarks still compile (`cargo bench --no-run`)
-- [ ] Changes are described in PR
-
-## Types of Contributions
-
-### Bug Reports
-
-- Use GitHub issues
-- Provide minimal reproduction case
-- Include system information
-- Reference relevant physics/mathematics
-
-### Feature Requests
-
-- Discuss in GitHub issues first
-- Consider breaking changes carefully
-- Provide use case and motivation
-- Consider implementation complexity
-
-### Code Contributions
-
-- Start with smaller changes to understand codebase
-- Focus on one feature/fix per PR
-- Consider performance implications
-- Add comprehensive tests
-
-### Documentation Contributions
-
-- Fix typos and improve clarity
-- Add examples and tutorials
-- Improve API documentation
-- Update mathematical explanations
-
-### Research Integration
-
-- Implement new CDT algorithms
-- Add support for different geometries
-- Contribute benchmarks from literature
-
-## Release Process
-
-### Version Numbering
-
-This project follows [Semantic Versioning](https://semver.org/):
-
-- **MAJOR**: Breaking API changes
-- **MINOR**: New features (backward compatible)
-- **PATCH**: Bug fixes and improvements
-
-### Release Checklist
-
-1. Update version in `Cargo.toml`
-2. Update `CHANGELOG.md`
-3. Run full test suite
-4. Create release tag
-5. Publish to crates.io (when ready)
 
 ## Getting Help
 
-### Resources
+- Use GitHub issues for bugs and feature requests.
+- Use discussions for broader CDT, architecture, or workflow questions.
+- Include command output, configuration, seeds, and platform information when reporting reproducibility or performance issues.
 
-- **GitHub Issues**: Bug reports and feature requests
-- **GitHub Discussions**: General questions and community discussion
-- **Documentation**: Comprehensive guides in `docs/` directory
-- **Just workflows**: Run `just help-workflows` for guidance
-
-### Physics and Mathematics
-
-For questions about the underlying physics and mathematics:
-
-- See [REFERENCES.md](REFERENCES.md) for foundational papers
-- Consult CDT literature for theoretical background
-- Ask in GitHub Discussions for concept clarification
-
-### Development Questions
-
-- Check existing issues and discussions
-- Ask specific, focused questions
-- Provide context about what you're trying to achieve
-- Include relevant code snippets or error messages
-
----
-
-Thank you for contributing to advancing computational quantum gravity research! 🌌
+Thank you for helping make computational quantum-gravity tooling more reliable and understandable.
 
 [cdt-lib]: https://github.com/acgetchell/causal-triangulations
-[rustup]: https://rustup.rs/
 [Just]: https://github.com/casey/just

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ verify, reproduce, or extend.
 
 Prerequisites:
 
-- Rust 1.96.0 or newer, managed by `rust-toolchain.toml`
+- Rust 1.96.0, pinned by `rust-toolchain.toml`; `Cargo.toml` also specifies `rust-version = "1.96.0"` as the required toolchain
 - Git
 - [Just] command runner: `cargo install just`
 - `uv` for Python support tooling

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/acgetchell/causal-triangulations"
 rust-version = "1.96.0"
-description = "Causal Dynamical Triangulations in d-dimensions"
+description = "Validated 1+1 Causal Dynamical Triangulations for quantum gravity"
 
 # Features removed - backend system is now internal implementation detail
 # Both delaunay and mock backends are always compiled

--- a/README.md
+++ b/README.md
@@ -9,32 +9,32 @@
 [![Codecov](https://codecov.io/gh/acgetchell/causal-triangulations/graph/badge.svg?token=CsbOJBypGC)](https://codecov.io/gh/acgetchell/causal-triangulations)
 [![Audit dependencies][audit-badge]][audit-workflow]
 
-Causal Dynamical Triangulations for quantum gravity in [Rust], built on fast Delaunay triangulation primitives.
+Causal Dynamical Triangulations for quantum gravity in [Rust], built on fast [Delaunay triangulation] primitives
+and composable, adaptable Metropolis-Hastings sampling via [`markov-chain-monte-carlo`].
+
+## Contents
+
+- [Introduction](#-introduction)
+- [Project Status](#-project-status)
+- [Ensemble And Volume Behavior](#-ensemble-and-volume-behavior)
+- [Features](#-features)
+- [Documentation Map](#-documentation-map)
+- [Requirements](#-requirements)
+- [Running The Binary](#-running-the-binary)
+- [Ecosystem](#-ecosystem)
+- [Benchmarking](#-benchmarking)
+- [Roadmap](#-roadmap)
+- [How to Contribute](#-how-to-contribute)
+- [References](#-references)
+- [AI Agents](#-ai-agents)
+- [License](#-license)
 
 ## 🌌 Introduction
 
-This library implements **Causal Dynamical Triangulations (CDT)** in [Rust]. CDT is a non-perturbative approach to quantum gravity that constructs discrete
-spacetime as triangulated manifolds with causal structure, providing a computational framework for studying quantum gravity phenomenology.
-
-For an introduction to Causal Dynamical Triangulations, see [this paper](https://arxiv.org/abs/hep-th/0105267).
-
-The library leverages high-performance [Delaunay triangulation] backends and provides a foundational toolkit for CDT research and exploration.
-
-## ✨ Features
-
-- [x] Delaunay-built 1+1 CDT strip and periodic toroidal S¹×S¹ constructors with foliation invariants
-- [x] Foliation-aware topology, causality, and simplex-classification validation
-- [x] Proposal-before-mutation Metropolis-Hastings simulation with rollback on failed accepted moves
-- [x] Regge action calculation with configurable coupling constants
-- [x] Alexander/Pachner-style local move proposals with causal constraints
-- [x] Volume-profile, Hausdorff-dimension, and spectral-dimension observables for CDT analysis
-- [x] Trace CSV simulation output for external analysis workflows; JSON summary/metadata for CLI/config export
-- [x] Resumable serde-backed CDT/MCMC checkpoints for durable chain continuation
-- [x] Focused public preludes for simulation, triangulation, geometry, action, and observables
-- [x] Command-line interface, examples, Criterion benchmarks, and CI-aligned validation tooling
-- [x] Cross-platform compatibility: Linux, macOS, Windows
-
-See [CHANGELOG.md](CHANGELOG.md) for release history.
+This library implements **Causal Dynamical Triangulations (CDT)** in [Rust]. CDT is a non-perturbative approach to quantum gravity defining the gravitational
+path integral over causally triangulated spacetimes and evaluating it using Markov Chain Monte Carlo. For an introduction to CDT, see Ambjørn and Loll (2001),
+[“Non-perturbative Lorentzian quantum gravity, causality and topology change”](https://arxiv.org/abs/hep-th/0105267). The library leverages high-performance
+[Delaunay triangulation] backends and provides a foundational toolkit for CDT research and exploration.
 
 ## 🚧 Project Status
 
@@ -44,7 +44,67 @@ upstream-backed MCMC sampler mechanics, trace/summary exports, resumable checkpo
 The library currently supports validated 1+1 CDT construction, foliation checks, Metropolis sampling, resumable checkpoints, and core observables.
 Higher-dimensional CDT support, visualization/export workflows, and advanced ensemble-analysis helpers remain roadmap work.
 
+Current scope:
+
+- Supported now: validated 1+1 open-boundary and toroidal CDT construction, local CDT move proposals, Metropolis sampling, trace/summary output, and core
+  observables.
+- Not supported yet: 2+1 or 3+1 CDT, production volume fixing, automated λ scans, visualization/export workflows, and full ensemble-analysis tooling.
+- Planned next: 1+1 refinement work for finite-volume scans, release binaries, analysis ergonomics, and explicit topology tracks for higher-dimensional CDT.
+
+For a copy-paste local run written for physicists rather than Rust contributors, start with the [Quick Start](docs/QUICKSTART.md).
+
 See [`docs/roadmap.md`](docs/roadmap.md) for current direction, near-term candidates, and non-goals.
+
+## ⚖️ Ensemble And Volume Behavior
+
+Current simulations do not apply volume fixing. Volume-changing moves may change the total number of vertices and simplices during a run, so the sampled
+ensemble is the grand-canonical, unfixed-volume ensemble defined by the configured CDT action and Metropolis-Hastings proposal rules. This is intentional for
+now: in 1+1 CDT, unfixed-volume simulations controlled by the cosmological constant are a standard toy-model setting, as in Israel and Lindner,
+[Quantum gravity on a laptop: 1+1 Dimensional Causal Dynamical Triangulation simulation](https://doi.org/10.1016/j.rinp.2012.10.001).
+
+In a grand-canonical CDT ensemble, the cosmological constant is the coupling that controls volume growth or shrinkage because it is conjugate to the lattice
+volume term in the action. Use `--cosmological-constant` to tune that behavior. Values too far from the useful finite-volume regime can drive runs toward
+minimum-volume configurations or toward rapid growth; this is expected physics for the unfixed-volume ensemble, not volume fixing.
+Automated λ-scan utilities for finding practical finite-volume windows are planned as [#143](https://github.com/acgetchell/causal-triangulations/issues/143);
+for v0.1.0, tune `--cosmological-constant` manually and inspect the reported volume and acceptance diagnostics.
+
+The default 1+1 action constants use `κ0 = 0`, `κ2 = 0`, and an edge-count cosmological constant `(2 / 3) ln 2`, mapping the crate's `λ N1` convention to the
+standard 2D CDT critical triangle-volume coupling `λc = ln 2` for closed 1+1 triangulations, where `N1 = 3 N2 / 2`. Open-boundary strips have boundary-count
+corrections, so the same default should be treated as a practical baseline rather than an exact open-boundary critical value. The Delaunay backend supplies
+construction and validation infrastructure for a well-formed initial PL triangulation; the simulation ensemble is defined by CDT moves, constraints, action,
+and Metropolis-Hastings acceptance, not by maintaining the Delaunay condition after every move.
+
+Higher-dimensional CDT studies often use explicit approximate volume fixing for finite-size numerical work. For example, Ambjørn et al. discuss quadratic
+volume fixing in [The Semiclassical Limit of Causal Dynamical Triangulations](https://arxiv.org/abs/1102.3929), and the toroidal phase-structure study uses
+quadratic volume fixing in [The phase structure of Causal Dynamical Triangulations with toroidal spatial topology](https://arxiv.org/abs/1802.10434). This
+crate may add such a mode later, but it should be opt-in because it samples a modified action rather than the current bare unfixed-volume ensemble.
+
+## ✨ Features
+
+- Delaunay-built 1+1 CDT strip and periodic toroidal S¹×S¹ constructors with foliation invariants
+- Foliation-aware topology, causality, and simplex-classification validation
+- Proposal-before-mutation Metropolis-Hastings simulation with rollback on failed accepted moves
+- Regge action calculation with configurable coupling constants
+- Alexander/Pachner-style local move proposals with causal constraints
+- Volume-profile, Hausdorff-dimension, and spectral-dimension observables for CDT analysis
+- Trace CSV simulation output for external analysis workflows; JSON summary/metadata for CLI/config export
+- Resumable serde-backed CDT/MCMC checkpoints for durable chain continuation
+- Focused public preludes for simulation, triangulation, geometry, action, and observables
+- Command-line interface, examples, Criterion benchmarks, and CI-aligned validation tooling
+- Cross-platform compatibility: Linux, macOS, Windows
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.
+
+## 🗺️ Documentation Map
+
+- [Quick Start](docs/QUICKSTART.md) — first local 1+1 CDT run, parameter meanings, output files, and troubleshooting
+- [CLI Examples](docs/CLI_EXAMPLES.md) — advanced command-line usage and output workflows
+- [Metropolis](docs/metropolis.md) — proposal-before-mutation ordering, detailed balance, trace semantics, and sampler/backend boundaries
+- [Moves](docs/moves.md) — CDT local move semantics, proposal ratios, rollback behavior, and action calibration
+- [Foliation](docs/foliation.md) — time labels, spacelike/timelike classification, causality validation, and toroidal time handling
+- [Roadmap](docs/roadmap.md) — near-term work, higher-dimensional topology tracks, and non-goals
+- [Code Organization](docs/code_organization.md) — module layout, backend boundaries, and architecture notes
+- [References](REFERENCES.md) — physics, numerical, and computational-geometry citations
 
 ## ⚙️ Requirements
 
@@ -54,73 +114,34 @@ See [`docs/roadmap.md`](docs/roadmap.md) for current direction, near-term candid
 
 - **Memory safety** for large-scale simulations
 - **Zero-cost abstractions** for performance-critical geometry operations
-- **Rich ecosystem** for scientific computing and parallel processing
+- **Validation tooling** for tests, documentation, benchmarks, and CI parity
 
-## 📋 Running The Binary
+## 💻 Running The Binary
 
 The crate installs a `cdt` binary. Use it to construct an initial 1+1 CDT triangulation, optionally run the Metropolis move loop, and write analysis-friendly
 trace CSV output plus JSON summary/metadata.
 
 ```bash
-# Build the binary
-cargo build --release
+cargo install causal-triangulations
+cdt --help
 
-# Show all supported options
-./target/release/cdt --help
-
-# Build an open-boundary triangulation and record the initial measurement
-./target/release/cdt --vertices-per-slice 4 --timeslices 5 --output-json open-boundary-summary.json
-
-# Build nonuniform open-boundary initial data from an explicit spatial volume profile
-./target/release/cdt --volume-profile 4,6,5 --output-json open-profile-summary.json
-
-# Run a periodic toroidal simulation and write both output formats
-./target/release/cdt \
-  --vertices-per-slice 8 \
-  --timeslices 6 \
-  --topology toroidal \
-  --steps 200 \
-  --thermalization-steps 20 \
+cdt \
+  --dimension 2 \
+  --vertices-per-slice 4 \
+  --timeslices 5 \
+  --steps 100 \
+  --thermalization-steps 10 \
   --measurement-frequency 10 \
-  --temperature 1.5 \
   --seed 105 \
   --simulate \
-  --output-csv toroidal-trace.csv \
-  --output-json toroidal-summary.json
+  --output-csv cdt-runs/quickstart/trace.csv \
+  --output-json cdt-runs/quickstart/summary.json
 ```
 
-Prefer `--vertices-per-slice` for regular equal-slice initial data; the binary computes the total initial vertex count as
-`vertices_per_slice × timeslices`. Use `--volume-profile N0,N1,...` for explicit nonuniform spatial slice volumes; when supplied without `--timeslices`, the
-number of profile entries defines the time-slice count. `--vertices` is still accepted when you already know the total for regular data, but it must divide
-evenly by `--timeslices`. Open-boundary runs require at least 4 vertices per slice and toroidal runs require at least 3 vertices per slice. Without
-`--simulate`, the binary only builds the initial triangulation and writes the step-0 measurement.
+For a fully annotated first run, see [Quick Start](docs/QUICKSTART.md). For advanced CLI usage, topology examples, and logging/output patterns, see
+[`docs/CLI_EXAMPLES.md`](docs/CLI_EXAMPLES.md).
 
-### Ensemble And Volume Behavior
-
-Current simulations do not apply volume fixing. Volume-changing moves may change the total number of vertices and simplices during a run, so the sampled
-ensemble is the unfixed-volume ensemble defined by the configured CDT action and Metropolis-Hastings proposal rules. This is intentional for now: in 1+1 CDT,
-unfixed-volume simulations controlled by the cosmological constant are a standard toy-model setting, as in Israel and Lindner,
-[Quantum gravity on a laptop: 1+1 Dimensional Causal Dynamical Triangulation simulation](https://doi.org/10.1016/j.rinp.2012.10.001).
-
-In an unfixed-volume ensemble, the cosmological constant is the coupling that controls volume growth or shrinkage because it is conjugate to the lattice
-volume term in the action. Use `--cosmological-constant` to tune that behavior. Values too far from the useful finite-volume regime can drive runs toward
-minimum-volume configurations or toward rapid growth; this is expected physics for the unfixed ensemble, not volume fixing.
-Automated λ-scan utilities for finding practical finite-volume windows are planned as [#143](https://github.com/acgetchell/causal-triangulations/issues/143);
-for v0.1.0, tune `--cosmological-constant` manually and inspect the reported volume and acceptance diagnostics.
-
-The default 1+1 action constants use `κ0 = 0`, `κ2 = 0`, and an edge-count cosmological constant `(2 / 3) ln 2`, mapping the crate's `λ N1` convention to the
-standard 2D CDT critical triangle-volume coupling `λc = ln 2` for closed toroidal triangulations. The Delaunay backend supplies construction and validation
-infrastructure for a well-formed initial PL triangulation; the simulation ensemble is defined by CDT moves, constraints, action, and Metropolis-Hastings
-acceptance, not by maintaining Delaunayhood after every move.
-
-Higher-dimensional CDT studies often use explicit approximate volume fixing for finite-size numerical work. For example, Ambjørn et al. discuss quadratic
-volume fixing in [The Semiclassical Limit of Causal Dynamical Triangulations](https://arxiv.org/abs/1102.3929), and the toroidal phase-structure study uses
-quadratic volume fixing in [The phase structure of Causal Dynamical Triangulations with toroidal spatial topology](https://arxiv.org/abs/1802.10434). This
-crate may add such a mode later, but it should be opt-in because it samples a modified action rather than the current bare unfixed-volume ensemble.
-
-### Ready-to-Use Scripts
-
-The `examples/scripts/` directory contains research workflows:
+The `examples/scripts/` directory contains ready-to-use research workflows:
 
 - **`basic_simulation.sh`** - Simple simulation command
 - **`parameter_sweep.sh`** - Temperature sweep setup
@@ -128,26 +149,22 @@ The `examples/scripts/` directory contains research workflows:
 
 For detailed documentation, sample output, and usage instructions for each script, see [examples/scripts/README.md](examples/scripts/README.md).
 
-For comprehensive CLI documentation and advanced usage patterns, see [`docs/CLI_EXAMPLES.md`](docs/CLI_EXAMPLES.md).
-
 ## 🧩 Ecosystem
 
 This crate is part of a broader Rust ecosystem for computational geometry and simulation:
 
 - [`delaunay`](https://crates.io/crates/delaunay) — geometric primitives and triangulations
-- `la-stack` — linear algebra utilities
+- [`la-stack`](https://crates.io/crates/la-stack) — linear algebra utilities
 - [`markov-chain-monte-carlo`](https://crates.io/crates/markov-chain-monte-carlo) — composable MCMC traits, including plan-before-commit proposals for CDT
   move ordering
 
-The long-term design separates:
+The design separates geometry, sampling, and CDT-specific physics. Within this crate, `src/geometry/` is the backend interface layer over `delaunay`,
+`src/cdt/` is the CDT domain layer, and `src/cdt/metropolis/` contains the thin adapters and runner code that consume `markov-chain-monte-carlo`.
 
-- **Geometry** (triangulations and invariants)
-- **Sampling** (MCMC algorithms)
-- **Physics** (CDT-specific dynamics and observables)
+- **Foliation‑aware data model**: explicit time labels; space‑like vs time‑like edges encoded in types.
+- **Testing**: unit, integration, and property-based tests for topology, causality, foliation, and simulation invariants.
 
-Within this crate, `src/geometry/` is the backend interface layer over `delaunay`, while `src/cdt/` is the CDT domain layer.
-
-## 📋 Benchmarking
+## 📈 Benchmarking
 
 Comprehensive performance benchmarks using [Criterion]:
 
@@ -178,15 +195,9 @@ performance testing workflow documentation.
 The high-level roadmap, including 1+1 maturity work, future 2+1 and 3+1 CDT topology tracks, observables, dual/Voronoi geometry, visualization, and non-goals,
 lives in [`docs/roadmap.md`](docs/roadmap.md).
 
-## Design notes
-
-- **Separation of concerns**: geometry primitives (Delaunay/Voronoi) are decoupled from CDT dynamics.
-- **Foliation‑aware data model**: explicit time labels; space‑like vs time‑like edges encoded in types.
-- **Testing**: unit + property tests for invariants (e.g., move reversibility, manifoldness).
-
 ## 🤝 How to Contribute
 
-We welcome contributions! Here's a 30-second quickstart:
+We welcome contributions. Here's a short local workflow:
 
 ```bash
 # Clone and setup
@@ -206,12 +217,12 @@ just --list          # See all available development commands
 # Run examples
 just run-example     # Basic simulation
 ./examples/scripts/basic_simulation.sh      # Shell script example
-./examples/scripts/parameter_sweep.sh       # Temperature sweep study
+./examples/scripts/parameter_sweep.sh       # Temperature sweep setup
 ./examples/scripts/performance_test.sh      # Performance benchmarking across system sizes
 ```
 
-`just setup` prints a checklist of external tools used by repository workflows (for example: `uv`, `taplo`, `actionlint`, `shfmt`, `shellcheck`, `jq`) and how
-to install them.
+`just setup` installs or verifies Cargo-hosted tools such as `dprint`, `rumdl`, `taplo-cli`, `typos-cli`, `cargo-nextest`, `cargo-llvm-cov`, and `zizmor`.
+It also prints a checklist for external tools such as `uv`, `actionlint`, `shfmt`, `shellcheck`, and `jq`.
 
 **Just Workflows:**
 
@@ -250,20 +261,8 @@ This includes foundational work on:
 
 ## 🤖 AI Agents
 
-This repository contains an `AGENTS.md` file, which defines the canonical rules and invariants for all AI coding assistants and autonomous agents working on
-this codebase.
-
-AI tools (including ChatGPT, Claude, CodeRabbit, Codex, and WARP) are expected to read and follow `AGENTS.md` when proposing or applying changes.
-
-Portions of this library were developed with the assistance of these AI tools:
-
-- [ChatGPT]
-- [Claude]
-- [CodeRabbit]
-- [Codex]
-- [WARP]
-
-> All code was written and/or reviewed and validated by the author.
+AI coding assistants should read [AGENTS.md](AGENTS.md) before proposing or applying changes. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup,
+testing, benchmarks, style, and pull-request guidance.
 
 ## 📝 License
 
@@ -273,12 +272,8 @@ This project's license is specified in [LICENSE](LICENSE).
 
 [Rust]: https://rust-lang.org
 [Delaunay triangulation]: https://crates.io/crates/delaunay
+[`markov-chain-monte-carlo`]: https://crates.io/crates/markov-chain-monte-carlo
 [Criterion]: https://github.com/bheisler/criterion.rs
-[ChatGPT]: https://openai.com/chatgpt
-[Claude]: https://www.anthropic.com/claude
-[CodeRabbit]: https://coderabbit.ai/
-[Codex]: https://openai.com/codex/
-[WARP]: https://www.warp.dev
 [ci-badge]: https://github.com/acgetchell/causal-triangulations/actions/workflows/ci.yml/badge.svg
 [ci-workflow]: https://github.com/acgetchell/causal-triangulations/actions/workflows/ci.yml
 [clippy-badge]: https://github.com/acgetchell/causal-triangulations/actions/workflows/rust-clippy.yml/badge.svg

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,243 +1,132 @@
-# CDT Benchmarking Guide
+# CDT Benchmarks
 
-This document describes the comprehensive benchmarking suite for the Causal Dynamical Triangulations library.
-
-## Overview
-
-The benchmarking suite measures performance of key CDT operations using the [criterion](https://crates.io/crates/criterion) benchmarking framework. The
-benchmarks are designed to track performance across different system sizes and identify performance regressions.
+This document describes the Criterion benchmark suites. For regression workflows, baselines, CI behavior, and report generation, see
+[`docs/PERFORMANCE_TESTING.md`](../docs/PERFORMANCE_TESTING.md).
 
 ## Running Benchmarks
 
-### All Benchmarks
-
 ```bash
 cargo bench
+just bench-ci
+cargo bench --profile perf --bench ci_performance_suite
 ```
 
-### CI Performance Suite
+Run a focused group:
 
 ```bash
-just bench-ci
+cargo bench triangulation_creation
+cargo bench edge_counting
+cargo bench geometry_queries
+cargo bench action_calculations
+cargo bench ergodic_moves
+cargo bench metropolis_simulation
+cargo bench simulation_analysis
+cargo bench cache_operations
+cargo bench validation
 ```
 
-The `ci_performance_suite` target is the smaller regression contract used by
-the performance tooling. It runs with the Cargo `perf` profile and focuses on
-CDT workflows that should stay comparable across releases:
+Criterion writes HTML reports under `target/criterion/`.
+
+## CI Performance Suite
+
+`ci_performance_suite` is the smaller benchmark contract used by the performance tooling. It runs with the Cargo `perf` profile and focuses on CDT workflows
+that should stay comparable across releases:
 
 - generating open-boundary and toroidal CDT triangulations;
 - validating generated triangulations;
 - attempting individual ergodic move types;
-- iterating proposal-site candidates through public move-attempt and single-step
-  Metropolis proposal paths;
-- executing ten random-move sweeps, where each sweep attempts one move per
-  current simplex;
+- iterating proposal-site candidates through public move-attempt and single-step Metropolis proposal paths;
+- executing ten random-move sweeps, where each sweep attempts one move per current simplex;
 - running short Metropolis simulations sized as ten initial sweeps.
 
-### Specific Benchmark Groups
+Keep this suite stable and release-relevant. Exploratory or noisy benchmarks belong in `cdt_benchmarks.rs`.
 
-```bash
-# Triangulation creation performance
-cargo bench triangulation_creation
+## Benchmark Groups
 
-# Edge counting performance (cached vs uncached)
-cargo bench edge_counting
+### `triangulation_creation`
 
-# Geometry query operations
-cargo bench geometry_queries
+Measures Delaunay-backed CDT construction across small to larger initial configurations.
 
-# Action calculations
-cargo bench action_calculations
+Use for:
 
-# Ergodic move operations
-cargo bench ergodic_moves
+- initial setup scaling;
+- open-boundary and toroidal constructor regressions;
+- backend construction changes.
 
-# Metropolis-Hastings simulation loop
-cargo bench metropolis_simulation
+### `edge_counting`
 
-# Simulation analysis operations
-cargo bench simulation_analysis
+Compares cached and uncached edge-count queries.
 
-# Cache operations
-cargo bench cache_operations
+Use for:
 
-# Validation operations
-cargo bench validation
+- cache effectiveness;
+- repeated action/observable queries;
+- validation and output hot paths.
 
-# CI regression contract
-cargo bench --profile perf --bench ci_performance_suite
+### `geometry_queries`
+
+Measures geometry interrogation operations such as vertex/edge/face iteration, Euler characteristic calculation, and structural validation.
+
+Use for backend query regressions and geometry abstraction overhead.
+
+### `action_calculations`
+
+Measures CDT Regge-action evaluation:
+
+```text
+S = -κ₀ N0 - κ₂ N2 + λ N1
 ```
 
-### Output Format
+Use for Metropolis target and observable hot paths.
 
-```bash
-# Generate HTML reports
-cargo bench -- --output-format html
+### `ergodic_moves`
 
-# Save benchmark results for comparison
-cargo bench -- --save-baseline my_baseline
-```
+Measures CDT move proposal and application paths:
 
-## Benchmark Categories
+- `Move22`: foliation-aware `(2,2)` edge flip;
+- `Move13Add`: local volume-add proposal;
+- `Move31Remove`: local inverse volume proposal;
+- `EdgeFlip`: API-compatible alias for the 2D k=2 edge flip;
+- random move selection and attempt paths.
 
-### 1. Triangulation Creation (`triangulation_creation`)
+The CI suite also includes `cdt_proposal_site_move_attempts_2d` and `cdt_single_metropolis_proposal_2d`. These exercise explicit proposal-site iteration,
+cloned proposed-state mutation, and reverse-site counting for the Hastings ratio. Check these before adding crate-internal benchmark hooks for isolated
+proposal-site enumeration.
 
-- **Purpose**: Measures time to create Delaunay triangulations of various sizes
-- **Test Sizes**: 5, 10, 20, 50, 100 vertices
-- **Metrics**: Time per triangulation, throughput (triangulations/second)
-- **Use Case**: Identifying scaling behavior for initial setup
+### `metropolis_simulation`
 
-### 2. Edge Counting (`edge_counting`)
+Measures short Metropolis-Hastings runs over real CDT move kernels.
 
-- **Purpose**: Compares cached vs uncached edge counting performance
-- **Test Sizes**: 10, 25, 50, 100, 200 vertices
-- **Variants**:
-  - `uncached`: Direct computation every time (O(E))
-  - `cached`: Using triangulation cache (O(1) when valid)
-- **Use Case**: Optimizing frequent edge count queries in simulations
+Includes configuration validation, proposal planning, accepted-move application, telemetry, and measurements.
 
-### 3. Geometry Queries (`geometry_queries`)
+### `simulation_analysis`
 
-- **Purpose**: Measures basic geometry operations performance
-- **Operations Tested**:
-  - `vertex_count`: Count vertices
-  - `face_count`: Count faces
-  - `euler_characteristic`: Calculate V - E + F
-  - `is_valid`: Validate triangulation
-  - `iterate_vertices`: Iterate over all vertices
-  - `iterate_edges`: Iterate over all edges
-  - `iterate_faces`: Iterate over all faces
-- **Use Case**: Profiling core geometry backend performance
+Measures post-run analysis such as acceptance rates, average action, and equilibrium measurement extraction.
 
-### 4. Action Calculations (`action_calculations`)
+Use for output and analysis workflow regressions.
 
-- **Purpose**: Measures CDT action computation performance
-- **Test Cases**: Small (10V), Medium (50V), Large (100V) triangulations
-- **Formula**: S = -κ₀V - κ₂F + λE (2D Regge action)
-- **Use Case**: Optimizing Monte Carlo step calculations
+### `cache_operations`
 
-### 5. Ergodic Moves (`ergodic_moves`)
+Measures cache refresh and invalidation costs.
 
-- **Purpose**: Measures performance of CDT move operations
-- **Move Types**:
-  - `Move22`: Edge flip between triangles
-  - `Move13Add`: Add vertex by triangle subdivision
-  - `Move31Remove`: Remove vertex by triangle merging
-  - `EdgeFlip`: Standard Delaunay edge flip
-- **Additional Tests**:
-  - `random_move_selection`: Random move type selection
-  - `random_move_attempt`: Complete random move attempt
-- **Use Case**: Optimizing Monte Carlo move proposal
+Use for repeated geometry-query and move-finalization paths.
 
-The CI suite also includes `cdt_proposal_site_move_attempts_2d` and
-`cdt_single_metropolis_proposal_2d`. These benchmarks exercise the public paths
-that iterate explicit proposal sites, apply a selected site on a cloned proposed
-state, and, for Metropolis proposals, compute reverse-site counts for the
-Hastings ratio. They are the first place to check before adding a
-crate-internal benchmark hook for isolated proposal-site enumeration.
+### `validation`
 
-### 6. Metropolis Simulation (`metropolis_simulation`)
+Measures CDT validation, including topology, foliation, causality, and simplex classification.
 
-- **Purpose**: Measures short Metropolis-Hastings runs over the CDT move kernels
-- **Test Configurations**: 10, 50, 100 requested MC steps
-- **Includes**: Configuration validation, move proposal acceptance, accepted move application, and measurements
-- **Use Case**: Tracking end-to-end simulation-loop overhead
+Use for correctness-checking overhead.
 
-### 7. Simulation Analysis (`simulation_analysis`)
+## Adding Benchmarks
 
-- **Purpose**: Measures post-simulation analysis performance
-- **Operations**:
-  - `acceptance_rate`: Calculate move acceptance statistics
-  - `average_action`: Calculate mean action over simulation
-  - `equilibrium_measurements`: Extract post-thermalization data
-- **Use Case**: Optimizing data analysis workflows
-
-### 8. Cache Operations (`cache_operations`)
-
-- **Purpose**: Measures triangulation caching performance
-- **Operations**:
-  - `refresh_cache`: Populate geometry cache
-  - `cache_invalidation`: Cache invalidation cost
-- **Use Case**: Optimizing repeated geometry queries
-
-### 9. Validation (`validation`)
-
-- **Purpose**: Measures triangulation validation performance
-- **Operations**:
-  - `validate_cdt_properties`: Full CDT property validation
-- **Use Case**: Profiling debugging and verification overhead
-
-## Performance Expectations
-
-### Typical Performance Ranges (Debug Builds)
-
-- **Triangulation Creation**: ~100μs - 10ms (size-dependent)
-- **Cached Edge Count**: ~1μs - 10μs
-- **Uncached Edge Count**: ~10μs - 1ms (size-dependent)
-- **Action Calculation**: ~100ns - 1μs
-- **Ergodic Move**: ~1μs - 100μs
-- **MC Step**: ~10μs - 1ms
-
-### Performance Optimization Targets
-
-- **Edge counting**: Achieve >90% cache hit rate in simulations
-- **Action calculations**: <1μs per calculation
-- **MC steps**: <100μs per step for medium triangulations
-- **Memory usage**: Linear scaling with vertex count
-
-## Interpreting Results
-
-### Key Metrics
-
-- **Mean**: Average execution time
-- **Std Dev**: Performance consistency
-- **Throughput**: Operations per second
-- **Regression**: Performance changes over time
-
-### Performance Analysis
-
-```bash
-# Compare with previous baseline
-cargo bench -- --baseline previous
-
-# Generate detailed HTML report
-cargo bench -- --output-format html
-
-# Profile with perf integration (Linux)
-cargo bench -- --profile-time=5
-```
-
-## Benchmark Configuration
-
-### Criterion Settings
-
-- **Sample Size**: Automatically determined by criterion
-- **Measurement Time**: 5 seconds per benchmark
-- **Warmup Time**: 3 seconds
-- **Confidence Level**: 95%
-- **Outlier Detection**: Automatic
-
-### Custom Configurations
-
-The benchmarks use criterion's default statistical analysis with:
-
-- Throughput measurements where applicable
-- HTML report generation enabled
-- Automatic outlier detection and handling
-- Cross-platform timing precision
-
-## Adding New Benchmarks
-
-### Template
+Use Criterion and keep setup outside the timed loop when setup is not the thing being measured:
 
 ```rust
-/// Benchmark new CDT operation
+use criterion::{Criterion, black_box};
+
 fn bench_new_operation(c: &mut Criterion) {
     let mut group = c.benchmark_group("new_operation");
-
-    // Setup test data
-    let triangulation = CdtTriangulation2D::new_with_delaunay(20, 1, 2)
-        .expect("Failed to create triangulation");
+    let triangulation = build_fixture();
 
     group.bench_function("operation_name", |b| {
         b.iter(|| {
@@ -248,54 +137,20 @@ fn bench_new_operation(c: &mut Criterion) {
 
     group.finish();
 }
-
-// Add to criterion_group! macro
-criterion_group!(
-    benches,
-    // ... existing benchmarks ...
-    bench_new_operation
-);
 ```
 
-### Best Practices
+Guidelines:
 
-1. Use `black_box()` to prevent compiler optimizations
-2. Create test data outside the benchmark loop when possible
-3. Include multiple test sizes for scaling analysis
-4. Add throughput measurements for size-dependent operations
-5. Document expected performance ranges and optimization targets
+- include enough sizes to show scaling;
+- use seeded or deterministic fixtures where possible;
+- name benchmarks by the behavior being measured;
+- keep the CI suite stable and reasonably fast;
+- document expected changes in PRs when benchmark behavior changes.
 
-## Continuous Integration
+## Interpreting Results
 
-### Automated Benchmarking
+Criterion reports means, confidence intervals, outliers, and change estimates when baselines are available. Small changes can be noise. Use
+[`docs/PERFORMANCE_TESTING.md`](../docs/PERFORMANCE_TESTING.md) for thresholded regression checks and report generation.
 
-```bash
-# Run the CI regression benchmark contract
-just bench-ci
-
-# Performance regression detection
-cargo bench -- --save-baseline main
-```
-
-### Performance Monitoring
-
-- Track benchmark results over time
-- Set up alerts for significant performance regressions
-- Compare performance across different hardware configurations
-- Profile memory usage alongside timing benchmarks
-
-## Hardware Considerations
-
-### Recommended Setup
-
-- **CPU**: Modern multi-core processor (benchmarks are mostly single-threaded)
-- **Memory**: 8GB+ RAM for large triangulation benchmarks
-- **Storage**: SSD for faster compilation and test data I/O
-
-### Platform Differences
-
-- macOS: Uses `mach_absolute_time()` for high-precision timing
-- Linux: Uses `clock_gettime()` with CLOCK_MONOTONIC
-- Windows: Uses `QueryPerformanceCounter()`
-
-Results may vary across platforms due to different timer precision and system overhead.
+Hardware, operating system, CPU load, and thermal behavior can change benchmark results. Prefer same-machine comparisons for local optimization work and CI
+baselines for PR-level regression signals.

--- a/docs/CLI_EXAMPLES.md
+++ b/docs/CLI_EXAMPLES.md
@@ -1,278 +1,93 @@
-# CDT-RS Command Line Interface Examples
+# CDT CLI Examples
 
-This document provides examples for using the `cdt` binary, the command-line interface for Causal Dynamical Triangulations simulations.
+This page collects advanced `cdt` command-line patterns. For a first run with parameter explanations and troubleshooting, start with
+[Quick Start](QUICKSTART.md).
 
-> **Current simulation status:** examples that pass `--simulate` run the Metropolis-Hastings loop over the 2D CDT move kernels. Omit `--simulate` when you only
-> want triangulation generation and the initial measurement.
+The examples use the installed `cdt` binary. From a repository clone, build with `cargo build --release` and replace `cdt` with `./target/release/cdt`.
 
-## Basic Usage
+> **Current simulation status:** commands with `--simulate` run the Metropolis-Hastings loop over the 2D CDT move kernels. Omit `--simulate` when you only want
+> triangulation generation and the initial measurement.
 
-The `cdt` binary accepts various command-line arguments to configure and run CDT simulations.
+## Argument Groups
 
-### Quick Start
+Initial spatial volume can be specified in one of three ways:
+
+- `--vertices-per-slice <N>` with `--timeslices <T>`: regular equal-slice initial data; total vertices are `N × T`.
+- `--vertices <N>` with `--timeslices <T>`: total regular initial vertex count; `N` must divide evenly by `T`.
+- `--volume-profile <N0,N1,...>`: explicit nonuniform initial spatial volumes. If `--timeslices` is omitted, the profile length sets it.
+
+Core simulation flags:
+
+- `--dimension <D>`: currently only `2`.
+- `--topology <open-boundary|toroidal>`: open strip or periodic S¹×S¹ initial data.
+- `--steps <N>`: number of Metropolis proposals to evaluate when `--simulate` is set.
+- `--thermalization-steps <N>`: early steps excluded from scheduled measurements.
+- `--measurement-frequency <N>`: scheduled measurement interval for JSON output.
+- `--seed <N>`: reproducible RNG seed.
+- `--output-csv <PATH>` and `--output-json <PATH>`: write scalar trace rows and structured summary/final state.
+
+Physics and sampler flags:
+
+- `--temperature <T>`: Metropolis sampler temperature; keep `1.0` unless deliberately studying sampler behavior.
+- `--coupling-0 <κ₀>` and `--coupling-2 <κ₂>`: vertex and triangle action couplings.
+- `--cosmological-constant <λ>`: edge-count cosmological coupling. In unfixed-volume runs it controls volume growth or shrinkage.
+
+## Topology Examples
+
+### Open-Boundary Strip
 
 ```bash
-# Basic 2D CDT triangulation with default parameters
-./target/release/cdt --vertices-per-slice 4 --timeslices 5
-
-# Run with custom simulation settings
-./target/release/cdt --vertices-per-slice 4 --timeslices 10 --temperature 1.5 --steps 2000 --simulate
+cdt \
+  --vertices-per-slice 4 \
+  --timeslices 5 \
+  --topology open-boundary \
+  --output-json open-boundary-summary.json
 ```
 
-## Command Line Arguments
+Open-boundary runs require at least 4 vertices per slice and at least 2 time slices.
 
-### Required Arguments
-
-- `--vertices-per-slice <N>`: Vertices on each initial spatial slice. Prefer this for regular CDT initial data; the binary computes
-  `total vertices = vertices-per-slice × timeslices`.
-- `--vertices <N>`: Total initial vertex count. Use this only when the total is already known; it must divide evenly by `--timeslices`.
-- `--volume-profile <N0,N1,...>`: Explicit vertices per initial spatial slice for nonuniform CDT initial data. The profile length defines `--timeslices` when
-  `--timeslices` is omitted.
-- `--timeslices <N>`: Number of time slices in the CDT foliation (required unless `--volume-profile` is supplied)
-
-### Optional Simulation Parameters
-
-- `--dimension <D>`: Dimensionality (currently only 2, default: 2)
-- `--temperature <T>`: Temperature for Metropolis algorithm (default: 1.0)
-- `--steps <N>`: Number of Monte Carlo steps (default: 1000)
-- `--thermalization-steps <N>`: Thermalization steps before measurements (default: 100)
-- `--measurement-frequency <N>`: Take measurement every N steps (default: 10)
-
-### Physics Parameters
-
-- `--coupling-0 <κ₀>`: Coupling constant for vertices (default: 0.0)
-- `--coupling-2 <κ₂>`: Coupling constant for triangles (default: 0.0)
-- `--cosmological-constant <λ>`: Edge-count cosmological constant (default: `(2 / 3) ln 2`)
-
-### Additional Options
-
-- `--simulate`: Request full Monte Carlo simulation (default: false). Omit `--simulate` for triangulation generation and initial measurements only.
-
-## Example Usage Scenarios
-
-### 1. Small Test Simulation
+### Periodic Toroidal Run
 
 ```bash
-# Quick triangulation-generation test with minimal parameters
-./target/release/cdt --vertices-per-slice 4 --timeslices 2
+cdt \
+  --vertices-per-slice 8 \
+  --timeslices 6 \
+  --topology toroidal \
+  --steps 200 \
+  --thermalization-steps 20 \
+  --measurement-frequency 10 \
+  --seed 105 \
+  --simulate \
+  --output-csv toroidal-trace.csv \
+  --output-json toroidal-summary.json
 ```
 
-**Expected Output:**
+Toroidal runs require at least 3 vertices per slice and at least 3 time slices. The constructor builds periodic S¹×S¹ initial data and validates topology,
+foliation, causality, and simplex classification before simulation.
 
-- Creates an 8-vertex, 2-timeslice open-boundary triangulation
-- Does not run Monte Carlo steps unless `--simulate` is passed
-- Reports the initial triangulation measurement
-
-### 2. Medium-Scale Physics Study
+### Nonuniform Initial Volume Profile
 
 ```bash
-./target/release/cdt \
-  --vertices-per-slice 5 \
-  --timeslices 10 \
-  --temperature 1.2 \
-  --steps 5000 \
-  --thermalization-steps 500 \
-  --measurement-frequency 25 \
-  --simulate
-```
-
-**Use Case:** Study phase transitions or scaling behavior
-
-### 3. Nonuniform Initial Volume Profile
-
-```bash
-./target/release/cdt \
+cdt \
   --volume-profile 4,6,5 \
   --steps 100 \
   --thermalization-steps 10 \
   --measurement-frequency 10 \
-  --simulate
+  --seed 42 \
+  --simulate \
+  --output-csv profile-trace.csv \
+  --output-json profile-summary.json
 ```
 
-**Use Case:** Start from explicit nonuniform spatial volumes `N(t)` instead of the regular equal-slice fixture.
+Use `--volume-profile` for explicit initial slice volumes `N(t)`. The run remains an unfixed-volume run unless a future volume-fixing action term is added
+explicitly.
 
-### 4. High-Temperature Simulation
+## Output Patterns
+
+### CSV And JSON For Analysis
 
 ```bash
-# High temperature configuration
-./target/release/cdt \
-  --vertices-per-slice 4 \
-  --timeslices 8 \
-  --temperature 10.0 \
-  --steps 3000 \
-  --simulate
-```
-
-**Use Case:** Explore classical geometry limit
-
-### 5. Low-Temperature Simulation
-
-```bash
-# Low temperature configuration
-./target/release/cdt \
-  --vertices-per-slice 4 \
-  --timeslices 12 \
-  --temperature 0.5 \
-  --steps 8000 \
-  --thermalization-steps 1000 \
-  --simulate
-```
-
-**Use Case:** Study quantum fluctuations and crumpled phase
-
-### 6. Custom Physics Parameters
-
-```bash
-# Modified coupling constants
-./target/release/cdt \
-  --vertices-per-slice 5 \
-  --timeslices 8 \
-  --coupling-0 0.8 \
-  --coupling-2 1.2 \
-  --cosmological-constant 0.05 \
-  --simulate
-```
-
-**Use Case:** Explore modified gravity or different action formulations
-
-### 7. Triangulation-Only Mode
-
-```bash
-# Generate triangulation without running Monte Carlo simulation
-./target/release/cdt --vertices-per-slice 5 --timeslices 20
-```
-
-**Use Case:** Generate initial configurations for other analysis tools
-
-## Advanced Usage Patterns
-
-### Batch Processing with Shell Scripts
-
-Create a script to run parameter sweeps:
-
-```bash
-#!/bin/bash
-# parameter_sweep.sh
-
-for temp in 0.5 1.0 1.5 2.0 2.5; do
-    echo "Running simulation at temperature $temp"
-    ./target/release/cdt \
-        --vertices-per-slice 4 \
-        --timeslices 10 \
-        --temperature $temp \
-        --steps 2000 \
-        --simulate \
-        > "results_T${temp}.log" 2>&1
-done
-```
-
-### Performance Testing
-
-```bash
-# Large simulation for performance testing
-./target/release/cdt \
-  --vertices-per-slice 8 \
-  --timeslices 25 \
-  --steps 10000 \
-  --measurement-frequency 100 \
-  --simulate
-```
-
-### Logging and Output
-
-Enable detailed logging:
-
-```bash
-# Set log level for detailed triangulation output
-RUST_LOG=debug ./target/release/cdt --vertices-per-slice 4 --timeslices 5
-
-# Show detailed simulation logging
-RUST_LOG=debug ./target/release/cdt --vertices-per-slice 4 --timeslices 5 --simulate
-
-# Log only errors and warnings
-RUST_LOG=warn ./target/release/cdt --vertices-per-slice 5 --timeslices 10 --simulate
-
-# Save output to file
-./target/release/cdt --vertices-per-slice 4 --timeslices 8 --simulate > simulation.log 2>&1
-```
-
-## Expected Output Format
-
-### Successful Run
-
-```text
-[INFO] Dimensionality: 2
-[INFO] Number of vertices: 20
-[INFO] Number of timeslices: 5
-[INFO] Topology: OpenBoundary
-[INFO] Using trait-based backend system
-[INFO] Triangulation created with 20 vertices, <edge-count> edges, <face-count> faces
-[INFO] CDT simulation completed successfully
-```
-
-### Error Cases
-
-```bash
-# Invalid parameters
-./target/release/cdt --vertices-per-slice 2 --timeslices 2
-# Error: vertices must be >= 4 · timeslices (8) for open-boundary topology
-
-# Unsupported dimension
-./target/release/cdt --vertices-per-slice 4 --timeslices 5 --dimension 4
-# Error: unsupported dimension
-```
-
-## Performance Considerations
-
-### Memory Usage
-
-- Small (≤20 vertices): <10 MB
-- Medium (20-100 vertices): 10-100 MB
-- Large (100+ vertices): 100+ MB
-
-### Runtime
-
-- Triangulation construction and validation: seconds for small examples
-- Full simulation timing with `--simulate`: use benchmarks or representative CLI runs
-
-### Optimization Tips
-
-1. **Use release builds** for performance: `cargo build --release`
-2. **Adjust measurement frequency** for long runs
-3. **Monitor memory** for large vertex counts
-4. **Use appropriate thermalization** (typically 10-20% of total steps)
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Binary not found**
-
-   ```bash
-   cargo build --release
-   ./target/release/cdt --help
-   ```
-
-2. **Insufficient memory**
-   - Reduce vertex count or steps
-   - Monitor system resources
-
-3. **Slow performance**
-   - Ensure using release build
-   - Check system load
-   - Consider reducing measurement frequency
-
-4. **Parameter validation errors**
-   - Check minimum values (open-boundary vertices per slice ≥ 4, toroidal vertices per slice ≥ 3)
-   - Verify dimension is 2
-
-## Integration with Other Tools
-
-### Data Analysis
-
-```bash
-# Write stable interchange files for dataframe or notebook tools
-./target/release/cdt \
+cdt \
   --vertices-per-slice 5 \
   --timeslices 10 \
   --steps 200 \
@@ -283,23 +98,67 @@ RUST_LOG=warn ./target/release/cdt --vertices-per-slice 5 --timeslices 10 --simu
   --output-json summary.json
 ```
 
-### Automation
+The CSV trace records one row per completed Metropolis step. The JSON file records configuration, summary statistics, move/proposal statistics, scheduled
+measurements, and the final triangulation state.
+
+### Logging
 
 ```bash
-# Use in makefiles or CI/CD
-make run-simulation: 
- ./target/release/cdt --vertices-per-slice $(VERTICES_PER_SLICE) --timeslices $(SLICES)
+RUST_LOG=info cdt --vertices-per-slice 4 --timeslices 5 --simulate
+RUST_LOG=debug cdt --vertices-per-slice 4 --timeslices 5 --simulate
+RUST_LOG=warn cdt --vertices-per-slice 5 --timeslices 10 --simulate
 ```
 
-## Help and Documentation
+Use `info` for normal run summaries, `debug` for detailed diagnostic output, and `warn` when you only want warnings and errors.
+
+## Batch Runs
+
+For maintained shell-script examples, see [`examples/scripts/README.md`](../examples/scripts/README.md). A minimal parameter sweep looks like:
 
 ```bash
-# Display all available options
-./target/release/cdt --help
-
-# Version information  
-./target/release/cdt --version
+for temp in 0.5 1.0 1.5 2.0; do
+  cdt \
+    --vertices-per-slice 4 \
+    --timeslices 8 \
+    --temperature "$temp" \
+    --steps 2000 \
+    --simulate \
+    --output-csv "sweep_T${temp}.csv" \
+    --output-json "sweep_T${temp}.json"
+done
 ```
 
-This CLI interface provides a way to explore CDT triangulation construction, validate simulation parameters, and run short Monte Carlo simulations from the
-command line.
+## Performance Runs
+
+Use release builds for representative timings. For benchmark-quality comparisons, use [benches/README.md](../benches/README.md) and
+[PERFORMANCE_TESTING.md](PERFORMANCE_TESTING.md) rather than ad hoc CLI timings.
+
+```bash
+cdt \
+  --vertices-per-slice 8 \
+  --timeslices 25 \
+  --steps 10000 \
+  --measurement-frequency 100 \
+  --simulate
+```
+
+## Troubleshooting
+
+`cdt: command not found`
+
+: Install with `cargo install causal-triangulations`, ensure `~/.cargo/bin` is on `PATH`, or use `./target/release/cdt` from a local clone.
+
+Parameter validation errors
+
+: Check minimum topology requirements: open-boundary runs need at least 4 vertices per slice, toroidal runs need at least 3 vertices per slice and at least
+  3 time slices. `--dimension` must be `2`.
+
+Unexpected volume growth or shrinkage
+
+: Current simulations are grand-canonical, unfixed-volume runs. Adjust `--cosmological-constant`, reduce the run length, or start from a smaller initial
+  volume while tuning.
+
+Slow runs
+
+: Use a release binary, reduce `--vertices-per-slice`, reduce `--timeslices`, increase `--measurement-frequency`, or use the Criterion benchmarks to isolate
+  the bottleneck.

--- a/docs/PERFORMANCE_TESTING.md
+++ b/docs/PERFORMANCE_TESTING.md
@@ -32,7 +32,7 @@ Useful direct analyzer commands:
 ```bash
 uv run performance-analysis --no-run
 uv run performance-analysis --no-run --threshold 5.0
-uv run performance-analysis --compare performance_baselines/baseline_pre-change_*.json
+uv run performance-analysis --compare performance_baselines/baseline_pre-change.json
 uv run performance-analysis --report performance-report.md
 ```
 

--- a/docs/PERFORMANCE_TESTING.md
+++ b/docs/PERFORMANCE_TESTING.md
@@ -1,392 +1,141 @@
 # Performance Testing Guide
 
-This document explains how to use the performance regression testing system for the Causal Dynamical Triangulations (CDT) library.
+This document explains the regression and reporting workflow around CDT performance benchmarks. For the benchmark inventory and instructions for adding new
+Criterion benchmarks, see [benches/README.md](../benches/README.md).
 
 ## Overview
 
-The CDT project uses [Criterion.rs](https://github.com/bheisler/criterion.rs) for benchmarking with a custom performance analysis system that:
+The performance workflow uses Criterion benchmark output plus `scripts/performance_analysis.py` to:
 
-- **Detects regressions** automatically on pull requests
-- **Tracks performance trends** over time
-- **Generates detailed reports** with statistical analysis
-- **Integrates with CI/CD** to prevent performance regressions
+- compare current results with saved baselines;
+- report regressions and improvements;
+- generate Markdown reports for PR or release review;
+- keep local and CI checks using the same benchmark contract.
 
-## Quick Start
+The default CI contract is `benches/ci_performance_suite.rs`. It is intentionally smaller than the full exploratory benchmark suite so it can provide a stable
+regression signal across platforms.
 
-### Running Performance Checks Locally
+## Local Commands
 
 ```bash
-# Check for performance regressions (10% threshold)
-just perf-check
-
-# Check with custom threshold (5% threshold)
-just perf-check 5.0
-
-# Save current performance as baseline
-just perf-baseline
-
-# Generate detailed performance report
-just perf-report
-
-# Analyze performance trends over last 7 days
-just perf-trends 7
+just bench-ci          # Run the CI regression benchmark contract
+just perf-check        # Compare current results against the latest baseline
+just perf-check 5.0    # Use a stricter 5% regression threshold
+just perf-baseline     # Save current results as a timestamped baseline
+just perf-baseline tag # Save current results with a descriptive tag
+just perf-report       # Generate a Markdown performance report
+just perf-trends 7     # Summarize recent baseline trends
 ```
 
-### Understanding Results
-
-The performance analysis categorizes benchmark changes:
-
-- 🔴 **Regressions**: Performance degraded beyond threshold
-- 🟢 **Improvements**: Performance improved beyond threshold
-- ✅ **Stable**: Changes within acceptable range
-- 🆕 **New**: First-time benchmarks
-
-## Detailed Usage
-
-### Command Reference
-
-#### `just perf-baseline [tag]`
-
-Save current benchmark results as a baseline for future comparisons.
+Useful direct analyzer commands:
 
 ```bash
-# Save baseline with automatic timestamp
-just perf-baseline
-
-# Save baseline with version tag
-just perf-baseline v1.2.0
-
-# Save baseline for feature branch
-just perf-baseline feature-optimization
-```
-
-**When to use**: Before major changes, releases, or when establishing new performance baselines.
-
-#### `just perf-check [threshold]`
-
-Run benchmarks and check for performance regressions.
-
-```bash
-# Default 10% regression threshold
-just perf-check
-
-# Strict 5% threshold for critical changes
-just perf-check 5.0
-
-# Relaxed 15% threshold for exploratory changes
-just perf-check 15.0
-```
-
-**Exit codes**:
-
-- `0`: No regressions detected
-- `1`: Performance regressions found (fails CI)
-
-#### `just perf-report [file]`
-
-Generate detailed performance analysis report.
-
-```bash
-# Generate report with timestamp
-just perf-report
-
-# Save to specific file
-just perf-report release-v1.2-performance.md
-
-# Generate report without running benchmarks
-uv run performance-analysis --no-run --report my-report.md
-```
-
-#### `just perf-trends [days]`
-
-Analyze performance trends over time.
-
-```bash
-# Last week's trends
-just perf-trends 7
-
-# Last month's trends  
-just perf-trends 30
-
-# Analyze specific benchmarks
-uv run performance-analysis --trends 14
-```
-
-### Advanced Usage
-
-#### Comparing Specific Baselines
-
-```bash
-# Compare against specific baseline file
-uv run performance-analysis --compare performance_baselines/baseline_v1.0.0_20231201_120000.json
-
-# Skip running benchmarks, use cached results
+uv run performance-analysis --no-run
 uv run performance-analysis --no-run --threshold 5.0
+uv run performance-analysis --compare performance_baselines/baseline_pre-change_*.json
+uv run performance-analysis --report performance-report.md
 ```
 
-#### Python API Usage
+`just perf-check` returns exit code `1` when regressions exceed the threshold. Local callers may treat that as blocking. In CI, benchmark noise is reported
+but does not by itself fail the PR workflow.
 
-```python
-from scripts.performance_analysis import PerformanceAnalyzer
-from pathlib import Path
+## CI Behavior
 
-# Initialize analyzer
-analyzer = PerformanceAnalyzer(Path("."))
+The performance workflow:
 
-# Extract current results
-results = analyzer.extract_criterion_results()
+- runs the CI benchmark suite on pull requests;
+- compares PR results with the main-branch baseline;
+- comments with regressions, improvements, stable benchmarks, and new benchmarks;
+- uploads report artifacts;
+- saves updated baselines on main after successful merges.
 
-# Compare with baseline
-baseline = analyzer.load_baseline()
-comparison = analyzer.compare_results(results, baseline, threshold=10.0)
-
-# Generate report
-report = analyzer.generate_report(comparison)
-```
-
-## CI/CD Integration
-
-### Automatic Performance Testing
-
-The project runs performance tests automatically:
-
-#### On Pull Requests
-
-- 🔍 **Regression Detection**: Compares PR performance against main branch baseline
-- 📊 **Detailed Reports**: Posts performance analysis as PR comments
-- ❌ **Blocks Merging**: Fails CI if regressions exceed threshold
-- 📁 **Artifact Storage**: Uploads performance reports for review
-
-#### On Main Branch
-
-- 💾 **Baseline Updates**: Automatically saves new baselines after successful merges
-- 🏷️ **Tagging**: Baselines tagged with commit SHA and timestamp
-- 📈 **Trend Tracking**: Enables long-term performance monitoring
-
-### Manual Workflow Triggers
-
-You can manually trigger performance analysis from GitHub Actions:
-
-1. Go to **Actions** tab in GitHub repository
-2. Select **Performance Testing** workflow
-3. Click **Run workflow**
-4. Configure options:
-   - **Threshold**: Regression detection sensitivity (default: 10%)
-   - **Save Baseline**: Whether to save results as new baseline
-
-### Interpreting CI Results
-
-#### Successful Performance Check ✅
-
-```text
-✅ Performance Check Passed
-   Total benchmarks: 40
-   Regressions: 0
-   Improvements: 3
-   Stable: 37
-   New: 0
-```
-
-#### Performance Regression Detected ❌
-
-```text
-🔴 Performance regressions detected!
-   triangulation_creation/delaunay_backend/100: +15.2% slower
-   Current: 12.5ms, Baseline: 10.8ms
-```
-
-The CI will:
-
-- ❌ **Fail the workflow** to prevent merging
-- 💬 **Post detailed comment** with regression analysis
-- 📊 **Upload report artifact** for detailed investigation
+Regression comments should be reviewed carefully, especially for changes touching geometry construction, move proposal enumeration, action calculation,
+Metropolis simulation, output generation, or validation.
 
 ## Benchmark Categories
 
-### Critical Benchmarks (Strict Thresholds)
+The CI suite focuses on release-relevant CDT paths:
 
-- **Triangulation Creation**: Core algorithm performance
-- **Action Calculations**: Physics computation efficiency
-- **Cached Operations**: Memory/caching system performance
+- open-boundary and toroidal triangulation construction;
+- topology, foliation, causality, and simplex-classification validation;
+- individual ergodic move attempts;
+- proposal-site iteration and single-step Metropolis proposal planning;
+- short random-move sweeps;
+- short Metropolis simulations.
 
-### Standard Benchmarks
+The broader Criterion suite includes exploratory groups for geometry queries, cache behavior, action calculations, simulation analysis, and validation. Those
+are documented in [benches/README.md](../benches/README.md).
 
-- **Geometry Queries**: Mesh interrogation operations
-- **Ergodic Moves**: Monte Carlo move operations
-- **Validation**: Correctness checking performance
+## Performance Workflow
 
-### Variable Benchmarks (Relaxed Thresholds)
-
-- **Metropolis Simulation**: Short `MetropolisAlgorithm::run()` paths over real CDT move kernels
-- **File I/O Operations**: System-dependent operations
-
-## Performance Optimization Workflow
-
-### 1. Identify Bottlenecks
+Before a performance-sensitive change:
 
 ```bash
-# Generate detailed performance report
-just perf-report bottleneck-analysis.md
-
-# Analyze recent trends
-just perf-trends 30
+just bench-ci
+just perf-baseline pre-change
 ```
 
-### 2. Create Optimization Branch
+During development:
 
 ```bash
-git checkout -b perf/optimize-triangulation
+just perf-check 15.0
 ```
 
-### 3. Save Pre-optimization Baseline
+Before review:
 
 ```bash
-just perf-baseline pre-optimization
+just perf-check
+just perf-report
 ```
 
-### 4. Implement Optimizations
-
-Make your performance improvements...
-
-### 5. Measure Impact
-
-```bash
-# Check improvements against pre-optimization baseline
-uv run performance-analysis --compare performance_baselines/baseline_pre-optimization_*.json
-
-# Strict threshold to ensure meaningful improvement
-just perf-check 3.0
-```
-
-### 6. Document Changes
-
-Include performance results in your PR description:
+For optimization PRs, include a short performance summary:
 
 ```markdown
 ## Performance Impact
 
-- Triangulation creation: **25% faster** (8.2ms → 6.1ms)
-- Memory usage: **15% reduction** in peak allocation
-- Cache hit rate: **Improved from 85% to 94%**
+- proposal-site enumeration: 18% faster on the CI suite
+- short Metropolis runs: stable within threshold
+- memory allocation: no new persistent allocations in the hot path
+```
+
+## Baselines
+
+- Main-branch baselines are saved by CI.
+- Feature baselines can be saved locally with descriptive tags.
+- Release baselines should use version tags.
+- The analyzer keeps recent baselines and report artifacts for comparison.
+
+Keep baseline names descriptive enough to recover the comparison later:
+
+```bash
+just perf-baseline pre-proposal-cache
+just perf-baseline v0.1.1
 ```
 
 ## Troubleshooting
 
-### Common Issues
+`No benchmark results found`
 
-#### "No benchmark results found"
+: Run `just bench-ci` first, or run `uv run performance-analysis --no-run` only after Criterion JSON output exists.
 
-```bash
-# Ensure benchmarks are compiled and run first
-just bench-ci
-just perf-check
-```
+`No baseline found for comparison`
 
-#### "No baseline found for comparison"
+: Save one with `just perf-baseline initial`, or compare directly against a known baseline file.
 
-```bash
-# Create initial baseline
-just perf-baseline initial
+High variance
 
-# Or run against existing results
-uv run performance-analysis --no-run
-```
+: Close other CPU-heavy work, rerun the benchmark, and compare trends rather than one noisy sample. Treat large PR comments as investigation prompts, not
+  automatic proof of a regression.
 
-#### "Performance variance too high"
+Need deeper timing data
 
-- Run benchmarks multiple times to establish confidence
-- Check for system load during benchmark execution
-- Consider using cloud CI for consistent results
+: Run a focused Criterion group from [benches/README.md](../benches/README.md), inspect the HTML report under `target/criterion/`, or use platform-specific
+  profilers. Memory profiling is not exposed as a Cargo feature in this crate; use external profilers or targeted benchmark instrumentation.
 
-### Performance Investigation
+## Components
 
-#### Detailed Timing Analysis
-
-```bash
-# Run with verbose output
-RUST_BACKTRACE=1 cargo bench --profile perf --bench ci_performance_suite -- --verbose
-
-# Analyze specific benchmark group
-cargo bench triangulation_creation
-```
-
-#### Memory Profiling Integration
-
-```bash
-# Run benchmarks with memory profiling (requires additional tools)
-cargo bench --features memory-profiling
-```
-
-## Best Practices
-
-### For Contributors
-
-1. **Run performance checks** before submitting PRs
-2. **Include performance impact** in PR descriptions
-3. **Investigate regressions** thoroughly - they may indicate real issues
-4. **Save baselines** before making significant algorithmic changes
-
-### For Maintainers
-
-1. **Review performance comments** on PRs carefully
-2. **Update baselines** after confirming acceptable changes
-3. **Monitor long-term trends** using `just perf-trends`
-4. **Set appropriate thresholds** for different types of changes
-
-### Performance-Sensitive Development
-
-```bash
-# Before implementing new features
-just perf-baseline feature-start
-
-# During development - check impact frequently  
-just perf-check 15.0  # Relaxed threshold during development
-
-# Before finalizing - ensure no major regressions
-just perf-check 5.0   # Strict threshold before completion
-```
-
-## Configuration
-
-### Threshold Guidelines
-
-| Change Type   | Recommended Threshold | Rationale                                   |
-| ------------- | --------------------- | ------------------------------------------- |
-| Bug fixes     | 5%                    | Should not impact performance significantly |
-| New features  | 10-15%                | May have some performance cost              |
-| Optimizations | 3%                    | Should show measurable improvement          |
-| Experimental  | 20%                   | Exploratory changes, focus on functionality |
-
-### Baseline Management
-
-- **Main branch baselines**: Automatically saved on merge
-- **Feature baselines**: Manually saved with descriptive tags
-- **Release baselines**: Tagged with version numbers
-- **Retention**: Last 10 baselines kept automatically
-
-## Architecture
-
-### Components
-
-1. **Criterion Benchmarks** (`benches/cdt_benchmarks.rs`, `benches/ci_performance_suite.rs`): Core and CI regression benchmark definitions
-2. **Performance Analyzer** (`scripts/performance_analysis.py`): Analysis and reporting engine
-3. **Justfile Integration**: User-friendly command interface
-4. **GitHub Actions** (`.github/workflows/performance.yml`): CI/CD automation
-5. **Baseline Storage** (`performance_baselines/`): Historical performance data
-
-### Data Flow
-
-```text
-┌───────────┐     ┌──────────┐     ┌─────────────┐
-│ Criterion │───▶│ Analysis │───▶│ Reports     │
-│ benches   │     │ script   │     │ comparisons │
-└───────────┘     └──────────┘     └─────────────┘
-      │                │                 │
-      ▼                ▼                 ▼
-┌───────────┐     ┌──────────┐     ┌─────────────┐
-│ JSON      │     │ Baseline │     │ CI comments │
-│ results   │     │ storage  │     │ artifacts   │
-└───────────┘     └──────────┘     └─────────────┘
-```
-
-This system provides comprehensive performance monitoring while remaining easy to use for both contributors and maintainers.
+- `benches/ci_performance_suite.rs`: stable CI regression contract
+- `benches/cdt_benchmarks.rs`: broader Criterion benchmark groups
+- `scripts/performance_analysis.py`: baseline comparison and report generation
+- `.github/workflows/performance.yml`: CI performance workflow
+- `performance_baselines/`: saved local and CI baselines

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,152 @@
+# Quick Start
+
+This guide is for physicists who want to run a small 1+1 CDT calculation without first learning Rust. It assumes macOS or Linux and uses the `cdt` command-line
+binary.
+
+The current release is a validated 1+1 CDT foundation. It can build open-boundary and toroidal initial triangulations, run the Metropolis move loop, and write
+CSV/JSON output for later analysis. It does not yet provide production ensemble-analysis tooling, automatic λ scans, or higher-dimensional CDT.
+
+## Install
+
+Prebuilt release binaries are planned in [#169](https://github.com/acgetchell/causal-triangulations/issues/169). When those assets exist, download the archive
+for your platform from [GitHub Releases](https://github.com/acgetchell/causal-triangulations/releases), unpack it, and put the `cdt` binary somewhere on your
+`PATH`. Until then, install the binary with Cargo:
+
+```bash
+cargo install causal-triangulations
+```
+
+Then check that the binary is on your path:
+
+```bash
+cdt --help
+```
+
+If you are working from a local clone instead of the published crate, build the release binary and replace `cdt` below with `./target/release/cdt`:
+
+```bash
+cargo build --release
+./target/release/cdt --help
+```
+
+## First Run
+
+Copy and paste this command:
+
+```bash
+RUST_LOG=info cdt \
+  --dimension 2 \
+  --vertices-per-slice 4 \
+  --timeslices 5 \
+  --topology open-boundary \
+  --steps 100 \
+  --thermalization-steps 10 \
+  --measurement-frequency 10 \
+  --temperature 1.0 \
+  --cosmological-constant 0.46209812037329684 \
+  --seed 105 \
+  --simulate \
+  --output-csv cdt-runs/quickstart/trace.csv \
+  --output-json cdt-runs/quickstart/summary.json
+```
+
+The command builds a small 1+1-dimensional CDT strip, runs 100 Metropolis-Hastings proposal steps, and writes results under `cdt-runs/quickstart/`. Parent
+directories are created automatically.
+
+The physics and algorithm parameters are:
+
+- `--dimension 2`: two-dimensional spacetime, i.e. 1 spatial dimension plus 1 time dimension. Higher CDT dimensions are roadmap work.
+- `--vertices-per-slice 4`: the initial spatial volume on each time slice.
+- `--timeslices 5`: the number of discrete proper-time slices in the foliation.
+- `--topology open-boundary`: an open strip in time. Use `toroidal` for periodic S¹×S¹ initial data.
+- `--steps 100`: the number of Metropolis proposals to evaluate.
+- `--thermalization-steps 10`: early steps excluded from the measurement schedule.
+- `--measurement-frequency 10`: record scheduled measurements every ten steps after thermalization.
+- `--temperature 1.0`: the Metropolis temperature in the sampler acceptance rule. This is an algorithmic tempering parameter, not a physical heat bath.
+- `--cosmological-constant 0.46209812037329684`: the edge-count cosmological coupling λ. In the current unfixed-volume ensemble it controls volume growth or
+  shrinkage.
+- `--seed 105`: fixes the random number streams so the run can be repeated exactly on the same version.
+- `--simulate`: run the Markov chain after constructing the initial triangulation.
+- `--output-csv` and `--output-json`: write a scalar trace and a structured summary/final state.
+
+## What You Should See
+
+With `RUST_LOG=info`, a successful run prints lines like this. Timestamps are omitted here:
+
+```text
+[INFO  causal_triangulations] Dimensionality: 2
+[INFO  causal_triangulations] Number of vertices: 20
+[INFO  causal_triangulations] Number of timeslices: 5
+[INFO  causal_triangulations] Topology: OpenBoundary
+[INFO  causal_triangulations] Wrote trace CSV to cdt-runs/quickstart/trace.csv
+[INFO  causal_triangulations] Wrote simulation JSON summary to cdt-runs/quickstart/summary.json
+[INFO  cdt] CDT simulation completed successfully
+```
+
+The two output files are:
+
+- `cdt-runs/quickstart/trace.csv`: one row per completed Metropolis step. The fixed columns include `chain_id`, `step`, `accepted`, `proposed`, and
+  `log_prob`; CDT adds the current action, vertex/edge/triangle counts, move-family code, action-delta diagnostics, seed halves, and volume-profile columns.
+- `cdt-runs/quickstart/summary.json`: run configuration, summary statistics, final triangulation data, move/proposal statistics, and scheduled measurements.
+
+The most useful quick checks are:
+
+- `accepted`: whether the proposed transition changed the chain state.
+- `proposed`: whether the step had a concrete local proposal; false entries are self-loops such as no available site for the selected move family.
+- `action`: the Regge action value used by the sampler.
+- `vertices`, `edges`, `triangles`: the current lattice size. In this release, volume-changing moves are allowed and no volume-fixing term is applied.
+- `volume_profile_*`: spatial slice volumes at the recorded step, padded with zeros for rectangular CSV output.
+
+Resumable CDT/MCMC checkpoints are available from the Rust library API and demonstrated in `examples/output_and_checkpoint.rs`. The quickstart CLI command
+writes trace and summary files, but it does not yet write a separate checkpoint file.
+
+## Tweak Physics
+
+Common changes map directly to CLI flags:
+
+- Increase the initial lattice size with `--vertices-per-slice` and `--timeslices`. For nonuniform initial slice volumes, use `--volume-profile 4,6,5`
+  instead of `--vertices-per-slice` and let the profile length set the time-slice count.
+- Change boundary conditions with `--topology open-boundary` or `--topology toroidal`. Open-boundary runs need at least 4 vertices per slice; toroidal runs
+  need at least 3 vertices per slice and at least 3 time slices.
+- Tune the unfixed-volume ensemble with `--cosmological-constant`. Values too far from the useful finite-volume window may drive the run toward
+  minimum-volume configurations or rapid growth.
+- Change the action couplings with `--coupling-0` and `--coupling-2`. In pure 1+1 gravity these terms are topological at fixed topology, so the defaults are
+  zero.
+- Run longer chains with `--steps`, raise `--thermalization-steps` for a longer burn-in period, and use `--measurement-frequency` to control scheduled
+  measurements in the JSON output.
+- Use `--temperature` for tempered sampler diagnostics. Keep `1.0` unless you are deliberately studying sampler behavior.
+- Use `--seed` for reproducible runs. Change the seed to sample a different random trajectory.
+- Use distinct `--output-csv` and `--output-json` paths for each run so results are not overwritten.
+
+## Troubleshooting
+
+`cdt: command not found`
+
+: Cargo usually installs binaries into `~/.cargo/bin`. Add that directory to your `PATH`, or use the local release binary path `./target/release/cdt` from a
+  repository clone.
+
+`cargo: command not found`
+
+: Install Rust with [rustup](https://rustup.rs/), then reopen your terminal and run `cargo --version`.
+
+`Unsupported dimension`
+
+: The CLI currently supports only `--dimension 2`, meaning 1+1 CDT.
+
+`vertices must be >= ...`
+
+: The requested initial triangulation is too small for the chosen topology. Increase `--vertices-per-slice`, or use `--topology open-boundary` for the
+  smallest quick checks.
+
+The run grows or shrinks quickly
+
+: This is expected in an unfixed-volume ensemble when λ is outside a useful finite-volume window. Shorten the run, start from a smaller lattice, and adjust
+  `--cosmological-constant`.
+
+The CSV has many rows but the JSON has fewer measurements
+
+: CSV trace output records every completed Metropolis step. Scheduled JSON measurements follow `--thermalization-steps` and `--measurement-frequency`.
+
+The command is slow
+
+: Use the release binary, reduce `--vertices-per-slice`, reduce `--timeslices`, or reduce `--steps`.

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -42,6 +42,7 @@ causal-triangulations/
 │   │   └── tooling-alignment.md
 │   ├── CLI_EXAMPLES.md
 │   ├── PERFORMANCE_TESTING.md
+│   ├── QUICKSTART.md
 │   ├── RELEASING.md
 │   ├── code_organization.md
 │   ├── foliation.md

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -190,6 +190,12 @@ Run:
 just spell-check
 ```
 
+The `typos` binary is provided by the Cargo crate `typos-cli`. `just setup-tools` installs the pinned version, or you can install it directly:
+
+```bash
+cargo install --locked typos-cli --version 1.47.2
+```
+
 If a legitimate technical word fails, add it to `typos.toml` under:
 
 ```toml

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -115,6 +115,8 @@ The useful `justfile` updates ported from `delaunay` are:
 - The planned-step sampler-state sync rule now anchors `record_planned_step(...)` to call statements so it continues to catch missing
   `sampler.replace_state(...)` after recorded planned steps without false-positive matches on the helper function declaration when that helper contains fallible
   telemetry construction.
+- The Markdown and spelling tool pins now use `rumdl` 0.2.10 and `typos-cli` 1.47.2 in both the justfile and `.github/workflows/ci.yml`, matching the
+  current Cargo-installed sibling-repository tools while preserving the existing `rumdl.toml`, `typos.toml`, and raw 160-column guard.
 
 ## Issue #162 CI And Security Alignment
 
@@ -127,8 +129,8 @@ Issue #162 refreshed the CI and security baseline against `markov-chain-monte-ca
   `taiki-e/install-action`.
 - Repository-owned Semgrep rules now also guard checkout credential persistence, `pull_request_target`, direct `github-script` expression interpolation,
   unlocked workflow `uv sync`, direct Python `subprocess.run` bypasses, and direct MCMC imports outside the CDT Metropolis adapter boundary.
-- Tool versions are pinned in workflow `env` blocks and mirrored in `justfile` constants for `cargo-nextest`, `dprint`, `rumdl`, `taplo`, `typos`, `zizmor`,
-  `cargo-llvm-cov`, and `git-cliff`.
+- Tool versions are pinned in workflow `env` blocks and mirrored in `justfile` constants for `cargo-nextest`, `dprint`, `rumdl`, `taplo`, `typos-cli`,
+  `zizmor`, `cargo-llvm-cov`, and `git-cliff`.
 - Local validation includes `just zizmor` through `lint-config`, while `.github/workflows/zizmor.yml` uploads the GitHub Actions security signal in CI.
 - `SECURITY.md` documents private vulnerability reporting and the repository security check set.
 

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -117,6 +117,10 @@ The useful `justfile` updates ported from `delaunay` are:
   telemetry construction.
 - The Markdown and spelling tool pins now use `rumdl` 0.2.10 and `typos-cli` 1.47.2 in both the justfile and `.github/workflows/ci.yml`, matching the
   current Cargo-installed sibling-repository tools while preserving the existing `rumdl.toml`, `typos.toml`, and raw 160-column guard.
+- The Cargo manifest description changed from `Causal Dynamical Triangulations in d-dimensions` to
+  `Validated 1+1 Causal Dynamical Triangulations for quantum gravity`. This mirrors a config/manifest change per the repository guideline and records why the
+  new wording was chosen: it makes the validated 1+1 scope and quantum-gravity domain explicit in package metadata. This update fulfills the
+  `{.github/**/*,*.yml,*.yaml,*.toml,*.json}` tooling-alignment requirement for the `Cargo.toml` description edit.
 
 ## Issue #162 CI And Security Alignment
 

--- a/docs/moves.md
+++ b/docs/moves.md
@@ -79,6 +79,34 @@ Move validation follows a two-layer design:
 Move code lives in the CDT domain layer. It may call `DelaunayBackend2D` methods and trait-backed mutation hooks, but it must not import upstream `delaunay::`
 APIs directly.
 
+The public CDT move interface will be revisited after [`delaunay#252`](https://github.com/acgetchell/delaunay/issues/252) lands. Until then, this crate keeps
+the current CDT-owned move API and maps it onto the available Delaunay k-flip primitives through the geometry backend layer.
+
+### Bistellar Flips And CDT Moves
+
+Pachner's theorem gives the PL-manifold backdrop: within a fixed topology, triangulations of a piecewise-linear manifold are connected by finite sequences of
+bistellar moves. The `delaunay` crate exposes the geometric 2D operations this crate needs as bistellar-style k-flips:
+
+- `flip_k2` — the geometric edge flip, corresponding to the 2D `(2,2)` move;
+- `flip_k1_insert` — local vertex insertion, the geometric substrate for a `(1,3)` subdivision;
+- `flip_k1_remove` — local vertex removal, the geometric substrate for a `(3,1)` collapse.
+
+CDT cannot apply arbitrary geometric k-flips directly. A CDT move must also preserve the discrete time foliation, keep every simplex classified as causal
+(`Up` or `Down` in 1+1), obey topology-specific slice-size constraints, and pass topology/causality validation after the edit. The implementation therefore
+maps Delaunay's local edit primitives into foliation-preserving CDT proposals:
+
+- `Move22` / `EdgeFlip` use the k=2 edge flip only when the replacement diagonal preserves adjacent-slice causality and simplex classification.
+- Open-boundary `Move13Add` uses k=1 insertion as a triangle subdivision and assigns the inserted vertex the time label required by the adjacent causal
+  simplex pattern.
+- Open-boundary `Move31Remove` uses k=1 removal only for removable degree-3 vertices whose replacement triangle remains causal and does not empty a time slice.
+- Toroidal `Move13Add` is realized as a spacelike-link split: subdivide an adjacent face, then flip the original spacelike link away so the closed-S¹ spatial
+  slice remains valid.
+- Toroidal `Move31Remove` uses the inverse flip-then-collapse path for degree-4 configurations produced by the spacelike-link split.
+
+This is why the public move API is expressed in CDT/Pachner language while the backend layer is expressed in Delaunay k-flip language. The local geometric
+operation is necessary but not sufficient; the CDT layer supplies the foliation, causality, topology, and proposal-ratio bookkeeping needed for a valid
+Metropolis-Hastings transition.
+
 Public `attempt_*` methods snapshot only after a valid local site has been selected and mutation is about to begin; ordinary geometric or causal rejections do
 not clone the triangulation. If a selected mutation or required post-mutation synchronization fails, the method restores that snapshot before returning the
 non-success `MoveResult`. Toroidal post-move topology or closed-ring foliation failures are treated as rollbackable local-site rejections, because the candidate
@@ -94,8 +122,8 @@ return `CdtError::MetropolisMoveApplicationFailed`.
 ## Ensemble And Volume Fixing
 
 Current CDT simulations do not add a volume-fixing term. The `(1,3)` and `(3,1)` kernels are genuine volume-changing proposals, so accepted moves may change
-the total number of vertices and simplices over time. The resulting Markov chain should therefore be interpreted as sampling the unfixed-volume ensemble
-specified by the configured action, cosmological term, proposal probabilities, and Metropolis-Hastings acceptance rule.
+the total number of vertices and simplices over time. The resulting Markov chain should therefore be interpreted as sampling the grand-canonical,
+unfixed-volume ensemble specified by the configured action, cosmological term, proposal probabilities, and Metropolis-Hastings acceptance rule.
 
 This is a valid 1+1 CDT setting rather than an implementation accident. Israel and Lindner use a 1+1 CDT Monte Carlo model where add/remove moves satisfy
 detailed balance and the cosmological constant controls whether the universe size is stable, shrinking, or diverging:
@@ -106,7 +134,9 @@ the lattice volume term, so changing it changes the relative acceptance of volum
 difference. The current binary exposes this as `--cosmological-constant`, and programmatic callers set it through `ActionConfig`.
 
 The default 1+1 action constants are calibrated to the standard 2D CDT critical cosmological coupling. They use zero curvature couplings and set the edge-count
-cosmological constant to `(2 / 3) ln 2`, mapping this crate's `λ N1` action convention to `λc N2` with `λc = ln 2` on closed toroidal triangulations.
+cosmological constant to `(2 / 3) ln 2`, mapping this crate's `λ N1` action convention to `λc N2` with `λc = ln 2` on closed 1+1 triangulations where
+`N1 = 3 N2 / 2`. Open-boundary strips have boundary-count corrections, so the same default is a practical baseline rather than an exact open-boundary critical
+value.
 
 Approximate volume fixing is also standard in higher-dimensional CDT when the scientific goal is a finite-size ensemble at a chosen lattice volume. In that
 case the fixing term is part of the sampled action, for example a quadratic penalty around a target volume, and detailed balance is with respect to the
@@ -117,5 +147,5 @@ fixing yet; if added, it should be explicit and opt-in.
 
 ## Planned Work
 
-- [ ] Weight `select_random_move()` by available application sites per move type to remove uniform-sampling chain bias
+- [ ] Evaluate move-family weighting by available application sites to improve proposal efficiency while preserving the documented Hastings correction
 - [ ] Broaden per-kernel toroidal move-site tests around periodic boundary simplices

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,7 +44,7 @@ The v0.1.0 foundation work focuses on making the crate a usable, validated 1+1 C
 
 Likely follow-up work before broadening the dimensional surface:
 
-- Weight move-type selection by available application sites to reduce uniform-sampling bias
+- Evaluate move-family weighting by available application sites to improve proposal efficiency while preserving the documented Hastings correction
 - Broaden per-kernel toroidal tests around spatial and temporal wrap-around simplices
 - Accept fixed triangle simplices directly in explicit-simplex generator APIs to remove per-triangle `Vec` adaptation
 - Add manual foliation assignment APIs with the same validation and synchronization guarantees as constructor-assigned labels

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -1,270 +1,113 @@
-# CDT-RS CLI Example Scripts
+# CLI Example Scripts
 
-This directory contains shell scripts that demonstrate how to use the `cdt` command-line binary for simulation-oriented scenarios.
+This directory contains maintained shell scripts for common `cdt` command-line workflows. For a first manual run, see
+[`docs/QUICKSTART.md`](../../docs/QUICKSTART.md). For individual CLI patterns, see [`docs/CLI_EXAMPLES.md`](../../docs/CLI_EXAMPLES.md).
 
-> **Current simulation status:** scripts that pass `--simulate` run the Metropolis-Hastings loop over the 2D CDT move kernels. Remove `--simulate` only when you
-> want triangulation construction without Monte Carlo steps.
+Commands that pass `--simulate` run the 2D CDT Metropolis-Hastings loop. Remove `--simulate` when you only want triangulation construction and the initial
+measurement.
 
-## Available Scripts
+## Scripts
 
-### 1. `basic_simulation.sh`
+### `basic_simulation.sh`
 
-**Purpose**: Demonstrates a simple CDT simulation command. **Usage**:
+Runs a small open-boundary simulation with logging enabled.
 
 ```bash
 ./examples/scripts/basic_simulation.sh
 ```
 
-**What it does**:
+Use this to check that the release binary builds and the CLI can run a short simulation.
 
-- Builds the cdt binary in release mode
-- Builds a 4-vertices-per-slice, 5-timeslice command with 1000 requested MC steps
-- Shows logging output for a short `--simulate` run
+### `parameter_sweep.sh`
 
-**Use this for**: First-time testing, verifying installation
-
-### 2. `parameter_sweep.sh`
-
-**Purpose**: Runs a systematic temperature-sweep command set. **Usage**:
+Runs a small temperature sweep and writes per-temperature logs to `sweep_results/`.
 
 ```bash
 ./examples/scripts/parameter_sweep.sh
 ```
 
-**What it does**:
+Use this as a starting point for acceptance, action, and volume diagnostics. Temperature is a sampler parameter here, not a claim about a physical heat bath.
 
-- Tests temperatures from 0.5 to 3.0
-- Requests 2000 MC steps for each temperature
-- Saves individual logs to `sweep_results/`
-- Runs each sweep point with `--simulate`
+### `performance_test.sh`
 
-**Use this for**: Parameter exploration setup and early phase-transition analysis
-
-### 3. `performance_test.sh`
-
-**Purpose**: Benchmarks CDT performance across different system sizes **Usage**:
+Runs CLI timing checks across several system sizes and writes `performance_results.txt`.
 
 ```bash
 ./examples/scripts/performance_test.sh
 ```
 
-**What it does**:
+Use this for quick command-level scaling checks. For regression-quality benchmarking, use `just bench-ci`, `just perf-check`, and the Criterion suites described
+in [`benches/README.md`](../../benches/README.md) and [`docs/PERFORMANCE_TESTING.md`](../../docs/PERFORMANCE_TESTING.md).
 
-- Tests small to extra-large system configurations
-- Measures current command runtime and setup overhead
-- Generates performance summary report
-- Saves results to `performance_results.txt`
+## Requirements
 
-**Use this for**: Construction and simulation scaling studies
+- Bash or zsh
+- Rust toolchain
+- `bc` for `performance_test.sh`
+- Project dependencies available to Cargo
 
-## Prerequisites
-
-### System Requirements
-
-- Bash shell (zsh also works)
-- `bc` calculator (for performance script)
-- Sufficient memory for large triangulation runs
-
-### Build Requirements
-
-- Rust toolchain (stable)
-- All project dependencies available
-
-## Quick Start
-
-1. **Make scripts executable** (already done):
-
-   ```bash
-   chmod +x examples/scripts/*.sh
-   ```
-
-2. **Run basic simulation**:
-
-   ```bash
-   ./examples/scripts/basic_simulation.sh
-   ```
-
-3. **Try a parameter sweep**:
-
-   ```bash
-   ./examples/scripts/parameter_sweep.sh
-   ```
-
-## Script Customization
-
-### Modifying Parameters
-
-Each script has configuration variables at the top that you can easily modify:
-
-**basic_simulation.sh**:
+The scripts build the release binary before running:
 
 ```bash
-# Edit the simulation parameters in the script
+cargo build --release
+```
+
+## Customization
+
+Each script keeps editable parameters near the top. Common knobs are:
+
+```bash
 VERTICES_PER_SLICE=4
 TIMESLICES=5
 STEPS=1000
 TEMPERATURE=1.0
 ```
 
-**parameter_sweep.sh**:
+For sweeps, edit the temperature list and fixed lattice parameters:
 
 ```bash
-# Modify temperature range or fixed parameters
 TEMPERATURES=(0.5 0.8 1.0 1.2 1.5 2.0 2.5 3.0)
 VERTICES_PER_SLICE=4
 TIMESLICES=8
 STEPS=2000
 ```
 
-**performance_test.sh**:
+For performance checks, edit the size tuples:
 
 ```bash
-# Add or modify system size configurations
 TEST_CONFIGS=(
-    "10 5 1000"      # Small
-    "20 8 2000"      # Medium
-    "50 10 3000"     # Large
-    "100 15 5000"    # Extra Large
-    "200 20 10000"   # Custom large config
+    "10 5 1000"
+    "20 8 2000"
+    "50 10 3000"
 )
 ```
 
-### Creating Custom Scripts
+## Outputs
 
-Template for new scripts:
+- `sweep_results/`: one log per sweep point
+- `performance_results.txt`: command-level timing summary
+- Terminal logs from `RUST_LOG=info`
 
-```bash
-#!/bin/bash
-set -e  # Exit on error
-
-echo "=== Custom CDT Script ==="
-
-# Build the binary
-cargo build --release
-
-# Run with custom parameters. Remove --simulate when you only want triangulation construction.
-RUST_LOG=info ./target/release/cdt \
-    --vertices-per-slice 4 \
-    --timeslices 10 \
-    --temperature 1.5 \
-    --steps 3000 \
-    --simulate
-
-echo "Custom command completed!"
-```
-
-## Expected Output
-
-### Current `--simulate` Runs
-
-Scripts that pass `--simulate` currently show:
-
-- Build confirmation
-- Progress messages
-- Simulation logs (with `RUST_LOG=info`)
-- Completed Metropolis-Hastings measurements when the sampled move applications remain valid
-- A non-zero exit from the `cdt` command if configuration validation fails or an accepted move cannot be applied after bounded retries
-
-### Error Handling
-
-Scripts include error checking for:
-
-- Build failures
-- Binary not found
-- Simulation crashes
-- Invalid parameters
-
-## Integration Examples
-
-### Makefile Integration
-
-```makefile
-.PHONY: run-basic run-sweep run-performance
-
-run-basic:
- ./examples/scripts/basic_simulation.sh
-
-run-sweep:
- ./examples/scripts/parameter_sweep.sh
-
-run-performance:
- ./examples/scripts/performance_test.sh
-```
-
-### CI/CD Integration
-
-```yaml
-# Example GitHub Actions step
-- name: Run CDT performance tests
-  run: |
-    ./examples/scripts/performance_test.sh
-    # Upload results artifact
-```
-
-### Data Analysis Pipeline
-
-```bash
-# Chain with analysis tools
-./examples/scripts/parameter_sweep.sh && python analyze_results.py sweep_results/
-```
-
-## Output Files
-
-### Generated by Scripts
-
-- `sweep_results/`: Directory with individual simulation logs
-- `performance_results.txt`: Performance benchmark data
-- Various log files depending on script configuration
-
-### Log Format
-
-Triangulation-only logs contain:
-
-```text
-[INFO] Dimensionality: 2
-[INFO] Number of vertices: 32
-[INFO] Number of timeslices: 8
-[INFO] Topology: OpenBoundary
-[INFO] Using trait-based backend system
-[INFO] Triangulation created with 32 vertices, <edge-count> edges, <face-count> faces
-[INFO] CDT simulation completed successfully
-```
+Typical successful logs include dimensionality, vertex count, time-slice count, topology, triangulation construction, output-file writes when configured, and
+completion status.
 
 ## Troubleshooting
 
-### Common Issues
+Permission denied:
 
-1. **Permission denied**:
+```bash
+chmod +x examples/scripts/*.sh
+```
 
-   ```bash
-   chmod +x examples/scripts/*.sh
-   ```
+`bc: command not found` on macOS:
 
-2. **Command not found**:
-   - Ensure you're in the project root directory
-   - Run `cargo build --release` first
+```bash
+brew install bc
+```
 
-3. **bc command not found** (macOS):
+Slow or memory-heavy runs:
 
-   ```bash
-   brew install bc
-   ```
-
-4. **Memory issues**:
-   - Reduce vertex counts in scripts
-   - Monitor system resources
-
-### Performance Tips
-
-- Use release builds (scripts do this automatically)
-- Adjust measurement frequency for long runs
-- Monitor memory usage for large systems
-- Run on systems with adequate RAM
-
-## Related Documentation
-
-- [`docs/CLI_EXAMPLES.md`](../../docs/CLI_EXAMPLES.md): Comprehensive CLI usage guide
-- [`examples/basic_cdt.rs`](../basic_cdt.rs): Library usage examples
-- [`benches/README.md`](../../benches/README.md): Benchmarking documentation
-
-These scripts provide a practical starting point for configuring CDT runs with the `cdt` binary.
+- Use the release build; the scripts already do this.
+- Reduce vertices per slice, time slices, or steps.
+- Increase measurement frequency for long simulations.
+- Prefer Criterion benchmarks for repeatable performance comparisons.

--- a/examples/scripts/parameter_sweep.sh
+++ b/examples/scripts/parameter_sweep.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Parameter sweep example for CDT simulations
 # This script runs multiple simulations across different temperatures
-# to study phase transitions and scaling behavior
+# to inspect acceptance, action, and volume diagnostics
 
 set -e # Exit on any error
 
@@ -73,6 +73,6 @@ done
 echo
 echo "Analysis suggestions:"
 echo "  - Plot acceptance rates vs temperature"
-echo "  - Analyze action values for phase transitions"
-echo "  - Study scaling behavior with system size"
+echo "  - Compare action and volume diagnostics across temperatures"
+echo "  - Repeat with larger systems before drawing scaling conclusions"
 echo "  - Use data from $OUTPUT_DIR/ for further analysis"

--- a/examples/scripts/parameter_sweep.sh
+++ b/examples/scripts/parameter_sweep.sh
@@ -36,9 +36,12 @@ for temp in "${TEMPERATURES[@]}"; do
 
 	# Create output filename
 	output_file="${OUTPUT_DIR}/simulation_T${temp}.log"
+	success_file="${output_file}.success"
+	status_file="${output_file}.status"
+	rm -f "$success_file" "$status_file"
 
 	# Run simulation and save output
-	RUST_LOG=info ./target/release/cdt \
+	if RUST_LOG=info ./target/release/cdt \
 		--vertices-per-slice $VERTICES_PER_SLICE \
 		--timeslices $TIMESLICES \
 		--temperature "$temp" \
@@ -46,9 +49,15 @@ for temp in "${TEMPERATURES[@]}"; do
 		--thermalization-steps 200 \
 		--measurement-frequency 20 \
 		--simulate \
-		>"$output_file" 2>&1
-
-	echo "  ✓ T = $temp completed, saved to $output_file"
+		>"$output_file" 2>&1; then
+		printf '0\n' >"$status_file"
+		touch "$success_file"
+		echo "  ✓ T = $temp completed, saved to $output_file"
+	else
+		status=$?
+		printf '%s\n' "$status" >"$status_file"
+		echo "  FAILED: T = $temp exited with status $status; see $output_file"
+	fi
 done
 
 echo
@@ -63,8 +72,13 @@ echo "------------|--------"
 
 for temp in "${TEMPERATURES[@]}"; do
 	output_file="${OUTPUT_DIR}/simulation_T${temp}.log"
-	if grep -q "CDT simulation completed successfully" "$output_file"; then
+	success_file="${output_file}.success"
+	status_file="${output_file}.status"
+	if [[ -f "$success_file" ]]; then
 		echo "    $temp    | SUCCESS"
+	elif [[ -f "$status_file" ]]; then
+		status="$(<"$status_file")"
+		echo "    $temp    | FAILED (${status})"
 	else
 		echo "    $temp    | FAILED"
 	fi

--- a/justfile
+++ b/justfile
@@ -10,9 +10,9 @@ cargo_llvm_cov_version := "0.8.7"
 cargo_nextest_version := "0.9.137"
 dprint_version := "0.54.0"
 git_cliff_version := "2.13.1"
-rumdl_version := "0.2.4"
+rumdl_version := "0.2.10"
 taplo_version := "0.10.0"
-typos_version := "1.47.0"
+typos_version := "1.47.2"
 zizmor_version := "1.25.2"
 
 # Common cargo-llvm-cov arguments for all coverage runs.
@@ -140,7 +140,7 @@ _ensure-typos:
     set -euo pipefail
     installed_version=""
     if command -v typos >/dev/null; then
-        installed_version="$(typos --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        installed_version="$(typos --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     fi
     if [[ "$installed_version" != "{{typos_version}}" ]]; then
         echo "❌ 'typos' {{typos_version}} not found. See 'just setup-tools' or install:"
@@ -710,7 +710,7 @@ setup-tools:
     fi
 
     typos_version="{{typos_version}}"
-    if ! have typos || [[ "$(typos --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$typos_version" ]]; then
+    if ! have typos || [[ "$(typos --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)" != "$typos_version" ]]; then
         echo "  ⏳ Installing typos-cli ${typos_version} (cargo)..."
         cargo install --locked typos-cli --version "${typos_version}"
     else

--- a/justfile
+++ b/justfile
@@ -34,7 +34,7 @@ _ensure-cargo-llvm-cov:
     set -euo pipefail
     installed_version=""
     if command -v cargo-llvm-cov >/dev/null; then
-        installed_version="$(cargo llvm-cov --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        installed_version="$(cargo llvm-cov --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     fi
     if [[ "$installed_version" != "{{cargo_llvm_cov_version}}" ]]; then
         echo "❌ 'cargo-llvm-cov' {{cargo_llvm_cov_version}} not found. See 'just setup-tools' or install:"
@@ -56,7 +56,7 @@ _ensure-cargo-nextest:
     set -euo pipefail
     installed_version=""
     if cargo nextest --version >/dev/null 2>&1; then
-        installed_version="$(cargo nextest --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        installed_version="$(cargo nextest --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     fi
     if [[ "$installed_version" != "{{cargo_nextest_version}}" ]]; then
         echo "❌ 'cargo-nextest' {{cargo_nextest_version}} not found. See 'just setup-tools' or install:"
@@ -69,7 +69,7 @@ _ensure-dprint:
     set -euo pipefail
     installed_version=""
     if command -v dprint >/dev/null; then
-        installed_version="$(dprint --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        installed_version="$(dprint --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     fi
     if [[ "$installed_version" != "{{dprint_version}}" ]]; then
         echo "❌ 'dprint' {{dprint_version}} not found. See 'just setup-tools' or install:"
@@ -82,7 +82,7 @@ _ensure-git-cliff:
     set -euo pipefail
     installed_version=""
     if command -v git-cliff >/dev/null; then
-        installed_version="$(git-cliff --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        installed_version="$(git-cliff --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     fi
     if [[ "$installed_version" != "{{git_cliff_version}}" ]]; then
         echo "❌ 'git-cliff' {{git_cliff_version}} not found. Install with:"
@@ -100,7 +100,7 @@ _ensure-rumdl:
     set -euo pipefail
     installed_version=""
     if command -v rumdl >/dev/null; then
-        installed_version="$(rumdl --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        installed_version="$(rumdl --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     fi
     if [[ "$installed_version" != "{{rumdl_version}}" ]]; then
         echo "❌ 'rumdl' {{rumdl_version}} not found. See 'just setup-tools' or install:"
@@ -126,7 +126,7 @@ _ensure-taplo:
     set -euo pipefail
     installed_version=""
     if command -v taplo >/dev/null; then
-        installed_version="$(taplo --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        installed_version="$(taplo --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     fi
     if [[ "$installed_version" != "{{taplo_version}}" ]]; then
         echo "❌ 'taplo' {{taplo_version}} not found. See 'just setup-tools' or install:"
@@ -165,7 +165,7 @@ _ensure-zizmor:
     set -euo pipefail
     installed_version=""
     if command -v zizmor >/dev/null; then
-        installed_version="$(zizmor --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        installed_version="$(zizmor --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     fi
     if [[ "$installed_version" != "{{zizmor_version}}" ]]; then
         echo "❌ 'zizmor' {{zizmor_version}} not found. See 'just setup-tools' or install:"
@@ -686,7 +686,7 @@ setup-tools:
 
     echo "Ensuring cargo tools..."
     dprint_version="{{dprint_version}}"
-    if ! have dprint || [[ "$(dprint --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$dprint_version" ]]; then
+    if ! have dprint || [[ "$(dprint --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)" != "$dprint_version" ]]; then
         echo "  ⏳ Installing dprint ${dprint_version} (cargo)..."
         cargo install --locked dprint --version "${dprint_version}"
     else
@@ -694,7 +694,7 @@ setup-tools:
     fi
 
     rumdl_version="{{rumdl_version}}"
-    if ! have rumdl || [[ "$(rumdl --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$rumdl_version" ]]; then
+    if ! have rumdl || [[ "$(rumdl --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)" != "$rumdl_version" ]]; then
         echo "  ⏳ Installing rumdl ${rumdl_version} (cargo)..."
         cargo install --locked rumdl --version "${rumdl_version}"
     else
@@ -702,7 +702,7 @@ setup-tools:
     fi
 
     taplo_version="{{taplo_version}}"
-    if ! have taplo || [[ "$(taplo --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$taplo_version" ]]; then
+    if ! have taplo || [[ "$(taplo --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)" != "$taplo_version" ]]; then
         echo "  ⏳ Installing taplo-cli ${taplo_version} (cargo)..."
         cargo install --locked taplo-cli --version "${taplo_version}"
     else
@@ -718,7 +718,7 @@ setup-tools:
     fi
 
     git_cliff_version="{{git_cliff_version}}"
-    if ! have git-cliff || [[ "$(git-cliff --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$git_cliff_version" ]]; then
+    if ! have git-cliff || [[ "$(git-cliff --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)" != "$git_cliff_version" ]]; then
         echo "  ⏳ Installing git-cliff ${git_cliff_version} (cargo)..."
         cargo install --locked git-cliff --version "${git_cliff_version}"
     else
@@ -726,7 +726,7 @@ setup-tools:
     fi
 
     cargo_llvm_cov_version="{{cargo_llvm_cov_version}}"
-    if ! have cargo-llvm-cov || [[ "$(cargo-llvm-cov --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$cargo_llvm_cov_version" ]]; then
+    if ! have cargo-llvm-cov || [[ "$(cargo-llvm-cov --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)" != "$cargo_llvm_cov_version" ]]; then
         echo "  ⏳ Installing cargo-llvm-cov ${cargo_llvm_cov_version} (cargo)..."
         cargo install --locked cargo-llvm-cov --version "${cargo_llvm_cov_version}"
     else
@@ -734,7 +734,7 @@ setup-tools:
     fi
 
     cargo_nextest_version="{{cargo_nextest_version}}"
-    if ! cargo nextest --version >/dev/null 2>&1 || [[ "$(cargo nextest --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$cargo_nextest_version" ]]; then
+    if ! cargo nextest --version >/dev/null 2>&1 || [[ "$(cargo nextest --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)" != "$cargo_nextest_version" ]]; then
         echo "  ⏳ Installing cargo-nextest ${cargo_nextest_version} (cargo)..."
         cargo install --locked cargo-nextest --version "${cargo_nextest_version}"
     else
@@ -749,7 +749,7 @@ setup-tools:
     fi
 
     zizmor_version="{{zizmor_version}}"
-    if ! have zizmor || [[ "$(zizmor --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$zizmor_version" ]]; then
+    if ! have zizmor || [[ "$(zizmor --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)" != "$zizmor_version" ]]; then
         echo "  ⏳ Installing zizmor ${zizmor_version} (cargo)..."
         cargo install --locked zizmor --version "${zizmor_version}"
     else


### PR DESCRIPTION
- Add a non-programmer quickstart for running 1+1 CDT simulations, interpreting CSV/JSON output, and tuning the main physics knobs.
- Refocus README around current 1+1 scope, grand-canonical volume behavior, the crate ecosystem, and reviewer-facing documentation entry points.
- Streamline CLI, script, contributing, benchmark, and performance docs so each guide has a distinct maintenance role.
- Document how Delaunay bistellar k-flips map onto foliation-preserving CDT/Pachner moves, including the planned interface revisit after delaunay#252.
- Align Markdown and spelling tool pins with sibling repositories.

Closes #187