### PR TITLE
refactor(geometry)!: stop returning faces from vertex removal

### DIFF
--- a/docs/moves.md
+++ b/docs/moves.md
@@ -91,6 +91,11 @@ bistellar moves. The `delaunay` crate exposes the geometric 2D operations this c
 - `flip_k1_insert` — local vertex insertion, the geometric substrate for a `(1,3)` subdivision;
 - `flip_k1_remove` — local vertex removal, the geometric substrate for a `(3,1)` collapse.
 
+The backend-neutral `TriangulationMut::remove_vertex` lifecycle operation is broader than the focused inverse k=1 move. It may select that fast path for a
+compatible local configuration or perform generic cavity retriangulation, and its `Result<()>` reports only whether the validated mutation committed. CDT
+callers rebuild foliation and query the resulting topology after success; they do not infer replacement faces from the return value. If a future workflow
+requires cavity metadata, the backend interface should expose a dedicated structured result rather than fabricate replacement handles.
+
 CDT cannot apply arbitrary geometric k-flips directly. A CDT move must also preserve the discrete time foliation, keep every simplex classified as causal
 (`Up` or `Down` in 1+1), obey topology-specific slice-size constraints, and pass topology/causality validation after the edit. The implementation therefore
 maps Delaunay's local edit primitives into foliation-preserving CDT proposals:

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -1305,7 +1305,7 @@ impl ErgodicsSystem {
 
     /// Applies a selected open-boundary vertex-removal site.
     ///
-    /// The candidate was already screened for causal and replacement-face
+    /// The candidate was already screened for causal and replacement-triangle
     /// preconditions; this function owns the backend edit, validation, and
     /// rollback boundary.
     fn apply_vertex_removal_site(
@@ -1318,7 +1318,7 @@ impl ErgodicsSystem {
         let removal = triangulation.remove_vertex(vertex);
 
         let result = match removal {
-            Ok(_) => self.finish_mutated_move(triangulation, MoveType::Move31Remove),
+            Ok(()) => self.finish_mutated_move(triangulation, MoveType::Move31Remove),
             Err(err) => {
                 reject_backend(BackendMutationOperation::RemoveVertex, removal_target, &err)
             }
@@ -1343,7 +1343,7 @@ impl ErgodicsSystem {
         let removal_target = format!("vertex {:?}", candidate.vertex.vertex_key());
         let removal = triangulation.remove_vertex(candidate.vertex);
         let result = match removal {
-            Ok(_) => self.finish_mutated_move(triangulation, MoveType::Move31Remove),
+            Ok(()) => self.finish_mutated_move(triangulation, MoveType::Move31Remove),
             Err(err) => {
                 reject_backend(BackendMutationOperation::RemoveVertex, removal_target, &err)
             }

--- a/src/cdt/triangulation/moves.rs
+++ b/src/cdt/triangulation/moves.rs
@@ -35,10 +35,10 @@ impl CdtTriangulation<DelaunayBackend2D> {
     pub(crate) fn remove_vertex(
         &mut self,
         vertex: DelaunayVertexHandle,
-    ) -> Result<Vec<DelaunayFaceHandle>, DelaunayError> {
-        let result = self.geometry.remove_vertex(vertex)?;
+    ) -> Result<(), DelaunayError> {
+        self.geometry.remove_vertex(vertex)?;
         self.bump_modification_count();
-        Ok(result)
+        Ok(())
     }
 
     /// Updates a vertex time label and marks CDT-derived state stale on success.
@@ -161,7 +161,8 @@ mod tests {
         assert!(tri.cache.edge_count.is_some());
         let after_subdivision_count = tri.metadata().modification_count;
 
-        tri.remove_vertex(subdivision.new_vertex.clone())
+        let (): () = tri
+            .remove_vertex(subdivision.new_vertex.clone())
             .expect("new subdivision vertex should be removable");
 
         assert_eq!(tri.vertex_count(), initial_vertices);

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -1469,10 +1469,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
         Ok(DelaunayVertexHandle { key })
     }
 
-    fn remove_vertex(
-        &mut self,
-        vertex: Self::VertexHandle,
-    ) -> Result<Vec<Self::FaceHandle>, Self::Error> {
+    fn remove_vertex(&mut self, vertex: Self::VertexHandle) -> Result<(), Self::Error> {
         if !self.dt.contains_vertex_key(vertex.key) {
             return Err(DelaunayError::InvalidVertex { key: vertex.key });
         }
@@ -1517,7 +1514,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
             },
             format!("vertex {:?}", vertex.key),
         )?;
-        Ok(Vec::new())
+        Ok(())
     }
 
     fn move_vertex(
@@ -2632,7 +2629,7 @@ mod tests {
         assert_eq!(backend.face_count(), original_face_count + 2);
         assert!(backend.is_valid());
 
-        backend
+        let (): () = backend
             .remove_vertex(subdivide.new_vertex)
             .expect("degree-3 inserted vertex should be removable");
         assert_eq!(backend.vertex_count(), original_vertex_count);

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -2738,6 +2738,41 @@ mod tests {
     }
 
     #[test]
+    fn generic_vertex_removal_retriangulates_cavity() {
+        let dt = build_delaunay2_with_data(&[
+            ([0.0, 0.0], 0),
+            ([1.0, 0.0], 0),
+            ([0.0, 1.0], 0),
+            ([1.0, 1.0], 0),
+            ([0.18, 0.42], 1),
+            ([0.52, 0.18], 1),
+            ([0.64, 0.72], 1),
+        ])
+        .expect("generic deletion fixture should build");
+        let mut backend = validated_backend(dt);
+        let vertex = backend
+            .vertices()
+            .find(|vertex| {
+                backend
+                    .vertex_coordinates(vertex)
+                    .is_ok_and(|coordinates| coordinates == [0.18, 0.42])
+            })
+            .expect("generic deletion fixture vertex should be present");
+        assert!(
+            backend.dt.can_flip_k1_remove(vertex.key).is_err(),
+            "fixture must exercise generic cavity deletion"
+        );
+        let original_vertex_count = backend.vertex_count();
+        let original_face_count = backend.face_count();
+
+        assert_matches!(backend.remove_vertex(vertex), Ok(()));
+
+        assert_eq!(backend.vertex_count(), original_vertex_count - 1);
+        assert_eq!(backend.face_count(), original_face_count - 2);
+        assert!(backend.is_valid());
+    }
+
+    #[test]
     fn backend_rejects_non_delaunay_connectivity() {
         let dt = build_delaunay2_with_data(&[
             ([0.0, 0.0], 0),

--- a/src/geometry/backends/mock.rs
+++ b/src/geometry/backends/mock.rs
@@ -135,6 +135,19 @@ pub enum MockError {
     #[error("Invalid face handle: {0}")]
     Face(usize),
 
+    /// A vertex exists, but still participates in stored topology.
+    #[error(
+        "Vertex {vertex} cannot be removed while incident topology remains: {incident_edges} edges, {incident_faces} faces"
+    )]
+    NonIsolatedVertex {
+        /// Vertex handle that was requested.
+        vertex: usize,
+        /// Number of stored edges incident to the vertex.
+        incident_edges: usize,
+        /// Number of stored faces incident to the vertex.
+        incident_faces: usize,
+    },
+
     /// Storage reservation failed.
     #[error("Reservation failed for {operation} requesting {requested_capacity} slots: {detail}")]
     ReservationFailed {
@@ -560,9 +573,29 @@ impl TriangulationMut for MockBackend {
     }
 
     fn remove_vertex(&mut self, vertex: Self::VertexHandle) -> Result<(), Self::Error> {
-        self.vertices
-            .remove(&vertex.0)
-            .ok_or(MockError::Vertex(vertex.0))?;
+        if !self.vertices.contains_key(&vertex.0) {
+            return Err(MockError::Vertex(vertex.0));
+        }
+
+        let incident_edges = self
+            .edges
+            .values()
+            .filter(|&&(v0, v1)| v0 == vertex.0 || v1 == vertex.0)
+            .count();
+        let incident_faces = self
+            .faces
+            .values()
+            .filter(|vertices| vertices.contains(&vertex.0))
+            .count();
+        if incident_edges != 0 || incident_faces != 0 {
+            return Err(MockError::NonIsolatedVertex {
+                vertex: vertex.0,
+                incident_edges,
+                incident_faces,
+            });
+        }
+
+        self.vertices.remove(&vertex.0);
         Ok(())
     }
 
@@ -951,6 +984,40 @@ mod tests {
         assert_eq!(backend.vertices().count(), 0);
         assert_eq!(backend.edges().count(), 0);
         assert_eq!(backend.faces().count(), 0);
+    }
+
+    #[test]
+    fn test_mock_backend_rejects_non_isolated_vertex_removal_without_mutation() {
+        let mut backend = MockBackend::create_triangle();
+        let vertex = MockVertexHandle(0);
+
+        assert_matches!(
+            backend.remove_vertex(vertex.clone()),
+            Err(MockError::NonIsolatedVertex {
+                vertex: 0,
+                incident_edges: 2,
+                incident_faces: 1,
+            })
+        );
+
+        assert_eq!(backend.vertex_count(), 3);
+        assert_eq!(backend.edge_count(), 3);
+        assert_eq!(backend.face_count(), 1);
+        assert_eq!(
+            backend
+                .incident_edges(&vertex)
+                .expect("rejected removal should preserve incident edges")
+                .len(),
+            2
+        );
+        assert_eq!(
+            backend
+                .adjacent_faces(&vertex)
+                .expect("rejected removal should preserve adjacent faces")
+                .len(),
+            1
+        );
+        assert!(backend.is_valid());
     }
 
     #[test]

--- a/src/geometry/backends/mock.rs
+++ b/src/geometry/backends/mock.rs
@@ -559,14 +559,11 @@ impl TriangulationMut for MockBackend {
         Ok(MockVertexHandle(id))
     }
 
-    fn remove_vertex(
-        &mut self,
-        vertex: Self::VertexHandle,
-    ) -> Result<Vec<Self::FaceHandle>, Self::Error> {
+    fn remove_vertex(&mut self, vertex: Self::VertexHandle) -> Result<(), Self::Error> {
         self.vertices
             .remove(&vertex.0)
             .ok_or(MockError::Vertex(vertex.0))?;
-        Ok(Vec::new())
+        Ok(())
     }
 
     fn move_vertex(
@@ -942,10 +939,9 @@ mod tests {
         assert_eq!(backend.vertex_count(), 5);
         assert_eq!(backend.face_count(), 3);
 
-        let removed_faces = backend
+        let (): () = backend
             .remove_vertex(vertex)
             .expect("mock vertex removal should succeed");
-        assert!(removed_faces.is_empty());
 
         backend.clear().expect("mock backend should clear storage");
         assert_eq!(backend.vertex_count(), 0);

--- a/src/geometry/traits.rs
+++ b/src/geometry/traits.rs
@@ -291,19 +291,18 @@ pub trait TriangulationMut: TriangulationQuery {
 
     /// Removes a vertex and lets the backend retriangulate the surrounding cavity.
     ///
-    /// Returns handles for backend-reported replacement faces when the backend
-    /// exposes them. Implementations may return an empty list when the mutation
-    /// succeeds but the upstream backend does not report replacement handles.
+    /// This generic lifecycle operation reports only success or failure. A backend
+    /// may implement it with a specialized inverse k=1 move when applicable, but
+    /// callers must query and validate the resulting topology instead of assuming
+    /// replacement-face or cavity metadata. If callers need such evidence in the
+    /// future, it should be exposed through a dedicated structured result type.
     ///
     /// # Errors
     ///
     /// Returns the backend error when the vertex handle is invalid, local
     /// topology is not removable, or the removal would violate backend
     /// invariants.
-    fn remove_vertex(
-        &mut self,
-        vertex: Self::VertexHandle,
-    ) -> Result<Vec<Self::FaceHandle>, Self::Error>;
+    fn remove_vertex(&mut self, vertex: Self::VertexHandle) -> Result<(), Self::Error>;
 
     /// Move a vertex to new coordinates
     ///


### PR DESCRIPTION
- Return unit after a validated removal instead of fabricating replacement-face handles.
- Preserve specialized inverse k=1 and generic cavity-retriangulation paths.
- Apply the contract consistently across CDT, Delaunay, and mock backends.

BREAKING CHANGE: TriangulationMut::remove_vertex now returns Result<(), Self::Error> instead of Result<Vec<Self::FaceHandle>, Self::Error>.

Closes #197