### PR TITLE
ci(tooling): standardize orthogonal validation buckets

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,8 @@
+[profile.ci]
+retries = 0
+fail-fast = false
+failure-output = "immediate-final"
+success-output = "never"
+status-level = "pass"
+final-status-level = "slow"
+slow-timeout = { period = "60s", terminate-after = 2 }

--- a/docs/code-organization.md
+++ b/docs/code-organization.md
@@ -17,6 +17,8 @@ This document lists the files checked into the repository and summarizes the arc
 
 ```text
 causal-triangulations/
+├── .config/
+│   └── nextest.toml
 ├── .github/
 │   ├── actions/
 │   │   └── setup-just/
@@ -86,6 +88,7 @@ causal-triangulations/
 │   │   ├── test_benchmark_utils.py
 │   │   ├── test_coverage_report.py
 │   │   ├── test_hardware_utils.py
+│   │   ├── test_notebook_check.py
 │   │   ├── test_postprocess_changelog.py
 │   │   ├── test_subprocess_utils.py
 │   │   └── test_tag_release.py

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -470,7 +470,7 @@ just publish-check
 | `src/`        | `just test-unit test-doc` (or `just ci`)     |
 | `scripts/`    | `just python-check test-python`              |
 | `notebooks/`  | `just notebook-check`                        |
-| Any Rust      | `just doc-check`                             |
+| Any Rust      | Also run `just doc-check` with the applicable Rust path command |
 
 ---
 

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -103,15 +103,15 @@ just ci
 
 This runs:
 
-- formatting checks
-- lint checks
-- repository-owned Semgrep rules
-- unit tests
-- integration tests
-- documentation builds
-- notebook output hygiene and headless execution
-- validated example runs
-- benchmark compilation
+- GitHub Actions, Markdown, JSON, TOML, YAML/CFF, Python, shell, and repository-owned Semgrep checks
+- production library/binary formatting, Clippy, and documentation builds
+- one release-profile nextest pass for library unit tests and integration-test crates
+- a separate rustdoc doctest bucket
+- notebook output hygiene, extracted-code checks, and fast headless execution
+- benchmark harness compilation and validated example runs
+
+The `ci` recipe is a flat union of these focused validators. It does not depend on broad `check`, `lint`, or `test-all` bundles. Each target class is compiled
+by the bucket that owns its validation.
 
 For heavier stabilization work, run the slow-test wrapper:
 
@@ -121,6 +121,15 @@ just ci-slow
 
 This runs the normal CI command and then feature-gated slow/stress tests through the repository `perf` Cargo profile. The slow suite includes large-scale
 toroidal debug probes, so optimized builds are part of the validation contract rather than an optional speed tweak.
+
+## Fast Validation Cycle
+
+Start with the smallest test selection that covers the change: a filtered library unit test, one rustdoc doctest filter, or one integration-test crate. Use
+the focused `test-unit`, `test-doc`, and `test-integration` recipes when the whole changed surface is the useful boundary.
+
+For final validation of non-core changes, compose each applicable bucket once, such as `just markdown-check`, `just python-check test-python`, or
+`just notebook-check`. For core Rust changes or an exact local simulation of GitHub validation, run `just ci` directly instead of first running overlapping
+broad bundles that `ci` will repeat.
 
 ## Semgrep
 
@@ -436,8 +445,10 @@ just publish-check
 | --------------------- | ------------------------ |
 | Run lints             | `just check`             |
 | Format code           | `just fix`               |
-| Run unit tests        | `just test`              |
+| Run unit tests        | `just test-unit`         |
+| Run unit + doctests   | `just test`              |
 | Run integration tests | `just test-integration`  |
+| Run broad Rust tests  | `just test-rust`         |
 | Run slow tests        | `just test-slow`         |
 | Run all tests         | `just test-all`          |
 | Run Python tests      | `just test-python`       |
@@ -453,12 +464,13 @@ just publish-check
 
 | Changed files | Command                                |
 | ------------- | -------------------------------------- |
-| `tests/`      | `just test-integration` (or `just ci`) |
-| `examples/`   | `just examples-validate`               |
-| `benches/`    | `just bench-compile`                   |
-| `src/`        | `just test`                            |
-| `scripts/`    | `just test-python`                     |
-| Any Rust      | `just doc-check`                       |
+| `tests/`      | `just test-integration` (or `just ci`)       |
+| `examples/`   | `just examples-validate`                     |
+| `benches/`    | `just bench-compile`                         |
+| `src/`        | `just test-unit test-doc` (or `just ci`)     |
+| `scripts/`    | `just python-check test-python`              |
+| `notebooks/`  | `just notebook-check`                        |
+| Any Rust      | `just doc-check`                             |
 
 ---
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -164,6 +164,12 @@ Run standard tests:
 just test
 ```
 
+This composes the focused library-unit and rustdoc-doctest buckets. Run only library unit tests with:
+
+```bash
+just test-unit
+```
+
 Run integration tests:
 
 ```bash
@@ -183,6 +189,14 @@ Run all tests:
 
 ```bash
 just test-all
+```
+
+`test-all` uses `test-rust` for broad Rust correctness and then runs the Python support-script suite. Broad runnable Rust tests use one release-profile nextest
+pass for library unit tests plus integration-test crates; rustdoc doctests remain separate:
+
+```bash
+just test-rust-ci
+just test-doc
 ```
 
 Run Python tests:
@@ -229,14 +243,18 @@ Before proposing patches agents should run:
 just ci
 ```
 
-The `ci` recipe runs `check bench-compile test-all examples-validate notebook-check`, which enforces:
+The `ci` recipe directly composes the GitHub-equivalent leaf validators instead of depending on `check`, `lint`, or `test-all`. It enforces:
 
-- **check** (via `lint`): formatting, clippy, documentation builds, markdown, spelling, config validation (JSON, TOML, YAML, GitHub Actions)
-- **bench-compile**: benchmarks compile without local-package warnings under Cargo's `build.warnings = "deny"` policy
-- **test-all**: unit tests and integration tests via nextest, rustdoc doctests via `cargo test --doc`, and Python tests via pytest
-- **notebook-check**: Jupyter notebooks are output-clean, pass extracted-code Ruff and ty checks, and execute headlessly through the uv-managed notebook
+- **repository and configuration checks**: GitHub Actions, Markdown, spelling, JSON, TOML, YAML/CFF, Python, shell, and repository-owned Semgrep rules
+- **core Rust checks**: formatting, production library/binary Clippy, and documentation builds
+- **Rust correctness**: library unit tests and integration-test crates in one release-profile `test-rust-ci` nextest pass, plus separate rustdoc doctests
+- **Python correctness**: pytest over support scripts, including the reusable notebook checker
+- **notebooks**: source notebooks are output-clean, extracted code passes Ruff and ty, and the fast notebook set executes headlessly through the uv-managed
   environment
-- **examples-validate**: Cargo examples build once, then the compiled binaries run successfully with stable output markers
+- **benchmarks and examples**: benchmark harnesses compile without warnings, and Cargo examples build once before running with stable output markers
+
+For non-core changes, run the smallest relevant test or integration crate first and compose each focused final bucket once. For core Rust changes or exact
+GitHub-equivalent evidence, run `just ci` directly rather than pre-running broad bundles that select the same tests.
 
 ---
 

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -279,6 +279,28 @@ notebook JSON boundary now also requires every cell `metadata` field to be an ob
 as `4.0` and booleans cannot enter the trusted notebook model through Python's numeric equality and subclass behavior. Notebook discovery is captured before
 linting so `find` failures remain fatal while a successful empty discovery still reports that no notebooks were found.
 
+## Issue #205 Orthogonal CI And Notebook Checker Alignment
+
+Issue #205 compares CDT's validation shape with the completed `markov-chain-monte-carlo` issue #95 implementation while preserving CDT's stronger notebook
+execution policy. The shared pieces are the flat GitHub-equivalent CI union, a release-profile nextest bucket for runnable Rust tests, focused changed-surface
+recipes, and a reusable notebook parser/linter. Delaunay's current notebook bucket remains intentionally lint-only, whereas CDT continues to execute the
+quickstart and visualization notebooks in routine CI and reserves the analysis-cache notebook for `notebook-check-slow`.
+
+- `just ci` names each distinct validator directly instead of reaching them through `check`, `lint`, or `test-all`. This keeps Markdown, configuration,
+  Python, notebooks, production Rust, runnable Rust tests, doctests, benchmarks, and examples independently selectable and avoids hidden target-class overlap.
+- `test-rust-ci` runs library unit tests and integration-test crates together with
+  `cargo nextest run --release --profile ci --lib --tests --verbose`; `test-rust` adds the separate rustdoc bucket because nextest does not execute doctests.
+  `test-unit`, `test-doc`, and `test-integration` remain debug-profile focused recipes for changed-surface work, with `test-lib` retained as a compatibility
+  alias. `.config/nextest.toml` defines the named CI profile with no retries, non-fail-fast execution, immediate final failure output, and a bounded slow-test
+  timeout so the command behaves consistently on every platform.
+- Default Clippy validation now covers production library and binary targets. The former all-target sweep remains available as `clippy-all-targets`, outside
+  `just ci`, because tests, examples, and benchmarks already have focused validators that compile their own target classes.
+- `scripts/notebook_check.py` now owns notebook discovery, JSON parsing, cell compilation, output hygiene, extracted-code Ruff/ty diagnostics, and multi-file
+  failure reporting. `notebook-output-check` calls the same checker with external-code checks disabled instead of maintaining a second `jq` implementation.
+  Just continues to own launch behavior, the fast/slow execution sets, output placement under `target/notebooks`, and explicit source-output cleanup.
+- No workflow or tool-version changes are needed: the existing platform matrix already delegates to `just ci`, and the pinned cargo-nextest/uv environment
+  provides every command used by the standardized buckets. The new nextest file supplies repository-owned profile policy rather than changing a tool pin.
+
 ## Deferred Updates
 
 These were evaluated but not ported in this pass:

--- a/justfile
+++ b/justfile
@@ -286,10 +286,10 @@ check: lint
 check-fast:
     cargo check
 
-# CI simulation: comprehensive validation (matches .github/workflows/ci.yml).
-# Rust unit/integration tests use nextest; doctests remain on cargo test because
-# nextest does not execute rustdoc doctests.
-ci: check bench-compile test-all examples-validate notebook-check
+# CI simulation: flat union of GitHub-equivalent focused validators.
+# Runnable Rust unit and integration tests share one release-profile nextest pass;
+# rustdoc doctests remain separate because nextest does not execute them.
+ci: action-lint zizmor markdown-check spell-check validate-json toml-fmt-check toml-lint yaml-fmt-check yaml-lint citation-check python-check test-python notebook-check shell-check semgrep semgrep-test fmt-check clippy doc-check test-rust-ci test-doc bench-compile examples-validate
     @echo "🎯 CI checks complete!"
 
 # CI with performance baseline
@@ -312,8 +312,12 @@ clean:
     rm -rf coverage_report
     rm -rf coverage
 
-# Code quality and formatting
+# Core production Rust linting used by default validation gates.
 clippy:
+    cargo clippy --workspace --all-features --lib --bins -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo
+
+# Optional broad Clippy sweep; focused CI buckets compile tests, examples, and benches.
+clippy-all-targets:
     cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo
 
 # Pre-commit workflow: comprehensive validation (checks + tests + release + benches)
@@ -383,14 +387,17 @@ help-workflows:
     @echo "  just coverage-ci       # Generate coverage for CI (XML)"
     @echo "  just examples          # Run all example scripts"
     @echo "  just examples-validate # Run examples and validate stable output markers"
-    @echo "  just test              # Lib and doc tests only (fast, used by CI)"
-    @echo "  just test-all          # All tests (lib + doc + integration + Python)"
+    @echo "  just test              # Focused unit and doctest buckets"
+    @echo "  just test-all          # Broad Rust and Python tooling tests"
     @echo "  just test-cli          # CLI integration tests only"
     @echo "  just test-examples     # Compile all examples as tests"
     @echo "  just test-integration  # Integration tests (tests/)"
     @echo "  just test-python       # Python tests only (pytest)"
     @echo "  just test-release      # All tests in release mode"
+    @echo "  just test-rust         # Broad release Rust tests plus doctests"
+    @echo "  just test-rust-ci      # Release unit and integration tests in one nextest pass"
     @echo "  just test-slow         # Feature-gated slow integration tests"
+    @echo "  just test-unit         # Focused library unit tests"
     @echo ""
     @echo "Quality Check Groups:"
     @echo "  just lint          # All linting (code + docs + config)"
@@ -429,7 +436,9 @@ help-workflows:
     @echo ""
     @echo "Running:"
     @echo "  just notebook         # Launch the quickstart notebook with uv-managed dependencies"
-    @echo "  just notebook-check   # Lint, check output hygiene, and execute notebooks headlessly"
+    @echo "  just notebook-lint    # Validate JSON, output hygiene, and extracted Python"
+    @echo "  just notebook-check   # Lint all notebooks and execute the fast notebook set"
+    @echo "  just notebook-check-slow # Include the explicitly configured heavy notebook"
     @echo "  just notebook-clear-outputs     # Clear outputs from the quickstart notebook"
     @echo "  just notebook-clear-outputs-all # Clear outputs from every notebook"
     @echo "  just notebook-execute # Execute the quickstart notebook headlessly for CI/HPC"
@@ -567,35 +576,10 @@ notebook-execute-slow output_dir="target/notebooks": _ensure-uv
     MPLBACKEND=Agg IPYTHONDIR="$output_path/.ipython" MPLCONFIGDIR="$output_path/.matplotlib" uv run --group notebooks jupyter nbconvert --execute --ExecutePreprocessor.timeout=1800 --ExecutePreprocessor.shutdown_kernel=immediate --to notebook --output-dir "{{ output_dir }}" notebooks/02_analysis_caches.ipynb
 
 notebook-lint: _ensure-uv
-    #!/usr/bin/env bash
-    set -euo pipefail
-    notebooks="$(find notebooks -type f -name '*.ipynb' | sort)"
-    if [ -z "$notebooks" ]; then
-        echo "No notebooks found to lint."
-        exit 0
-    fi
-    while IFS= read -r notebook; do
-        uv run --group notebooks notebook-check --lint "$notebook" --repo-root .
-    done <<< "$notebooks"
+    uv run --group notebooks notebook-check --lint --repo-root .
 
-notebook-output-check: _ensure-jq
-    #!/usr/bin/env bash
-    set -euo pipefail
-    found=0
-    violations=0
-    while IFS= read -r notebook; do
-        found=1
-        jq empty "$notebook"
-        dirty_cells="$(jq '[.cells[] | select(.cell_type == "code") | select((.execution_count != null) or (((.outputs // []) | length) > 0))] | length' "$notebook")"
-        if [ "$dirty_cells" -gt 0 ]; then
-            printf '%s: %s code cell(s) have outputs or execution counts\n' "$notebook" "$dirty_cells" >&2
-            violations=1
-        fi
-    done < <(find notebooks -type f -name '*.ipynb' | sort)
-    if [ "$found" -eq 0 ]; then
-        echo "No notebooks found to check."
-    fi
-    exit "$violations"
+notebook-output-check: _ensure-uv
+    uv run --group notebooks notebook-check --lint --repo-root . --no-ruff --no-format --no-ty
 
 notebook-setup: _ensure-uv
     uv sync --group notebooks
@@ -1010,11 +994,11 @@ tag version: python-sync
 tag-force version: python-sync
     uv run tag-release {{ version }} --force
 
-# Testing: fast tests (lib via nextest + rustdoc doctests via cargo test)
-test: test-lib test-doc
+# Focused local Rust buckets: unit tests plus rustdoc doctests.
+test: test-unit test-doc
 
-# Testing: comprehensive suite (Rust runnable tests via nextest + doctests + Python)
-test-all: test test-integration test-python
+# Broad Rust correctness plus Python tooling tests.
+test-all: test-rust test-python
     @echo "✅ All tests passed!"
 
 test-cli: _ensure-cargo-nextest
@@ -1030,7 +1014,19 @@ test-examples: _ensure-cargo-nextest
 test-integration: _ensure-cargo-nextest
     cargo nextest run --tests --verbose
 
-test-lib: _ensure-cargo-nextest
+# Backward-compatible alias for the former recipe name.
+test-lib: test-unit
+
+# Broad Rust test workflow; doctests remain a separate cargo-test bucket.
+test-rust: test-rust-ci test-doc
+    @echo "✅ Rust tests passed!"
+
+# Broad release-profile Rust CI bucket: lib unit and integration tests together.
+test-rust-ci: _ensure-cargo-nextest
+    cargo nextest run --release --profile ci --lib --tests --verbose
+
+# Focused library unit tests for changed-surface validation.
+test-unit: _ensure-cargo-nextest
     cargo nextest run --lib --verbose
 
 test-python: _ensure-uv

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -63,7 +63,20 @@ uv run coverage_report --help
 ```
 
 `coverage-report` summarizes the Cobertura XML produced by `just coverage-ci`.
-`notebook-check` inspects `.ipynb` files, rejects committed outputs, and runs Ruff and ty over extracted code cells.
+
+The notebook checker discovers `notebooks/**/*.ipynb` when no paths are supplied, validates notebook JSON, compiles code cells with cell-aware diagnostics,
+rejects committed outputs/execution counts, and runs Ruff and ty over extracted code:
+
+```bash
+just notebook-lint
+just notebook-check
+just notebook-check-slow
+just notebook-output-check
+uv run --group notebooks notebook-check --summary --repo-root .
+```
+
+`just notebook-check` executes only the fast notebook set and writes executed notebooks/artifacts under `target/notebooks`; the slow recipe adds the heavier
+analysis-cache notebook. `notebook-output-check` reuses the same JSON and output-hygiene implementation while skipping extracted-code tools.
 
 ## Shell helpers
 

--- a/scripts/notebook_check.py
+++ b/scripts/notebook_check.py
@@ -107,6 +107,15 @@ def parse_positive_int(value: str) -> int:
     return parsed
 
 
+def resolve_repo_root(path: Path) -> Path:
+    """Resolve and validate the repository root path."""
+    repo_root = path.resolve()
+    if not repo_root.is_dir():
+        msg = f"repository root does not exist or is not a directory: {repo_root}"
+        raise FileNotFoundError(msg)
+    return repo_root
+
+
 def parse_cell_source(source: Any, *, path: Path, index: int) -> str:
     """Parse a notebook cell source as joined text."""
     if isinstance(source, list):
@@ -134,9 +143,9 @@ def parse_execution_count(value: Any, *, path: Path, index: int) -> int | None:
     """Parse a notebook code-cell execution count."""
     if value is None:
         return None
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
         return value
-    msg = f"{path}: cell {index}: execution_count must be an integer or null"
+    msg = f"{path}: cell {index}: execution_count must be a nonnegative integer or null"
     raise TypeError(msg)
 
 
@@ -199,6 +208,14 @@ def load_notebook(path: Path) -> NotebookDocument:
         nbformat_minor=nbformat_minor,
         cells=tuple(parse_notebook_cell(cell, path=path, index=index) for index, cell in enumerate(cells, start=1)),
     )
+
+
+def discover_notebooks(repo_root: Path) -> list[Path]:
+    """Return source notebooks under the conventional notebooks directory."""
+    notebook_root = repo_root / "notebooks"
+    if not notebook_root.is_dir():
+        return []
+    return sorted(path for path in notebook_root.glob("**/*.ipynb") if ".ipynb_checkpoints" not in path.parts)
 
 
 def code_cells(notebook: NotebookDocument) -> list[NotebookCell]:
@@ -355,7 +372,7 @@ def extract_code(notebook: NotebookDocument) -> CodeSnapshot:
     return CodeSnapshot(source="".join(chunks), line_to_cell=line_to_cell)
 
 
-def ruff_lint_diagnostics(path: Path, notebook: NotebookDocument) -> list[Diagnostic]:
+def ruff_lint_diagnostics(path: Path, notebook: NotebookDocument, project_root: Path) -> list[Diagnostic]:
     """Run Ruff lint checks on extracted notebook code when Ruff is available."""
     snapshot = extract_code(notebook)
     command = [
@@ -371,6 +388,7 @@ def ruff_lint_diagnostics(path: Path, notebook: NotebookDocument) -> list[Diagno
         result = run_safe_command(
             command[0],
             command[1:],
+            cwd=project_root,
             input=snapshot.source,
             timeout=30,
             check=False,
@@ -399,7 +417,7 @@ def ruff_lint_diagnostics(path: Path, notebook: NotebookDocument) -> list[Diagno
     return diagnostics
 
 
-def ruff_format_diagnostics(path: Path, notebook: NotebookDocument) -> list[Diagnostic]:
+def ruff_format_diagnostics(path: Path, notebook: NotebookDocument, project_root: Path) -> list[Diagnostic]:
     """Run Ruff format check on extracted notebook code when Ruff is available."""
     snapshot = extract_code(notebook)
     command = ["ruff", "format", "--check", "--stdin-filename", f"{path.stem}_notebook.py", "-"]
@@ -407,6 +425,7 @@ def ruff_format_diagnostics(path: Path, notebook: NotebookDocument) -> list[Diag
         result = run_safe_command(
             command[0],
             command[1:],
+            cwd=project_root,
             input=snapshot.source,
             timeout=30,
             check=False,
@@ -441,6 +460,7 @@ def ty_diagnostics(path: Path, notebook: NotebookDocument, project_root: Path) -
             result = run_safe_command(
                 command[0],
                 command[1:],
+                cwd=project_root,
                 timeout=30,
                 check=False,
             )
@@ -488,19 +508,20 @@ def code_cell_diagnostics(path: Path, notebook: NotebookDocument, options: LintO
 def external_tool_diagnostics(path: Path, notebook: NotebookDocument, options: LintOptions) -> list[Diagnostic]:
     """Return diagnostics from Ruff and ty checks over extracted notebook code."""
     diagnostics: list[Diagnostic] = []
+    project_root = options.project_root or Path.cwd()
     if options.run_ruff or options.run_format:
         if shutil.which("ruff") is None:
             diagnostics.append(Diagnostic("error", 0, "ruff is required for notebook linting; run through `uv run` or install Ruff"))
         else:
             if options.run_ruff:
-                diagnostics.extend(ruff_lint_diagnostics(path, notebook))
+                diagnostics.extend(ruff_lint_diagnostics(path, notebook, project_root))
             if options.run_format:
-                diagnostics.extend(ruff_format_diagnostics(path, notebook))
+                diagnostics.extend(ruff_format_diagnostics(path, notebook, project_root))
     if options.run_ty:
         if shutil.which("ty") is None:
             diagnostics.append(Diagnostic("error", 0, "ty is required for notebook linting; run through `uv run` or install ty"))
         else:
-            diagnostics.extend(ty_diagnostics(path, notebook, options.project_root or Path.cwd()))
+            diagnostics.extend(ty_diagnostics(path, notebook, project_root))
     return diagnostics
 
 
@@ -542,6 +563,35 @@ def execute(path: Path, repo_root: Path, timeout: int) -> None:
     print(f"OK executed {path}")
 
 
+def lint_notebooks(paths: list[Path], options: LintOptions) -> int:
+    """Lint every notebook and preserve diagnostics for later paths after a failure."""
+    status = 0
+    for path in paths:
+        try:
+            result = lint(path, options)
+        except (OSError, TypeError, ValueError) as error:
+            print(f"{path}: notebook: error: {error}", file=sys.stderr)
+            status = 1
+            continue
+        status = max(status, result)
+        if result == 0:
+            print(f"OK linted {path}")
+    return status
+
+
+def execute_notebooks(paths: list[Path], repo_root: Path, timeout: int) -> None:
+    """Execute every selected notebook in order."""
+    for path in paths:
+        execute(path, repo_root, timeout)
+
+
+def selected_notebooks(paths: list[Path], repo_root: Path) -> list[Path]:
+    """Return explicit notebook paths or discover all source notebooks."""
+    if paths:
+        return [path if path.is_absolute() else repo_root / path for path in paths]
+    return discover_notebooks(repo_root)
+
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -553,35 +603,41 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="validate JSON, compile code cells, run Ruff and ty when available, and report common notebook issues",
     )
     mode.add_argument("--execute", action="store_true", help="execute the notebook in memory")
-    parser.add_argument("notebook", type=Path)
+    parser.add_argument("notebooks", nargs="*", type=Path, help="notebooks to check; defaults to notebooks/**/*.ipynb")
     parser.add_argument("--allow-outputs", action="store_true", help="do not fail lint when code cells contain outputs or execution counts")
     parser.add_argument("--strict", action="store_true", help="treat warning diagnostics as lint failures")
     parser.add_argument("--no-ruff", action="store_true", help="skip Ruff lint checks for extracted notebook code")
     parser.add_argument("--no-format", action="store_true", help="skip Ruff format checks for extracted notebook code")
     parser.add_argument("--no-ty", action="store_true", help="skip ty checks for extracted notebook code")
-    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="working directory for execution")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="repository root for discovery and execution")
     parser.add_argument("--timeout", type=parse_positive_int, default=120, help="per-cell execution timeout in seconds")
     return parser.parse_args(argv)
 
 
 def run(args: argparse.Namespace) -> int:
     """Run notebook checker actions for parsed arguments."""
+    repo_root = resolve_repo_root(args.repo_root)
+    paths = selected_notebooks(args.notebooks, repo_root)
+    if not paths:
+        print("No notebooks found.")
+        return 0
     if args.summary:
-        summarize(args.notebook)
+        for path in paths:
+            summarize(path)
         return 0
     if args.lint:
-        return lint(
-            args.notebook,
+        return lint_notebooks(
+            paths,
             LintOptions(
                 allow_outputs=args.allow_outputs,
                 strict=args.strict,
                 run_ruff=not args.no_ruff,
                 run_format=not args.no_format,
                 run_ty=not args.no_ty,
-                project_root=args.repo_root,
+                project_root=repo_root,
             ),
         )
-    execute(args.notebook, args.repo_root, args.timeout)
+    execute_notebooks(paths, repo_root, args.timeout)
     return 0
 
 

--- a/scripts/tests/test_notebook_check.py
+++ b/scripts/tests/test_notebook_check.py
@@ -1,11 +1,13 @@
 """Tests for notebook_check.py notebook linting diagnostics."""
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+import notebook_check
 from notebook_check import (
     LintOptions,
     NotebookDocument,
@@ -26,6 +28,7 @@ def write_notebook(path: Path, cells: list[dict[str, Any]]) -> None:
         "nbformat": 4,
         "nbformat_minor": 5,
     }
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(notebook),
         encoding="utf-8",
@@ -48,6 +51,11 @@ def code_cell(source: Any, *, outputs: Any = None, execution_count: Any = None) 
         "outputs": [] if outputs is None else outputs,
         "source": source,
     }
+
+
+def completed_process(stdout: str = "", *, returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    """Return a typed subprocess result for command-wrapper mocks."""
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
 
 
 def test_load_notebook_rejects_missing_cells(tmp_path: Path) -> None:
@@ -110,11 +118,12 @@ def test_load_notebook_rejects_unknown_cell_type(tmp_path: Path) -> None:
         load_notebook(notebook)
 
 
-def test_load_notebook_rejects_bad_execution_count(tmp_path: Path) -> None:
+@pytest.mark.parametrize("execution_count", ["1", True, -1])
+def test_load_notebook_rejects_bad_execution_count(tmp_path: Path, execution_count: object) -> None:
     notebook = tmp_path / "bad-execution-count.ipynb"
-    write_notebook(notebook, [code_cell("x = 1", execution_count="1")])
+    write_notebook(notebook, [code_cell("x = 1", execution_count=execution_count)])
 
-    with pytest.raises(TypeError, match="execution_count must be an integer or null"):
+    with pytest.raises(TypeError, match="execution_count must be a nonnegative integer or null"):
         load_notebook(notebook)
 
 
@@ -183,6 +192,38 @@ def test_external_tool_diagnostics_report_missing_tools(monkeypatch: pytest.Monk
     assert "ty is required for notebook linting; run through `uv run` or install ty" in messages
 
 
+def test_ruff_diagnostics_run_from_project_root_and_map_cell(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    notebook_path = tmp_path / "notebooks" / "ruff.ipynb"
+    write_notebook(notebook_path, [code_cell("import os\n")])
+    notebook = load_notebook(notebook_path)
+    calls: list[Path | None] = []
+
+    def fake_run_safe_command(
+        command: str,
+        args: list[str],
+        cwd: Path | None = None,
+        **kwargs: Any,
+    ) -> subprocess.CompletedProcess[str]:
+        assert command == "ruff"
+        assert args[0] == "check"
+        assert kwargs["input"]
+        calls.append(cwd)
+        return completed_process(
+            "F401 [*] `os` imported but unused\n  --> ruff_notebook.py:2:8\nFound 1 error.\n",
+            returncode=1,
+        )
+
+    monkeypatch.setattr(notebook_check, "run_safe_command", fake_run_safe_command)
+
+    diagnostics = notebook_check.ruff_lint_diagnostics(notebook_path, notebook, tmp_path)
+
+    assert calls == [tmp_path]
+    assert diagnostics == [notebook_check.Diagnostic("error", 1, "ruff check: F401 [*] `os` imported but unused")]
+
+
 def test_main_lint_reports_errors_to_stderr(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     notebook = tmp_path / "dirty.ipynb"
     write_notebook(notebook, [code_cell("x = 1", outputs=[{"output_type": "stream", "name": "stdout", "text": "1"}], execution_count=3)])
@@ -194,6 +235,21 @@ def test_main_lint_reports_errors_to_stderr(tmp_path: Path, capsys: pytest.Captu
     assert captured.out == ""
     assert f"{notebook}: cell 1: error: has 1 output block(s); clear outputs before committing" in captured.err
     assert f"{notebook}: cell 1: error: execution_count=3; clear execution counts" in captured.err
+
+
+def test_lint_notebooks_continues_after_invalid_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    invalid = tmp_path / "invalid.ipynb"
+    invalid.write_text("not-json", encoding="utf-8")
+    valid = tmp_path / "valid.ipynb"
+    write_notebook(valid, [code_cell("value = 1\n")])
+    options = LintOptions(run_ruff=False, run_format=False, run_ty=False, project_root=tmp_path)
+
+    result = notebook_check.lint_notebooks([invalid, valid], options)
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert f"{invalid}: notebook: error:" in captured.err
+    assert f"OK linted {valid}" in captured.out
 
 
 def test_main_reports_missing_notebook_without_traceback(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -234,3 +290,36 @@ def test_extract_code_maps_lines_to_source_cells(tmp_path: Path) -> None:
     assert "# %% notebook cell 3" in snapshot.source
     assert snapshot.line_to_cell[2] == 2
     assert snapshot.line_to_cell[5] == 3
+
+
+def test_discover_notebooks_sorts_sources_and_ignores_checkpoints(tmp_path: Path) -> None:
+    second = tmp_path / "notebooks" / "02_second.ipynb"
+    first = tmp_path / "notebooks" / "01_first.ipynb"
+    checkpoint = tmp_path / "notebooks" / ".ipynb_checkpoints" / "01_first-checkpoint.ipynb"
+    for path in (second, first, checkpoint):
+        write_notebook(path, [code_cell("value = 1\n")])
+
+    assert notebook_check.discover_notebooks(tmp_path) == [first, second]
+
+
+def test_main_discovers_repository_notebooks(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    notebook = tmp_path / "notebooks" / "valid.ipynb"
+    write_notebook(notebook, [code_cell("value = 1\n")])
+
+    result = main(["--lint", "--repo-root", str(tmp_path), "--no-ruff", "--no-format", "--no-ty"])
+
+    assert result == 0
+    assert f"OK linted {notebook}" in capsys.readouterr().out
+
+
+def test_main_reports_empty_discovery(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    result = main(["--lint", "--repo-root", str(tmp_path), "--no-ruff", "--no-format", "--no-ty"])
+
+    assert result == 0
+    assert capsys.readouterr().out == "No notebooks found.\n"
+
+
+def test_selected_notebooks_resolves_relative_paths(tmp_path: Path) -> None:
+    paths = notebook_check.selected_notebooks([Path("notebooks/valid.ipynb")], tmp_path)
+
+    assert paths == [tmp_path / "notebooks" / "valid.ipynb"]


### PR DESCRIPTION
- Flatten CI into focused validators with one release-profile Rust test bucket.
- Keep doctests and optional all-target Clippy checks independently selectable.
- Reuse the notebook checker for discovery, output hygiene, and multi-file diagnostics.
- Document focused validation workflows and fast versus slow notebook execution.

Closes #205