### PR TITLE
fix(tooling): refresh dependencies and harden validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "thursday"
+      time: "03:00"
+      timezone: "America/Los_Angeles"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
@@ -13,6 +16,11 @@ updates:
       - "github-actions"
     groups:
       github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
         patterns:
           - "*"
 
@@ -21,15 +29,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "thursday"
+      time: "04:00"
+      timezone: "America/Los_Angeles"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "rust"
-    # Group all updates together
+    # Group version and security updates separately
     groups:
       dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      rust-security:
+        applies-to: security-updates
         patterns:
           - "*"
 
@@ -38,6 +54,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "thursday"
+      time: "05:00"
+      timezone: "America/Los_Angeles"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
@@ -46,5 +65,10 @@ updates:
       - "python"
     groups:
       dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      python-security:
+        applies-to: security-updates
         patterns:
           - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,14 +68,40 @@ jobs:
         id: tool_versions
         shell: bash
         run: |
+          set -euo pipefail
+
+          resolve_version() {
+            local name="$1"
+            local value
+
+            if ! value="$(just --evaluate "$name")"; then
+              echo "::error::Failed to resolve $name from justfile" >&2
+              return 1
+            fi
+            if [[ -z "$value" ]]; then
+              echo "::error::Resolved empty $name from justfile" >&2
+              return 1
+            fi
+
+            printf '%s\n' "$value"
+          }
+
+          cargo_nextest_version="$(resolve_version cargo_nextest_version)"
+          dprint_version="$(resolve_version dprint_version)"
+          rumdl_version="$(resolve_version rumdl_version)"
+          taplo_version="$(resolve_version taplo_version)"
+          typos_version="$(resolve_version typos_version)"
+          uv_version="$(resolve_version uv_version)"
+          zizmor_version="$(resolve_version zizmor_version)"
+
           {
-            echo "CARGO_NEXTEST_VERSION=$(just --evaluate cargo_nextest_version)"
-            echo "DPRINT_VERSION=$(just --evaluate dprint_version)"
-            echo "RUMDL_VERSION=$(just --evaluate rumdl_version)"
-            echo "TAPLO_VERSION=$(just --evaluate taplo_version)"
-            echo "TYPOS_VERSION=$(just --evaluate typos_version)"
-            echo "UV_VERSION=$(just --evaluate uv_version)"
-            echo "ZIZMOR_VERSION=$(just --evaluate zizmor_version)"
+            echo "CARGO_NEXTEST_VERSION=$cargo_nextest_version"
+            echo "DPRINT_VERSION=$dprint_version"
+            echo "RUMDL_VERSION=$rumdl_version"
+            echo "TAPLO_VERSION=$taplo_version"
+            echo "TYPOS_VERSION=$typos_version"
+            echo "UV_VERSION=$uv_version"
+            echo "ZIZMOR_VERSION=$zizmor_version"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Python

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -43,9 +43,30 @@ jobs:
         id: tool_versions
         shell: bash
         run: |
+          set -euo pipefail
+
+          resolve_version() {
+            local name="$1"
+            local value
+
+            if ! value="$(just --evaluate "$name")"; then
+              echo "::error::Failed to resolve $name from justfile" >&2
+              return 1
+            fi
+            if [[ -z "$value" ]]; then
+              echo "::error::Resolved empty $name from justfile" >&2
+              return 1
+            fi
+
+            printf '%s\n' "$value"
+          }
+
+          clippy_sarif_version="$(resolve_version clippy_sarif_version)"
+          sarif_fmt_version="$(resolve_version sarif_fmt_version)"
+
           {
-            echo "CLIPPY_SARIF_VERSION=$(just --evaluate clippy_sarif_version)"
-            echo "SARIF_FMT_VERSION=$(just --evaluate sarif_fmt_version)"
+            echo "CLIPPY_SARIF_VERSION=$clippy_sarif_version"
+            echo "SARIF_FMT_VERSION=$sarif_fmt_version"
           } >> "$GITHUB_OUTPUT"
 
       - name: Install clippy-sarif

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,9 +681,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "markov-chain-monte-carlo"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00d59c60c04dd1225aa5758207755b2bc673472241c356dc52dc77f1636bed6"
+checksum = "ffdc51077610657c94e902101fca2d7e4a90059daaa0701775c30974c3313a5e"
 dependencies = [
  "rand 0.10.2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ debug = "line-tables-only"
 [dependencies]
 clap = { version = "4.6.5", features = [ "derive" ] }
 delaunay = "0.8.0"
-markov-chain-monte-carlo = { version = "0.4.0", features = [ "serde" ] }
+markov-chain-monte-carlo = { version = "0.4.1", features = [ "serde" ] }
 dirs = "6.0.0"
 env_logger = "0.11.11"
 log = "0.4.33"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # causal-triangulations
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20513228.svg)](https://doi.org/10.5281/zenodo.20513228)
-[![Crates.io](https://img.shields.io/crates/v/causal-triangulations.svg)](https://crates.io/crates/causal-triangulations)
-[![Downloads](https://img.shields.io/crates/d/causal-triangulations.svg)](https://crates.io/crates/causal-triangulations)
-[![License](https://img.shields.io/crates/l/causal-triangulations.svg)](LICENSE)
+[![Crates.io](https://badgen.net/crates/v/causal-triangulations)](https://crates.io/crates/causal-triangulations)
+[![Downloads](https://badgen.net/crates/d/causal-triangulations)](https://crates.io/crates/causal-triangulations)
+[![License](https://badgen.net/github/license/acgetchell/causal-triangulations)](LICENSE)
 [![Docs.rs](https://docs.rs/causal-triangulations/badge.svg)](https://docs.rs/causal-triangulations)
 [![CI][ci-badge]][ci-workflow]
 [![rust-clippy analyze][clippy-badge]][clippy-workflow]

--- a/benches/cdt_benchmarks.rs
+++ b/benches/cdt_benchmarks.rs
@@ -9,6 +9,9 @@
 //! - Action calculations
 //! - Ergodic move operations
 
+#[path = "support/or_abort.rs"]
+mod benchmark_support;
+
 use causal_triangulations::prelude::action::ActionConfig;
 use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveType};
 use causal_triangulations::prelude::simulation::{MetropolisAlgorithm, MetropolisConfig};
@@ -16,6 +19,8 @@ use causal_triangulations::prelude::triangulation::{CdtTriangulation2D, Triangul
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hint::black_box;
+
+use benchmark_support::OrAbort;
 
 #[derive(Clone, Copy)]
 enum SetupOperation {
@@ -26,6 +31,7 @@ enum SetupOperation {
     RunSimulation,
     BuildSimulationResults,
     UpdateMetadata,
+    ReadTriangulationAdjacency,
 }
 
 impl Display for SetupOperation {
@@ -38,15 +44,10 @@ impl Display for SetupOperation {
             Self::RunSimulation => formatter.write_str("run simulation"),
             Self::BuildSimulationResults => formatter.write_str("build simulation results"),
             Self::UpdateMetadata => formatter.write_str("update metadata"),
+            Self::ReadTriangulationAdjacency => {
+                formatter.write_str("read benchmark triangulation adjacency")
+            }
         }
-    }
-}
-
-/// Fails fast when benchmark fixture setup cannot satisfy its invariant.
-fn require_result<T>(result: Result<T, impl Display>, operation: SetupOperation) -> T {
-    match result {
-        Ok(value) => value,
-        Err(error) => panic!("{operation}: {error}"),
     }
 }
 
@@ -61,14 +62,12 @@ fn bench_triangulation_creation(c: &mut Criterion) {
             &vertex_count,
             |b, &vertex_count| {
                 b.iter(|| {
-                    let triangulation = require_result(
-                        CdtTriangulation2D::from_random_points(
-                            black_box(vertex_count),
-                            black_box(1),
-                            black_box(2),
-                        ),
-                        SetupOperation::CreateTriangulation,
-                    );
+                    let triangulation = CdtTriangulation2D::from_random_points(
+                        black_box(vertex_count),
+                        black_box(1),
+                        black_box(2),
+                    )
+                    .or_abort(SetupOperation::CreateTriangulation);
                     black_box(triangulation)
                 });
             },
@@ -124,10 +123,8 @@ fn bench_edge_counting(c: &mut Criterion) {
 
 /// Benchmark geometry query operations
 fn bench_geometry_queries(c: &mut Criterion) {
-    let triangulation = require_result(
-        CdtTriangulation2D::from_random_points(50, 1, 2),
-        SetupOperation::CreateTestTriangulation,
-    );
+    let triangulation = CdtTriangulation2D::from_random_points(50, 1, 2)
+        .or_abort(SetupOperation::CreateTestTriangulation);
 
     let geometry = triangulation.geometry();
 
@@ -223,10 +220,7 @@ fn bench_ergodic_moves(c: &mut Criterion) {
     let mut group = c.benchmark_group("ergodic_moves");
 
     let seed_triangulation = || {
-        require_result(
-            CdtTriangulation2D::from_cdt_strip(4, 3),
-            SetupOperation::BuildCdtBenchmarkStrip,
-        )
+        CdtTriangulation2D::from_cdt_strip(4, 3).or_abort(SetupOperation::BuildCdtBenchmarkStrip)
     };
 
     // Benchmark different move types
@@ -296,23 +290,18 @@ fn bench_metropolis_simulation(c: &mut Criterion) {
             &steps,
             |b, &steps| {
                 b.iter(|| {
-                    let triangulation = require_result(
-                        CdtTriangulation2D::from_cdt_strip(4, 5),
-                        SetupOperation::CreateCdtStrip,
-                    );
+                    let triangulation = CdtTriangulation2D::from_cdt_strip(4, 5)
+                        .or_abort(SetupOperation::CreateCdtStrip);
 
-                    let config = require_result(
-                        MetropolisConfig::new(1.0, steps, 5, 5),
-                        SetupOperation::RunSimulation,
-                    )
-                    .with_seed(42);
+                    let config = MetropolisConfig::new(1.0, steps, 5, 5)
+                        .or_abort(SetupOperation::RunSimulation)
+                        .with_seed(42);
                     let action_config = ActionConfig::default();
                     let algorithm = MetropolisAlgorithm::new(config, action_config);
 
-                    let results = require_result(
-                        algorithm.run(black_box(triangulation)),
-                        SetupOperation::RunSimulation,
-                    );
+                    let results = algorithm
+                        .run(black_box(triangulation))
+                        .or_abort(SetupOperation::RunSimulation);
                     black_box(results)
                 });
             },
@@ -327,20 +316,15 @@ fn bench_simulation_analysis(c: &mut Criterion) {
     let mut group = c.benchmark_group("simulation_analysis");
 
     // Create a sample simulation result
-    let triangulation = require_result(
-        CdtTriangulation2D::from_cdt_strip(5, 3),
-        SetupOperation::CreateCdtStrip,
-    );
+    let triangulation =
+        CdtTriangulation2D::from_cdt_strip(5, 3).or_abort(SetupOperation::CreateCdtStrip);
 
-    let config = require_result(
-        MetropolisConfig::new(1.0, 100, 10, 5),
-        SetupOperation::BuildSimulationResults,
-    )
-    .with_seed(42);
-    let results = require_result(
-        MetropolisAlgorithm::new(config, ActionConfig::default()).run(triangulation),
-        SetupOperation::BuildSimulationResults,
-    );
+    let config = MetropolisConfig::new(1.0, 100, 10, 5)
+        .or_abort(SetupOperation::BuildSimulationResults)
+        .with_seed(42);
+    let results = MetropolisAlgorithm::new(config, ActionConfig::default())
+        .run(triangulation)
+        .or_abort(SetupOperation::BuildSimulationResults);
 
     group.bench_function("acceptance_rate", |b| {
         b.iter(|| {
@@ -372,24 +356,18 @@ fn bench_simulation_analysis(c: &mut Criterion) {
 
     group.bench_function("hausdorff_dimension_estimate", |b| {
         b.iter(|| {
-            let estimate = match results.hausdorff_dimension_estimate() {
-                Ok(estimate) => estimate,
-                Err(error) => {
-                    panic!("benchmark triangulation adjacency should be readable: {error}")
-                }
-            };
+            let estimate = results
+                .hausdorff_dimension_estimate()
+                .or_abort(SetupOperation::ReadTriangulationAdjacency);
             black_box(estimate)
         });
     });
 
     group.bench_function("spectral_dimension_estimate", |b| {
         b.iter(|| {
-            let estimate = match results.spectral_dimension_estimate() {
-                Ok(estimate) => estimate,
-                Err(error) => {
-                    panic!("benchmark triangulation adjacency should be readable: {error}")
-                }
-            };
+            let estimate = results
+                .spectral_dimension_estimate()
+                .or_abort(SetupOperation::ReadTriangulationAdjacency);
             black_box(estimate)
         });
     });
@@ -410,10 +388,8 @@ fn bench_cache_operations(c: &mut Criterion) {
 
     group.bench_function("refresh_cache", |b| {
         b.iter(|| {
-            let mut triangulation = require_result(
-                CdtTriangulation2D::from_cdt_strip(10, 5),
-                SetupOperation::CreateCdtStrip,
-            );
+            let mut triangulation =
+                CdtTriangulation2D::from_cdt_strip(10, 5).or_abort(SetupOperation::CreateCdtStrip);
             triangulation.refresh_cache();
             black_box(triangulation)
         });
@@ -422,18 +398,15 @@ fn bench_cache_operations(c: &mut Criterion) {
     group.bench_function("metadata_cache_invalidation", |b| {
         b.iter_batched(
             || {
-                let mut triangulation = require_result(
-                    CdtTriangulation2D::from_cdt_strip(10, 5),
-                    SetupOperation::CreateCdtStrip,
-                );
+                let mut triangulation = CdtTriangulation2D::from_cdt_strip(10, 5)
+                    .or_abort(SetupOperation::CreateCdtStrip);
                 triangulation.refresh_cache();
                 triangulation
             },
             |mut triangulation| {
-                require_result(
-                    triangulation.set_time_slices(2),
-                    SetupOperation::UpdateMetadata,
-                );
+                triangulation
+                    .set_time_slices(2)
+                    .or_abort(SetupOperation::UpdateMetadata);
                 black_box(triangulation)
             },
             BatchSize::SmallInput,
@@ -445,10 +418,8 @@ fn bench_cache_operations(c: &mut Criterion) {
 
 /// Benchmark triangulation validation
 fn bench_validation(c: &mut Criterion) {
-    let triangulation = require_result(
-        CdtTriangulation2D::from_random_points(30, 1, 2),
-        SetupOperation::CreateTriangulation,
-    );
+    let triangulation = CdtTriangulation2D::from_random_points(30, 1, 2)
+        .or_abort(SetupOperation::CreateTriangulation);
 
     let mut group = c.benchmark_group("validation");
 

--- a/benches/ci_performance_suite.rs
+++ b/benches/ci_performance_suite.rs
@@ -15,6 +15,9 @@
 //! 6. Public proposal-site iteration paths used by move attempts and one-step
 //!    Metropolis proposal planning.
 
+#[path = "support/or_abort.rs"]
+mod benchmark_support;
+
 use causal_triangulations::prelude::action::ActionConfig;
 use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveStatistics, MoveType};
 use causal_triangulations::prelude::simulation::{MetropolisAlgorithm, MetropolisConfig};
@@ -23,6 +26,8 @@ use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hint::black_box;
 use std::time::Duration;
+
+use benchmark_support::OrAbort;
 
 const SWEEP_COUNT: u32 = 10;
 const BENCH_SEED: u64 = 0xCDA7_2026;
@@ -158,22 +163,6 @@ const PROPOSAL_FIXTURES: &[CdtFixture] = &[
     },
 ];
 
-/// Fails fast when benchmark fixture setup cannot satisfy its invariant.
-fn require_result<T>(result: Result<T, impl Display>, operation: SetupOperation) -> T {
-    match result {
-        Ok(value) => value,
-        Err(error) => panic!("{operation}: {error}"),
-    }
-}
-
-/// Fails fast when benchmark fixture setup cannot produce a required value.
-fn require_option<T>(value: Option<T>, operation: SetupOperation) -> T {
-    let Some(value) = value else {
-        panic!("{operation}");
-    };
-    value
-}
-
 impl CdtFixture {
     /// Builds the requested CDT topology for a benchmark fixture.
     fn build(self) -> CdtTriangulation2D {
@@ -185,7 +174,7 @@ impl CdtFixture {
                 CdtTriangulation2D::from_toroidal_cdt(self.vertices_per_slice, self.time_slices)
             }
         };
-        require_result(result, SetupOperation::BuildCdtFixture)
+        result.or_abort(SetupOperation::BuildCdtFixture)
     }
 }
 
@@ -219,41 +208,31 @@ fn prepare_fixture(fixture: CdtFixture) -> PreparedFixture {
 
 /// Runs one Metropolis proposal step through the public simulation driver.
 fn run_single_metropolis_proposal(triangulation: CdtTriangulation2D) {
-    let config = require_result(
-        MetropolisConfig::new(1.0, 1, 0, 1),
-        SetupOperation::RunSingleMetropolisProposal,
-    )
-    .with_seed(BENCH_SEED);
-    let results = require_result(
-        MetropolisAlgorithm::new(config, ActionConfig::default()).run(triangulation),
-        SetupOperation::RunSingleMetropolisProposal,
-    );
+    let config = MetropolisConfig::new(1.0, 1, 0, 1)
+        .or_abort(SetupOperation::RunSingleMetropolisProposal)
+        .with_seed(BENCH_SEED);
+    let results = MetropolisAlgorithm::new(config, ActionConfig::default())
+        .run(triangulation)
+        .or_abort(SetupOperation::RunSingleMetropolisProposal);
     black_box(results.proposal_stats());
 }
 
 /// Converts Criterion throughput element counts without silently truncating.
 fn usize_to_u64(value: usize) -> u64 {
-    require_result(u64::try_from(value), SetupOperation::ConvertBenchmarkSize)
+    u64::try_from(value).or_abort(SetupOperation::ConvertBenchmarkSize)
 }
 
 /// Computes the Metropolis step budget for the ten-sweep CI workload.
 fn ten_sweep_step_count(simplices: usize) -> u32 {
-    require_result(
-        u32::try_from(sweep_attempt_count(simplices)),
-        SetupOperation::ConvertSweepStepCount,
-    )
+    u32::try_from(sweep_attempt_count(simplices)).or_abort(SetupOperation::ConvertSweepStepCount)
 }
 
 /// Encodes the CDT convention that one sweep attempts one move per simplex.
 fn sweep_attempt_count(simplices: usize) -> usize {
-    let sweeps = require_result(
-        usize::try_from(SWEEP_COUNT),
-        SetupOperation::ConvertSweepCount,
-    );
-    require_option(
-        simplices.checked_mul(sweeps),
-        SetupOperation::ComputeSweepStepCount,
-    )
+    let sweeps = usize::try_from(SWEEP_COUNT).or_abort(SetupOperation::ConvertSweepCount);
+    simplices
+        .checked_mul(sweeps)
+        .or_abort(SetupOperation::ComputeSweepStepCount)
 }
 
 /// Runs ten random-move sweeps and validates the evolved triangulation.
@@ -268,10 +247,9 @@ fn run_random_move_sweeps(mut triangulation: CdtTriangulation2D, seed: u64) -> M
         }
     }
 
-    require_result(
-        triangulation.validate(),
-        SetupOperation::ValidateRandomSweepWorkload,
-    );
+    triangulation
+        .validate()
+        .or_abort(SetupOperation::ValidateRandomSweepWorkload);
     black_box(triangulation.face_count());
     ergodics.stats().clone()
 }
@@ -279,15 +257,12 @@ fn run_random_move_sweeps(mut triangulation: CdtTriangulation2D, seed: u64) -> M
 /// Runs a short Metropolis simulation sized to match the ten-sweep workload.
 fn run_metropolis_ten_sweeps(triangulation: CdtTriangulation2D, simplices: usize) -> usize {
     let steps = ten_sweep_step_count(simplices);
-    let config = require_result(
-        MetropolisConfig::new(1.0, steps, 0, steps),
-        SetupOperation::RunTenSweepMetropolis,
-    )
-    .with_seed(BENCH_SEED);
-    let results = require_result(
-        MetropolisAlgorithm::new(config, ActionConfig::default()).run(triangulation),
-        SetupOperation::RunTenSweepMetropolis,
-    );
+    let config = MetropolisConfig::new(1.0, steps, 0, steps)
+        .or_abort(SetupOperation::RunTenSweepMetropolis)
+        .with_seed(BENCH_SEED);
+    let results = MetropolisAlgorithm::new(config, ActionConfig::default())
+        .run(triangulation)
+        .or_abort(SetupOperation::RunTenSweepMetropolis);
     black_box(results.acceptance_rate());
     results.steps().len()
 }

--- a/benches/support/or_abort.rs
+++ b/benches/support/or_abort.rs
@@ -1,0 +1,30 @@
+//! Shared fail-fast helpers for benchmark fixture setup.
+
+use std::fmt::Display;
+
+/// Converts successful benchmark setup values or aborts with operation context.
+pub trait OrAbort<T> {
+    /// Returns the setup value or panics with the operation and failure detail.
+    #[track_caller]
+    fn or_abort(self, operation: impl Display) -> T;
+}
+
+impl<T, E: Display> OrAbort<T> for Result<T, E> {
+    #[track_caller]
+    fn or_abort(self, operation: impl Display) -> T {
+        match self {
+            Ok(value) => value,
+            Err(error) => panic!("{operation}: {error}"),
+        }
+    }
+}
+
+impl<T> OrAbort<T> for Option<T> {
+    #[track_caller]
+    fn or_abort(self, operation: impl Display) -> T {
+        let Some(value) = self else {
+            panic!("{operation}");
+        };
+        value
+    }
+}

--- a/docs/code-organization.md
+++ b/docs/code-organization.md
@@ -34,6 +34,8 @@ causal-triangulations/
 │   ├── CODEOWNERS
 │   └── dependabot.yml
 ├── benches/
+│   ├── support/
+│   │   └── or_abort.rs
 │   ├── README.md
 │   ├── cdt_benchmarks.rs
 │   └── ci_performance_suite.rs
@@ -214,7 +216,7 @@ against new CDT-local generic acceptance draws or manual accepted/rejected sampl
 - `notebooks/` — notebook front ends and analysis consumers for CLI-generated artifacts such as trace CSV and JSON summary files. Notebook code may run the
   binary for tutorials, but simulation logic stays in Rust.
 - `tests/` — CLI, integration, physics, property-based, regression, slow-debug, and project-rule tests.
-- `benches/` — Criterion benchmark harnesses and CI performance suites.
+- `benches/` — Criterion benchmark harnesses and CI performance suites, with shared fail-fast fixture setup support under `benches/support/`.
 - `docs/` — user guides, architecture notes, development rules, and release/testing/performance documentation.
 - `scripts/` — Python and shell support tooling for benchmarks, coverage, changelog/release work, examples, and validation.
 
@@ -372,5 +374,5 @@ Notebook files live in `notebooks/` and should wrap the CLI or consume generated
 
 - `delaunay` (v0.8) — geometry backend (Delaunay triangulations, vertex data for time labels, checked TDS reconstruction with topology context,
   `set_vertex_data_by_key` for O(1) label mutation)
-- `markov-chain-monte-carlo` (v0.4) — MCMC framework (`DelayedProposal`, `Chain::step_delayed`, `Target`)
+- `markov-chain-monte-carlo` (v0.4.1) — MCMC framework (`DelayedProposal`, `Chain::step_delayed`, invariant-bearing `Step<Info>` telemetry, `Target`)
 - `num-traits` — `ToPrimitive` and `NumCast` for checked or saturating numeric conversions

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -195,7 +195,7 @@ just spell-check
 The `typos` binary is provided by the Cargo crate `typos-cli`. `just setup-tools` installs the pinned version, or you can install it directly:
 
 ```bash
-cargo install --locked typos-cli --version 1.48.0
+cargo install --locked typos-cli --version "$(just --evaluate typos_version)"
 ```
 
 If a legitimate technical word fails, add it to `typos.toml` under:

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -192,7 +192,8 @@ Run:
 just spell-check
 ```
 
-The `typos` binary is provided by the Cargo crate `typos-cli`. `just setup-tools` installs the pinned version, or you can install it directly:
+The `typos` binary is provided by the Cargo crate `typos-cli`. `just setup-tools` installs the pinned version. To install it directly while still using the
+repository pin, first ensure `just` is installed because this command resolves `typos_version` with `just --evaluate`:
 
 ```bash
 cargo install --locked typos-cli --version "$(just --evaluate typos_version)"

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -276,7 +276,8 @@ was upgraded from 0.2.50 to 0.2.51 before reconciling the repository pin.
 
 Issue #223 completes the uv alignment by making actionlint reuse the shared exact-version guard instead of checking only for an executable named `uv`. The
 notebook JSON boundary now also requires every cell `metadata` field to be an object and parses `nbformat` as an actual JSON integer equal to 4, so values such
-as `4.0` and booleans cannot enter the trusted notebook model through Python's numeric equality and subclass behavior.
+as `4.0` and booleans cannot enter the trusted notebook model through Python's numeric equality and subclass behavior. Notebook discovery is captured before
+linting so `find` failures remain fatal while a successful empty discovery still reports that no notebooks were found.
 
 ## Deferred Updates
 

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -118,8 +118,8 @@ The useful `justfile` updates ported from `delaunay` are:
 - The planned-step sampler-state sync rule now anchors `record_planned_step(...)` to call statements so it continues to catch missing
   `sampler.replace_state(...)` after recorded planned steps without false-positive matches on the helper function declaration when that helper contains fallible
   telemetry construction.
-- The Markdown and spelling tool pins now use `rumdl` 0.2.47 and `typos-cli` 1.48.0 in the justfile, matching the
-  current Cargo-installed sibling-repository tools while preserving the existing `rumdl.toml`, `typos.toml`, and raw 160-column guard.
+- The Markdown and spelling tool pins in the justfile match the current Cargo-installed sibling-repository tools while preserving the existing
+  `rumdl.toml`, `typos.toml`, and raw 160-column guard.
 - The Cargo manifest description changed from `Causal Dynamical Triangulations in d-dimensions` to
   `Validated 1+1 Causal Dynamical Triangulations for quantum gravity`. This mirrors a config/manifest change per the repository guideline and records why the
   new wording was chosen: it makes the validated 1+1 scope and quantum-gravity domain explicit in package metadata. This update fulfills the
@@ -204,7 +204,8 @@ and Dependabot review/merge sequence. Registry and Homebrew metadata confirm the
 
 - The `justfile` is the single source of truth for cargo-audit, cargo-llvm-cov, cargo-machete, cargo-nextest, dprint, git-cliff, just, rumdl, sarif tooling,
   Taplo, typos-cli, uv, and zizmor. Workflows bootstrap `just` through the repository-local composite action, then resolve every remaining tool version with
-  `just --evaluate` instead of duplicating workflow `env` pins.
+  `just --evaluate` instead of duplicating workflow `env` pins. Multi-version exports validate every lookup before writing any step outputs, preventing failed
+  or empty evaluations from being masked by successful `echo` commands.
 - Shared Rust dependencies move to their current stable releases, including `delaunay` 0.8.0, Clap 4.6.5, rand 0.10.2, serde 1.0.229, serde_json 1.0.151,
   thiserror 2.0.19, env_logger 0.11.11, and log 0.4.33. The `delaunay` upgrade requires Rust 1.97.1, so `Cargo.toml`, `rust-toolchain.toml`, and current MSRV
   documentation move together; historical release notes remain unchanged.
@@ -243,10 +244,39 @@ reviewer required by the `main` ruleset instead of copying automation patterns t
   overlapping runs for the same pull request are canceled.
 - The workflow checks out no pull-request content and invokes no external actions. Its explicit `contents: write` and `pull-requests: write` permissions are
   limited to observing the protected-branch gates and performing the guarded squash merge; the owner PAT is used only for the review-request comment.
+- Routine GitHub Actions, Cargo, and uv version updates are grouped and staggered at 03:00, 04:00, and 05:00 America/Los_Angeles time each Thursday so this
+  repository does not contend with the sibling repositories' CodeRabbit and CI update windows.
+- Each ecosystem keeps wildcard version and security groups separate because Dependabot otherwise defaults groups to version updates and opens individual
+  security-update pull requests.
 
 The `CODERABBIT_REVIEW_TOKEN` Dependabot secret and the post-merge `main` ruleset update remain live repository settings rather than checked-in configuration.
 Actions review approval stays disabled; the ruleset must continue to preserve strict status checks, existing bypasses and required checks, and the CodeRabbit
 requirement while adding one required approval and review-thread resolution.
+
+## August 2026 Dependency And Rust Refresh
+
+The August refresh verified the published dependency boundary against crates.io and the upstream release notes. `delaunay` 0.8.0 remains the newest release,
+while `markov-chain-monte-carlo` moves from 0.4.0 to 0.4.1. The MCMC release raises its MSRV to Rust 1.97.1 and makes `Step<Info>` telemetry fields private, so
+the CDT adapter now reads proposal metadata, outcomes, and cached log probabilities through the upstream invariant-preserving accessors.
+
+`Cargo.toml`, `rust-toolchain.toml`, contributor documentation, and the installed validation toolchain remain synchronized on Rust 1.97.1. The repository keeps
+using Rust 1.97.0's Cargo-owned `build.warnings` control for warning-denying benchmark compilation and uses the already-stable, diagnostic-friendly
+`assert_matches!` API consistently throughout tests and public examples. The new Rust 1.97 integer bit-isolation and bit-width APIs were audited, but CDT has
+no manual highest/lowest-bit scans to simplify; adding a contrived use would not improve the numerical or topology code. Rust 1.97.1 itself is a compiler
+correctness point release fixing an LLVM miscompilation rather than a source-language feature release.
+
+Benchmark fixture failures now use one shared postfix `OrAbort` trait with harness-local typed `SetupOperation` enums. Keeping only the genuinely shared
+behavior in the support module avoids compiling one union enum whose harness-specific variants are dead in the other benchmark binary. Both Criterion
+harnesses retain fail-fast setup semantics while avoiding nested prefix helpers and duplicated unwrap behavior.
+
+The command-layer pins were also refreshed from installed tools and package-manager metadata: uv 0.12.1, cargo-nextest 0.9.143, rumdl 0.2.51, and zizmor
+1.29.0. The `justfile` remains the single source of truth for these versions, and GitHub Actions continues to resolve them with `just --evaluate` rather than
+carrying duplicate workflow literals. Local Homebrew uv and Cargo-installed cargo-nextest and zizmor were already current; the Cargo-installed rumdl binary
+was upgraded from 0.2.50 to 0.2.51 before reconciling the repository pin.
+
+Issue #223 completes the uv alignment by making actionlint reuse the shared exact-version guard instead of checking only for an executable named `uv`. The
+notebook JSON boundary now also requires every cell `metadata` field to be an object and parses `nbformat` as an actual JSON integer equal to 4, so values such
+as `4.0` and booleans cannot enter the trusted notebook model through Python's numeric equality and subclass behavior.
 
 ## Deferred Updates
 

--- a/justfile
+++ b/justfile
@@ -569,14 +569,14 @@ notebook-execute-slow output_dir="target/notebooks": _ensure-uv
 notebook-lint: _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
-    found=0
-    while IFS= read -r notebook; do
-        found=1
-        uv run --group notebooks notebook-check --lint "$notebook" --repo-root .
-    done < <(find notebooks -type f -name '*.ipynb' | sort)
-    if [ "$found" -eq 0 ]; then
+    notebooks="$(find notebooks -type f -name '*.ipynb' | sort)"
+    if [ -z "$notebooks" ]; then
         echo "No notebooks found to lint."
+        exit 0
     fi
+    while IFS= read -r notebook; do
+        uv run --group notebooks notebook-check --lint "$notebook" --repo-root .
+    done <<< "$notebooks"
 
 notebook-output-check: _ensure-jq
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -9,17 +9,17 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 cargo_audit_version := "0.22.2"
 cargo_llvm_cov_version := "0.8.7"
 cargo_machete_version := "0.9.2"
-cargo_nextest_version := "0.9.140"
+cargo_nextest_version := "0.9.143"
 clippy_sarif_version := "0.8.0"
 dprint_version := "0.55.2"
 git_cliff_version := "2.13.1"
-just_version := "1.57.0"
-rumdl_version := "0.2.47"
+just_version := "1.58.0"
+rumdl_version := "0.2.51"
 sarif_fmt_version := "0.8.0"
 taplo_version := "0.10.0"
-typos_version := "1.48.0"
-uv_version := "0.12.0"
-zizmor_version := "1.28.0"
+typos_version := "1.49.0"
+uv_version := "0.12.1"
+zizmor_version := "1.29.0"
 
 # Common cargo-llvm-cov arguments for all coverage runs.
 # Excludes benches/examples from reports while allowing integration tests to
@@ -29,10 +29,9 @@ _coverage_base_args := '''--ignore-filename-regex '(^|/)(benches|examples)/' \
   --verbose'''
 
 # Internal helpers: ensure external tooling is installed
-_ensure-actionlint:
+_ensure-actionlint: _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
-    command -v uv >/dev/null || { echo "❌ 'uv' not found. See 'just setup' or https://github.com/astral-sh/uv"; exit 1; }
     uv run actionlint -version >/dev/null
 
 _ensure-cargo-llvm-cov:
@@ -567,6 +566,18 @@ notebook-execute-slow output_dir="target/notebooks": _ensure-uv
     mkdir -p "$output_path/.ipython" "$output_path/.matplotlib"
     MPLBACKEND=Agg IPYTHONDIR="$output_path/.ipython" MPLCONFIGDIR="$output_path/.matplotlib" uv run --group notebooks jupyter nbconvert --execute --ExecutePreprocessor.timeout=1800 --ExecutePreprocessor.shutdown_kernel=immediate --to notebook --output-dir "{{ output_dir }}" notebooks/02_analysis_caches.ipynb
 
+notebook-lint: _ensure-uv
+    #!/usr/bin/env bash
+    set -euo pipefail
+    found=0
+    while IFS= read -r notebook; do
+        found=1
+        uv run --group notebooks notebook-check --lint "$notebook" --repo-root .
+    done < <(find notebooks -type f -name '*.ipynb' | sort)
+    if [ "$found" -eq 0 ]; then
+        echo "No notebooks found to lint."
+    fi
+
 notebook-output-check: _ensure-jq
     #!/usr/bin/env bash
     set -euo pipefail
@@ -585,18 +596,6 @@ notebook-output-check: _ensure-jq
         echo "No notebooks found to check."
     fi
     exit "$violations"
-
-notebook-lint: _ensure-uv
-    #!/usr/bin/env bash
-    set -euo pipefail
-    found=0
-    while IFS= read -r notebook; do
-        found=1
-        uv run --group notebooks notebook-check --lint "$notebook" --repo-root .
-    done < <(find notebooks -type f -name '*.ipynb' | sort)
-    if [ "$found" -eq 0 ]; then
-        echo "No notebooks found to lint."
-    fi
 
 notebook-setup: _ensure-uv
     uv sync --group notebooks

--- a/scripts/notebook_check.py
+++ b/scripts/notebook_check.py
@@ -140,11 +140,20 @@ def parse_execution_count(value: Any, *, path: Path, index: int) -> int | None:
     raise TypeError(msg)
 
 
+def parse_cell_metadata(value: Any, *, path: Path, index: int) -> dict[str, Any]:
+    """Parse a notebook cell metadata object."""
+    if not isinstance(value, dict):
+        msg = f"{path}: cell {index}: metadata must be an object"
+        raise TypeError(msg)
+    return value
+
+
 def parse_notebook_cell(raw_cell: Any, *, path: Path, index: int) -> NotebookCell:
     """Parse a raw nbformat cell into validated notebook metadata."""
     if not isinstance(raw_cell, dict):
         msg = f"{path}: cell {index}: expected cell to be an object"
         raise TypeError(msg)
+    parse_cell_metadata(raw_cell.get("metadata"), path=path, index=index)
     return NotebookCell(
         index=index,
         cell_type=parse_cell_type(raw_cell.get("cell_type"), path=path, index=index),
@@ -152,6 +161,17 @@ def parse_notebook_cell(raw_cell: Any, *, path: Path, index: int) -> NotebookCel
         output_count=parse_output_count(raw_cell.get("outputs"), path=path, index=index),
         execution_count=parse_execution_count(raw_cell.get("execution_count"), path=path, index=index),
     )
+
+
+def parse_notebook_format(value: Any, *, path: Path) -> int:
+    """Parse the supported major nbformat version without numeric coercion."""
+    if not isinstance(value, int) or isinstance(value, bool):
+        msg = f"{path}: expected nbformat to be the integer 4, got {value!r}"
+        raise TypeError(msg)
+    if value != 4:
+        msg = f"{path}: expected nbformat 4, got {value!r}"
+        raise ValueError(msg)
+    return value
 
 
 def load_notebook(path: Path) -> NotebookDocument:
@@ -164,9 +184,7 @@ def load_notebook(path: Path) -> NotebookDocument:
     if not isinstance(notebook, dict):
         msg = f"{path}: expected notebook JSON to be an object"
         raise TypeError(msg)
-    if notebook.get("nbformat") != 4:
-        msg = f"{path}: expected nbformat 4, got {notebook.get('nbformat')!r}"
-        raise ValueError(msg)
+    nbformat = parse_notebook_format(notebook.get("nbformat"), path=path)
     cells = notebook.get("cells")
     if not isinstance(cells, list):
         msg = f"{path}: expected notebook cells to be a list"
@@ -177,7 +195,7 @@ def load_notebook(path: Path) -> NotebookDocument:
         raise TypeError(msg)
     return NotebookDocument(
         path=path,
-        nbformat=4,
+        nbformat=nbformat,
         nbformat_minor=nbformat_minor,
         cells=tuple(parse_notebook_cell(cell, path=path, index=index) for index, cell in enumerate(cells, start=1)),
     )

--- a/scripts/tests/test_notebook_check.py
+++ b/scripts/tests/test_notebook_check.py
@@ -74,6 +74,26 @@ def test_load_notebook_rejects_wrong_nbformat(tmp_path: Path) -> None:
         load_notebook(notebook)
 
 
+@pytest.mark.parametrize("invalid_nbformat", [4.0, True])
+def test_load_notebook_rejects_non_integer_nbformat(tmp_path: Path, invalid_nbformat: object) -> None:
+    notebook = tmp_path / "invalid-nbformat-type.ipynb"
+    notebook.write_text(
+        json.dumps({"cells": [], "nbformat": invalid_nbformat, "nbformat_minor": 5, "metadata": {}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match="expected nbformat to be the integer 4"):
+        load_notebook(notebook)
+
+
+def test_load_notebook_rejects_non_object_cell_metadata(tmp_path: Path) -> None:
+    notebook = tmp_path / "bad-cell-metadata.ipynb"
+    write_notebook(notebook, [{**code_cell("x = 1"), "metadata": []}])
+
+    with pytest.raises(TypeError, match="cell 1: metadata must be an object"):
+        load_notebook(notebook)
+
+
 def test_load_notebook_rejects_bad_cell_source(tmp_path: Path) -> None:
     notebook = tmp_path / "bad-source.ipynb"
     write_notebook(notebook, [code_cell(["valid", 5])])

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -711,7 +711,7 @@ pub(crate) enum InsertionLabel {
 ///
 /// The candidate keeps both backend operations together: subdivide the chosen
 /// face at `point`, label the new vertex, then flip the original spacelike edge.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct ToroidalInsertionCandidate {
     edge: DelaunayEdgeHandle,
     face: DelaunayFaceHandle,
@@ -723,7 +723,7 @@ pub(crate) struct ToroidalInsertionCandidate {
 ///
 /// The vertex cannot be collapsed directly in periodic CDT; the stored edge is
 /// flipped first to expose the inverse local volume move.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct ToroidalRemovalCandidate {
     vertex: DelaunayVertexHandle,
     flip_edge: DelaunayEdgeHandle,
@@ -734,7 +734,7 @@ pub(crate) struct ToroidalRemovalCandidate {
 /// Metropolis planning samples one of these after counting the same site
 /// universe used in the Hastings correction, so selection and denominator
 /// semantics remain aligned.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum ProposalSite {
     EdgeFlip(DelaunayEdgeHandle),
     FaceSubdivision {
@@ -2974,7 +2974,7 @@ mod tests {
         let Some(toroidal_site) = toroidal_selection.site else {
             panic!("toroidal fixture should expose insertion sites");
         };
-        assert!(matches!(toroidal_site, ProposalSite::ToroidalInsertion(_)));
+        assert_matches!(toroidal_site, ProposalSite::ToroidalInsertion(_));
 
         let strip_selection = system.select_proposal_site(&strip, MoveType::Move13Add);
         assert_eq!(
@@ -2988,7 +2988,7 @@ mod tests {
         let Some(strip_site) = strip_selection.site else {
             panic!("open-boundary strip fixture should expose insertion sites");
         };
-        assert!(matches!(strip_site, ProposalSite::FaceSubdivision { .. }));
+        assert_matches!(strip_site, ProposalSite::FaceSubdivision { .. });
     }
 
     #[test]

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -815,7 +815,7 @@ impl MetropolisAlgorithm {
                 };
                 debug_assert_eq!(
                     sampler.proposal_ref().last_step_info(),
-                    planned_step.info,
+                    planned_step.info().copied(),
                     "CDT proposal telemetry cache should mirror the upstream planned-step info"
                 );
                 record_planned_step(
@@ -824,7 +824,8 @@ impl MetropolisAlgorithm {
                     step,
                     &planned_step,
                     planned_step
-                        .info
+                        .info()
+                        .copied()
                         .ok_or_else(|| missing_planned_step_info(step.get()))?,
                     sampler.proposal_ref().last_proposal_stats(),
                     sampler.chain_ref().state(),
@@ -942,8 +943,8 @@ fn record_planned_step(
         state,
         step,
         PlannedStepRecord {
-            outcome: planned_step.outcome,
-            log_prob_after: planned_step.log_prob_after,
+            outcome: planned_step.outcome(),
+            log_prob_after: planned_step.log_prob_after(),
             info,
             proposal_stats,
             triangulation,
@@ -3655,13 +3656,14 @@ mod tests {
             .expect("ordinary no-site outcomes must be planned-step rejections, not errors");
 
         let info = step
-            .info
+            .info()
+            .copied()
             .expect("planned CDT steps should report proposal info");
         assert_eq!(proposal.last_step_info(), Some(info));
         assert_eq!(proposal.last_proposal_stats().move_family_proposals(), 1);
         assert_eq!(proposal.last_proposal_stats().accepted_transitions(), 0);
         assert_eq!(proposal.last_proposal_stats().metropolis_rejections(), 0);
-        assert!(!step.outcome.is_accepted() || step.log_prob_after.is_some());
+        assert!(!step.outcome().is_accepted() || step.log_prob_after().is_some());
     }
 
     #[test]


### PR DESCRIPTION
- Update markov-chain-monte-carlo to 0.4.1 and adopt its invariant-preserving Step telemetry accessors.
- Refresh repository tool pins, fail fast on unresolved workflow versions, and separate staggered Dependabot security updates.
- Reject malformed notebook metadata and non-integer nbformat values at the parser boundary.
- Consolidate benchmark setup failures behind the shared postfix OrAbort helper and replace unreliable README badges.

Closes #199
Closes #203
Closes #223