### PR TITLE
fix(security): override Semgrep's vulnerable MCP dependency

### DIFF
--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -213,6 +213,9 @@ and Dependabot review/merge sequence. Registry and Homebrew metadata confirm the
   warning flags because they enforce separate lint and documentation surfaces.
 - Shared Python tooling aligns with `la-stack` at pytest 9.1.1, Ruff 0.16.1, Semgrep 1.172.0, and Ty 0.0.65. Notebook and build dependencies take the newer
   applicable sibling minimums without changing this repository's Python 3.13 support baseline.
+- Semgrep 1.172.0 still pins the MCP Python SDK to vulnerable version 1.23.3. Until Semgrep publishes its pending 1.28.1 dependency bump, uv overrides that
+  transitive pin to MCP 1.28.1, matching Semgrep's upstream remediation and clearing all three affected transport and task-handler advisories. Remove the
+  override when a released Semgrep version carries the fixed pin directly.
 - The stronger `delaunay` Dependabot workflow explicitly waits for a CodeRabbit approval on the triggering head SHA and for all required checks before merging
   that exact approved head. Live ruleset alignment uses its one-approval, resolved-thread, and CodeRabbit-app binding policy while preserving this repository's
   deletion/non-fast-forward rules, bypass actor, merge methods, strict checking, and complete required-check set.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,8 @@ python_functions = [ "test_*" ]
 
 [tool.uv]
 package = true
+# Remove after Semgrep publishes its pending MCP 1.28.1 security bump.
+override-dependencies = [ "mcp==1.28.1" ]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,9 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
+[manifest]
+overrides = [{ name = "mcp", specifier = "==1.28.1" }]
+
 [[package]]
 name = "actionlint-py"
 version = "1.7.12.24"
@@ -1247,7 +1250,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.23.3"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1265,9 +1268,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a4/d06a303f45997e266f2c228081abe299bbcba216cb806128e2e49095d25f/mcp-1.23.3.tar.gz", hash = "sha256:b3b0da2cc949950ce1259c7bfc1b081905a51916fcd7c8182125b85e70825201", size = 600697, upload-time = "2025-12-09T16:04:37.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/c6/13c1a26b47b3f3a3b480783001ada4268917c9f42d78a079c336da2e75e5/mcp-1.23.3-py3-none-any.whl", hash = "sha256:32768af4b46a1b4f7df34e2bfdf5c6011e7b63d7f1b0e321d0fdef4cd6082031", size = 231570, upload-time = "2025-12-09T16:04:35.56Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Pin the transitive MCP SDK to patched version 1.28.1.
- Document the temporary override and its removal condition.