### PR TITLE
feat(cdt): add causal-filtered Delaunay strip construction

### DIFF
--- a/docs/code-organization.md
+++ b/docs/code-organization.md
@@ -237,6 +237,9 @@ through to upstream `delaunay::` APIs directly.
   raw geometry queries remain `usize` so backend construction, clearing, and collection-style count APIs can represent zero
 - `from_cdt_strip(vertices_per_slice, num_slices)` — Delaunay-built open-boundary 1+1 CDT strip with strict Up/Down simplex classification and upstream Level
   1–4 Delaunay validation before wrapping
+- `from_filtered_delaunay_strip(vertices_per_slice, num_slices)` — open-boundary 1+1 CDT initial-state constructor that starts from surplus labeled Delaunay
+  points, removes vertices incident to non-strict CDT simplices through the backend `remove_vertex` path, and returns only after the strict causal simplex
+  violation count converges to zero and full initial validation passes
 - `from_cdt_strip_profile(volume_profile)` — open-boundary 1+1 CDT strip from explicit nonuniform per-slice vertex counts; builds labeled point data and
   delegates triangulation to the Delaunay constructor before strict initial validation
 - `from_toroidal_cdt(vertices_per_slice, num_slices)` — periodic Delaunay S¹×S¹ toroidal CDT (χ = 0) with upstream Level 1–4 validation before wrapping;
@@ -244,7 +247,7 @@ through to upstream `delaunay::` APIs directly.
 - `from_toroidal_cdt_profile(volume_profile)` — periodic S¹×S¹ toroidal CDT from explicit per-slice vertex counts, preserving closed spatial slices and
   periodic time
 - `assign_foliation_by_y(num_slices)` — bin existing vertices into time slices
-- Query methods: `time_label`, `edge_type`, `vertices_at_time`, `slice_sizes`, `has_foliation`
+- Query methods: `time_label`, `edge_type`, `vertices_at_time`, `slice_sizes`, `has_foliation`, `strict_causal_simplex_violation_count`
 - Validation: constructors require upstream Delaunay Level 1–4 validation for initial meshes; `validate()` is the post-move/final-state contract and requires
   upstream structural validity plus CDT topology, foliation, causality, and strict Up/Down simplex classification
 - Mutable backend access is not exposed. CDT code mutates Delaunay state only through narrow crate-internal operations (`flip_edge`, `subdivide_face`,

--- a/docs/foliation.md
+++ b/docs/foliation.md
@@ -59,6 +59,11 @@ The regular open-boundary strip constructor places vertices in a lightly perturb
 
 Parameters: `vertices_per_slice ≥ 4`, `num_slices ≥ 2`.
 
+`from_filtered_delaunay_strip()` is the CDT-plusplus-influenced construction path. It starts from an overcomplete labeled Delaunay triangulation, counts
+non-strict causal simplices, removes a vertex incident to an offending simplex through the backend `remove_vertex` operation, rebuilds foliation bookkeeping
+from live vertex labels, and repeats until the count converges to zero. The current pass budget is bounded, but success is defined by the CDT invariant, not by
+the number of cleanup passes used.
+
 `from_cdt_strip_profile()` places each open spatial slice according to the corresponding profile entry and delegates triangulation to the Delaunay point-data
 constructor. The returned mesh must pass the same initial-constructor contract as the regular open strip: upstream Delaunay Level 1-4 validation plus CDT
 topology, foliation, causality, and strict Up/Down simplex classification.
@@ -105,6 +110,28 @@ Simplex types are encoded as `i32` simplex data (`Up = 1`, `Down = -1`) and can 
 foliated triangulations this bulk path is strict: every face must classify as `Up` or `Down`, otherwise `classify_all_simplices()` and
 `validate_simplex_classification()` return a validation error.
 
+## Strict Causal Simplex Invariant
+
+For a current foliated triangulation, every top-dimensional simplex must be strictly causal. In the current 1+1 implementation, that means every finite
+triangle face must classify as `Up` `(2,1)` or `Down` `(1,2)`. Pure spacelike faces, all-timelike/non-spacelike faces, faces spanning more than adjacent time
+slices, malformed faces, and faces with missing time labels are all violations.
+
+This is a CDT-domain invariant. It is deliberately separate from upstream Delaunay Level 4 validation: Delaunay-ness asks whether the geometric triangulation
+satisfies an empty-circumsphere predicate, while strict causal simplex validation asks whether the foliation makes every top-dimensional cell an allowed CDT
+cell. A useful mental model is a parallel CDT validation level rather than Delaunay Level 5:
+
+- initial Delaunay-backed constructors require upstream Delaunay Level 4 and zero strict causal simplex violations;
+- evolved CDT states must remain structurally valid and keep zero strict causal simplex violations, but they are not required to preserve the Delaunay
+  empty-circumsphere property.
+
+`strict_causal_simplex_violation_count()` exposes the invariant as a count. Valid constructor output and valid post-move states must have count zero. The
+filtered constructor uses the count as its convergence condition, following the CDT-plusplus practice of repeatedly removing acausal or unclassified
+simplices/vertices until no violations remain. Unlike `validate_simplex_classification()`, this counter requires current foliation bookkeeping so that zero
+means the strict causal invariant was actually evaluated.
+
+When higher-dimensional CDT support is added, this invariant should remain dimension-neutral: every top-dimensional simplex must realize one of the allowed
+causal CDT simplex types for that dimension, such as the corresponding adjacent-slice distributions in 2+1, 3+1, and 4+1 dimensions.
+
 ## Validation
 
 Two validation methods enforce foliation correctness:
@@ -138,6 +165,14 @@ Strict simplex-classification check:
 - Succeeds vacuously when no foliation is present
 - Requires every foliated face to classify as `Up` or `Down`
 - Returns `CdtError::ValidationFailed { check: "simplex_classification", .. }` for same-slice or otherwise unclassifiable triangles
+
+### `strict_causal_simplex_violation_count()`
+
+Invariant counter:
+
+- Requires stored foliation bookkeeping, so unfoliated triangulations return `FoliationError::MissingBookkeeping`
+- Requires current foliation bookkeeping, so stale label snapshots return `FoliationError::StaleBookkeeping`
+- Returns the number of finite faces that do not satisfy the strict causal simplex invariant
 
 ## Error Handling
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,6 +18,8 @@ Completed foundation work:
 - [x] Validated open-boundary and toroidal S¹×S¹ 1+1 CDT constructors, including explicit per-slice spatial volume profiles.
 - [x] Per-vertex foliation labels, adjacent-slice causality checks, topology validation, and strict Up/Down simplex classification.
 - [x] Real 2D local CDT move kernels over checked Delaunay edit operations, with rollback or rejection on invariant failures.
+- [x] Causality-filtering Delaunay construction path inspired by CDT++ ([#192](https://github.com/acgetchell/causal-triangulations/issues/192)), with repeated
+  removal of vertices incident to non-strict causal simplices until the strict violation count converges to zero.
 - [x] Planned-proposal Metropolis execution through `markov-chain-monte-carlo`, including proposal-site weighting and resumable chunked sweeps.
 - [x] CLI support, trace/summary exports, checkpoints, and core observables for downstream analysis.
 - [x] Repository validation loop covering Rust, Python support scripts, Semgrep rules, documentation, notebooks, examples, and benchmarks.
@@ -31,9 +33,8 @@ Likely follow-up work before broadening the dimensional surface:
 - Broaden per-kernel toroidal tests around spatial and temporal wrap-around simplices
 - Accept fixed triangle simplices directly in explicit-simplex generator APIs to remove per-triangle `Vec` adaptation
 - Add manual foliation assignment APIs with the same validation and synchronization guarantees as constructor-assigned labels
-- Add a causality-filtering Delaunay construction path inspired by CDT++ ([#192](https://github.com/acgetchell/causal-triangulations/issues/192)): generate a
-  Delaunay PL-manifold from surplus labeled points, delete vertices incident to acausal simplices through backend retriangulation, and accept only states that
-  pass the existing CDT validators.
+- Integrate upstream embedded-triangulation validation from `delaunay` once acgetchell/delaunay#449 is available, so evolved CDT states can reject overlapping
+  simplices without requiring Delaunay Level 4 ([#195](https://github.com/acgetchell/causal-triangulations/issues/195)).
 - Add tutorial-style examples for open-boundary strips, toroidal runs, observables, and interpreting Metropolis acceptance behavior
 
 ## v0.1.1 Maturity And Ensemble Controls

--- a/docs/scientific-basis.md
+++ b/docs/scientific-basis.md
@@ -84,12 +84,15 @@ foliation/topology/causality constraints, the configured action, and Metropolis-
 The predecessor implementation, [`CDT-plusplus`](https://github.com/acgetchell/CDT-plusplus), used CGAL Delaunay triangulations as a geometric substrate and
 then filtered the result through CDT causality rules. Its key reusable lesson is the separation between generic triangulation editing and CDT-domain validity:
 start from a Delaunay-built PL manifold, classify cells by stored time labels, identify acausal or unclassified cells, delete selected offending vertices
-through the geometry backend, and let the backend retriangulate the affected cavities before rechecking CDT invariants.
+through the geometry backend, and let the backend retriangulate the affected cavities before rechecking CDT invariants. In large constructions this may require
+many passes; the Rust implementation treats convergence to zero strict causal simplex violations as the acceptance condition rather than assuming one cleanup
+pass is enough.
 
 That approach is not treated as current validation evidence for this Rust crate. `CDT-plusplus` is referenced as implementation lineage and a source of design
-experience; it may become a useful independent regression oracle if modernized enough to build and run representative fixtures. The planned Rust follow-up is
-tracked as [`causal-triangulations#192`](https://github.com/acgetchell/causal-triangulations/issues/192): implement a causality-filtering Delaunay construction
-path without moving generic PL-manifold editing into the CDT layer.
+experience; it may become a useful independent regression oracle if modernized enough to build and run representative fixtures. The Rust follow-up tracked as
+[`causal-triangulations#192`](https://github.com/acgetchell/causal-triangulations/issues/192) implements a causality-filtering Delaunay construction path
+without moving generic PL-manifold editing into the CDT layer. The invariant itself is documented in [`docs/foliation.md`](foliation.md): every current foliated
+top-dimensional simplex must be strictly causal, with `strict_causal_simplex_violation_count() == 0`.
 
 ## Move And Sampler Contract
 

--- a/src/cdt/foliation.rs
+++ b/src/cdt/foliation.rs
@@ -152,6 +152,8 @@ pub fn classify_simplex(t0: Option<u32>, t1: Option<u32>, t2: Option<u32>) -> Op
 pub enum FoliationError {
     /// No time slices were supplied for foliation bookkeeping.
     EmptyFoliation,
+    /// The triangulation has no stored foliation bookkeeping.
+    MissingBookkeeping,
     /// `slice_sizes` length does not match `num_slices`.
     SliceSizeMismatch {
         /// Actual length of the `slice_sizes` vector.
@@ -380,6 +382,7 @@ impl fmt::Display for FoliationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::EmptyFoliation => write!(f, "foliation must contain at least one time slice"),
+            Self::MissingBookkeeping => write!(f, "triangulation has no foliation bookkeeping"),
             Self::SliceSizeMismatch {
                 slice_sizes_len,
                 num_slices,
@@ -908,6 +911,15 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "foliation must contain at least one time slice"
+        );
+    }
+
+    #[test]
+    fn test_foliation_error_missing_bookkeeping_display() {
+        let err = FoliationError::MissingBookkeeping;
+        assert_eq!(
+            err.to_string(),
+            "triangulation has no foliation bookkeeping"
         );
     }
 

--- a/src/cdt/triangulation/builders.rs
+++ b/src/cdt/triangulation/builders.rs
@@ -1407,7 +1407,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cdt::foliation::{EdgeType, FoliationError, SimplexType};
+    use crate::cdt::foliation::{EdgeType, Foliation, FoliationError, SimplexType};
     use crate::errors::TriangulationMetadataField;
     use crate::geometry::generators::{build_delaunay2_from_simplices, build_delaunay2_with_data};
     use approx::assert_relative_eq;
@@ -1422,6 +1422,17 @@ mod tests {
         ])
         .expect("Should build labeled triangle");
         DelaunayBackend2D::from_triangulation(dt).expect("test Delaunay triangle should validate")
+    }
+
+    fn same_slice_non_strict_triangle() -> CdtTriangulation<DelaunayBackend2D> {
+        let mut tri = CdtTriangulation::try_new(labeled_triangle_backend([0, 0, 0]), 1, 2)
+            .expect("single Delaunay triangle should satisfy bare topology");
+        tri.foliation = Some(
+            Foliation::from_slice_sizes(vec![3], checked_nonzero_slice_count(1))
+                .expect("single nonempty slice should form foliation bookkeeping"),
+        );
+        tri.mark_foliation_synchronized();
+        tri
     }
 
     /// Builds a Delaunay strip and verifies it is a strict CDT mesh.
@@ -1938,6 +1949,90 @@ mod tests {
             tri.strict_causal_simplex_violation_count()
                 .expect("two-slice filtered strip should expose a strict-causality count"),
             0
+        );
+    }
+
+    #[test]
+    fn test_invalid_simplex_removal_candidate_allows_surplus_same_slice_vertex() {
+        let tri = same_slice_non_strict_triangle();
+
+        let candidate = tri
+            .invalid_simplex_removal_candidate(2, 3, 2.0)
+            .expect("surplus same-slice face should be inspectable")
+            .expect("same-slice face should yield a removable vertex");
+
+        assert_eq!(
+            tri.geometry().vertex_data_by_key(candidate.vertex_key()),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn test_invalid_simplex_removal_candidate_respects_minimum_slice_size() {
+        let tri = same_slice_non_strict_triangle();
+
+        let err = tri
+            .invalid_simplex_removal_candidate(3, 3, 2.0)
+            .expect_err("minimum slice size should prevent removal");
+
+        assert_matches!(
+            err,
+            CdtError::DelaunayGenerationFailed {
+                vertex_count: 3,
+                coordinate_range: (0.0, 2.0),
+                attempt: 1,
+                ref underlying_error,
+            } if underlying_error.contains("minimum size 3")
+        );
+    }
+
+    #[test]
+    fn test_invalid_simplex_removal_candidate_returns_none_for_strict_strip() {
+        let tri = strict_strip(4, 2);
+
+        assert!(
+            tri.invalid_simplex_removal_candidate(4, 8, 2.0)
+                .expect("strict strip should be inspectable")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_filter_invalid_open_delaunay_simplices_rejects_missing_live_label() {
+        let mut tri = same_slice_non_strict_triangle();
+        let vertex = tri
+            .geometry()
+            .vertices()
+            .next()
+            .expect("test triangle should contain a vertex");
+        tri.set_vertex_data(&vertex, None)
+            .expect("test vertex should accept clearing its label");
+
+        assert_matches!(
+            tri.filter_invalid_open_delaunay_simplices(2, 1, 3, 2.0),
+            Err(CdtError::Foliation(FoliationError::MissingVertexLabel {
+                vertex: 0
+            }))
+        );
+    }
+
+    #[test]
+    fn test_filter_invalid_open_delaunay_simplices_reports_pass_budget_exhaustion() {
+        let mut tri = same_slice_non_strict_triangle();
+
+        let err = tri
+            .filter_invalid_open_delaunay_simplices(2, 0, 3, 2.0)
+            .expect_err("zero-pass budget should report remaining violations");
+
+        assert_matches!(
+            err,
+            CdtError::DelaunayGenerationFailed {
+                vertex_count: 3,
+                coordinate_range: (0.0, 2.0),
+                attempt: 1,
+                ref underlying_error,
+            } if underlying_error.contains("exhausted 0 causal-filtering passes")
+                && underlying_error.contains("1 non-strict simplices remaining")
         );
     }
 

--- a/src/cdt/triangulation/builders.rs
+++ b/src/cdt/triangulation/builders.rs
@@ -5,14 +5,21 @@
 use super::CdtTriangulation;
 use crate::cdt::foliation::{Foliation, FoliationError};
 use crate::config::CdtTopology;
-use crate::errors::{CdtError, CdtResult, DelaunayValidationLevel, GenerationParameterIssue};
+use crate::errors::{
+    BackendMutationOperation, CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure,
+    DelaunayValidationLevel, GenerationParameterIssue,
+};
 use crate::geometry::DelaunayBackend2D;
+use crate::geometry::backends::delaunay::DelaunayVertexHandle;
 use crate::geometry::generators::{
     DelaunayTriangulation2D, build_delaunay2_with_data, build_periodic_toroidal_delaunay2,
     generate_delaunay2,
 };
 use crate::geometry::traits::TriangulationQuery;
 use std::num::NonZeroU32;
+
+/// Default pass budget for CDT++-style causality filtering.
+const FILTERED_DELAUNAY_MAX_PASSES: u32 = 50;
 
 /// Rewrites toroidal builder failures with CDT-level generation context.
 ///
@@ -444,6 +451,30 @@ fn open_profile_vertices(profile: &[u32], total_vertices: u32) -> CdtResult<Vec<
 }
 
 impl CdtTriangulation<DelaunayBackend2D> {
+    /// Rebuilds open-boundary foliation bookkeeping from live backend labels.
+    ///
+    /// The filtered constructor mutates the backend between passes, so it cannot
+    /// reuse stored slice sizes. Rebuilding from vertex payloads preserves the
+    /// public guarantee that a zero strict-causal violation count was computed
+    /// from the current geometry rather than stale bookkeeping.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FoliationError`] when live labels are missing, out of range, or
+    /// cannot form valid open-boundary foliation bookkeeping.
+    fn rebuild_open_foliation_from_live_labels(&mut self) -> CdtResult<()> {
+        let slice_sizes = Self::live_slice_sizes_from_vertex_labels(
+            &self.geometry,
+            self.metadata.time_slices.get(),
+        )?;
+        let foliation = Foliation::from_slice_sizes(slice_sizes, self.metadata.time_slices)
+            .map_err(CdtError::from)?;
+
+        self.foliation = Some(foliation);
+        self.mark_foliation_synchronized();
+        Ok(())
+    }
+
     /// Re-reads current backend labels during validation so stale stored bookkeeping is detected.
     pub(super) fn live_slice_sizes_from_vertex_labels(
         backend: &DelaunayBackend2D,
@@ -634,14 +665,286 @@ impl CdtTriangulation<DelaunayBackend2D> {
                 return Err(FoliationError::EmptySlice { slice }.into());
             }
         }
-        let foliation =
-            Foliation::from_slice_sizes(slice_sizes, checked_nonzero_slice_count(time_slices))
-                .map_err(CdtError::from)?;
-
         let mut tri = Self::try_new(backend, time_slices, dimension)?;
-        tri.foliation = Some(foliation);
+        tri.foliation = Some(
+            Foliation::from_slice_sizes(slice_sizes, checked_nonzero_slice_count(time_slices))
+                .map_err(CdtError::from)?,
+        );
         tri.mark_foliation_synchronized();
         tri.validate_initial_delaunay_cdt()?;
+        Ok(tri)
+    }
+
+    /// Selects a removable vertex from the first non-strict CDT simplex.
+    ///
+    /// The selector prefers extreme time labels on acausal faces and never
+    /// removes the last vertex above the caller's per-slice minimum. It is the
+    /// local policy behind [`Self::from_filtered_delaunay_strip`]'s convergence
+    /// loop, not a general move proposal for simulation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::ValidationFailed`] if the offending face cannot be
+    /// inspected or has missing vertex labels. Returns
+    /// [`CdtError::DelaunayGenerationFailed`] if every candidate slice is already
+    /// at the caller's per-slice minimum.
+    fn invalid_simplex_removal_candidate(
+        &self,
+        minimum_slice_size: usize,
+        total_vertices: u32,
+        coordinate_max: f64,
+    ) -> CdtResult<Option<DelaunayVertexHandle>> {
+        let slice_sizes = self.slice_sizes();
+
+        for face in self.geometry.faces() {
+            if self.simplex_type(&face).is_some() {
+                continue;
+            }
+
+            let vertices =
+                self.geometry
+                    .face_vertices(&face)
+                    .map_err(|err| CdtError::ValidationFailed {
+                        check: CdtValidationCheck::SimplexClassification,
+                        failure: CdtValidationFailure::FaceVerticesUnavailable {
+                            face: format!("{:?}", face.simplex_key()),
+                            detail: err.to_string(),
+                        },
+                    })?;
+            let mut labeled_vertices = Vec::with_capacity(vertices.len());
+            for vertex in vertices {
+                let label = self
+                    .geometry
+                    .vertex_data_by_key(vertex.vertex_key())
+                    .ok_or_else(|| CdtError::ValidationFailed {
+                        check: CdtValidationCheck::SimplexClassification,
+                        failure: CdtValidationFailure::MissingVertexTimeLabel {
+                            vertex: format!("{:?}", vertex.vertex_key()),
+                        },
+                    })?;
+                labeled_vertices.push((vertex, label));
+            }
+
+            let Some(min_label) = labeled_vertices.iter().map(|(_, label)| *label).min() else {
+                return Ok(None);
+            };
+            let Some(max_label) = labeled_vertices.iter().map(|(_, label)| *label).max() else {
+                return Ok(None);
+            };
+            let mut candidates: Vec<_> = if max_label.saturating_sub(min_label) > 1 {
+                labeled_vertices
+                    .iter()
+                    .filter(|(_, label)| *label == min_label || *label == max_label)
+                    .collect()
+            } else {
+                labeled_vertices.iter().collect()
+            };
+            candidates.sort_by_key(|(_, label)| {
+                let count = labeled_vertices
+                    .iter()
+                    .filter(|(_, other)| *other == *label)
+                    .count();
+                (count, *label)
+            });
+
+            for (vertex, label) in candidates {
+                let Some(&slice_size) = slice_sizes.get(*label as usize) else {
+                    continue;
+                };
+                if slice_size > minimum_slice_size {
+                    return Ok(Some((*vertex).clone()));
+                }
+            }
+
+            return Err(CdtError::DelaunayGenerationFailed {
+                vertex_count: total_vertices,
+                coordinate_range: (0.0, coordinate_max),
+                attempt: 1,
+                underlying_error: format!(
+                    "filtered Delaunay construction found non-strict face {:?}, but every offending slice is already at the minimum size {minimum_slice_size}",
+                    face.simplex_key(),
+                ),
+            });
+        }
+
+        Ok(None)
+    }
+
+    /// Removes vertices incident to non-strict CDT simplices until the violation count is zero.
+    ///
+    /// This is the bounded CDT-plusplus-style filtering loop used by
+    /// [`Self::from_filtered_delaunay_strip`]. Each pass rebuilds foliation
+    /// bookkeeping from live labels, counts non-strict simplices through
+    /// [`Self::strict_causal_simplex_violation_count`], removes one offending
+    /// vertex, and lets the Delaunay backend retriangulate the cavity.
+    ///
+    /// # Errors
+    ///
+    /// Returns foliation or validation errors from rebuilding and recounting.
+    /// Returns [`CdtError::DelaunayGenerationFailed`] if the pass budget is
+    /// exhausted or no removable offending vertex exists. Returns
+    /// [`CdtError::BackendMutationFailed`] if backend vertex removal fails.
+    fn filter_invalid_open_delaunay_simplices(
+        &mut self,
+        minimum_vertices_per_slice: usize,
+        max_passes: u32,
+        total_vertices: u32,
+        coordinate_max: f64,
+    ) -> CdtResult<()> {
+        for pass in 0..=max_passes {
+            self.rebuild_open_foliation_from_live_labels()?;
+            let violations = self.strict_causal_simplex_violation_count()?;
+            if violations == 0 {
+                return Ok(());
+            }
+            if pass == max_passes {
+                return Err(CdtError::DelaunayGenerationFailed {
+                    vertex_count: total_vertices,
+                    coordinate_range: (0.0, coordinate_max),
+                    attempt: pass + 1,
+                    underlying_error: format!(
+                        "filtered Delaunay construction exhausted {max_passes} causal-filtering passes with {violations} non-strict simplices remaining"
+                    ),
+                });
+            }
+
+            let Some(vertex) = self.invalid_simplex_removal_candidate(
+                minimum_vertices_per_slice,
+                total_vertices,
+                coordinate_max,
+            )?
+            else {
+                return Err(CdtError::DelaunayGenerationFailed {
+                    vertex_count: total_vertices,
+                    coordinate_range: (0.0, coordinate_max),
+                    attempt: pass + 1,
+                    underlying_error: format!(
+                        "filtered Delaunay construction found {violations} non-strict simplices but no removable offending vertex"
+                    ),
+                });
+            };
+
+            let target = format!("vertex {:?}", vertex.vertex_key());
+            self.remove_vertex(vertex)
+                .map_err(|err| CdtError::BackendMutationFailed {
+                    operation: BackendMutationOperation::RemoveVertex,
+                    target,
+                    detail: err.to_string(),
+                })?;
+        }
+
+        Ok(())
+    }
+
+    /// Construct a Delaunay-backed 1+1 CDT strip by filtering surplus labeled points.
+    ///
+    /// Starts from a valid Delaunay triangulation containing a regular
+    /// open-boundary CDT strip plus deterministic surplus vertices whose
+    /// coordinates are intentionally placed near the opposite temporal boundary.
+    /// The constructor repeatedly counts non-strict causal simplices through
+    /// [`Self::strict_causal_simplex_violation_count`], removes a vertex incident
+    /// to one such simplex through
+    /// [`TriangulationMut::remove_vertex`](crate::geometry::traits::TriangulationMut::remove_vertex),
+    /// lets the Delaunay backend retriangulate each cavity, and returns only
+    /// after the violation count reaches zero and the full initial CDT validation
+    /// contract passes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::InvalidGenerationParameters`] under the same
+    /// parameter bounds as [`Self::from_cdt_strip`]. Returns
+    /// [`CdtError::DelaunayGenerationFailed`] if the overcomplete Delaunay
+    /// construction fails, filtering cannot make progress without violating the
+    /// requested per-slice minimum, or the 50-pass filtering budget is exhausted.
+    /// Returns [`CdtError::BackendMutationFailed`] if backend vertex removal
+    /// fails. Returns validation errors if the filtered triangulation does not
+    /// satisfy CDT topology, foliation, causality, and simplex-classification
+    /// invariants.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::*;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::from_filtered_delaunay_strip(4, 3)?;
+    ///     assert_eq!(tri.slice_sizes(), &[4, 4, 4]);
+    ///     assert_eq!(tri.strict_causal_simplex_violation_count()?, 0);
+    ///     tri.validate_simplex_classification()?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn from_filtered_delaunay_strip(
+        vertices_per_slice: u32,
+        num_slices: u32,
+    ) -> CdtResult<Self> {
+        if vertices_per_slice < 4 {
+            return Err(CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::InsufficientVerticesPerSlice,
+                provided_value: vertices_per_slice.to_string(),
+                expected_range: "≥ 4".to_string(),
+            });
+        }
+        if num_slices < 2 {
+            return Err(CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::InsufficientNumberOfTimeSlices,
+                provided_value: num_slices.to_string(),
+                expected_range: "≥ 2".to_string(),
+            });
+        }
+
+        let core_vertices = vertices_per_slice.checked_mul(num_slices).ok_or_else(|| {
+            CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::VertexCountOverflow,
+                provided_value: format!("{vertices_per_slice} × {num_slices}"),
+                expected_range: "product ≤ u32::MAX".to_string(),
+            }
+        })?;
+        let surplus_vertices = if num_slices > 2 { 2 } else { 0 };
+        let total_vertices = core_vertices.checked_add(surplus_vertices).ok_or_else(|| {
+            CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::VertexCountOverflow,
+                provided_value: format!("{core_vertices} + {surplus_vertices}"),
+                expected_range: "sum ≤ u32::MAX".to_string(),
+            }
+        })?;
+
+        let coordinate_max = f64::from(num_slices).max(2.0);
+        let mut vertex_specs = open_profile_vertices(
+            &vec![vertices_per_slice; num_slices as usize],
+            core_vertices,
+        )?;
+        vertex_specs.try_reserve_exact(surplus_vertices as usize).map_err(|err| {
+            strip_generation_error(
+                total_vertices,
+                coordinate_max,
+                format!(
+                    "from_filtered_delaunay_strip() failed to reserve {surplus_vertices} surplus vertex specs: {err}"
+                ),
+            )
+        })?;
+
+        if num_slices > 2 {
+            let midpoint = 0.5;
+            vertex_specs.push(([midpoint, f64::from(num_slices - 1) - 0.1], 0));
+            vertex_specs.push(([midpoint, 0.1], num_slices - 1));
+        }
+
+        let dt = build_delaunay2_with_data(&vertex_specs)
+            .map_err(|err| remap_strip_generation_error(err, total_vertices, coordinate_max))?;
+        let backend = validated_backend(dt)?;
+        let mut tri = Self::try_new(backend, num_slices, 2)?;
+        let minimum_vertices_per_slice = usize::try_from(vertices_per_slice).map_err(|err| {
+            strip_generation_error(total_vertices, coordinate_max, err.to_string())
+        })?;
+        tri.filter_invalid_open_delaunay_simplices(
+            minimum_vertices_per_slice,
+            FILTERED_DELAUNAY_MAX_PASSES,
+            total_vertices,
+            coordinate_max,
+        )?;
+        tri.validate_initial_delaunay_cdt()?;
+
         Ok(tri)
     }
 
@@ -1590,6 +1893,94 @@ mod tests {
         assert!(tri.validate_foliation().is_ok());
         assert!(tri.validate_causality_delaunay().is_ok());
         assert!(tri.validate_simplex_classification().is_ok());
+        assert_eq!(
+            tri.strict_causal_simplex_violation_count()
+                .expect("Delaunay strip should expose a current strict-causality count"),
+            0
+        );
+    }
+
+    #[test]
+    fn test_from_filtered_delaunay_strip_removes_surplus_invalid_vertices() {
+        let tri = CdtTriangulation::from_filtered_delaunay_strip(4, 3)
+            .expect("filtered Delaunay strip should build");
+
+        assert_eq!(tri.vertex_count(), 12);
+        assert_eq!(tri.slice_sizes(), &[4, 4, 4]);
+        assert!(tri.has_foliation());
+        assert!(tri.geometry().validate_delaunay().is_ok());
+        assert!(tri.validate_topology().is_ok());
+        assert!(tri.validate_foliation().is_ok());
+        assert!(tri.validate_causality_delaunay().is_ok());
+        assert!(tri.validate_simplex_classification().is_ok());
+        assert_eq!(
+            tri.strict_causal_simplex_violation_count()
+                .expect("filtered strip should expose a current strict-causality count"),
+            0
+        );
+    }
+
+    #[test]
+    fn test_from_filtered_delaunay_strip_accepts_two_slice_boundary() {
+        let tri = CdtTriangulation::from_filtered_delaunay_strip(4, 2)
+            .expect("filtered Delaunay strip should build without surplus vertices");
+
+        assert_eq!(tri.vertex_count(), 8);
+        assert_eq!(tri.face_count(), 6);
+        assert_eq!(tri.slice_sizes(), &[4, 4]);
+        assert!(tri.has_foliation());
+        assert!(tri.geometry().validate_delaunay().is_ok());
+        assert!(tri.validate_topology().is_ok());
+        assert!(tri.validate_foliation().is_ok());
+        assert!(tri.validate_causality_delaunay().is_ok());
+        assert!(tri.validate_simplex_classification().is_ok());
+        assert_eq!(
+            tri.strict_causal_simplex_violation_count()
+                .expect("two-slice filtered strip should expose a strict-causality count"),
+            0
+        );
+    }
+
+    #[test]
+    fn test_from_filtered_delaunay_strip_rejects_invalid_parameters() {
+        let few_vertices = CdtTriangulation::from_filtered_delaunay_strip(3, 3);
+        assert_matches!(
+            few_vertices,
+            Err(CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::InsufficientVerticesPerSlice,
+                ..
+            })
+        );
+
+        let few_slices = CdtTriangulation::from_filtered_delaunay_strip(4, 1);
+        assert_matches!(
+            few_slices,
+            Err(CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::InsufficientNumberOfTimeSlices,
+                ..
+            })
+        );
+
+        let product_overflow = CdtTriangulation::from_filtered_delaunay_strip(u32::MAX, 2);
+        assert_matches!(
+            product_overflow,
+            Err(CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::VertexCountOverflow,
+                ref provided_value,
+                ref expected_range,
+            }) if provided_value == "4294967295 × 2"
+                && expected_range == "product ≤ u32::MAX"
+        );
+
+        let surplus_overflow = CdtTriangulation::from_filtered_delaunay_strip(1_431_655_765, 3);
+        assert_matches!(
+            surplus_overflow,
+            Err(CdtError::InvalidGenerationParameters {
+                issue: GenerationParameterIssue::VertexCountOverflow,
+                ref provided_value,
+                ref expected_range,
+            }) if provided_value == "4294967295 + 2" && expected_range == "sum ≤ u32::MAX"
+        );
     }
 
     #[test]

--- a/src/cdt/triangulation/foliation.rs
+++ b/src/cdt/triangulation/foliation.rs
@@ -1179,6 +1179,49 @@ impl CdtTriangulation<DelaunayBackend2D> {
         Ok(())
     }
 
+    /// Counts top-dimensional simplices that are not strict causal CDT simplices.
+    ///
+    /// In the current 1+1 implementation, the top-dimensional simplices are
+    /// triangle faces, and a strict causal CDT triangle must classify as `Up`
+    /// `(2,1)` or `Down` `(1,2)`. Purely spacelike faces, purely
+    /// timelike/non-spacelike faces, multi-slice faces, missing-label faces,
+    /// and malformed faces all contribute to this count. A valid foliated CDT
+    /// initial state has count zero.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FoliationError::MissingBookkeeping`] if the triangulation has
+    /// no stored foliation to classify against.
+    ///
+    /// Returns [`FoliationError::StaleBookkeeping`] if stored foliation
+    /// bookkeeping belongs to an older geometry revision.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::*;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::from_cdt_strip(4, 2)?;
+    ///     assert_eq!(tri.strict_causal_simplex_violation_count()?, 0);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn strict_causal_simplex_violation_count(&self) -> CdtResult<usize> {
+        if self.foliation.is_none() {
+            return Err(FoliationError::MissingBookkeeping.into());
+        }
+        if !self.has_current_foliation() {
+            return Err(self.stale_foliation_error());
+        }
+
+        Ok(self
+            .geometry
+            .faces()
+            .filter(|face| self.simplex_type(face).is_none())
+            .count())
+    }
+
     /// Classifies every triangle and stores the result as simplex data.
     ///
     /// # Errors
@@ -1473,6 +1516,11 @@ mod tests {
             .expect("Delaunay strip causality should validate");
         tri.validate_simplex_classification()
             .expect("all Delaunay strip simplices should classify");
+        assert_eq!(
+            tri.strict_causal_simplex_violation_count()
+                .expect("strict strip count should succeed"),
+            0
+        );
         tri
     }
 
@@ -1841,6 +1889,10 @@ mod tests {
         assert_eq!(tri.simplex_type(&face), None);
         assert_eq!(tri.face_edge_types(&face), None);
         assert_eq!(tri.simplex_type_from_data(&face), None);
+        assert_matches!(
+            tri.strict_causal_simplex_violation_count(),
+            Err(CdtError::Foliation(FoliationError::StaleBookkeeping { .. }))
+        );
 
         for result in [
             tri.validate_foliation(),
@@ -1864,6 +1916,10 @@ mod tests {
         }
         tri.validate_simplex_classification()
             .expect("missing foliation should validate vacuously");
+        assert_matches!(
+            tri.strict_causal_simplex_violation_count(),
+            Err(CdtError::Foliation(FoliationError::MissingBookkeeping))
+        );
 
         let mut tri = strict_strip(5, 3);
         for face in tri.geometry().faces() {
@@ -1938,6 +1994,31 @@ mod tests {
                     expected: 2,
                 }
             ))
+        );
+    }
+
+    #[test]
+    fn strict_causal_simplex_violation_count_reports_non_strict_faces() {
+        let backend = labeled_triangle_backend([0, 0, 0]);
+        let mut tri = CdtTriangulation::try_new(backend, 1, 2)
+            .expect("single Delaunay triangle should satisfy bare topology");
+        tri.foliation = Some(
+            Foliation::from_slice_sizes(vec![3], slice_count(1))
+                .expect("single nonempty slice should be constructible"),
+        );
+        tri.mark_foliation_synchronized();
+
+        assert_eq!(
+            tri.strict_causal_simplex_violation_count()
+                .expect("current foliation should count non-strict faces"),
+            1
+        );
+        assert_matches!(
+            tri.validate_simplex_classification(),
+            Err(CdtError::ValidationFailed {
+                check: CdtValidationCheck::SimplexClassification,
+                failure: CdtValidationFailure::NonStrictSimplex { .. },
+            })
         );
     }
 

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -318,6 +318,8 @@ pub enum DelaunayOperation {
     InsertVertex,
     /// Move a vertex to new coordinates.
     MoveVertex,
+    /// Remove a vertex through the upstream vertex-removal API.
+    RemoveVertex,
     /// Build a vertex for face subdivision.
     SubdivideFace,
     /// Remove a vertex through the upstream k=1 flip API.
@@ -337,6 +339,7 @@ impl fmt::Display for DelaunayOperation {
         match self {
             Self::InsertVertex => formatter.write_str("insert_vertex"),
             Self::MoveVertex => formatter.write_str("move_vertex"),
+            Self::RemoveVertex => formatter.write_str("remove_vertex"),
             Self::SubdivideFace => formatter.write_str("subdivide_face"),
             Self::FlipK1Remove => formatter.write_str("flip_k1_remove"),
             Self::FlipK1Insert => formatter.write_str("flip_k1_insert"),
@@ -447,6 +450,17 @@ pub enum DelaunayError {
         /// Coordinates of the vertex passed to the insertion routine.
         coordinates: Vec<f64>,
         /// Underlying insertion diagnostic.
+        detail: String,
+    },
+
+    /// A vertex-removal mutation failed after the vertex handle was accepted.
+    #[error("{operation} failed on {target}: {detail}")]
+    RemovalFailed {
+        /// Vertex-removal operation that failed.
+        operation: DelaunayOperation,
+        /// Human-readable target passed to the removal operation.
+        target: String,
+        /// Underlying removal diagnostic.
         detail: String,
     },
 
@@ -1474,31 +1488,26 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
 
         let dt_before = self.dt.clone();
         let facets_before = self.interior_facets_by_edge.clone();
-        let info = match self.dt.flip_k1_remove(vertex.key) {
-            Ok(info) => info,
+        match self.dt.remove_vertex(vertex.key) {
+            Ok(_) => {}
             Err(err) => {
                 self.restore_mutation_snapshot(dt_before, facets_before);
-                return Err(DelaunayError::FlipFailed {
-                    operation: DelaunayOperation::FlipK1Remove,
+                return Err(DelaunayError::RemovalFailed {
+                    operation: DelaunayOperation::RemoveVertex,
                     target: format!("vertex {:?}", vertex.key),
                     detail: err.to_string(),
                 });
             }
-        };
+        }
         self.rebuild_interior_facet_index();
         self.invalidate_query_caches();
         self.validate_mutation_or_restore(
             dt_before,
             facets_before,
-            DelaunayOperation::FlipK1Remove,
+            DelaunayOperation::RemoveVertex,
             format!("vertex {:?}", vertex.key),
         )?;
-        Ok(info
-            .new_simplices
-            .iter()
-            .copied()
-            .map(|key| DelaunayFaceHandle { key })
-            .collect())
+        Ok(Vec::new())
     }
 
     fn move_vertex(
@@ -1848,6 +1857,7 @@ mod tests {
         let cases = [
             (DelaunayOperation::InsertVertex, "insert_vertex"),
             (DelaunayOperation::MoveVertex, "move_vertex"),
+            (DelaunayOperation::RemoveVertex, "remove_vertex"),
             (DelaunayOperation::SubdivideFace, "subdivide_face"),
             (DelaunayOperation::FlipK1Remove, "flip_k1_remove"),
             (DelaunayOperation::FlipK1Insert, "flip_k1_insert"),
@@ -1889,6 +1899,16 @@ mod tests {
         assert_eq!(
             flip.to_string(),
             "flip_k2 failed on edge VertexKey(1v1) -- VertexKey(2v1): non-convex cavity"
+        );
+
+        let removal = DelaunayError::RemovalFailed {
+            operation: DelaunayOperation::RemoveVertex,
+            target: "vertex VertexKey(1v1)".to_string(),
+            detail: "cavity is not retriangulable".to_string(),
+        };
+        assert_eq!(
+            removal.to_string(),
+            "remove_vertex failed on vertex VertexKey(1v1): cavity is not retriangulable"
         );
 
         let malformed = DelaunayError::UnexpectedFlipOutput {

--- a/src/geometry/traits.rs
+++ b/src/geometry/traits.rs
@@ -289,7 +289,11 @@ pub trait TriangulationMut: TriangulationQuery {
         coords: &[Self::Coordinate],
     ) -> Result<Self::VertexHandle, Self::Error>;
 
-    /// Remove a vertex from the triangulation
+    /// Removes a vertex and lets the backend retriangulate the surrounding cavity.
+    ///
+    /// Returns handles for backend-reported replacement faces when the backend
+    /// exposes them. Implementations may return an empty list when the mutation
+    /// succeeds but the upstream backend does not report replacement handles.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
- Add `from_filtered_delaunay_strip` to build open-boundary CDT starts by removing vertices incident to non-strict causal simplices until the strict violation count reaches zero.
- Expose `strict_causal_simplex_violation_count` as a current-foliation invariant check for detecting non-causal top-dimensional simplices.
- Route Delaunay-backed vertex removal through the upstream `remove_vertex` API and document the temporary empty replacement-face return contract.
- Document the CDT-plusplus influence and the distinction between Delaunay Level 4 validation and the CDT strict-causality invariant.

Closes #192