### PR TITLE
feat(cdt): expose borrowed proposal-policy views

### DIFF
--- a/docs/code-organization.md
+++ b/docs/code-organization.md
@@ -117,6 +117,7 @@ causal-triangulations/
 │   │   │   ├── runner.rs
 │   │   │   └── telemetry.rs
 │   │   ├── observables.rs
+│   │   ├── proposal_policy.rs
 │   │   ├── results.rs
 │   │   └── triangulation/
 │   │       ├── builders.rs
@@ -160,6 +161,7 @@ causal-triangulations/
 │   ├── integration_tests.rs
 │   ├── large_scale_debug.rs
 │   ├── physics_integration.rs
+│   ├── proposal_policy.rs
 │   ├── proptest_foliation.rs
 │   ├── proptest_metropolis.rs
 │   └── regressions.rs
@@ -306,6 +308,18 @@ See `docs/metropolis.md` for the current planned-proposal ordering and
   dimension estimates.
 - `scalar_trace()` and `write_trace_csv()` expose step diagnostics through `markov-chain-monte-carlo::Trace`, using a rectangular CSV table suitable for Polars
   and other downstream dataframe tools.
+
+### `cdt/proposal_policy.rs` — Borrowed Proposal-Policy Inspection
+
+- `CdtProposalPolicyView` borrows a validated triangulation and one synchronized family cache without exposing mutable geometry or cloning the triangulation.
+- `MoveType::REVERSIBLE_1P1`, `MoveType::identifier`, and `MoveType::reverse` define the stable family order, external identifiers, and reverse mapping.
+- `CdtProposalSiteId` is an opaque family ordinal with triangulation-instance and modification-version provenance; fresh views reject foreign, stale,
+  cross-family, and out-of-range IDs through `CdtProposalSiteIdError`.
+- Offered-site counts and deterministic ID iteration share `MoveSiteCache` and the exact visitor used by conventional sampler selection and reverse-site
+  accounting. These sites belong to the actual proposal support but are not an eligible/executable-site mask: later backend edits or CDT validation may still
+  reject an offered site as an ordinary self-loop proposal.
+- `tests/proposal_policy.rs` verifies the public boundary, including empty families, ordering, state facts, invalidation, and representative accepted toroidal
+  inverse moves.
 
 ### `cdt/observables.rs` — User-facing estimators
 

--- a/docs/metropolis.md
+++ b/docs/metropolis.md
@@ -170,6 +170,51 @@ A CDT proposal is represented by an explicit local site selected from the curren
 4. Treat ordinary local or backend rejections as self-loop proposals, not hard failures.
 5. Score successful transitions with the Metropolis-Hastings proposal ratio for the actual proposal kernel.
 
+### Borrowed Proposal-Policy View
+
+`CdtProposal::policy_view()` and `ErgodicsSystem::proposal_policy_view()` expose the canonical offered-site universe without exposing Delaunay handles or a
+mutable triangulation. Each `CdtProposalPolicyView` is scoped to one move family so the conventional sampler can inspect only the selected family; an external
+policy can iterate `MoveType::REVERSIBLE_1P1` to inspect every family through the same boundary.
+
+The policy view and opaque site-ID types are available from `prelude::simulation`; `prelude::moves` remains focused on local move kernels, move families, and
+move statistics. `MoveType` intentionally appears in both scoped preludes because it identifies both kernel operations and simulation proposal families. The
+stable family order and identifiers are:
+
+| Family | Identifier | Reverse family |
+| ------ | ---------- | -------------- |
+| `Move22` | `move-2-2` | `Move22` |
+| `Move13Add` | `move-1-3-add` | `Move31Remove` |
+| `Move31Remove` | `move-3-1-remove` | `Move13Add` |
+| `EdgeFlip` | `edge-flip` | `EdgeFlip` |
+
+`Move22` and `EdgeFlip` remain distinct policy identifiers for compatibility with the conventional four-family distribution, although both use the same 2D
+k=2 flip kernel and therefore expose the same site universe.
+
+The view exposes the selected and reverse families, CDT topology, invariant-bearing simplex counts, borrowed slice sizes, the offered-site count, and an
+exact-size iterator of opaque `CdtProposalSiteId` values. Empty families return count zero and an empty iterator. IDs use deterministic ascending ordinals for
+an unchanged triangulation version; the ordinal is not a persistent geometry key and no private backend handle is part of the public contract.
+
+The view borrows both the triangulation and the versioned family cache, so Rust prevents state or cache mutation while inspection is active. Creating a view
+does not clone `CdtTriangulation2D`. Synchronizing an uncached family may allocate its canonical site vector, while subsequent counting and ID iteration
+allocate nothing. A detached site ID records triangulation identity and modification version: callers must validate it against a fresh view before reuse, and
+receive a typed foreign-state, stale-state, family-mismatch, or ordinal error when it is no longer valid. Accepted mutations make earlier IDs stale for that
+state; clones, deserialized values, and replacement triangulations have a different identity and reject those IDs as foreign.
+
+The conventional sampler now reads counts and selected private site descriptors through this view over `MoveSiteCache`; there is no second site-enumeration
+implementation for policy consumers.
+
+#### Offered Sites Versus Eligible Sites
+
+- An **offered site** passed the deterministic pre-mutation guards, can be sampled by the checked planner, and contributes to the proposal denominator below.
+  A later composite backend edit, allocation failure, or post-mutation CDT validation may still reject it as ordinary self-loop probability, as described
+  under [Ordinary Rejections](#ordinary-rejections).
+- An **eligible site**, also called an executable site, would satisfy a stronger contract: for an unchanged state, all deterministic backend mutation
+  preconditions and CDT postconditions needed by the move are known before sampling. This would support an executable-only action mask, although it still
+  could not guarantee resource availability.
+
+The current policy view exposes offered sites, not eligible sites. Proposal policies, including future learned policies, must therefore use its IDs and counts
+as the actual proposal support and must not interpret them as a guarantee that execution will succeed.
+
 For state `x`, move family `m`, and a sampleable site set `S_m(x)`, a uniformly sampled site contributes:
 
 ```text

--- a/src/cdt/ergodic_moves.rs
+++ b/src/cdt/ergodic_moves.rs
@@ -8,6 +8,7 @@
 //! - (3,1) moves: collapse a degree-3 vertex back to one triangle
 //! - edge flips: retained as an API-compatible alias for the 2D (2,2) move
 
+use crate::cdt::proposal_policy::CdtProposalPolicyView;
 use crate::config::CdtTopology;
 use crate::errors::{BackendMutationOperation, CdtError, CdtResult, CheckpointResumeFailure};
 use crate::geometry::CdtTriangulation2D;
@@ -31,6 +32,75 @@ pub enum MoveType {
     Move31Remove,
     /// Edge flip: API-compatible alias for the 2D (2,2) move
     EdgeFlip,
+}
+
+impl MoveType {
+    /// Stable ordering of the reversible 1+1 CDT proposal families.
+    ///
+    /// Policy implementations should iterate this array instead of relying on
+    /// enum discriminants or serialization details. The order is part of the
+    /// public proposal-policy contract.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::MoveType;
+    ///
+    /// assert_eq!(MoveType::REVERSIBLE_1P1.len(), 4);
+    /// assert_eq!(MoveType::REVERSIBLE_1P1[0], MoveType::Move22);
+    /// ```
+    pub const REVERSIBLE_1P1: [Self; 4] = [
+        Self::Move22,
+        Self::Move13Add,
+        Self::Move31Remove,
+        Self::EdgeFlip,
+    ];
+
+    /// Returns the stable textual identifier for this move family.
+    ///
+    /// These identifiers are intended for policy tables, telemetry schemas,
+    /// and other external mappings. They do not expose enum discriminants or
+    /// checkpoint serialization.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::MoveType;
+    ///
+    /// assert_eq!(MoveType::Move13Add.identifier(), "move-1-3-add");
+    /// ```
+    #[must_use]
+    pub const fn identifier(self) -> &'static str {
+        match self {
+            Self::Move22 => "move-2-2",
+            Self::Move13Add => "move-1-3-add",
+            Self::Move31Remove => "move-3-1-remove",
+            Self::EdgeFlip => "edge-flip",
+        }
+    }
+
+    /// Returns the reversible family used to propose the inverse transition.
+    ///
+    /// The two flip names are self-inverse, while `(1,3)` and `(3,1)` are an
+    /// inverse pair.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::MoveType;
+    ///
+    /// assert_eq!(MoveType::Move13Add.reverse(), MoveType::Move31Remove);
+    /// assert_eq!(MoveType::EdgeFlip.reverse(), MoveType::EdgeFlip);
+    /// ```
+    #[must_use]
+    pub const fn reverse(self) -> Self {
+        match self {
+            Self::Move22 => Self::Move22,
+            Self::Move13Add => Self::Move31Remove,
+            Self::Move31Remove => Self::Move13Add,
+            Self::EdgeFlip => Self::EdgeFlip,
+        }
+    }
 }
 
 /// Result of attempting an ergodic move.
@@ -672,12 +742,6 @@ impl MoveSiteCache {
         }
     }
 
-    /// Counts one cached move family after synchronizing with the triangulation.
-    fn site_count(&mut self, triangulation: &CdtTriangulation2D, move_type: MoveType) -> usize {
-        self.ensure_current(triangulation, move_type);
-        self.family(move_type).sites.len()
-    }
-
     /// Materializes every sampleable site for one move family.
     fn collect_family(
         triangulation: &CdtTriangulation2D,
@@ -847,6 +911,42 @@ impl ErgodicsSystem {
         }
     }
 
+    /// Returns an immutable proposal-policy view for one move family.
+    ///
+    /// The view borrows `triangulation` and this system's canonical versioned
+    /// site cache. Cache synchronization may allocate when this family has not
+    /// yet been inspected for the current state, but the returned view counts
+    /// and iterates sites without further allocation or triangulation clones.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveType};
+    /// use causal_triangulations::prelude::triangulation::*;
+    ///
+    /// # fn main() -> CdtResult<()> {
+    /// let triangulation = CdtTriangulation::from_cdt_strip(4, 3)?;
+    /// let mut moves = ErgodicsSystem::new();
+    /// let view = moves.proposal_policy_view(&triangulation, MoveType::Move13Add);
+    /// assert_eq!(view.family(), MoveType::Move13Add);
+    /// assert_eq!(view.reverse_family(), MoveType::Move31Remove);
+    /// assert_eq!(view.offered_sites().len(), view.offered_site_count());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn proposal_policy_view<'a>(
+        &'a mut self,
+        triangulation: &'a CdtTriangulation2D,
+        move_type: MoveType,
+    ) -> CdtProposalPolicyView<'a> {
+        self.site_cache.ensure_current(triangulation, move_type);
+        CdtProposalPolicyView::new(
+            triangulation,
+            move_type,
+            &self.site_cache.family(move_type).sites,
+        )
+    }
+
     /// Samples one concrete proposal site from the same cached universe used for proposal counts.
     ///
     /// The cache materializes the deterministic visitor output once per
@@ -857,20 +957,22 @@ impl ErgodicsSystem {
         triangulation: &CdtTriangulation2D,
         move_type: MoveType,
     ) -> ProposalSiteSelection {
-        self.site_cache.ensure_current(triangulation, move_type);
-        let family = self.site_cache.family(move_type);
-        let site_count = family.sites.len();
+        let site_count = self
+            .proposal_policy_view(triangulation, move_type)
+            .offered_site_count();
         let selected_site = if site_count == 0 {
             None
         } else {
             let index = self.rng.random_range(0..site_count);
-            Some(family.sites[index].clone())
+            let view = self.proposal_policy_view(triangulation, move_type);
+            view.site_at(index)
         };
+        let geometric_candidate_seen = self.site_cache.family(move_type).geometric_candidate_seen;
 
         ProposalSiteSelection {
             site_count,
             site: selected_site,
-            geometric_candidate_seen: family.geometric_candidate_seen,
+            geometric_candidate_seen,
         }
     }
 
@@ -1927,7 +2029,10 @@ pub(crate) fn proposal_site_count(
     triangulation: &CdtTriangulation2D,
     move_type: MoveType,
 ) -> usize {
-    MoveSiteCache::default().site_count(triangulation, move_type)
+    let mut cache = MoveSiteCache::default();
+    cache.ensure_current(triangulation, move_type);
+    CdtProposalPolicyView::new(triangulation, move_type, &cache.family(move_type).sites)
+        .offered_site_count()
 }
 
 /// Visits every sampleable proposal site for one move family.
@@ -2139,9 +2244,24 @@ mod tests {
                 triangulation.metadata().modification_count(),
             );
             let counted = proposal_site_count(triangulation, move_type);
+            let view = system.proposal_policy_view(triangulation, move_type);
+            let viewed = view.offered_site_count();
+            let viewed_ids = view.offered_sites().collect::<Vec<_>>();
+            for (ordinal, site) in viewed_ids.iter().enumerate() {
+                assert_eq!(site.family(), move_type);
+                assert_eq!(site.ordinal(), ordinal);
+                view.validate_site(*site)
+                    .expect("fresh policy-view site should validate");
+            }
             let sampled = system.select_proposal_site(triangulation, move_type);
 
             assert_eq!(counted, family.sites.len(), "count drift for {move_type:?}");
+            assert_eq!(viewed, counted, "policy-view drift for {move_type:?}");
+            assert_eq!(
+                viewed_ids.len(),
+                counted,
+                "policy-view enumeration drift for {move_type:?}"
+            );
             assert_eq!(
                 sampled.site_count, counted,
                 "sampling drift for {move_type:?}"

--- a/src/cdt/metropolis/adapter.rs
+++ b/src/cdt/metropolis/adapter.rs
@@ -6,6 +6,7 @@ use super::helpers::{action_for, proposed_delta_action, simplex_counts, validate
 use super::telemetry::{CdtProposalSiteRejection, ProposalStatistics};
 use crate::cdt::action::ActionConfig;
 use crate::cdt::ergodic_moves::{ErgodicsSystem, MoveResult, MoveType, proposal_site_count};
+use crate::cdt::proposal_policy::CdtProposalPolicyView;
 use crate::errors::{CdtError, CdtResult, MetropolisMoveApplicationFailure};
 use crate::geometry::CdtTriangulation2D;
 use markov_chain_monte_carlo::{
@@ -442,6 +443,37 @@ impl CdtProposal {
         }
     }
 
+    /// Returns CDT's canonical borrowed policy view for one move family.
+    ///
+    /// This is the public inspection boundary for conventional and external
+    /// family policies. The returned view borrows `state` and this proposal's
+    /// versioned site cache, exposes no mutable geometry, and does not clone the
+    /// triangulation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::simulation::{
+    ///     ActionConfig, CdtProposal, CdtResult, CdtTriangulation, MoveType,
+    /// };
+    ///
+    /// # fn main() -> CdtResult<()> {
+    /// let state = CdtTriangulation::from_cdt_strip(4, 3)?;
+    /// let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7);
+    /// let view = proposal.policy_view(&state, MoveType::Move13Add);
+    /// assert_eq!(view.reverse_family(), MoveType::Move31Remove);
+    /// assert_eq!(view.offered_sites().len(), view.offered_site_count());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn policy_view<'a>(
+        &'a mut self,
+        state: &'a CdtTriangulation2D,
+        family: MoveType,
+    ) -> CdtProposalPolicyView<'a> {
+        self.moves.proposal_policy_view(state, family)
+    }
+
     /// Rebuilds a proposal planner from checkpointed ergodic-move state.
     ///
     /// Resumed simulations use this to hand the upstream sampler the exact
@@ -650,7 +682,7 @@ pub(crate) fn propose_concrete_plan(
         }
     };
     let delta_action = action_after - action_before;
-    let reverse_site_count = proposal_site_count(&proposed_state, reverse_move_type(move_type));
+    let reverse_site_count = proposal_site_count(&proposed_state, move_type.reverse());
 
     Ok(Some(CdtProposalPlan {
         move_type,
@@ -687,14 +719,4 @@ pub(crate) fn restore_checkpoint_state(
     target: &CdtTarget,
 ) -> Result<CdtTriangulation2D, McmcError> {
     Chain::from_checkpoint(checkpoint, target).map(Chain::into_state)
-}
-
-/// Returns the inverse CDT move family used for reverse proposal accounting.
-const fn reverse_move_type(move_type: MoveType) -> MoveType {
-    match move_type {
-        MoveType::Move22 => MoveType::Move22,
-        MoveType::Move13Add => MoveType::Move31Remove,
-        MoveType::Move31Remove => MoveType::Move13Add,
-        MoveType::EdgeFlip => MoveType::EdgeFlip,
-    }
 }

--- a/src/cdt/proposal_policy.rs
+++ b/src/cdt/proposal_policy.rs
@@ -1,0 +1,416 @@
+#![forbid(unsafe_code)]
+
+//! Borrowed, invariant-safe views for 1+1 CDT proposal policies.
+
+use crate::cdt::ergodic_moves::{MoveType, ProposalSite};
+use crate::cdt::triangulation::CdtSimplexCounts;
+use crate::config::CdtTopology;
+use crate::errors::CdtResult;
+use crate::geometry::CdtTriangulation2D;
+use std::error::Error;
+use std::fmt;
+use std::iter::FusedIterator;
+use std::ops::Range;
+
+/// Opaque identifier for one canonical offered proposal site.
+///
+/// An identifier names one ordinal in one move family's deterministic site
+/// ordering for a specific triangulation instance and modification version. It
+/// deliberately does not expose Delaunay handles or mutation representation.
+/// Identifiers may outlive the borrowed view that created them, but callers
+/// must validate them against a fresh view before reuse. An accepted mutation
+/// makes earlier IDs stale for that state; clones, deserialized values, and
+/// replacement triangulations have a different identity and reject the IDs as
+/// foreign.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveType};
+/// use causal_triangulations::prelude::triangulation::*;
+///
+/// # fn main() -> CdtResult<()> {
+/// let triangulation = CdtTriangulation::from_cdt_strip(4, 3)?;
+/// let mut moves = ErgodicsSystem::with_seed(7);
+/// let view = moves.proposal_policy_view(&triangulation, MoveType::Move13Add);
+/// let Some(site) = view.offered_sites().next() else {
+///     return Ok(());
+/// };
+/// assert_eq!(site.family(), MoveType::Move13Add);
+/// assert_eq!(view.validate_site(site), Ok(()));
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CdtProposalSiteId {
+    family: MoveType,
+    ordinal: usize,
+    instance_id: u64,
+    modification_count: u64,
+}
+
+impl CdtProposalSiteId {
+    /// Returns the move family that owns this site identifier.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveType};
+    /// use causal_triangulations::prelude::triangulation::*;
+    ///
+    /// # fn main() -> CdtResult<()> {
+    /// let triangulation = CdtTriangulation::from_cdt_strip(4, 3)?;
+    /// let mut moves = ErgodicsSystem::new();
+    /// let view = moves.proposal_policy_view(&triangulation, MoveType::Move13Add);
+    /// if let Some(site) = view.offered_sites().next() {
+    ///     assert_eq!(site.family(), MoveType::Move13Add);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub const fn family(self) -> MoveType {
+        self.family
+    }
+
+    /// Returns this site's zero-based ordinal in its family view.
+    ///
+    /// Ordinals are deterministic only while the inspected triangulation stays
+    /// unchanged. They are not persistent geometry identifiers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveType};
+    /// use causal_triangulations::prelude::triangulation::*;
+    ///
+    /// # fn main() -> CdtResult<()> {
+    /// let triangulation = CdtTriangulation::from_cdt_strip(4, 3)?;
+    /// let mut moves = ErgodicsSystem::new();
+    /// let view = moves.proposal_policy_view(&triangulation, MoveType::Move13Add);
+    /// let ordinals = view.offered_sites().map(|site| site.ordinal()).collect::<Vec<_>>();
+    /// assert_eq!(ordinals, (0..view.offered_site_count()).collect::<Vec<_>>());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub const fn ordinal(self) -> usize {
+        self.ordinal
+    }
+}
+
+/// Failure to use a proposal-site identifier with a policy view.
+///
+/// The variants distinguish cross-owner identifiers, stale versions,
+/// cross-family use, and invalid ordinals so callers never need to parse error
+/// strings when deciding whether to rebuild policy inputs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CdtProposalSiteIdError {
+    /// The identifier belongs to a different triangulation instance.
+    ForeignTriangulation {
+        /// Family recorded by the rejected identifier.
+        family: MoveType,
+        /// Family-local ordinal recorded by the rejected identifier.
+        ordinal: usize,
+    },
+    /// The triangulation was mutated after the identifier was issued.
+    StaleState {
+        /// Family recorded by the rejected identifier.
+        family: MoveType,
+        /// Family-local ordinal recorded by the rejected identifier.
+        ordinal: usize,
+        /// Modification version captured by the identifier.
+        identifier_version: u64,
+        /// Current modification version observed through the view.
+        current_version: u64,
+    },
+    /// The identifier belongs to another move-family view.
+    FamilyMismatch {
+        /// Family selected by the current view.
+        expected: MoveType,
+        /// Family recorded by the rejected identifier.
+        actual: MoveType,
+    },
+    /// The requested ordinal is outside the current offered-site set.
+    OrdinalOutOfRange {
+        /// Move family whose site set was indexed.
+        family: MoveType,
+        /// Rejected zero-based ordinal.
+        ordinal: usize,
+        /// Number of offered sites in the current view.
+        offered_site_count: usize,
+    },
+}
+
+impl fmt::Display for CdtProposalSiteIdError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ForeignTriangulation { family, ordinal } => write!(
+                formatter,
+                "proposal site {}[{ordinal}] belongs to another triangulation",
+                family.identifier()
+            ),
+            Self::StaleState {
+                family,
+                ordinal,
+                identifier_version,
+                current_version,
+            } => write!(
+                formatter,
+                "proposal site {}[{ordinal}] is stale: identifier version {identifier_version}, current version {current_version}",
+                family.identifier()
+            ),
+            Self::FamilyMismatch { expected, actual } => write!(
+                formatter,
+                "proposal site family mismatch: expected {}, received {}",
+                expected.identifier(),
+                actual.identifier()
+            ),
+            Self::OrdinalOutOfRange {
+                family,
+                ordinal,
+                offered_site_count,
+            } => write!(
+                formatter,
+                "proposal site {}[{ordinal}] is outside the {offered_site_count}-site offered set",
+                family.identifier()
+            ),
+        }
+    }
+}
+
+impl Error for CdtProposalSiteIdError {}
+
+/// Allocation-free iterator over opaque offered-site identifiers.
+///
+/// Identifiers are yielded in ascending family-local ordinal order. The order
+/// is deterministic for the unchanged triangulation version borrowed by the
+/// parent [`CdtProposalPolicyView`].
+#[derive(Debug, Clone)]
+pub struct CdtProposalSiteIds {
+    family: MoveType,
+    instance_id: u64,
+    modification_count: u64,
+    ordinals: Range<usize>,
+}
+
+impl Iterator for CdtProposalSiteIds {
+    type Item = CdtProposalSiteId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.ordinals.next().map(|ordinal| CdtProposalSiteId {
+            family: self.family,
+            ordinal,
+            instance_id: self.instance_id,
+            modification_count: self.modification_count,
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.ordinals.size_hint()
+    }
+}
+
+impl DoubleEndedIterator for CdtProposalSiteIds {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.ordinals.next_back().map(|ordinal| CdtProposalSiteId {
+            family: self.family,
+            ordinal,
+            instance_id: self.instance_id,
+            modification_count: self.modification_count,
+        })
+    }
+}
+
+impl ExactSizeIterator for CdtProposalSiteIds {}
+impl FusedIterator for CdtProposalSiteIds {}
+
+/// Immutable policy view for one reversible 1+1 CDT move family.
+///
+/// The view borrows both the canonical triangulation and the selected family's
+/// versioned offered-site cache. Rust therefore prevents mutating either owner
+/// while the view is alive. Creating the view does not clone the triangulation;
+/// after cache synchronization, counting and iterating IDs allocate nothing.
+/// An **offered site** passed the deterministic pre-mutation guards and belongs
+/// to the conventional sampler's proposal denominator. A later composite
+/// backend edit, allocation failure, or post-mutation CDT validation can still
+/// reject the sampled site as an ordinary self-loop proposal.
+///
+/// An **eligible site**, also called an executable site, would satisfy the
+/// stronger contract that, for an unchanged state, all deterministic backend
+/// mutation preconditions and CDT postconditions needed by the move are known
+/// before sampling. This view exposes offered sites, not eligible sites, and
+/// therefore does not provide an executable-only action mask or guarantee that
+/// execution will succeed.
+///
+/// A view is family-scoped so conventional sampling can inspect only the chosen
+/// family. External policies can iterate [`MoveType::REVERSIBLE_1P1`] and create
+/// one short-lived view per family without introducing a second site-enumeration
+/// implementation.
+///
+/// # Examples
+///
+/// ```
+/// use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveType};
+/// use causal_triangulations::prelude::triangulation::*;
+///
+/// # fn main() -> CdtResult<()> {
+/// let triangulation = CdtTriangulation::from_cdt_strip(4, 3)?;
+/// let mut moves = ErgodicsSystem::new();
+/// for family in MoveType::REVERSIBLE_1P1 {
+///     let view = moves.proposal_policy_view(&triangulation, family);
+///     assert_eq!(view.offered_sites().len(), view.offered_site_count());
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[must_use = "a proposal-policy view must be inspected before its cache borrow is released"]
+pub struct CdtProposalPolicyView<'a> {
+    triangulation: &'a CdtTriangulation2D,
+    family: MoveType,
+    sites: &'a [ProposalSite],
+}
+
+impl<'a> CdtProposalPolicyView<'a> {
+    /// Creates a public view over an already synchronized canonical site set.
+    pub(crate) const fn new(
+        triangulation: &'a CdtTriangulation2D,
+        family: MoveType,
+        sites: &'a [ProposalSite],
+    ) -> Self {
+        Self {
+            triangulation,
+            family,
+            sites,
+        }
+    }
+
+    /// Returns the selected move family.
+    #[must_use]
+    pub const fn family(&self) -> MoveType {
+        self.family
+    }
+
+    /// Returns the family needed to reverse a realized transition.
+    #[must_use]
+    pub const fn reverse_family(&self) -> MoveType {
+        self.family.reverse()
+    }
+
+    /// Returns the current CDT topology without exposing geometry internals.
+    #[must_use]
+    pub const fn topology(&self) -> CdtTopology {
+        self.triangulation.metadata().topology()
+    }
+
+    /// Returns the invariant-bearing simplex counts for the inspected state.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying typed count error if a backend reports a zero
+    /// simplex count instead of a constructed CDT state.
+    pub fn simplex_counts(&self) -> CdtResult<CdtSimplexCounts> {
+        self.triangulation.simplex_counts()
+    }
+
+    /// Returns the borrowed per-time-slice vertex counts.
+    ///
+    /// The slice is empty for an unfoliated state. It borrows the same
+    /// triangulation as the policy view and cannot outlive it.
+    #[must_use]
+    pub fn slice_sizes(&self) -> &[usize] {
+        self.triangulation.slice_sizes()
+    }
+
+    /// Returns the number of sites offered by this proposal family.
+    ///
+    /// This is the conventional sampler's proposal denominator, not a promise
+    /// that every later backend edit and post-mutation validation will succeed.
+    #[must_use]
+    pub const fn offered_site_count(&self) -> usize {
+        self.sites.len()
+    }
+
+    /// Iterates opaque identifiers for every canonical offered site.
+    ///
+    /// Empty families return an empty exact-size iterator. Iteration allocates
+    /// nothing and follows deterministic ascending ordinal order.
+    #[must_use]
+    pub const fn offered_sites(&self) -> CdtProposalSiteIds {
+        CdtProposalSiteIds {
+            family: self.family,
+            instance_id: self.triangulation.instance_id(),
+            modification_count: self.triangulation.metadata().modification_count(),
+            ordinals: 0..self.sites.len(),
+        }
+    }
+
+    /// Returns the identifier at one family-local ordinal.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdtProposalSiteIdError::OrdinalOutOfRange`] when `ordinal` is
+    /// not smaller than [`Self::offered_site_count`].
+    pub const fn site_id(
+        &self,
+        ordinal: usize,
+    ) -> Result<CdtProposalSiteId, CdtProposalSiteIdError> {
+        if ordinal >= self.sites.len() {
+            return Err(CdtProposalSiteIdError::OrdinalOutOfRange {
+                family: self.family,
+                ordinal,
+                offered_site_count: self.sites.len(),
+            });
+        }
+        Ok(CdtProposalSiteId {
+            family: self.family,
+            ordinal,
+            instance_id: self.triangulation.instance_id(),
+            modification_count: self.triangulation.metadata().modification_count(),
+        })
+    }
+
+    /// Validates that an identifier still names a site in this exact view.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed error for foreign triangulations, stale modification
+    /// versions, family mismatches, or an invalid ordinal.
+    pub fn validate_site(&self, site: CdtProposalSiteId) -> Result<(), CdtProposalSiteIdError> {
+        if site.instance_id != self.triangulation.instance_id() {
+            return Err(CdtProposalSiteIdError::ForeignTriangulation {
+                family: site.family,
+                ordinal: site.ordinal,
+            });
+        }
+        let current_version = self.triangulation.metadata().modification_count();
+        if site.modification_count != current_version {
+            return Err(CdtProposalSiteIdError::StaleState {
+                family: site.family,
+                ordinal: site.ordinal,
+                identifier_version: site.modification_count,
+                current_version,
+            });
+        }
+        if site.family != self.family {
+            return Err(CdtProposalSiteIdError::FamilyMismatch {
+                expected: self.family,
+                actual: site.family,
+            });
+        }
+        if site.ordinal >= self.sites.len() {
+            return Err(CdtProposalSiteIdError::OrdinalOutOfRange {
+                family: self.family,
+                ordinal: site.ordinal,
+                offered_site_count: self.sites.len(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Clones one private site descriptor at a checked cache ordinal.
+    pub(crate) fn site_at(&self, ordinal: usize) -> Option<ProposalSite> {
+        self.sites.get(ordinal).cloned()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,8 @@ pub mod cdt {
     }
     /// User-facing CDT observable estimators.
     pub mod observables;
+    /// Borrowed proposal-policy inspection for validated 1+1 CDT states.
+    pub mod proposal_policy;
     /// Simulation result containers and measurement summaries.
     pub mod results;
     /// CDT triangulation state.
@@ -197,6 +199,9 @@ pub use cdt::metropolis::{
     MonteCarloStepOutcome, ProposalStatistics, RejectedProposalStepTelemetry, StepOutcome,
 };
 pub use cdt::observables::{estimate_hausdorff_dimension, estimate_spectral_dimension};
+pub use cdt::proposal_policy::{
+    CdtProposalPolicyView, CdtProposalSiteId, CdtProposalSiteIdError, CdtProposalSiteIds,
+};
 pub use cdt::results::{Measurement, SimulationResultsBackend};
 pub use cdt::triangulation::{
     CdtMetadata, CdtSimplexCounts, CdtTriangulation, CdtValidationProfile, SimulationEvent,
@@ -377,7 +382,8 @@ pub mod prelude {
     ///
     /// This prelude intentionally contains only the move API. Combine it with
     /// `prelude::triangulation::*` and, for explicit Delaunay fixtures,
-    /// `prelude::geometry::*`.
+    /// `prelude::geometry::*`. Proposal-policy inspection types belong to
+    /// [`crate::prelude::simulation`].
     ///
     /// ```
     /// use causal_triangulations::prelude::moves::*;
@@ -436,6 +442,9 @@ pub mod prelude {
             CdtProposalInfo, CdtProposalPlan, CdtTarget, MetropolisAlgorithm, MetropolisConfig,
             MonteCarloStep, MonteCarloStepOutcome, ProposalStatistics,
             RejectedProposalStepTelemetry,
+        };
+        pub use crate::cdt::proposal_policy::{
+            CdtProposalPolicyView, CdtProposalSiteId, CdtProposalSiteIdError, CdtProposalSiteIds,
         };
         pub use crate::cdt::results::{Measurement, SimulationResultsBackend};
         pub use crate::cdt::triangulation::SimulationEvent;

--- a/tests/proposal_policy.rs
+++ b/tests/proposal_policy.rs
@@ -1,0 +1,162 @@
+//! Public-contract tests for the borrowed CDT proposal-policy view.
+
+use causal_triangulations::prelude::geometry::{DelaunayBackend2D, build_delaunay2_with_data};
+use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveResult, MoveType};
+use causal_triangulations::prelude::simulation::{
+    ActionConfig, CdtProposal, CdtProposalSiteIdError,
+};
+use causal_triangulations::prelude::triangulation::{CdtResult, CdtTriangulation};
+use std::assert_matches;
+
+fn single_triangle() -> causal_triangulations::geometry::CdtTriangulation2D {
+    let triangulation =
+        build_delaunay2_with_data(&[([0.0, 0.0], 0), ([1.0, 0.0], 0), ([0.5, 1.0], 1)])
+            .expect("build labeled triangle");
+    let backend = DelaunayBackend2D::from_triangulation(triangulation)
+        .expect("test Delaunay triangle should validate");
+    CdtTriangulation::from_labeled_delaunay(backend, 2, 2).expect("wrap labeled triangle")
+}
+
+#[test]
+fn move_family_identifiers_and_reverse_mapping_are_stable() {
+    assert_eq!(
+        MoveType::REVERSIBLE_1P1.map(MoveType::identifier),
+        ["move-2-2", "move-1-3-add", "move-3-1-remove", "edge-flip",]
+    );
+
+    for family in MoveType::REVERSIBLE_1P1 {
+        assert_eq!(family.reverse().reverse(), family);
+    }
+}
+
+#[test]
+fn policy_view_has_deterministic_order_and_explicit_empty_families() -> CdtResult<()> {
+    let empty_triangulation = single_triangle();
+    let mut empty_moves = ErgodicsSystem::with_seed(7);
+
+    let empty = empty_moves.proposal_policy_view(&empty_triangulation, MoveType::Move22);
+    assert_eq!(empty.offered_site_count(), 0);
+    assert_eq!(empty.offered_sites().len(), 0);
+    assert_eq!(empty.offered_sites().next(), None);
+
+    let triangulation = CdtTriangulation::from_toroidal_cdt(4, 4)?;
+    let mut first_moves = ErgodicsSystem::with_seed(7);
+    let first_order = {
+        let view = first_moves.proposal_policy_view(&triangulation, MoveType::Move13Add);
+        assert!(view.offered_site_count() > 1);
+        assert_eq!(view.simplex_counts()?.vertex_count(), 16);
+        assert_eq!(view.slice_sizes(), &[4, 4, 4, 4]);
+        view.offered_sites().collect::<Vec<_>>()
+    };
+    let mut second_moves = ErgodicsSystem::with_seed(99);
+    let second_order = second_moves
+        .proposal_policy_view(&triangulation, MoveType::Move13Add)
+        .offered_sites()
+        .collect::<Vec<_>>();
+    let mut proposal = CdtProposal::with_seed(ActionConfig::default(), 7);
+    let proposal_count = proposal
+        .policy_view(&triangulation, MoveType::Move13Add)
+        .offered_site_count();
+
+    assert_eq!(first_order, second_order);
+    assert_eq!(first_order[0].ordinal(), 0);
+    assert_eq!(
+        first_order.last().map(|site| site.ordinal()),
+        Some(first_order.len() - 1)
+    );
+    assert_eq!(proposal_count, first_order.len());
+    Ok(())
+}
+
+#[test]
+fn policy_view_rejects_invalid_family_ordinals_and_foreign_ids() -> CdtResult<()> {
+    let triangulation = CdtTriangulation::from_toroidal_cdt(4, 4)?;
+    let foreign = triangulation.clone();
+    let mut moves = ErgodicsSystem::new();
+    let site = moves
+        .proposal_policy_view(&triangulation, MoveType::Move13Add)
+        .site_id(0)
+        .expect("toroidal fixture should expose insertion site zero");
+
+    let wrong_family = moves.proposal_policy_view(&triangulation, MoveType::Move31Remove);
+    assert_matches!(
+        wrong_family.validate_site(site),
+        Err(CdtProposalSiteIdError::FamilyMismatch {
+            expected: MoveType::Move31Remove,
+            actual: MoveType::Move13Add,
+        })
+    );
+
+    let foreign_view = moves.proposal_policy_view(&foreign, MoveType::Move13Add);
+    assert_matches!(
+        foreign_view.validate_site(site),
+        Err(CdtProposalSiteIdError::ForeignTriangulation { .. })
+    );
+
+    let current = moves.proposal_policy_view(&triangulation, MoveType::Move13Add);
+    let offered_site_count = current.offered_site_count();
+    assert_matches!(
+        current.site_id(offered_site_count),
+        Err(CdtProposalSiteIdError::OrdinalOutOfRange {
+            family: MoveType::Move13Add,
+            ordinal,
+            offered_site_count: actual_count,
+        }) if ordinal == offered_site_count && actual_count == offered_site_count
+    );
+    Ok(())
+}
+
+#[test]
+fn accepted_toroidal_sequence_invalidates_old_site_ids() -> CdtResult<()> {
+    let mut triangulation = CdtTriangulation::from_toroidal_cdt(8, 8)?;
+    let mut moves = ErgodicsSystem::with_seed(0);
+    let stale_site = moves
+        .proposal_policy_view(&triangulation, MoveType::Move13Add)
+        .site_id(0)
+        .expect("toroidal fixture should expose insertion site zero");
+
+    let mut inserted = false;
+    for _ in 0..64 {
+        match moves.attempt_13_move(&mut triangulation) {
+            MoveResult::Success => {
+                inserted = true;
+                break;
+            }
+            MoveResult::CausalityViolation
+            | MoveResult::GeometricViolation
+            | MoveResult::Rejected(_) => {}
+            MoveResult::HardFailure(error) => {
+                panic!("unexpected hard failure during toroidal insertion: {error}")
+            }
+        }
+    }
+    assert!(inserted, "representative toroidal insertion should succeed");
+
+    let current = moves.proposal_policy_view(&triangulation, MoveType::Move13Add);
+    assert_matches!(
+        current.validate_site(stale_site),
+        Err(CdtProposalSiteIdError::StaleState { .. })
+    );
+
+    let mut removed = false;
+    for _ in 0..64 {
+        match moves.attempt_31_move(&mut triangulation) {
+            MoveResult::Success => {
+                removed = true;
+                break;
+            }
+            MoveResult::CausalityViolation
+            | MoveResult::GeometricViolation
+            | MoveResult::Rejected(_) => {}
+            MoveResult::HardFailure(error) => {
+                panic!("unexpected hard failure during toroidal removal: {error}")
+            }
+        }
+    }
+    assert!(
+        removed,
+        "representative toroidal inverse move should succeed"
+    );
+    triangulation.validate()?;
+    Ok(())
+}

--- a/tests/proposal_policy.rs
+++ b/tests/proposal_policy.rs
@@ -3,7 +3,7 @@
 use causal_triangulations::prelude::geometry::{DelaunayBackend2D, build_delaunay2_with_data};
 use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveResult, MoveType};
 use causal_triangulations::prelude::simulation::{
-    ActionConfig, CdtProposal, CdtProposalSiteIdError,
+    ActionConfig, CdtProposal, CdtProposalSiteIdError, CdtTopology,
 };
 use causal_triangulations::prelude::triangulation::{CdtResult, CdtTriangulation};
 use std::assert_matches;
@@ -43,10 +43,20 @@ fn policy_view_has_deterministic_order_and_explicit_empty_families() -> CdtResul
     let mut first_moves = ErgodicsSystem::with_seed(7);
     let first_order = {
         let view = first_moves.proposal_policy_view(&triangulation, MoveType::Move13Add);
+        assert_eq!(view.family(), MoveType::Move13Add);
+        assert_eq!(view.reverse_family(), MoveType::Move31Remove);
+        assert_eq!(view.topology(), CdtTopology::Toroidal);
         assert!(view.offered_site_count() > 1);
         assert_eq!(view.simplex_counts()?.vertex_count(), 16);
         assert_eq!(view.slice_sizes(), &[4, 4, 4, 4]);
-        view.offered_sites().collect::<Vec<_>>()
+        let sites = view.offered_sites().collect::<Vec<_>>();
+        let reverse_ordinals = view
+            .offered_sites()
+            .rev()
+            .map(|site| site.ordinal())
+            .collect::<Vec<_>>();
+        assert_eq!(reverse_ordinals, (0..sites.len()).rev().collect::<Vec<_>>());
+        sites
     };
     let mut second_moves = ErgodicsSystem::with_seed(99);
     let second_order = second_moves
@@ -79,30 +89,51 @@ fn policy_view_rejects_invalid_family_ordinals_and_foreign_ids() -> CdtResult<()
         .expect("toroidal fixture should expose insertion site zero");
 
     let wrong_family = moves.proposal_policy_view(&triangulation, MoveType::Move31Remove);
+    let wrong_family_error = wrong_family
+        .validate_site(site)
+        .expect_err("a site from another move family must be rejected");
+    let wrong_family_diagnostic = wrong_family_error.to_string();
     assert_matches!(
-        wrong_family.validate_site(site),
-        Err(CdtProposalSiteIdError::FamilyMismatch {
+        wrong_family_error,
+        CdtProposalSiteIdError::FamilyMismatch {
             expected: MoveType::Move31Remove,
             actual: MoveType::Move13Add,
-        })
+        }
     );
+    assert!(wrong_family_diagnostic.contains("expected move-3-1-remove"));
+    assert!(wrong_family_diagnostic.contains("received move-1-3-add"));
 
     let foreign_view = moves.proposal_policy_view(&foreign, MoveType::Move13Add);
+    let foreign_error = foreign_view
+        .validate_site(site)
+        .expect_err("a site from another triangulation must be rejected");
+    let foreign_diagnostic = foreign_error.to_string();
     assert_matches!(
-        foreign_view.validate_site(site),
-        Err(CdtProposalSiteIdError::ForeignTriangulation { .. })
+        foreign_error,
+        CdtProposalSiteIdError::ForeignTriangulation {
+            family: MoveType::Move13Add,
+            ordinal: 0,
+        }
     );
+    assert!(foreign_diagnostic.contains("move-1-3-add[0]"));
+    assert!(foreign_diagnostic.contains("another triangulation"));
 
     let current = moves.proposal_policy_view(&triangulation, MoveType::Move13Add);
     let offered_site_count = current.offered_site_count();
+    let ordinal_error = current
+        .site_id(offered_site_count)
+        .expect_err("the first ordinal after the offered set must be rejected");
+    let ordinal_diagnostic = ordinal_error.to_string();
     assert_matches!(
-        current.site_id(offered_site_count),
-        Err(CdtProposalSiteIdError::OrdinalOutOfRange {
+        ordinal_error,
+        CdtProposalSiteIdError::OrdinalOutOfRange {
             family: MoveType::Move13Add,
             ordinal,
             offered_site_count: actual_count,
-        }) if ordinal == offered_site_count && actual_count == offered_site_count
+        } if ordinal == offered_site_count && actual_count == offered_site_count
     );
+    assert!(ordinal_diagnostic.contains(&format!("move-1-3-add[{offered_site_count}]")));
+    assert!(ordinal_diagnostic.contains(&format!("{offered_site_count}-site offered set")));
     Ok(())
 }
 
@@ -133,10 +164,25 @@ fn accepted_toroidal_sequence_invalidates_old_site_ids() -> CdtResult<()> {
     assert!(inserted, "representative toroidal insertion should succeed");
 
     let current = moves.proposal_policy_view(&triangulation, MoveType::Move13Add);
-    assert_matches!(
-        current.validate_site(stale_site),
-        Err(CdtProposalSiteIdError::StaleState { .. })
-    );
+    let stale_error = current
+        .validate_site(stale_site)
+        .expect_err("an accepted mutation must make an earlier site ID stale");
+    let stale_diagnostic = stale_error.to_string();
+    let CdtProposalSiteIdError::StaleState {
+        family,
+        ordinal,
+        identifier_version,
+        current_version,
+    } = stale_error
+    else {
+        panic!("expected stale-state error, received {stale_error:?}");
+    };
+    assert_eq!(family, MoveType::Move13Add);
+    assert_eq!(ordinal, 0);
+    assert!(identifier_version < current_version);
+    assert!(stale_diagnostic.contains("move-1-3-add[0] is stale"));
+    assert!(stale_diagnostic.contains(&format!("identifier version {identifier_version}")));
+    assert!(stale_diagnostic.contains(&format!("current version {current_version}")));
 
     let mut removed = false;
     for _ in 0..64 {

--- a/tests/proposal_policy.rs
+++ b/tests/proposal_policy.rs
@@ -3,7 +3,7 @@
 use causal_triangulations::prelude::geometry::{DelaunayBackend2D, build_delaunay2_with_data};
 use causal_triangulations::prelude::moves::{ErgodicsSystem, MoveResult, MoveType};
 use causal_triangulations::prelude::simulation::{
-    ActionConfig, CdtProposal, CdtProposalSiteIdError, CdtTopology,
+    ActionConfig, CdtProposal, CdtProposalSiteId, CdtProposalSiteIdError, CdtTopology,
 };
 use causal_triangulations::prelude::triangulation::{CdtResult, CdtTriangulation};
 use std::assert_matches;
@@ -53,7 +53,7 @@ fn policy_view_has_deterministic_order_and_explicit_empty_families() -> CdtResul
         let reverse_ordinals = view
             .offered_sites()
             .rev()
-            .map(|site| site.ordinal())
+            .map(CdtProposalSiteId::ordinal)
             .collect::<Vec<_>>();
         assert_eq!(reverse_ordinals, (0..sites.len()).rev().collect::<Vec<_>>());
         sites


### PR DESCRIPTION
Closes #221

- Add stable move-family identifiers and opaque, versioned site IDs for deterministic proposal-policy inspection.
- Share the canonical offered-site universe with conventional and external policies without exposing mutable geometry.
- Distinguish offered proposal support from stronger eligible-site guarantees and preserve failed offers as self-loops.
- Reject foreign, stale, cross-family, and out-of-range site identifiers with typed errors.