### PR TITLE
feat(cdt)!: add lifecycle validation profiles (#196)

### DIFF
--- a/benches/cdt_benchmarks.rs
+++ b/benches/cdt_benchmarks.rs
@@ -416,16 +416,16 @@ fn bench_cache_operations(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmark triangulation validation
+/// Benchmark embedding validation for an unfoliated geometry fixture.
 fn bench_validation(c: &mut Criterion) {
     let triangulation = CdtTriangulation2D::from_random_points(30, 1, 2)
         .or_abort(SetupOperation::CreateTriangulation);
 
     let mut group = c.benchmark_group("validation");
 
-    group.bench_function("validate", |b| {
+    group.bench_function("validate_embedding", |b| {
         b.iter(|| {
-            let result = triangulation.validate();
+            let result = triangulation.geometry().validate_embedding();
             black_box(result)
         });
     });

--- a/docs/code-organization.md
+++ b/docs/code-organization.md
@@ -257,8 +257,10 @@ through to upstream `delaunay::` APIs directly.
   periodic time
 - `assign_foliation_by_y(num_slices)` — bin existing vertices into time slices
 - Query methods: `time_label`, `edge_type`, `vertices_at_time`, `slice_sizes`, `has_foliation`, `strict_causal_simplex_violation_count`
-- Validation: constructors require upstream Level 1–5 Delaunay validation for initial meshes; `validate()` is the post-move/final-state contract and requires
-  upstream Level 1–4 embedding validity plus CDT topology, foliation, causality, and strict Up/Down simplex classification
+- Validation: `CdtValidationProfile` names initial-Delaunay, evolved, and optional strict-Delaunay contracts. Constructors require Level 1–5 for initial
+  meshes; `validate()` selects the evolved profile with Level 1–4 embedding validity plus CDT topology, foliation, causality, and strict Up/Down simplex
+  classification; `validate_with_profile()` exposes explicit lifecycle and strict-mode selection. Named profiles reject missing foliation rather than
+  treating the mandatory causal checks as vacuously successful; raw unfoliated geometry experiments use a separate internal geometry/topology contract.
 - Mutable backend access is not exposed. CDT code mutates Delaunay state only through narrow crate-internal operations (`flip_edge`, `subdivide_face`,
   `remove_vertex`, `set_vertex_data`) that invalidate cached counts and foliation synchronization bookkeeping on success.
 
@@ -269,7 +271,7 @@ The implementation lives under `src/cdt/triangulation/` and is wired from `src/l
 - `moves.rs` — narrow crate-internal Delaunay mutation hooks used by ergodic moves
 - `state.rs` — module entry point, `CdtTriangulation`, `CdtMetadata`, `SimulationEvent`, serialization, cached geometry accessors, and backend-agnostic
   state methods
-- `validation.rs` — full CDT validation and Delaunay-backed causality checks
+- `validation.rs` — named CDT validation profiles, whole-state validation, and Delaunay-backed causality checks
 
 ### `config.rs` — `CdtTopology` enum
 

--- a/docs/foliation.md
+++ b/docs/foliation.md
@@ -84,16 +84,21 @@ The upstream validation hierarchy separates the properties needed by CDT evoluti
   straight-line-embedding property needed to rule out folded or overlapping geometry.
 - **Level 5 — Delaunay**: the realized triangulation also satisfies the empty-circumsphere predicate.
 
-Initial CDT constructors are therefore stricter than post-move validation:
+[`CdtValidationProfile`](../src/cdt/triangulation/validation.rs) names the three lifecycle contracts:
 
-- **Initialization**: regular `from_cdt_strip()`, profiled `from_cdt_strip_profile()`, regular `from_toroidal_cdt()`, and
-  `from_toroidal_cdt_profile()` must pass upstream Level 1-5 validation before returning. This certifies those starting meshes as valid embedded
-  PL-manifold Delaunay triangulations.
-- **After ergodic moves / simulation completion**: `CdtTriangulation::validate()` requires upstream Level 1-4 embedding validity plus CDT topology,
-  foliation, causality, and simplex-classification invariants. It intentionally omits Level 5 because the CDT move kernels are not expected to preserve the
-  Delaunay empty-circumsphere predicate.
+- `InitialDelaunay` requires Levels 1-5, including embedding and Delaunay-ness, plus topology, foliation, causality, and strict simplex classification. It is
+  the constructor profile before evolution.
+- `Evolved` requires the Levels 1-4 embedded/non-overlapping realization plus the same CDT-domain predicates. It is the profile for move finalization,
+  checkpoints, results, and ordinary public validation.
+- `StrictDelaunay` adds Level 5 to the evolved contract for optional diagnostics or workflows that intentionally restrict evolved states to Delaunay
+  triangulations.
 
-Call `triangulation.geometry().validate_delaunay()` when a workflow needs the optional stricter Level 1-5 check on an evolved state.
+`CdtTriangulation::validate()` is shorthand for `validate_with_profile(CdtValidationProfile::Evolved)`. Initial constructors use `InitialDelaunay`, and callers
+can opt into the stronger `StrictDelaunay` profile without making Level 5 part of the normal evolved-state ensemble.
+
+All named CDT profiles require current foliation bookkeeping so strict causal simplex validity is actually evaluated. Raw triangulations from
+`from_random_points()` and `from_seeded_points()` remain available for geometry tests and experiments, but they are outside these named CDT profiles;
+`validate()` returns `FoliationError::MissingBookkeeping` until foliation is assigned.
 
 ## Edge Classification
 
@@ -155,11 +160,14 @@ Structural checks:
    single connected cycle
 5. For toroidal topology, timelike edges connect each slice to both neighboring time slices modulo `T`
 
-Ergodic moves resynchronize foliation bookkeeping from live vertex labels after mutation. On toroidal triangulations, the move kernel immediately reruns
-`validate_topology()` and `validate_foliation()` before recording success; failures are rolled back and returned as ordinary local-site rejections. The
-upstream bistellar-edit transaction validates the affected result against the Level 1-4 realization contract before it returns success, so CDT move
-finalization does not repeat the global embedding scan. Explicit `validate()` calls, configured cadence checks, and final result construction still recheck the
-whole evolved-state contract.
+Foliated ergodic moves resynchronize foliation bookkeeping from live vertex labels after mutation, then finalize through the `Evolved` profile. The upstream
+bistellar-edit transaction validates the affected result against the Level 1-4 realization contract before it returns success, so move finalization carries
+that internal embedding evidence into the profile instead of repeating the same global scan. It still checks topology, foliation, causality, and strict simplex
+classification before recording success; failures are rolled back. Explicit `validate()` calls, configured cadence checks, and final result construction have
+no mutation-boundary evidence, so they run the complete `Evolved` profile and recheck the whole embedding.
+
+Unfoliated geometry experiments use a separate internal geometry/topology contract for mutation, checkpoint, and result integrity. That compatibility path is
+not a CDT validation profile and makes no causal-validity claim.
 
 ### `validate_causality_delaunay()`
 

--- a/docs/moves.md
+++ b/docs/moves.md
@@ -63,8 +63,10 @@ Owns a `MoveStatistics` instance and a thread-local RNG. Public API:
 - `attempt_random_move(&mut CdtTriangulation2D) -> MoveResult` — delegates to one of the above
 
 Accepted moves mutate the triangulation through narrow CDT-owned edit operations, then rebuild CDT foliation bookkeeping from live vertex labels and refresh
-simplex classifications. On toroidal triangulations, move finalization also rechecks χ = 0 and the closed-S¹ per-slice foliation invariant before recording
-success. The raw mutable backend is not exposed as part of the CDT API.
+simplex classifications. Foliated move finalization uses the evolved CDT validation profile, carrying forward the backend transaction's successful embedding
+check while rechecking CDT-domain invariants. On toroidal triangulations, it also rechecks χ = 0 and the closed-S¹ per-slice foliation invariant before
+recording success. Unfoliated geometry experiments retain a separate geometry/topology-only finalization contract and do not claim CDT causal validity. The raw
+mutable backend is not exposed as part of the CDT API.
 
 ## Architecture
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,6 +20,9 @@ Completed foundation work:
 - [x] Real 2D local CDT move kernels over checked Delaunay edit operations, with rollback or rejection on invariant failures.
 - [x] Causality-filtering Delaunay construction path inspired by CDT++ ([#192](https://github.com/acgetchell/causal-triangulations/issues/192)), with repeated
   removal of vertices incident to non-strict causal simplices until the strict violation count converges to zero.
+- [x] Upstream Level 1-4 embedded/non-overlapping validation for evolved states
+  ([#195](https://github.com/acgetchell/causal-triangulations/issues/195)), separated from optional Level 5 Delaunay validation and mandatory strict causal
+  profiles ([#196](https://github.com/acgetchell/causal-triangulations/issues/196)).
 - [x] Planned-proposal Metropolis execution through `markov-chain-monte-carlo`, including proposal-site weighting and resumable chunked sweeps.
 - [x] CLI support, trace/summary exports, checkpoints, and core observables for downstream analysis.
 - [x] Repository validation loop covering Rust, Python support scripts, Semgrep rules, documentation, notebooks, examples, and benchmarks.
@@ -33,8 +36,6 @@ Likely follow-up work before broadening the dimensional surface:
 - Broaden per-kernel toroidal tests around spatial and temporal wrap-around simplices
 - Accept fixed triangle simplices directly in explicit-simplex generator APIs to remove per-triangle `Vec` adaptation
 - Add manual foliation assignment APIs with the same validation and synchronization guarantees as constructor-assigned labels
-- Integrate upstream embedded-triangulation validation from `delaunay` once acgetchell/delaunay#449 is available, so evolved CDT states can reject overlapping
-  simplices without requiring Delaunay Level 4 ([#195](https://github.com/acgetchell/causal-triangulations/issues/195)).
 - Add tutorial-style examples for open-boundary strips, toroidal runs, observables, and interpreting Metropolis acceptance behavior
 
 ## v0.1.1 Maturity And Ensemble Controls

--- a/src/cdt/metropolis/runner.rs
+++ b/src/cdt/metropolis/runner.rs
@@ -860,7 +860,7 @@ impl MetropolisRunState {
             checkpoint.config.temperature(),
         )?;
         let triangulation = restore_checkpoint_state(checkpoint.chain, &target)?;
-        triangulation.validate_evolved_cdt()?;
+        triangulation.validate_supported_state()?;
         let actual_action = action_for(&checkpoint.action_config, &triangulation);
         if !actions_match(actual_action, stored_action) {
             return Err(checkpoint_resume_failed(
@@ -897,7 +897,7 @@ impl MetropolisRunState {
         config: MetropolisConfig,
         action_config: ActionConfig,
     ) -> CdtResult<CdtMcmcCheckpoint> {
-        self.triangulation.validate_evolved_cdt()?;
+        self.triangulation.validate_supported_state()?;
         let (accepted, rejected) = chain_counters(&self.move_stats)?;
         let current_step = NonZeroU32::new(self.current_step).ok_or_else(|| {
             checkpoint_resume_failed(CheckpointResumeFailure::StepTelemetryLengthMismatch {
@@ -1166,7 +1166,7 @@ impl AcceptedCandidate {
 
     /// Validates the staged triangulation at the configured backend cadence.
     fn validate_if_due(&self, accepted_moves: u64) -> CdtResult<()> {
-        validate_evolved_cdt_candidate_if_due(&self.triangulation, accepted_moves)
+        validate_supported_state_candidate_if_due(&self.triangulation, accepted_moves)
     }
 
     /// Splits the validated accepted candidate for commitment to run state.
@@ -1232,14 +1232,17 @@ const fn missing_planned_step_info(step: u32) -> CdtError {
     CdtError::PlannedProposalTelemetryMissing { step }
 }
 
-/// Runs the expensive full evolved-state validation only when the backend policy is due.
+/// Runs expensive full state validation only when the backend policy is due.
 #[cfg(test)]
-fn validate_evolved_cdt_if_due(state: &MetropolisRunState) -> CdtResult<()> {
-    validate_evolved_cdt_candidate_if_due(&state.triangulation, state.move_stats.total_accepted())
+fn validate_supported_state_if_due(state: &MetropolisRunState) -> CdtResult<()> {
+    validate_supported_state_candidate_if_due(
+        &state.triangulation,
+        state.move_stats.total_accepted(),
+    )
 }
 
-/// Runs expensive evolved-state validation for a staged accepted triangulation.
-fn validate_evolved_cdt_candidate_if_due(
+/// Runs expensive state-appropriate validation for a staged accepted triangulation.
+fn validate_supported_state_candidate_if_due(
     triangulation: &CdtTriangulation2D,
     accepted_moves: u64,
 ) -> CdtResult<()> {
@@ -1247,7 +1250,7 @@ fn validate_evolved_cdt_candidate_if_due(
         .geometry()
         .should_check_delaunay_after(accepted_moves)
     {
-        triangulation.validate_evolved_cdt()?;
+        triangulation.validate_supported_state()?;
     }
     Ok(())
 }
@@ -1693,7 +1696,7 @@ mod tests {
         state.move_stats.record_success(MoveType::Move22);
 
         assert!(
-            validate_evolved_cdt_if_due(&state).is_err(),
+            validate_supported_state_if_due(&state).is_err(),
             "EveryN(1) should run full validation after the first accepted move"
         );
     }
@@ -1715,7 +1718,7 @@ mod tests {
         let mut state = empty_run_state(triangulation);
         state.move_stats.record_success(MoveType::Move22);
 
-        validate_evolved_cdt_if_due(&state)
+        validate_supported_state_if_due(&state)
             .expect("EndOnly should skip cadence validation on accepted moves");
         assert!(
             state

--- a/src/cdt/results.rs
+++ b/src/cdt/results.rs
@@ -818,7 +818,7 @@ impl SimulationResultsParts {
     ) -> CdtResult<Self> {
         config.validate();
         action_config.validate();
-        triangulation.validate_evolved_cdt()?;
+        triangulation.validate_supported_state()?;
         validate_result_telemetry(
             &config,
             &move_stats,
@@ -847,7 +847,7 @@ impl TryFrom<SimulationResultsBackendWire> for SimulationResultsBackend {
     fn try_from(wire: SimulationResultsBackendWire) -> Result<Self, Self::Error> {
         wire.config.validate();
         wire.action_config.validate();
-        wire.triangulation.validate_evolved_cdt()?;
+        wire.triangulation.validate_supported_state()?;
         Self::new(
             wire.config,
             wire.action_config,

--- a/src/cdt/triangulation/state.rs
+++ b/src/cdt/triangulation/state.rs
@@ -24,6 +24,8 @@ mod foliation;
 mod moves;
 mod validation;
 
+pub use validation::CdtValidationProfile;
+
 static NEXT_TRIANGULATION_INSTANCE_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Returns a fresh process-local identity for transient triangulation caches.
@@ -574,10 +576,12 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// Validates a deserialized checkpoint before exposing restored CDT state.
     ///
     /// This keeps serde deserialization aligned with the public constructor and
-    /// post-move contracts: checkpoint data must restore to a fully valid CDT
-    /// triangulation, including geometry, topology, foliation, and causality.
+    /// post-move contracts. Foliated checkpoint data must restore to a fully
+    /// valid CDT triangulation, including geometry, topology, foliation, and
+    /// causality; explicitly unfoliated geometry experiments restore through the
+    /// separate geometry/topology contract.
     fn validate_checkpoint_invariants(&self) -> CdtResult<()> {
-        self.validate_evolved_cdt()
+        self.validate_supported_state()
     }
 }
 

--- a/src/cdt/triangulation/validation.rs
+++ b/src/cdt/triangulation/validation.rs
@@ -3,6 +3,7 @@
 //! Whole-triangulation validation and causality checks.
 
 use super::CdtTriangulation;
+use crate::cdt::foliation::FoliationError;
 use crate::errors::{
     CdtError, CdtResult, CdtValidationCheck, CdtValidationFailure, DelaunayValidationLevel,
 };
@@ -10,6 +11,44 @@ use crate::geometry::DelaunayBackend2D;
 use crate::geometry::backends::delaunay::DelaunayError;
 use crate::geometry::traits::TriangulationQuery;
 use std::num::NonZeroUsize;
+
+/// Named invariant sets for validating a CDT triangulation.
+///
+/// Every profile requires a structurally valid, nondegenerate, non-overlapping
+/// embedding together with valid CDT topology, foliation, causality, and strict
+/// simplex classification. [`Self::InitialDelaunay`] and
+/// [`Self::StrictDelaunay`] additionally require the Level 5 Delaunay
+/// empty-circumsphere predicate, while [`Self::Evolved`] intentionally does not.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::triangulation::*;
+///
+/// fn main() -> CdtResult<()> {
+///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
+///     tri.validate_with_profile(CdtValidationProfile::InitialDelaunay)?;
+///     tri.validate_with_profile(CdtValidationProfile::Evolved)?;
+///     Ok(())
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CdtValidationProfile {
+    /// Initial Delaunay-backed CDT state before Monte Carlo evolution.
+    InitialDelaunay,
+    /// Evolved CDT state, which need not remain Delaunay.
+    Evolved,
+    /// Optional strict validation requiring an evolved state to remain Delaunay.
+    StrictDelaunay,
+}
+
+/// Records whether the current embedding was checked at the backend mutation boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EmbeddingValidationState {
+    Required,
+    AlreadyValidated,
+}
 
 impl CdtTriangulation<DelaunayBackend2D> {
     /// Validate post-construction CDT properties.
@@ -26,10 +65,12 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// # Errors
     ///
     /// Returns [`CdtError::DelaunayValidationFailed`] if the backend fails
-    /// upstream Level 1-4 embedding validation. Returns
-    /// [`CdtError::ValidationFailed`] if causality or simplex-classification checks
-    /// fail, and returns topology or foliation errors from the corresponding
-    /// validators when those invariants are violated.
+    /// upstream Level 1-4 embedding validation. Returns [`CdtError::Foliation`]
+    /// with [`FoliationError::MissingBookkeeping`] when no foliation is present,
+    /// returns [`CdtError::ValidationFailed`] if causality or
+    /// simplex-classification checks fail, and returns topology or foliation
+    /// errors from the corresponding validators when those invariants are
+    /// violated.
     ///
     /// # Examples
     ///
@@ -37,13 +78,45 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// use causal_triangulations::prelude::triangulation::*;
     ///
     /// fn main() -> CdtResult<()> {
-    ///     let tri = CdtTriangulation::from_seeded_points(5, 2, 2, 53)?;
+    ///     let tri = CdtTriangulation::from_cdt_strip(4, 3)?;
     ///     tri.validate()?;
     ///     Ok(())
     /// }
     /// ```
     pub fn validate(&self) -> CdtResult<()> {
-        self.validate_evolved_cdt()
+        self.validate_with_profile(CdtValidationProfile::Evolved)
+    }
+
+    /// Validates this triangulation against a named CDT invariant profile.
+    ///
+    /// The evolved profile requires straight-line embedding validity and all
+    /// CDT-domain invariants without requiring the Delaunay empty-circumsphere
+    /// predicate. The initial and strict-Delaunay profiles add that predicate.
+    /// In every profile, embedding and strict causal simplex validity are
+    /// independent mandatory checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtError::DelaunayValidationFailed`] when the selected geometry
+    /// predicate fails. Returns [`CdtError::Foliation`] with
+    /// [`FoliationError::MissingBookkeeping`] when no foliation is present,
+    /// returns [`CdtError::ValidationFailed`] for causality or strict
+    /// simplex-classification failures, and propagates topology or foliation
+    /// errors from their corresponding validators.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::triangulation::*;
+    ///
+    /// fn main() -> CdtResult<()> {
+    ///     let tri = CdtTriangulation::from_toroidal_cdt(4, 3)?;
+    ///     tri.validate_with_profile(CdtValidationProfile::StrictDelaunay)?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn validate_with_profile(&self, profile: CdtValidationProfile) -> CdtResult<()> {
+        self.validate_profile(profile, EmbeddingValidationState::Required)
     }
 
     /// Configures how often simulation runs perform full evolved-state validation.
@@ -69,19 +142,99 @@ impl CdtTriangulation<DelaunayBackend2D> {
 
     /// Validates the post-move/final CDT invariant contract.
     pub(crate) fn validate_evolved_cdt(&self) -> CdtResult<()> {
-        self.geometry
-            .validate_embedding()
-            .map_err(|err| CdtError::DelaunayValidationFailed {
-                level: DelaunayValidationLevel::Four,
-                detail: format!(
-                    "{}; triangulation counts: V={}, E={}, F={}",
-                    validation_detail(err),
-                    self.geometry.vertex_count(),
-                    self.geometry.edge_count(),
-                    self.geometry.face_count(),
-                ),
-            })?;
+        self.validate_with_profile(CdtValidationProfile::Evolved)
+    }
+
+    /// Validates either a foliated CDT state or an explicitly unfoliated geometry state.
+    ///
+    /// Raw point-cloud constructors are retained for geometry tests and experiments,
+    /// but they are not valid inputs to a named CDT profile because causality cannot
+    /// be evaluated without foliation bookkeeping.
+    pub(crate) fn validate_supported_state(&self) -> CdtResult<()> {
+        if self.foliation.is_none() {
+            return self.validate_unfoliated_geometry(EmbeddingValidationState::Required);
+        }
+        self.validate_evolved_cdt()
+    }
+
+    /// Completes evolved-state validation from the backend embedding result.
+    #[cfg(test)]
+    fn validate_evolved_cdt_after_embedding(
+        &self,
+        embedding_validation: Result<(), DelaunayError>,
+    ) -> CdtResult<()> {
+        self.validate_embedding_result(embedding_validation)?;
         self.validate_evolved_cdt_domain()
+    }
+
+    /// Applies the selected profile with explicit backend embedding evidence.
+    fn validate_profile(
+        &self,
+        profile: CdtValidationProfile,
+        embedding_state: EmbeddingValidationState,
+    ) -> CdtResult<()> {
+        self.require_profile_foliation()?;
+        self.validate_geometry_for_profile(profile, embedding_state)?;
+        self.validate_evolved_cdt_domain()
+    }
+
+    /// Rejects named CDT profiles when their causal invariant cannot be evaluated.
+    fn require_profile_foliation(&self) -> CdtResult<()> {
+        if self.foliation.is_none() {
+            return Err(FoliationError::MissingBookkeeping.into());
+        }
+        Ok(())
+    }
+
+    /// Validates the geometry and topology contract for raw unfoliated experiments.
+    fn validate_unfoliated_geometry(
+        &self,
+        embedding_state: EmbeddingValidationState,
+    ) -> CdtResult<()> {
+        debug_assert!(self.foliation.is_none());
+        self.validate_geometry_for_profile(CdtValidationProfile::Evolved, embedding_state)?;
+        self.validate_topology()
+    }
+
+    /// Validates the geometry predicate selected by the CDT profile.
+    fn validate_geometry_for_profile(
+        &self,
+        profile: CdtValidationProfile,
+        embedding_state: EmbeddingValidationState,
+    ) -> CdtResult<()> {
+        match profile {
+            CdtValidationProfile::Evolved => {
+                if embedding_state == EmbeddingValidationState::Required {
+                    self.validate_embedding_result(self.geometry.validate_embedding())?;
+                }
+            }
+            CdtValidationProfile::InitialDelaunay | CdtValidationProfile::StrictDelaunay => {
+                self.geometry.validate_delaunay().map_err(|err| {
+                    CdtError::DelaunayValidationFailed {
+                        level: DelaunayValidationLevel::Five,
+                        detail: validation_detail(err),
+                    }
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Maps backend embedding diagnostics into the public CDT error contract.
+    fn validate_embedding_result(
+        &self,
+        embedding_validation: Result<(), DelaunayError>,
+    ) -> CdtResult<()> {
+        embedding_validation.map_err(|err| CdtError::DelaunayValidationFailed {
+            level: DelaunayValidationLevel::Four,
+            detail: format!(
+                "{}; triangulation counts: V={}, E={}, F={}",
+                validation_detail(err),
+                self.geometry.vertex_count(),
+                self.geometry.edge_count(),
+                self.geometry.face_count(),
+            ),
+        })
     }
 
     /// Validates CDT-owned invariants after a realized backend mutation succeeds.
@@ -91,13 +244,22 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// the global Level 4 scan here would make every proposal pay for the same
     /// whole-mesh predicate twice, so move finalization checks only the
     /// CDT-owned topology, foliation, causality, and simplex-classification
-    /// contract.
+    /// contract. A foliated move still enters the evolved profile with explicit
+    /// evidence that its embedding predicate has already passed. Raw unfoliated
+    /// geometry experiments instead retain their geometry/topology-only contract.
     pub(crate) fn validate_after_realized_mutation(&self) -> CdtResult<()> {
-        self.validate_evolved_cdt_domain()
+        if self.foliation.is_none() {
+            return self.validate_unfoliated_geometry(EmbeddingValidationState::AlreadyValidated);
+        }
+        self.validate_profile(
+            CdtValidationProfile::Evolved,
+            EmbeddingValidationState::AlreadyValidated,
+        )
     }
 
     /// Validates invariants owned by the CDT domain layer.
     fn validate_evolved_cdt_domain(&self) -> CdtResult<()> {
+        self.require_profile_foliation()?;
         self.validate_topology()?;
         self.validate_foliation()?;
         self.validate_causality()?;
@@ -112,12 +274,11 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// the stricter CDT foliation, topology, causality, and simplex-classification
     /// invariants before any simulation code can observe them.
     pub(crate) fn validate_initial_delaunay_cdt(&mut self) -> CdtResult<()> {
-        self.geometry
-            .validate_delaunay()
-            .map_err(|err| CdtError::DelaunayValidationFailed {
-                level: DelaunayValidationLevel::Five,
-                detail: validation_detail(err),
-            })?;
+        self.require_profile_foliation()?;
+        self.validate_geometry_for_profile(
+            CdtValidationProfile::InitialDelaunay,
+            EmbeddingValidationState::Required,
+        )?;
         self.validate_topology()?;
         self.validate_foliation()?;
         self.validate_causality()?;
@@ -132,7 +293,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// # Errors
     ///
     /// Returns [`CdtError::Foliation`] with
-    /// [`FoliationError::StaleBookkeeping`](crate::cdt::foliation::FoliationError::StaleBookkeeping)
+    /// [`FoliationError::StaleBookkeeping`]
     /// when stored foliation bookkeeping is stale. Returns
     /// [`CdtError::ValidationFailed`] when face vertices or labels cannot be
     /// resolved, and returns [`CdtError::CausalityViolation`] if any edge spans
@@ -177,7 +338,7 @@ impl CdtTriangulation<DelaunayBackend2D> {
     /// # Errors
     ///
     /// Returns [`CdtError::Foliation`] with
-    /// [`FoliationError::StaleBookkeeping`](crate::cdt::foliation::FoliationError::StaleBookkeeping)
+    /// [`FoliationError::StaleBookkeeping`]
     /// when stored foliation bookkeeping is stale (`has_current_foliation()` is
     /// false). Returns [`CdtError::ValidationFailed`] when a face cannot be
     /// resolved to three vertices, any face vertex is unlabeled, or a triangle
@@ -423,13 +584,85 @@ mod tests {
     }
 
     #[test]
-    fn validate_succeeds_for_known_good_seed() {
+    fn named_profiles_reject_unfoliated_state() {
         let triangulation = CdtTriangulation::from_seeded_points(5, 2, 2, 53)
             .expect("Failed to create triangulation");
 
+        for profile in [
+            CdtValidationProfile::InitialDelaunay,
+            CdtValidationProfile::Evolved,
+            CdtValidationProfile::StrictDelaunay,
+        ] {
+            assert_matches!(
+                triangulation.validate_with_profile(profile),
+                Err(CdtError::Foliation(FoliationError::MissingBookkeeping))
+            );
+        }
+        assert_matches!(
+            triangulation.validate(),
+            Err(CdtError::Foliation(FoliationError::MissingBookkeeping))
+        );
+    }
+
+    #[test]
+    fn named_profiles_accept_initial_delaunay_state() {
+        let triangulation =
+            CdtTriangulation::from_cdt_strip(4, 3).expect("initial CDT strip should build");
+
+        for profile in [
+            CdtValidationProfile::InitialDelaunay,
+            CdtValidationProfile::Evolved,
+            CdtValidationProfile::StrictDelaunay,
+        ] {
+            triangulation
+                .validate_with_profile(profile)
+                .unwrap_or_else(|error| panic!("{profile:?} should accept initial state: {error}"));
+        }
+    }
+
+    #[test]
+    fn evolved_profile_rejects_noncausal_foliated_state() {
+        let dt = build_delaunay2_with_data(&[([0.0, 0.0], 0), ([1.0, 1.0], 1), ([0.0, 2.0], 2)])
+            .expect("noncollinear triangle should build");
+        let backend =
+            DelaunayBackend2D::from_triangulation(dt).expect("single triangle should be Delaunay");
+        let mut triangulation = CdtTriangulation::try_new(backend, 3, 2)
+            .expect("triangle should enter unfoliated geometry state");
         triangulation
-            .validate()
-            .expect("known good triangulation should validate");
+            .assign_foliation_by_y(NonZeroU32::new(3).expect("fixture has three nonempty slices"))
+            .expect("y bands should establish current foliation bookkeeping");
+
+        assert_matches!(
+            triangulation.validate_with_profile(CdtValidationProfile::Evolved),
+            Err(CdtError::CausalityViolation {
+                time_0: 0,
+                time_1: 2,
+                step_distance: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn validate_reports_embedding_failure_with_triangulation_counts() {
+        let backend = labeled_triangle_backend([0, 0, 1]);
+        let triangulation = CdtTriangulation::try_new(backend, 2, 2)
+            .expect("triangle should enter unfoliated CDT state");
+
+        let error = triangulation
+            .validate_evolved_cdt_after_embedding(Err(DelaunayError::ValidationFailed {
+                level: DelaunayValidationLevel::Four,
+                detail: "non-adjacent simplices intersect".to_string(),
+            }))
+            .expect_err("embedding failure should reject evolved CDT state");
+
+        assert_matches!(
+            error,
+            CdtError::DelaunayValidationFailed {
+                level: DelaunayValidationLevel::Four,
+                detail,
+            } if detail
+                == "non-adjacent simplices intersect; triangulation counts: V=3, E=3, F=1"
+        );
     }
 
     #[test]

--- a/src/geometry/backends/delaunay.rs
+++ b/src/geometry/backends/delaunay.rs
@@ -650,24 +650,33 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize>
         operation: DelaunayOperation,
         target: impl Display,
     ) -> Result<(), DelaunayError> {
-        if let Err(err) = self.validate_embedding() {
-            self.restore_mutation_snapshot(dt_before, facets_before);
-            return Err(match err {
-                DelaunayError::ValidationFailed { level, detail } => {
-                    DelaunayError::ValidationFailed {
-                        level,
-                        detail: format!(
-                            "{operation} produced invalid geometry for {target}: {detail}"
-                        ),
-                    }
-                }
-                other => DelaunayError::ValidationFailed {
-                    level: DelaunayValidationLevel::Four,
-                    detail: format!("{operation} produced invalid geometry for {target}: {other}"),
-                },
-            });
-        }
-        Ok(())
+        let validation = self.validate_embedding();
+        self.restore_if_embedding_invalid(validation, dt_before, facets_before, operation, target)
+    }
+
+    /// Completes embedding validation, restoring a rejected mutation on failure.
+    fn restore_if_embedding_invalid(
+        &mut self,
+        validation: Result<(), DelaunayError>,
+        dt_before: RawTriangulation<VertexData, SimplexData, D>,
+        facets_before: HashMap<EdgeKey, FacetHandle>,
+        operation: DelaunayOperation,
+        target: impl Display,
+    ) -> Result<(), DelaunayError> {
+        let Err(error) = validation else {
+            return Ok(());
+        };
+        self.restore_mutation_snapshot(dt_before, facets_before);
+        Err(match error {
+            DelaunayError::ValidationFailed { level, detail } => DelaunayError::ValidationFailed {
+                level,
+                detail: format!("{operation} produced invalid geometry for {target}: {detail}"),
+            },
+            other => DelaunayError::ValidationFailed {
+                level: DelaunayValidationLevel::Four,
+                detail: format!("{operation} produced invalid geometry for {target}: {other}"),
+            },
+        })
     }
 
     /// Returns whether the keyed edge is present in the triangulation.
@@ -1742,18 +1751,19 @@ impl<VertexData: DataType, SimplexData: DataType, const D: usize> TriangulationM
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::CdtTriangulation;
     use crate::geometry::DelaunayBackend2D;
     use crate::geometry::generators::{
         DelaunayTriangulation2D, build_delaunay2_from_simplices, build_delaunay2_with_data,
         generate_delaunay2, random_delaunay2, seeded_delaunay2,
     };
+    use crate::{CdtTriangulation, CdtValidationProfile};
     use delaunay::DelaunayRepairPolicy;
     use delaunay::prelude::construction::{ConstructionOptions, DelaunayTriangulationBuilder};
     use serde_json::{Value, error::Category};
     use slotmap::KeyData;
     use std::assert_matches;
     use std::collections::HashSet;
+    use std::num::NonZeroU32;
 
     /// Wraps generated test fixtures through the public checked constructor.
     fn validated_backend(dt: DelaunayTriangulation2D) -> DelaunayBackend2D {
@@ -1766,8 +1776,8 @@ mod tests {
         let vertices = [
             Vertex::try_new_with_data([0.0, 0.0], 0_u32).expect("valid vertex"),
             Vertex::try_new_with_data([4.0, 0.0], 0).expect("valid vertex"),
-            Vertex::try_new_with_data([4.0, 2.0], 1).expect("valid vertex"),
-            Vertex::try_new_with_data([1.0, 2.0], 1).expect("valid vertex"),
+            Vertex::try_new_with_data([4.0, 1.0], 1).expect("valid vertex"),
+            Vertex::try_new_with_data([1.0, 1.0], 1).expect("valid vertex"),
         ];
         let simplices = vec![vec![0, 1, 2], vec![0, 2, 3]];
         let dt =
@@ -2113,11 +2123,91 @@ mod tests {
             })
         );
 
-        let triangulation = CdtTriangulation::try_new(backend, 2, 2)
+        let mut initial_triangulation = CdtTriangulation::try_new(backend.clone(), 2, 2)
+            .expect("embedding-valid quad should enter unfoliated CDT state");
+        initial_triangulation
+            .assign_foliation_by_y(NonZeroU32::new(2).expect("fixture has two slices"))
+            .expect("quad labels should form a strict causal foliation");
+        assert_matches!(
+            initial_triangulation.validate_initial_delaunay_cdt(),
+            Err(crate::CdtError::DelaunayValidationFailed {
+                level: DelaunayValidationLevel::Five,
+                ..
+            })
+        );
+
+        let mut triangulation = CdtTriangulation::try_new(backend, 2, 2)
             .expect("embedding-valid quad should enter unfoliated CDT state");
         triangulation
+            .assign_foliation_by_y(NonZeroU32::new(2).expect("fixture has two slices"))
+            .expect("quad labels should form a strict causal foliation");
+        triangulation
             .validate()
+            .expect("default validation should use the evolved profile");
+        triangulation
+            .validate_with_profile(CdtValidationProfile::Evolved)
             .expect("evolved CDT validation should not require Level 5 Delaunay-ness");
+        assert_matches!(
+            triangulation.validate_with_profile(CdtValidationProfile::StrictDelaunay),
+            Err(crate::CdtError::DelaunayValidationFailed {
+                level: DelaunayValidationLevel::Five,
+                ..
+            })
+        );
+    }
+
+    #[test]
+    fn embedding_validation_failure_restores_mutation_snapshot() {
+        let dt = build_delaunay2_with_data(&[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.0, 1.0], 0)])
+            .expect("triangle should build");
+        let mut backend = validated_backend(dt);
+        let serialized_before = serde_json::to_value(&backend).expect("backend should serialize");
+        let dt_before = backend.dt.clone();
+        let facets_before = backend.interior_facets_by_edge.clone();
+        let expected_facets = facets_before.clone();
+        backend
+            .insert_vertex(&[0.25, 0.25])
+            .expect("inside-point insertion should commit");
+
+        backend
+            .validate_structural()
+            .expect("inside-point insertion should preserve structural validity");
+        backend
+            .validate_embedding()
+            .expect("inside-point insertion should preserve the embedding");
+        assert_ne!(
+            serde_json::to_value(&backend).expect("mutated backend should serialize"),
+            serialized_before,
+            "test setup should mutate the triangulation before injecting failure"
+        );
+
+        let error = backend
+            .restore_if_embedding_invalid(
+                Err(DelaunayError::ValidationFailed {
+                    level: DelaunayValidationLevel::Four,
+                    detail: "non-adjacent simplices intersect".to_string(),
+                }),
+                dt_before,
+                facets_before,
+                DelaunayOperation::InsertVertex,
+                "[0.25, 0.25]",
+            )
+            .expect_err("failed embedding validation should reject the mutation");
+
+        assert_matches!(
+            error,
+            DelaunayError::ValidationFailed {
+                level: DelaunayValidationLevel::Four,
+                detail,
+            } if detail.contains(
+                "insert_vertex produced invalid geometry for [0.25, 0.25]: non-adjacent simplices intersect"
+            )
+        );
+        assert_eq!(
+            serde_json::to_value(&backend).expect("restored backend should serialize"),
+            serialized_before
+        );
+        assert_eq!(backend.interior_facets_by_edge, expected_facets);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,9 @@ pub use cdt::metropolis::{
 };
 pub use cdt::observables::{estimate_hausdorff_dimension, estimate_spectral_dimension};
 pub use cdt::results::{Measurement, SimulationResultsBackend};
-pub use cdt::triangulation::{CdtMetadata, CdtSimplexCounts, CdtTriangulation, SimulationEvent};
+pub use cdt::triangulation::{
+    CdtMetadata, CdtSimplexCounts, CdtTriangulation, CdtValidationProfile, SimulationEvent,
+};
 pub use config::{
     CdtConfig, CdtConfigOverrides, CdtTopology, DimensionOverride, TestConfig, ValidatedCdtConfig,
     ValidatedInitialVolume,
@@ -366,7 +368,9 @@ pub mod prelude {
         pub use crate::errors::{CdtError, CdtResult};
         pub use crate::geometry::CdtTriangulation2D;
         pub use crate::geometry::traits::TriangulationQuery;
-        pub use crate::{CdtMetadata, CdtSimplexCounts, CdtTriangulation, SimulationEvent};
+        pub use crate::{
+            CdtMetadata, CdtSimplexCounts, CdtTriangulation, CdtValidationProfile, SimulationEvent,
+        };
     }
 
     /// Focused exports for local CDT move kernels and move statistics.


### PR DESCRIPTION
- Add initial, evolved, and strict-Delaunay profiles that separate required embedding checks from optional Delaunay validation.
- Require current foliation and strict causal simplex validation for named CDT profiles while preserving a geometry-only path for raw experiments.
- Reuse backend embedding evidence during move finalization and checkpoint creation to avoid duplicate global validation.

BREAKING CHANGE: CdtTriangulation::validate() now rejects unfoliated triangulations with CdtError::Foliation(FoliationError::MissingBookkeeping). Assign foliation before validating a CDT profile; raw geometry workflows should validate the backend embedding directly.