### PR TITLE
feat(cdt): validate evolved straight-line embeddings (#195)

### DIFF
--- a/docs/code-organization.md
+++ b/docs/code-organization.md
@@ -245,20 +245,20 @@ through to upstream `delaunay::` APIs directly.
 - `CdtSimplexCounts` carries the CDT-domain proof that constructed triangulations have positive vertex, edge, and triangle counts as `NonZeroUsize`, while
   raw geometry queries remain `usize` so backend construction, clearing, and collection-style count APIs can represent zero
 - `from_cdt_strip(vertices_per_slice, num_slices)` — Delaunay-built open-boundary 1+1 CDT strip with strict Up/Down simplex classification and upstream Level
-  1–4 Delaunay validation before wrapping
+  1–5 Delaunay validation before wrapping
 - `from_filtered_delaunay_strip(vertices_per_slice, num_slices)` — open-boundary 1+1 CDT initial-state constructor that starts from surplus labeled Delaunay
   points, removes vertices incident to non-strict CDT simplices through the backend `remove_vertex` path, and returns only after the strict causal simplex
   violation count converges to zero and full initial validation passes
 - `from_cdt_strip_profile(volume_profile)` — open-boundary 1+1 CDT strip from explicit nonuniform per-slice vertex counts; builds labeled point data and
   delegates triangulation to the Delaunay constructor before strict initial validation
-- `from_toroidal_cdt(vertices_per_slice, num_slices)` — periodic Delaunay S¹×S¹ toroidal CDT (χ = 0) with upstream Level 1–4 validation before wrapping;
+- `from_toroidal_cdt(vertices_per_slice, num_slices)` — periodic Delaunay S¹×S¹ toroidal CDT (χ = 0) with upstream Level 1–5 validation before wrapping;
   requires `vertices_per_slice ≥ 3` and `num_slices ≥ 3`
 - `from_toroidal_cdt_profile(volume_profile)` — periodic S¹×S¹ toroidal CDT from explicit per-slice vertex counts, preserving closed spatial slices and
   periodic time
 - `assign_foliation_by_y(num_slices)` — bin existing vertices into time slices
 - Query methods: `time_label`, `edge_type`, `vertices_at_time`, `slice_sizes`, `has_foliation`, `strict_causal_simplex_violation_count`
-- Validation: constructors require upstream Delaunay Level 1–4 validation for initial meshes; `validate()` is the post-move/final-state contract and requires
-  upstream structural validity plus CDT topology, foliation, causality, and strict Up/Down simplex classification
+- Validation: constructors require upstream Level 1–5 Delaunay validation for initial meshes; `validate()` is the post-move/final-state contract and requires
+  upstream Level 1–4 embedding validity plus CDT topology, foliation, causality, and strict Up/Down simplex classification
 - Mutable backend access is not exposed. CDT code mutates Delaunay state only through narrow crate-internal operations (`flip_edge`, `subdivide_face`,
   `remove_vertex`, `set_vertex_data`) that invalidate cached counts and foliation synchronization bookkeeping on success.
 
@@ -335,6 +335,7 @@ See `docs/metropolis.md` for the current planned-proposal ordering and
 - Wraps the upstream `delaunay` triangulation in `DelaunayBackend`
 - Defines crate-owned opaque handles (`DelaunayVertexHandle`, `DelaunayEdgeHandle`, `DelaunayFaceHandle`) so CDT code does not depend on upstream key types
 - Translates upstream Delaunay operations and errors into this crate's trait contracts
+- Exposes named validation adapters for Level 1–3 structure, Level 1–4 embedding/realization, and Level 1–5 Delaunay validity
 - Together with `geometry/generators.rs`, this is the only place that directly imports from the `delaunay` crate
 
 ### `geometry/generators.rs` — Delaunay triangulation generators

--- a/docs/foliation.md
+++ b/docs/foliation.md
@@ -65,7 +65,7 @@ from live vertex labels, and repeats until the count converges to zero. The curr
 the number of cleanup passes used.
 
 `from_cdt_strip_profile()` places each open spatial slice according to the corresponding profile entry and delegates triangulation to the Delaunay point-data
-constructor. The returned mesh must pass the same initial-constructor contract as the regular open strip: upstream Delaunay Level 1-4 validation plus CDT
+constructor. The returned mesh must pass the same initial-constructor contract as the regular open strip: upstream Delaunay Level 1-5 validation plus CDT
 topology, foliation, causality, and strict Up/Down simplex classification.
 
 The toroidal constructor starts from an `N × T` lattice in a periodic domain, applies bounded deterministic offsets to put cocircular lattice points in
@@ -77,16 +77,23 @@ It preserves closed spatial slices, periodic time, χ = 0, and strict CDT simple
 
 ## Initialization vs Evolution Validation
 
-Initial CDT constructors are stricter than post-move validation:
+The upstream validation hierarchy separates the properties needed by CDT evolution:
+
+- **Levels 1-3 — structure and topology**: storage consistency, simplex connectivity, and pseudomanifold constraints.
+- **Level 4 — embedding/realization**: every maximal simplex is nondegenerate, and distinct simplices intersect only in their shared face. This is the
+  straight-line-embedding property needed to rule out folded or overlapping geometry.
+- **Level 5 — Delaunay**: the realized triangulation also satisfies the empty-circumsphere predicate.
+
+Initial CDT constructors are therefore stricter than post-move validation:
 
 - **Initialization**: regular `from_cdt_strip()`, profiled `from_cdt_strip_profile()`, regular `from_toroidal_cdt()`, and
-  `from_toroidal_cdt_profile()` must pass upstream Delaunay Level 1-4 validation before returning. This certifies those starting meshes as valid,
-  well-behaved PL-manifold Delaunay triangulations.
-- **After ergodic moves / simulation completion**: `CdtTriangulation::validate()` requires upstream structural validity plus CDT topology, foliation, causality,
-  and simplex-classification invariants. It intentionally does not require Level 4 Delaunay-ness, because the CDT move kernels are not expected to preserve the
+  `from_toroidal_cdt_profile()` must pass upstream Level 1-5 validation before returning. This certifies those starting meshes as valid embedded
+  PL-manifold Delaunay triangulations.
+- **After ergodic moves / simulation completion**: `CdtTriangulation::validate()` requires upstream Level 1-4 embedding validity plus CDT topology,
+  foliation, causality, and simplex-classification invariants. It intentionally omits Level 5 because the CDT move kernels are not expected to preserve the
   Delaunay empty-circumsphere predicate.
 
-If the move set is ever changed to preserve Delaunay-ness, final-state validation should be tightened to include Level 4 as well.
+Call `triangulation.geometry().validate_delaunay()` when a workflow needs the optional stricter Level 1-5 check on an evolved state.
 
 ## Edge Classification
 
@@ -117,13 +124,13 @@ For a current foliated triangulation, every top-dimensional simplex must be stri
 triangle face must classify as `Up` `(2,1)` or `Down` `(1,2)`. Pure spacelike faces, all-timelike/non-spacelike faces, faces spanning more than adjacent time
 slices, malformed faces, and faces with missing time labels are all violations.
 
-This is a CDT-domain invariant. It is deliberately separate from upstream Delaunay Level 4 validation: Delaunay-ness asks whether the geometric triangulation
-satisfies an empty-circumsphere predicate, while strict causal simplex validation asks whether the foliation makes every top-dimensional cell an allowed CDT
-cell. A useful mental model is a parallel CDT validation level rather than Delaunay Level 5:
+This is a CDT-domain invariant, separate from both upstream geometric checks. Level 4 asks whether simplices form a nondegenerate, non-overlapping embedding;
+Level 5 asks whether that embedding satisfies the Delaunay empty-circumsphere predicate; strict causal simplex validation asks whether the foliation makes
+every top-dimensional cell an allowed CDT cell.
 
-- initial Delaunay-backed constructors require upstream Delaunay Level 4 and zero strict causal simplex violations;
-- evolved CDT states must remain structurally valid and keep zero strict causal simplex violations, but they are not required to preserve the Delaunay
-  empty-circumsphere property.
+- initial Delaunay-backed constructors require upstream Levels 1-5 and zero strict causal simplex violations;
+- evolved CDT states must preserve the Level 1-4 embedding and keep zero strict causal simplex violations, but they are not required to preserve the Level 5
+  Delaunay property.
 
 `strict_causal_simplex_violation_count()` exposes the invariant as a count. Valid constructor output and valid post-move states must have count zero. The
 filtered constructor uses the count as its convergence condition, following the CDT-plusplus practice of repeatedly removing acausal or unclassified
@@ -149,7 +156,10 @@ Structural checks:
 5. For toroidal topology, timelike edges connect each slice to both neighboring time slices modulo `T`
 
 Ergodic moves resynchronize foliation bookkeeping from live vertex labels after mutation. On toroidal triangulations, the move kernel immediately reruns
-`validate_topology()` and `validate_foliation()` before recording success; failures are rolled back and returned as ordinary local-site rejections.
+`validate_topology()` and `validate_foliation()` before recording success; failures are rolled back and returned as ordinary local-site rejections. The
+upstream bistellar-edit transaction validates the affected result against the Level 1-4 realization contract before it returns success, so CDT move
+finalization does not repeat the global embedding scan. Explicit `validate()` calls, configured cadence checks, and final result construction still recheck the
+whole evolved-state contract.
 
 ### `validate_causality_delaunay()`
 

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -945,7 +945,7 @@ impl ErgodicsSystem {
     ///     )?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -996,7 +996,7 @@ impl ErgodicsSystem {
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -1058,7 +1058,7 @@ impl ErgodicsSystem {
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -1116,7 +1116,7 @@ impl ErgodicsSystem {
     ///     )?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -1156,7 +1156,7 @@ impl ErgodicsSystem {
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -1360,7 +1360,7 @@ impl ErgodicsSystem {
         if let Err(err) = triangulation.synchronize_foliation_from_live_labels() {
             return MoveResult::HardFailure(err);
         }
-        if let Err(err) = triangulation.validate_evolved_cdt() {
+        if let Err(err) = triangulation.validate_after_realized_mutation() {
             if err.is_post_mutation_candidate_rejection() {
                 return MoveResult::GeometricViolation;
             }
@@ -2134,6 +2134,7 @@ mod tests {
     use crate::cdt::foliation::FoliationError;
     use crate::errors::{CdtValidationCheck, CdtValidationFailure, DelaunayValidationLevel};
     use crate::geometry::DelaunayBackend2D;
+    use crate::geometry::backends::delaunay::DelaunayError;
     use crate::geometry::generators::{build_delaunay2_from_simplices, build_delaunay2_with_data};
     use approx::assert_relative_eq;
     use std::assert_matches;
@@ -2330,6 +2331,28 @@ mod tests {
     }
 
     #[test]
+    fn backend_embedding_failure_remains_a_recoverable_rejection() {
+        let result = reject_backend(
+            BackendMutationOperation::FlipEdge,
+            "candidate edge".to_string(),
+            DelaunayError::ValidationFailed {
+                level: DelaunayValidationLevel::Four,
+                detail: "simplices intersect outside their shared face".to_string(),
+            },
+        );
+
+        assert_matches!(
+            result,
+            MoveResult::Rejected(CdtError::BackendMutationFailed {
+                operation: BackendMutationOperation::FlipEdge,
+                target,
+                detail,
+            }) if target == "candidate edge"
+                && detail.contains("simplices intersect outside their shared face")
+        );
+    }
+
+    #[test]
     fn move_statistics_defaults_hard_failures_for_legacy_payloads() {
         let stats: MoveStatistics = serde_json::from_str(
             r#"{
@@ -2426,6 +2449,9 @@ mod tests {
                 .is_ok()
         );
         assert!(triangulation.validate_causality().is_ok());
+        triangulation
+            .validate()
+            .expect("accepted k=2 move should preserve full evolved CDT invariants");
     }
 
     #[test]

--- a/src/cdt/triangulation/builders.rs
+++ b/src/cdt/triangulation/builders.rs
@@ -49,7 +49,7 @@ pub(super) fn remap_toroidal_generation_error(
 /// Validates a generated Delaunay triangulation before wrapping it in CDT state.
 fn validated_backend(dt: DelaunayTriangulation2D) -> CdtResult<DelaunayBackend2D> {
     DelaunayBackend2D::from_triangulation(dt).map_err(|err| CdtError::DelaunayValidationFailed {
-        level: DelaunayValidationLevel::Four,
+        level: DelaunayValidationLevel::Five,
         detail: err.to_string(),
     })
 }
@@ -720,7 +720,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// Returns [`CdtError::ValidationFailed`] if any vertex is unlabeled or
     /// has a time label outside `0..time_slices`, or if any time slice is empty.
     /// Returns [`CdtError::DelaunayValidationFailed`] if the backend fails the
-    /// upstream Level 1-4 Delaunay validator. Returns topology, foliation,
+    /// upstream Level 1-5 Delaunay validator. Returns topology, foliation,
     /// causality, or classification errors if the labels do not form a strict
     /// CDT mesh.
     ///
@@ -739,7 +739,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -1064,7 +1064,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// be reserved, if the underlying Delaunay builder rejects the points, if
     /// `build_delaunay2_with_data()` returns a vertex or face count that does not
     /// match the requested strip. Returns [`CdtError::DelaunayValidationFailed`]
-    /// if the constructed backend does not satisfy the Level 1-4 Delaunay
+    /// if the constructed backend does not satisfy the Level 1-5 Delaunay
     /// validator. Returns [`CdtError::Foliation`],
     /// [`CdtError::CausalityViolation`], or [`CdtError::ValidationFailed`] if the
     /// constructed strip fails CDT validation.
@@ -1212,7 +1212,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// or if the generated backend vertex or face count does not match the
     /// requested profile.
     /// Returns [`CdtError::DelaunayValidationFailed`] if the constructed backend
-    /// fails the Level 1-4 Delaunay validator. Returns [`CdtError::TopologyMismatch`],
+    /// fails the Level 1-5 Delaunay validator. Returns [`CdtError::TopologyMismatch`],
     /// [`CdtError::Foliation`], [`CdtError::CausalityViolation`], or
     /// [`CdtError::ValidationFailed`] if the constructed mesh violates CDT
     /// invariants.
@@ -1275,7 +1275,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// The triangulation is built through
     /// [`crate::geometry::generators::build_periodic_toroidal_delaunay2`],
     /// which uses the upstream periodic image-point constructor and then
-    /// requires full Delaunay Level 1-4 validation before the CDT wrapper is
+    /// requires full Delaunay Level 1-5 validation before the CDT wrapper is
     /// returned.
     ///
     /// # Mesh structure
@@ -1459,7 +1459,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// be reserved, if the periodic Delaunay constructor rejects the profiled point
     /// data, or if the resulting vertex or face counts do not match the requested
     /// profile. Returns [`CdtError::DelaunayValidationFailed`] if the constructed
-    /// backend fails the Level 1-4 Delaunay validator. Returns
+    /// backend fails the Level 1-5 Delaunay validator. Returns
     /// [`CdtError::TopologyMismatch`], [`CdtError::Foliation`],
     /// [`CdtError::CausalityViolation`], or [`CdtError::ValidationFailed`] if the
     /// constructed mesh violates CDT invariants.
@@ -1600,7 +1600,7 @@ mod tests {
             .expect("Delaunay strip topology should validate");
         tri.geometry()
             .validate_delaunay()
-            .expect("Delaunay strip should pass upstream Level 1-4 validation");
+            .expect("Delaunay strip should pass upstream Level 1-5 validation");
         tri.validate_simplex_classification()
             .expect("all Delaunay strip simplices should classify");
         for face in tri.geometry().faces() {
@@ -2498,7 +2498,7 @@ mod tests {
         assert_eq!(tri.geometry().periodic_domain(), Some([4.0, 3.0]));
         tri.geometry()
             .validate_delaunay()
-            .expect("initial toroidal CDT must pass upstream Level 1-4 validation");
+            .expect("initial toroidal CDT must pass upstream Level 1-5 validation");
         tri.validate_topology()
             .expect("initial toroidal CDT must satisfy torus topology");
         tri.validate_foliation()

--- a/src/cdt/triangulation/state.rs
+++ b/src/cdt/triangulation/state.rs
@@ -892,7 +892,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -920,7 +920,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -958,7 +958,7 @@ impl<B: TriangulationQuery> CdtTriangulation<B> {
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;

--- a/src/cdt/triangulation/validation.rs
+++ b/src/cdt/triangulation/validation.rs
@@ -15,18 +15,18 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// Validate post-construction CDT properties.
     ///
     /// This is the invariant set required after ergodic moves and completed
-    /// simulations: upstream structural geometry validity plus CDT topology,
+    /// simulations: upstream straight-line embedding validity plus CDT topology,
     /// foliation, causality, and simplex-classification checks. It intentionally
-    /// does not require the Level 4 Delaunay empty-circumsphere predicate,
+    /// does not require the Level 5 Delaunay empty-circumsphere predicate,
     /// because local CDT moves are not expected to preserve Delaunay-ness.
     ///
     /// Constructors that create initial simulation meshes perform the stricter
-    /// Level 1-4 Delaunay validation before returning.
+    /// Level 1-5 Delaunay validation before returning.
     ///
     /// # Errors
     ///
-    /// Returns [`CdtError::DelaunayValidationFailed`] if backend structural
-    /// geometry fails upstream validation. Returns
+    /// Returns [`CdtError::DelaunayValidationFailed`] if the backend fails
+    /// upstream Level 1-4 embedding validation. Returns
     /// [`CdtError::ValidationFailed`] if causality or simplex-classification checks
     /// fail, and returns topology or foliation errors from the corresponding
     /// validators when those invariants are violated.
@@ -70,9 +70,9 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// Validates the post-move/final CDT invariant contract.
     pub(crate) fn validate_evolved_cdt(&self) -> CdtResult<()> {
         self.geometry
-            .validate_structural()
+            .validate_embedding()
             .map_err(|err| CdtError::DelaunayValidationFailed {
-                level: DelaunayValidationLevel::Three,
+                level: DelaunayValidationLevel::Four,
                 detail: format!(
                     "{}; triangulation counts: V={}, E={}, F={}",
                     validation_detail(err),
@@ -81,6 +81,23 @@ impl CdtTriangulation<DelaunayBackend2D> {
                     self.geometry.face_count(),
                 ),
             })?;
+        self.validate_evolved_cdt_domain()
+    }
+
+    /// Validates CDT-owned invariants after a realized backend mutation succeeds.
+    ///
+    /// The Delaunay backend's mutation boundary guarantees structural and
+    /// straight-line realization validity before returning success. Repeating
+    /// the global Level 4 scan here would make every proposal pay for the same
+    /// whole-mesh predicate twice, so move finalization checks only the
+    /// CDT-owned topology, foliation, causality, and simplex-classification
+    /// contract.
+    pub(crate) fn validate_after_realized_mutation(&self) -> CdtResult<()> {
+        self.validate_evolved_cdt_domain()
+    }
+
+    /// Validates invariants owned by the CDT domain layer.
+    fn validate_evolved_cdt_domain(&self) -> CdtResult<()> {
         self.validate_topology()?;
         self.validate_foliation()?;
         self.validate_causality()?;
@@ -98,7 +115,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
         self.geometry
             .validate_delaunay()
             .map_err(|err| CdtError::DelaunayValidationFailed {
-                level: DelaunayValidationLevel::Four,
+                level: DelaunayValidationLevel::Five,
                 detail: validation_detail(err),
             })?;
         self.validate_topology()?;
@@ -136,7 +153,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -183,7 +200,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,8 @@ pub enum DelaunayValidationLevel {
     Three,
     /// Validate Levels 1 through 4.
     Four,
+    /// Validate Levels 1 through 5.
+    Five,
 }
 
 impl fmt::Display for DelaunayValidationLevel {
@@ -31,6 +33,7 @@ impl fmt::Display for DelaunayValidationLevel {
             Self::Two => formatter.write_str("Level 1-2"),
             Self::Three => formatter.write_str("Level 1-3"),
             Self::Four => formatter.write_str("Level 1-4"),
+            Self::Five => formatter.write_str("Level 1-5"),
         }
     }
 }
@@ -1734,13 +1737,13 @@ mod tests {
     #[test]
     fn test_delaunay_validation_failed_error() {
         let error = CdtError::DelaunayValidationFailed {
-            level: DelaunayValidationLevel::Four,
+            level: DelaunayValidationLevel::Five,
             detail: "upstream validation failed".to_string(),
         };
         let display = format!("{error}");
         assert_eq!(
             display,
-            "Delaunay validation failed [Level 1-4]: upstream validation failed"
+            "Delaunay validation failed [Level 1-5]: upstream validation failed"
         );
     }
 
@@ -1750,6 +1753,7 @@ mod tests {
         assert_eq!(DelaunayValidationLevel::Two.to_string(), "Level 1-2");
         assert_eq!(DelaunayValidationLevel::Three.to_string(), "Level 1-3");
         assert_eq!(DelaunayValidationLevel::Four.to_string(), "Level 1-4");
+        assert_eq!(DelaunayValidationLevel::Five.to_string(), "Level 1-5");
     }
 
     #[test]

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -33,10 +33,6 @@ type RawTriangulation<VertexData, SimplexData, const D: usize> =
 type RawVertex<VertexData, const D: usize> = Vertex<VertexData, D>;
 /// Upstream stable mesh-interchange value used by CDT summary exports.
 pub(crate) type DelaunayMeshExport<const D: usize> = MeshExport<D>;
-type MutationSnapshot<VertexData, SimplexData, const D: usize> = (
-    RawTriangulation<VertexData, SimplexData, D>,
-    HashMap<EdgeKey, FacetHandle>,
-);
 
 /// Delaunay backend wrapping the delaunay crate's triangulation (f64 coordinates).
 ///
@@ -615,9 +611,9 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
         v1: VertexKey,
         dt_before: RawTriangulation<VertexData, SimplexData, D>,
         facets_before: HashMap<EdgeKey, FacetHandle>,
-    ) -> Result<(EdgeKey, MutationSnapshot<VertexData, SimplexData, D>), DelaunayError> {
+    ) -> Result<EdgeKey, DelaunayError> {
         match self.dt.edge_key(v0, v1) {
-            Ok(key) => Ok((key, (dt_before, facets_before))),
+            Ok(key) => Ok(key),
             Err(err) => {
                 self.restore_mutation_snapshot(dt_before, facets_before);
                 Err(DelaunayError::UnexpectedFlipOutput {
@@ -641,33 +637,33 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
             })
     }
 
-    /// Validates a completed backend mutation and restores the previous snapshot on failure.
+    /// Validates embedding after a mutation without an upstream realization postcondition.
     ///
-    /// This keeps local edit APIs from publishing geometry that violates the evolved-state
-    /// Level 1-3 structural contract.
-    fn validate_mutation_or_restore(
+    /// High-level upstream bistellar flips already run cumulative Level 1-4
+    /// realization validation transactionally and therefore do not call this
+    /// helper. Other mutation paths are checked here so every successful backend
+    /// edit has the same postcondition without duplicating whole-mesh scans.
+    fn validate_embedding_or_restore(
         &mut self,
         dt_before: RawTriangulation<VertexData, SimplexData, D>,
         facets_before: HashMap<EdgeKey, FacetHandle>,
         operation: DelaunayOperation,
         target: impl Display,
     ) -> Result<(), DelaunayError> {
-        if let Err(err) = self.validate_structural() {
+        if let Err(err) = self.validate_embedding() {
             self.restore_mutation_snapshot(dt_before, facets_before);
             return Err(match err {
                 DelaunayError::ValidationFailed { level, detail } => {
                     DelaunayError::ValidationFailed {
                         level,
                         detail: format!(
-                            "{operation} produced invalid structural geometry for {target}: {detail}"
+                            "{operation} produced invalid geometry for {target}: {detail}"
                         ),
                     }
                 }
                 other => DelaunayError::ValidationFailed {
-                    level: DelaunayValidationLevel::Three,
-                    detail: format!(
-                        "{operation} produced invalid structural geometry for {target}: {other}"
-                    ),
+                    level: DelaunayValidationLevel::Four,
+                    detail: format!("{operation} produced invalid geometry for {target}: {other}"),
                 },
             });
         }
@@ -688,7 +684,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
 
     /// Creates a Delaunay backend from an existing validated Delaunay triangulation.
     ///
-    /// The input is validated with the upstream Level 1-4 Delaunay validator before
+    /// The input is validated with the upstream Level 1-5 Delaunay validator before
     /// the backend is returned, so public callers cannot wrap malformed or
     /// non-Delaunay connectivity.
     ///
@@ -709,7 +705,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///         ([0.5, 1.0], 1),
     ///     ])
     ///     .map_err(|err| DelaunayError::ValidationFailed {
-    ///         level: DelaunayValidationLevel::Four,
+    ///         level: DelaunayValidationLevel::Five,
     ///         detail: err.to_string(),
     ///     })?;
     ///
@@ -744,7 +740,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///         ([0.5, 1.0], 1),
     ///     ])
     ///     .map_err(|err| DelaunayError::ValidationFailed {
-    ///         level: DelaunayValidationLevel::Four,
+    ///         level: DelaunayValidationLevel::Five,
     ///         detail: err.to_string(),
     ///     })?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt)?;
@@ -762,8 +758,9 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// Check if the triangulation is valid and satisfies the Delaunay property.
     ///
     /// Uses the upstream cumulative validation (`DelaunayTriangulation::validate`) which
-    /// checks neighbor pointer consistency, Euler characteristic, coherent orientation
-    /// (Levels 1–3) and the Delaunay in-sphere property (Level 4).
+    /// checks structural and topological validity (Levels 1–3), straight-line
+    /// embedding validity (Level 4), and the Delaunay empty-circumsphere property
+    /// (Level 5).
     ///
     /// # Examples
     ///
@@ -777,7 +774,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///         ([0.5, 1.0], 1),
     ///     ])
     ///     .map_err(|err| DelaunayError::ValidationFailed {
-    ///         level: DelaunayValidationLevel::Four,
+    ///         level: DelaunayValidationLevel::Five,
     ///         detail: err.to_string(),
     ///     })?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt)?;
@@ -793,14 +790,14 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     /// Validates the triangulation with the upstream full Delaunay validator.
     ///
     /// This delegates to [`DelaunayTriangulation::validate`], which performs
-    /// the cumulative Level 1-4 checks: neighbor pointer consistency, Euler
-    /// characteristic, coherent orientation, and the Delaunay in-sphere
+    /// the cumulative Level 1-5 checks: structural and topological validity,
+    /// straight-line embedding validity, and the Delaunay empty-circumsphere
     /// predicate.
     ///
     /// # Errors
     ///
     /// Returns [`DelaunayError::ValidationFailed`] with the upstream diagnostic
-    /// when any Level 1-4 validation check fails.
+    /// when any Level 1-5 validation check fails.
     ///
     /// # Examples
     ///
@@ -814,7 +811,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///         ([0.5, 1.0], 1),
     ///     ])
     ///     .map_err(|err| DelaunayError::ValidationFailed {
-    ///         level: DelaunayValidationLevel::Four,
+    ///         level: DelaunayValidationLevel::Five,
     ///         detail: err.to_string(),
     ///     })?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt)?;
@@ -826,6 +823,49 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
         self.dt
             .validate()
             .map_err(|err| DelaunayError::ValidationFailed {
+                level: DelaunayValidationLevel::Five,
+                detail: err.to_string(),
+            })
+    }
+
+    /// Validates the straight-line embedding without requiring Delaunay-ness.
+    ///
+    /// This delegates to the upstream cumulative Level 1-4 realization validator.
+    /// It checks structural and topological validity, rejects degenerate maximal
+    /// simplices, and rejects intersections outside shared faces. It deliberately
+    /// omits the Level 5 empty-circumsphere predicate so evolved CDT states can be
+    /// geometrically safe without remaining Delaunay.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DelaunayError::ValidationFailed`] with the upstream diagnostic
+    /// when any Level 1-4 embedding validation check fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::geometry::*;
+    ///
+    /// fn main() -> Result<(), DelaunayError> {
+    ///     let dt = build_delaunay2_with_data(&[
+    ///         ([0.0, 0.0], 0_u32),
+    ///         ([1.0, 0.0], 0),
+    ///         ([0.5, 1.0], 1),
+    ///     ])
+    ///     .map_err(|err| DelaunayError::ValidationFailed {
+    ///         level: DelaunayValidationLevel::Five,
+    ///         detail: err.to_string(),
+    ///     })?;
+    ///     let backend = DelaunayBackend2D::from_triangulation(dt)?;
+    ///     backend.validate_embedding()?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn validate_embedding(&self) -> Result<(), DelaunayError> {
+        self.dt
+            .as_triangulation()
+            .validate_realization()
+            .map_err(|err| DelaunayError::ValidationFailed {
                 level: DelaunayValidationLevel::Four,
                 detail: err.to_string(),
             })
@@ -835,11 +875,9 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///
     /// This delegates to the upstream triangulation validator, which performs
     /// cumulative Level 1-3 TDS, topology, and manifold checks without
-    /// requiring the Level 4 empty-circumsphere predicate. CDT layers its own
-    /// topology, foliation, causality, and classification checks above this
-    /// structural backend check for evolved states, because ergodic CDT moves
-    /// are not expected to preserve Delaunay-ness. Use
-    /// [`Self::validate_delaunay`] for initialization-grade Level 1-4
+    /// requiring Level 4 embedding validity or the Level 5 empty-circumsphere
+    /// predicate. Use [`Self::validate_embedding`] for evolved-state geometric
+    /// safety and [`Self::validate_delaunay`] for initialization-grade Level 1-5
     /// validation.
     ///
     /// # Errors
@@ -861,7 +899,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -902,7 +940,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///     ])?;
     ///     let mut backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -948,7 +986,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -1017,7 +1055,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -1057,7 +1095,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///     ])?;
     ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -1105,7 +1143,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///     ])?;
     ///     let mut backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -1166,7 +1204,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
     ///     ])?;
     ///     let mut backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;
@@ -1451,8 +1489,8 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationQ
 
         // Use structural/topological validation via the
         // Triangulation layer (neighbor pointers, Euler characteristic, coherent
-        // orientation) WITHOUT the Level 4 Delaunay property check.
-        // Use is_delaunay() for the full Levels 1–4 check.
+        // orientation) without Level 4 embedding or Level 5 Delaunay checks.
+        // Use validate_embedding() for Levels 1–4 and is_delaunay() for Levels 1–5.
         self.dt.as_triangulation().validate().is_ok()
     }
 }
@@ -1479,7 +1517,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
             }
         };
         self.rebuild_interior_facet_index();
-        self.validate_mutation_or_restore(
+        self.validate_embedding_or_restore(
             dt_before,
             facets_before,
             DelaunayOperation::InsertVertex,
@@ -1523,16 +1561,14 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
             }
         }
         self.rebuild_interior_facet_index();
-        self.validate_mutation_or_restore(
-            dt_before,
-            facets_before,
-            if inverse_k1 {
-                DelaunayOperation::FlipK1Remove
-            } else {
-                DelaunayOperation::RemoveVertex
-            },
-            format!("vertex {:?}", vertex.key),
-        )?;
+        if !inverse_k1 {
+            self.validate_embedding_or_restore(
+                dt_before,
+                facets_before,
+                DelaunayOperation::RemoveVertex,
+                format!("vertex {:?}", vertex.key),
+            )?;
+        }
         Ok(())
     }
 
@@ -1612,15 +1648,10 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
                 actual: format!("{actual} inserted-face vertices including unexpected {extra:?}"),
             });
         }
-        let (replacement_edge, (dt_before, facets_before)) =
+        let replacement_edge =
             self.replacement_edge_key_or_restore(v0, v1, dt_before, facets_before)?;
         self.rebuild_interior_facet_index();
-        self.validate_mutation_or_restore(
-            dt_before,
-            facets_before,
-            DelaunayOperation::FlipK2,
-            format!("edge {:?} -- {:?}", edge.key.v0(), edge.key.v1()),
-        )?;
+        // `flip_k2` commits only after upstream cumulative realization validation.
         let affected_faces = info
             .new_simplices
             .iter()
@@ -1683,12 +1714,7 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
             });
         }
         self.rebuild_interior_facet_index();
-        self.validate_mutation_or_restore(
-            dt_before,
-            facets_before,
-            DelaunayOperation::FlipK1Insert,
-            format!("face {:?} at point {:?}", face.key, point),
-        )?;
+        // `flip_k1_insert` commits only after upstream cumulative realization validation.
         Ok(SubdivisionResult::new(
             DelaunayVertexHandle { key: new_vertex },
             info.new_simplices
@@ -1716,12 +1742,14 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CdtTriangulation;
     use crate::geometry::DelaunayBackend2D;
     use crate::geometry::generators::{
         DelaunayTriangulation2D, build_delaunay2_from_simplices, build_delaunay2_with_data,
         generate_delaunay2, random_delaunay2, seeded_delaunay2,
     };
     use delaunay::DelaunayRepairPolicy;
+    use delaunay::prelude::construction::{ConstructionOptions, DelaunayTriangulationBuilder};
     use serde_json::{Value, error::Category};
     use slotmap::KeyData;
     use std::assert_matches;
@@ -1731,6 +1759,31 @@ mod tests {
     fn validated_backend(dt: DelaunayTriangulation2D) -> DelaunayBackend2D {
         DelaunayBackend2D::from_triangulation(dt)
             .expect("test Delaunay triangulation should validate")
+    }
+
+    /// Builds an embedding-valid explicit quad whose chosen diagonal is not Delaunay.
+    fn embedded_non_delaunay_backend() -> DelaunayBackend2D {
+        let vertices = [
+            Vertex::try_new_with_data([0.0, 0.0], 0_u32).expect("valid vertex"),
+            Vertex::try_new_with_data([4.0, 0.0], 0).expect("valid vertex"),
+            Vertex::try_new_with_data([4.0, 2.0], 1).expect("valid vertex"),
+            Vertex::try_new_with_data([1.0, 2.0], 1).expect("valid vertex"),
+        ];
+        let simplices = vec![vec![0, 1, 2], vec![0, 2, 3]];
+        let dt =
+            DelaunayTriangulationBuilder::try_from_vertices_and_simplices(&vertices, &simplices)
+                .expect("valid explicit simplex indices")
+                .simplex_data_type::<i32>()
+                .construction_options(
+                    ConstructionOptions::default().without_final_delaunay_enforcement(),
+                )
+                .build()
+                .expect("non-Delaunay quad should pass Levels 1-4 embedding validation");
+        let interior_facets_by_edge = DelaunayBackend2D::build_interior_facets_by_edge(&dt);
+        DelaunayBackend {
+            dt,
+            interior_facets_by_edge,
+        }
     }
 
     /// `serde_json` wraps custom visitor failures as data errors; assert that
@@ -2027,18 +2080,44 @@ mod tests {
 
     #[test]
     fn test_is_valid_and_is_delaunay_consistency() {
-        // is_delaunay (Levels 1–4) implies is_valid (Levels 1–3)
+        // is_delaunay (Levels 1–5) implies embedding validity (Levels 1–4)
+        // and structural validity (Levels 1–3).
         let dt = random_delaunay2(5, (0.0, 10.0));
         let backend = validated_backend(dt);
 
         assert!(backend.is_valid(), "Triangulation should be valid");
         backend
             .validate_delaunay()
-            .expect("full upstream Level 1-4 validation should pass");
+            .expect("full upstream Level 1-5 validation should pass");
         assert!(
             backend.is_delaunay(),
             "Valid Delaunay triangulation should pass is_delaunay"
         );
+    }
+
+    #[test]
+    fn embedding_validation_accepts_non_delaunay_straight_line_realization() {
+        let backend = embedded_non_delaunay_backend();
+
+        backend
+            .validate_structural()
+            .expect("explicit quad should pass Levels 1-3 structural validation");
+        backend
+            .validate_embedding()
+            .expect("explicit quad should pass Level 4 embedding validation");
+        assert_matches!(
+            backend.validate_delaunay(),
+            Err(DelaunayError::ValidationFailed {
+                level: DelaunayValidationLevel::Five,
+                ..
+            })
+        );
+
+        let triangulation = CdtTriangulation::try_new(backend, 2, 2)
+            .expect("embedding-valid quad should enter unfoliated CDT state");
+        triangulation
+            .validate()
+            .expect("evolved CDT validation should not require Level 5 Delaunay-ness");
     }
 
     #[test]
@@ -2591,8 +2670,8 @@ mod tests {
 
     #[test]
     fn test_is_valid_runs_structural_validation() {
-        // is_valid() runs Levels 1–3 (structural/topological) via as_triangulation().validate();
-        // is_delaunay() runs Levels 1–4 (including the Delaunay property).
+        // is_valid() runs Levels 1–3, validate_embedding() runs Levels 1–4,
+        // and is_delaunay() runs Levels 1–5.
         // For a well-formed Delaunay triangulation both should pass.
         let dt = seeded_delaunay2(8, (0.0, 10.0), 99);
         let backend = validated_backend(dt);
@@ -2605,7 +2684,7 @@ mod tests {
             delaunay,
             "Seeded triangulation should satisfy Delaunay property"
         );
-        // is_delaunay() (Levels 1–4) implies is_valid() (Levels 1–3)
+        // is_delaunay() (Levels 1–5) implies is_valid() (Levels 1–3)
         assert!(delaunay && valid, "is_delaunay() should imply is_valid()");
     }
 

--- a/src/geometry/generators.rs
+++ b/src/geometry/generators.rs
@@ -466,7 +466,7 @@ pub fn build_toroidal_delaunay2(
 ///
 /// This uses the upstream periodic image-point constructor rather than explicit
 /// simplex assembly. The builder requests [`TopologyGuarantee::PLManifold`], so
-/// the resulting toroidal mesh is suitable for the full Delaunay Level 1-4
+/// the resulting toroidal mesh is suitable for the full Delaunay Level 1-5
 /// validation path exposed by
 /// [`DelaunayBackend::validate_delaunay`](crate::geometry::backends::delaunay::DelaunayBackend::validate_delaunay).
 ///
@@ -482,7 +482,7 @@ pub fn build_toroidal_delaunay2(
 ///
 /// Build the minimal 3 × 3 periodic toroidal lattice used by
 /// [`CdtTriangulation::from_toroidal_cdt`](crate::CdtTriangulation::from_toroidal_cdt)
-/// and validate it with the upstream Level 1-4 checks:
+/// and validate it with the upstream Level 1-5 checks:
 ///
 /// ```
 /// use causal_triangulations::{CdtError, CdtResult, DelaunayValidationLevel};
@@ -513,12 +513,12 @@ pub fn build_toroidal_delaunay2(
 ///
 ///     let backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
 ///         CdtError::DelaunayValidationFailed {
-///             level: DelaunayValidationLevel::Four,
+///             level: DelaunayValidationLevel::Five,
 ///             detail: err.to_string(),
 ///         }
 ///     })?;
 ///     backend.validate_delaunay().map_err(|err| CdtError::DelaunayValidationFailed {
-///         level: DelaunayValidationLevel::Four,
+///         level: DelaunayValidationLevel::Five,
 ///         detail: err.to_string(),
 ///     })?;
 ///     Ok(())
@@ -677,6 +677,75 @@ mod tests {
     }
 
     #[test]
+    fn explicit_non_overlapping_faces_pass_embedding_validation() {
+        let vertices = [
+            ([0.0, 0.0], 0_u32),
+            ([1.0, 0.0], 0),
+            ([0.0, 1.0], 1),
+            ([1.0, 1.0], 1),
+        ];
+        let simplices = vec![vec![0, 1, 2], vec![1, 3, 2]];
+
+        let dt = build_delaunay2_from_simplices(&vertices, &simplices)
+            .expect("non-overlapping explicit faces should build");
+
+        dt.as_triangulation()
+            .validate_realization()
+            .expect("non-overlapping explicit faces should pass Levels 1-4");
+    }
+
+    #[test]
+    fn explicit_crossing_edges_fail_embedding_validation() {
+        let vertices = [
+            ([1.850_341_970_997_476_4, 3.808_736_162_215_642_4], 0_u32),
+            ([-1.705_108_018_057_679, 3.541_228_835_829_82], 0),
+            ([-1.151_312_061_387_885_3, 0.227_299_663_756_810_77], 0),
+            ([0.478_746_443_632_698_25, 2.055_189_799_064_582], 0),
+            ([-1.383_321_070_900_029, -1.797_028_018_114_396_3], 0),
+            ([3.030_089_610_961_752_6, 2.181_406_554_808_236_6], 0),
+        ];
+        let simplices = vec![
+            vec![0, 2, 3],
+            vec![5, 3, 2],
+            vec![4, 3, 1],
+            vec![3, 4, 0],
+            vec![3, 5, 1],
+        ];
+
+        let error = build_delaunay2_from_simplices(&vertices, &simplices)
+            .expect_err("crossing non-adjacent edges must fail embedding validation");
+        let CdtError::DelaunayGenerationFailed {
+            underlying_error, ..
+        } = error
+        else {
+            panic!("expected a Delaunay generation failure");
+        };
+        assert!(
+            underlying_error.contains("intersect outside their shared face"),
+            "unexpected crossing-edge diagnostic: {underlying_error}"
+        );
+    }
+
+    #[test]
+    fn explicit_degenerate_triangle_fails_embedding_validation() {
+        let vertices = [([0.0, 0.0], 0_u32), ([1.0, 0.0], 0), ([2.0, 0.0], 1)];
+        let simplices = vec![vec![0, 1, 2]];
+
+        let error = build_delaunay2_from_simplices(&vertices, &simplices)
+            .expect_err("collinear triangle must fail embedding validation");
+        let CdtError::DelaunayGenerationFailed {
+            underlying_error, ..
+        } = error
+        else {
+            panic!("expected a Delaunay generation failure");
+        };
+        assert!(
+            underlying_error.to_ascii_lowercase().contains("degenerate"),
+            "unexpected degenerate-triangle diagnostic: {underlying_error}"
+        );
+    }
+
+    #[test]
     fn test_build_delaunay2_from_simplices_rejects_bad_index() {
         // Simplex references vertex 3 which doesn't exist (only indices 0..3 are valid).
         let vertices = [([0.0, 0.0], 0u32), ([1.0, 0.0], 0), ([0.5, 1.0], 1)];
@@ -750,7 +819,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_periodic_toroidal_delaunay2_3x3_validates_level_1_to_4() {
+    fn test_build_periodic_toroidal_delaunay2_3x3_validates_level_1_to_5() {
         const N: usize = 3;
         const T: usize = 3;
         const DOMAIN: [f64; 2] = [3.0, 3.0];
@@ -782,7 +851,7 @@ mod tests {
             .expect("periodic toroidal mesh should validate");
         backend
             .validate_delaunay()
-            .expect("periodic toroidal mesh must pass upstream Level 1-4 validation");
+            .expect("periodic toroidal mesh must pass upstream Level 1-5 validation");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,7 +497,7 @@ pub mod prelude {
     ///
     ///     let mut backend = DelaunayBackend2D::from_triangulation(dt).map_err(|err| {
     ///         CdtError::DelaunayValidationFailed {
-    ///             level: DelaunayValidationLevel::Four,
+    ///             level: DelaunayValidationLevel::Five,
     ///             detail: err.to_string(),
     ///         }
     ///     })?;

--- a/tests/proptest_foliation.rs
+++ b/tests/proptest_foliation.rs
@@ -70,7 +70,7 @@ fn cdt_strip_builds_delaunay_mesh() {
     assert_eq!(tri.face_count(), 16);
     tri.geometry()
         .validate_delaunay()
-        .expect("Delaunay CDT strip should pass upstream Level 1-4 validation");
+        .expect("Delaunay CDT strip should pass upstream Level 1-5 validation");
     tri.validate_topology()
         .expect("Delaunay CDT strip topology should validate");
     tri.validate_foliation()
@@ -145,7 +145,7 @@ proptest! {
         let expected_slice_sizes = vec![vertices_per_slice as usize; num_slices as usize];
         prop_assert_eq!(tri.slice_sizes(), expected_slice_sizes.as_slice());
         prop_assert!(tri.geometry().validate_delaunay().is_ok(),
-            "toroidal CDT must pass upstream Level 1-4 Delaunay validation");
+            "toroidal CDT must pass upstream Level 1-5 Delaunay validation");
         prop_assert!(tri.validate_topology().is_ok());
         prop_assert!(tri.validate_foliation().is_ok());
         prop_assert!(tri.validate_causality().is_ok());
@@ -178,7 +178,7 @@ proptest! {
         // Must have foliation
         prop_assert!(tri.has_foliation(), "CDT strip must have foliation");
         prop_assert!(tri.geometry().validate_delaunay().is_ok(),
-            "CDT strip must pass upstream Level 1-4 Delaunay validation");
+            "CDT strip must pass upstream Level 1-5 Delaunay validation");
 
         // Every slice has the right count
         let sizes = tri.slice_sizes();


### PR DESCRIPTION
- Separate Level 1-4 embedding checks from Level 1-5 Delaunay validation.
- Reject overlapping or degenerate evolved geometries without requiring Delaunay-ness.
- Preserve recoverable proposal rejections while avoiding duplicate whole-mesh validation.

Closes #195