### PR TITLE
fix(tooling): harden Python release and fixture helpers

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,10 @@ type: software
 title: "causal-triangulations: A Causal Dynamical Triangulation library for quantum gravity research"
 version: "0.1.0"
 doi: 10.5281/zenodo.20513228
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.20513229
+    description: "Zenodo DOI for version 0.1.0"
 date-released: 2026-06-02
 url: "https://github.com/acgetchell/causal-triangulations"
 repository-code: "https://github.com/acgetchell/causal-triangulations"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,7 +63,9 @@ Alternative: edit `Cargo.toml` manually and update `version = "..."` under `[pac
 
 Update release metadata to match the crate version:
 
-- `CITATION.cff`: update `version` and `date-released`
+- `CITATION.cff`: update `version` and `date-released`; keep the top-level `doi` as the all-versions Zenodo concept DOI and add the concrete release-record DOI
+  under `identifiers` with an explicit version description.
+- `pyproject.toml` and `uv.lock`: keep the support package version synchronized while preserving `scripts/README.md` as the package README.
 
 Review version references in documentation and metadata:
 
@@ -88,6 +90,10 @@ just changelog-unreleased "$TAG"
 just ci
 just publish-check
 ```
+
+The `just ci` citation bucket includes the release metadata check. It requires exactly one top-level ISO CFF release date and compares it with the generated
+UTC date on the current package-version heading in `CHANGELOG.md`. Tag creation separately refuses a requested version that differs from `Cargo.toml` before
+inspecting or changing any Git tag.
 
 5. Stage and commit release artifacts
 

--- a/docs/code-organization.md
+++ b/docs/code-organization.md
@@ -87,6 +87,8 @@ causal-triangulations/
 │   │   ├── test_archive_changelog.py
 │   │   ├── test_benchmark_models.py
 │   │   ├── test_benchmark_utils.py
+│   │   ├── test_check_release_metadata.py
+│   │   ├── test_check_semgrep_fixtures.py
 │   │   ├── test_coverage_report.py
 │   │   ├── test_hardware_utils.py
 │   │   ├── test_notebook_check.py
@@ -97,6 +99,7 @@ causal-triangulations/
 │   ├── archive_changelog.py
 │   ├── benchmark_models.py
 │   ├── benchmark_utils.py
+│   ├── check_release_metadata.py
 │   ├── check_semgrep_fixtures.py
 │   ├── coverage_report.py
 │   ├── hardware_utils.py

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -287,9 +287,16 @@ Compatibility aliases remain available as granular recipes:
 
 ## CITATION.cff Validation
 
-Citation metadata should pass both YAML style linting and CFF schema validation.
+Citation metadata should pass YAML style linting, CFF schema validation, and the release metadata synchronization gate.
 
-Run:
+Run the metadata gate independently with:
+
+```bash
+just release-metadata-check
+```
+
+It requires exactly one top-level ISO `date-released` value, matches it to the generated current-package changelog heading when present, and validates the
+Python support package's README target. The broader citation check includes this gate:
 
 ```bash
 just citation-check

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -342,6 +342,23 @@ Issue #222 treats cached-observable allocation counts as deterministic correctne
 with the stable Criterion suite, and the performance workflow invokes the same recipe before baseline analysis. Allocation failures are blocking on every path,
 while statistically noisy Criterion regressions retain their existing report-only pull-request behavior.
 
+## Issue #249 Python Release Helper Hardening
+
+Issue #249 ports the fail-closed release and fixture-validation patterns from `la-stack` while preserving CDT's destination-local, directory-fsynced changelog
+publication design. Tag creation now parses `Cargo.toml` directly and rejects a requested tag/package-version mismatch before any Git tag lookup or mutation.
+Changelog headings accept strict SemVer 2.0.0 only, reject duplicate `Unreleased` and release sections, render the complete output set before publication, and
+expose one injectable replace boundary for deterministic publication and rollback tests. CDT retains its stronger recovery-copy behavior when a rollback itself
+fails and reports the publication plus rollback errors together.
+
+The new `release-metadata-check` recipe extends the existing citation gate. It requires one top-level ISO `date-released` value, matches that value
+to the generated UTC date on the current Cargo package-version changelog heading when present, and verifies that the `causal-triangulations-scripts` package
+ships `scripts/README.md` rather than the Rust crate README. `CITATION.cff` keeps the Zenodo concept DOI at top level and records the v0.1.0 record DOI under
+`identifiers`, preserving the CFF distinction between all-version and per-version identifiers.
+
+The Semgrep fixture harness now validates the JSON container and each `check_id`, `start.line`, and `end.line`, then matches annotations by rule ID and source
+line within the reported span. Mismatches go to stderr. Shared subprocess wrappers use a finite five-minute default timeout, while existing benchmark paths
+retain explicit longer limits, and project-root discovery accepts an explicit file or directory start.
+
 ## Deferred Updates
 
 These were evaluated but not ported in this pass:

--- a/justfile
+++ b/justfile
@@ -304,8 +304,12 @@ ci-baseline tag="ci":
 ci-slow: ci test-slow
     @echo "✅ CI + slow tests passed!"
 
-# Validate CITATION.cff against the Citation File Format schema.
-citation-check: _ensure-uv
+# Validate release-date synchronization and support-package metadata.
+release-metadata-check: _ensure-uv
+    uv run check-release-metadata
+
+# Validate CITATION.cff against the Citation File Format schema and release metadata gate.
+citation-check: release-metadata-check _ensure-uv
     uvx --from cffconvert==2.0.0 cffconvert --validate -i CITATION.cff
 
 # Clean build artifacts
@@ -432,7 +436,9 @@ help-workflows:
     @echo "  just tag <ver>                   # Create git tag with changelog content"
     @echo ""
     @echo "Static Analysis:"
+    @echo "  just citation-check      # Validate CFF schema and synchronized release metadata"
     @echo "  just publish-check       # Validate crates.io metadata and dry-run publish"
+    @echo "  just release-metadata-check # Validate release dates and Python package README"
     @echo "  just semgrep             # Run repository-owned Semgrep rules"
     @echo "  just semgrep-test        # Test repository-owned Semgrep rules"
     @echo "  just unused-deps         # Check for unused direct Cargo dependencies"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "causal-triangulations-scripts"
 version = "0.1.0"
 description = "Python utility scripts for the causal-triangulations Rust library"
-readme = "README.md"
+readme = "scripts/README.md"
 requires-python = ">=3.14"
 license = "BSD-3-Clause"
 authors = [ { name = "Adam Getchell", email = "adam@adamgetchell.org" } ]
@@ -34,6 +34,7 @@ dependencies = [ "packaging>=26.3" ]
 [project.scripts]
 archive-changelog = "archive_changelog:main"
 benchmark-utils = "benchmark_utils:main"
+check-release-metadata = "check_release_metadata:main"
 coverage-report = "coverage_report:main"
 hardware-utils = "hardware_utils:main"
 notebook-check = "notebook_check:main"
@@ -50,6 +51,7 @@ py-modules = [
     "archive_changelog",
     "benchmark_models",
     "benchmark_utils",
+    "check_release_metadata",
     "coverage_report",
     "hardware_utils",
     "notebook_check",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,12 +25,16 @@ just changelog
 just changelog-unreleased v0.1.0
 uv run postprocess-changelog --help
 uv run archive-changelog --help
+uv run check-release-metadata --help
 uv run tag-release v0.1.0 --help
 just tag v0.1.0
 ```
 
 `just changelog` runs `git-cliff`, applies markdown hygiene, and archives completed minor release series under `docs/archive/changelog/`. Use
-`just changelog-unreleased vX.Y.Z` while preparing a release PR before the final tag exists.
+`just changelog-unreleased vX.Y.Z` while preparing a release PR before the final tag exists. `just release-metadata-check` requires the CFF release date to
+match the generated current-version changelog heading when present and verifies that the Python support package ships this README.
+
+Shared subprocess wrappers apply a five-minute default timeout. Benchmark paths that may run longer pass their own explicit benchmark-specific timeout.
 
 ### Benchmark utilities
 

--- a/scripts/archive_changelog.py
+++ b/scripts/archive_changelog.py
@@ -29,9 +29,17 @@ from postprocess_changelog import normalize_entry_headings_text, postprocess_tex
 
 # Matches ``## [X.Y.Z]`` or ``## [Unreleased]``
 _VERSION_HEADING_RE = re.compile(r"^## \[")
+_HEADING_SUFFIX_PATTERN = r"(?:\([^)]+\))?(?:\s|$)"
+_UNRELEASED_HEADING_RE = re.compile(rf"^## \[Unreleased\]{_HEADING_SUFFIX_PATTERN}")
 
-# Extracts a semver version from a ``## [X.Y.Z]`` heading (linked or plain).
-_VERSION_RE = re.compile(r"^## \[(\d+\.\d+\.\d+[^\]]*)\]")
+# Extracts a strict SemVer 2.0.0 version from a ``## [X.Y.Z]`` heading.
+_SEMVER_ALNUM_ID = r"(?:(?=[0-9A-Za-z-]*[A-Za-z-])[0-9A-Za-z-]+)"
+_SEMVER_PATTERN = (
+    r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+    rf"(?:-(?:(?:0|[1-9]\d*)|{_SEMVER_ALNUM_ID})(?:\.(?:(?:0|[1-9]\d*)|{_SEMVER_ALNUM_ID}))*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+)
+_VERSION_RE = re.compile(rf"^## \[({_SEMVER_PATTERN})\]{_HEADING_SUFFIX_PATTERN}")
 
 # Matches a reference-style link definition: ``[label]: URL``
 _LINK_DEF_RE = re.compile(r"^\[([^\]]+)\]:\s+\S+")
@@ -160,21 +168,32 @@ def parse_changelog(text: str) -> tuple[str, str, list[tuple[str, str]]]:
     preamble = "\n".join(lines[: headings[0]])
 
     unreleased = ""
+    unreleased_line: int | None = None
     version_blocks: list[tuple[str, str]] = []
+    version_lines: dict[str, int] = {}
 
     for idx, start in enumerate(headings):
         end = headings[idx + 1] if idx + 1 < len(headings) else len(lines)
         block = "\n".join(lines[start:end])
 
         heading_line = lines[start]
-        if "Unreleased" in heading_line:
+        if _UNRELEASED_HEADING_RE.match(heading_line):
+            if unreleased_line is not None:
+                msg = f"Duplicate Unreleased changelog heading at lines {unreleased_line} and {start + 1}"
+                raise ValueError(msg)
             unreleased = block
+            unreleased_line = start + 1
         else:
             m = _VERSION_RE.match(heading_line)
             if not m:
-                # Skip headings that don't contain a recognisable semver.
-                continue
-            version_blocks.append((m.group(1), block))
+                msg = f"Unrecognized changelog version heading at line {start + 1}: {heading_line!r}; expected '## [Unreleased]' or a semantic version"
+                raise ValueError(msg)
+            version = m.group(1)
+            if version in version_lines:
+                msg = f"Duplicate changelog version {version!r} at lines {version_lines[version]} and {start + 1}"
+                raise ValueError(msg)
+            version_lines[version] = start + 1
+            version_blocks.append((version, block))
 
     return preamble, unreleased, version_blocks
 
@@ -237,6 +256,11 @@ def _stage_output(path: Path, content: bytes) -> Path:
     return temporary_path
 
 
+def _replace_path(source: Path, destination: Path) -> Path:
+    """Replace one path through the injectable publication boundary."""
+    return source.replace(destination)
+
+
 def _fsync_directory(path: Path) -> None:
     """Persist directory-entry changes where the platform supports it."""
     if os.name == "nt":
@@ -260,7 +284,7 @@ def _rollback_outputs(
             if backup is None:
                 path.unlink(missing_ok=True)
             else:
-                backup.replace(path)
+                _replace_path(backup, path)
         except OSError as rollback_error:
             rollback_errors.append((path, rollback_error))
         else:
@@ -288,7 +312,7 @@ def _publish_outputs(outputs: dict[Path, str]) -> None:
 
         try:
             for path in outputs:
-                staged[path].replace(path)
+                _replace_path(staged[path], path)
                 staged.pop(path)
                 published.append(path)
             for parent in sorted({path.parent for path in outputs}):
@@ -300,7 +324,8 @@ def _publish_outputs(outputs: dict[Path, str]) -> None:
                 recovery_locations = ", ".join(f"{destination} -> {backup}" for destination, backup in sorted(preserved_backups.items()))
                 recovery_detail = f"; original content retained at {recovery_locations}" if recovery_locations else "; no original-content backup was available"
                 message = f"failed to publish changelog outputs and encountered {len(rollback_errors)} rollback error(s){recovery_detail}"
-                raise RuntimeError(message) from publish_error
+                visible_rollback_errors = [OSError(f"failed to restore {path}: {rollback_error}") for path, rollback_error in rollback_errors]
+                raise ExceptionGroup(message, [publish_error, *visible_rollback_errors]) from None
             raise
     finally:
         backup_paths = (path for path in backups.values() if path is not None and path not in preserved_backups.values())
@@ -507,7 +532,16 @@ def archive_changelog(
 # ---------------------------------------------------------------------------
 
 
-def main() -> None:
+def _print_cli_error(error: BaseException, *, indent: str = "") -> None:
+    """Print one expected CLI failure, including nested exception-group details."""
+    prefix = "Error: " if not indent else f"{indent}- "
+    print(f"{prefix}{error}", file=sys.stderr)
+    if isinstance(error, BaseExceptionGroup):
+        for nested_error in error.exceptions:
+            _print_cli_error(nested_error, indent=f"{indent}  ")
+
+
+def main(argv: list[str] | None = None) -> int:
     """CLI entry point for ``archive-changelog``."""
     parser = argparse.ArgumentParser(
         prog="archive-changelog",
@@ -524,16 +558,21 @@ def main() -> None:
         default=None,
         help=f"Archive output directory (default: {_DEFAULT_ARCHIVE_DIR})",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     changelog = Path(args.path)
     if not changelog.is_file():
         print(f"Error: {changelog} not found", file=sys.stderr)
-        sys.exit(1)
+        return 1
 
     archive_dir = Path(args.archive_dir) if args.archive_dir else None
-    archive_changelog(changelog, archive_dir)
+    try:
+        archive_changelog(changelog, archive_dir)
+    except (ExceptionGroup, OSError, ValueError) as error:
+        _print_cli_error(error)
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env -S uv run
+"""Validate release dates and Python support-package metadata."""
+
+import argparse
+import re
+import sys
+import tomllib
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import TypeGuard
+
+_CITATION_DATE_RE = re.compile(r"^date-released:\s*(?P<quote>['\"]?)(?P<date>\d{4}-\d{2}-\d{2})(?P=quote)\s*(?:#.*)?$")
+_EXPECTED_PYTHON_README = "scripts/README.md"
+
+type ParsedObject = dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseDate:
+    """One validated release date with source context."""
+
+    path: Path
+    line: int
+    value: str
+
+
+def _is_parsed_object(value: object) -> TypeGuard[ParsedObject]:
+    """Return whether a parsed value is an object with string keys."""
+    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
+
+
+def _required_table(data: ParsedObject, key: str, path: Path) -> ParsedObject:
+    """Return a required top-level TOML table."""
+    table = data.get(key)
+    if not _is_parsed_object(table):
+        msg = f"{path}: missing [{key}] table"
+        raise TypeError(msg)
+    return table
+
+
+def _read_toml(path: Path) -> ParsedObject:
+    """Parse a TOML file and require an object at its root."""
+    data: object = tomllib.loads(path.read_text(encoding="utf-8"))
+    if not _is_parsed_object(data):
+        msg = f"{path}: expected a TOML object"
+        raise TypeError(msg)
+    return data
+
+
+def _package_version(path: Path) -> str:
+    """Read the authoritative Cargo package version."""
+    package = _required_table(_read_toml(path), "package", path)
+    version = package.get("version")
+    if not isinstance(version, str) or not version:
+        msg = f"{path}: [package].version must be a non-empty string"
+        raise TypeError(msg)
+    return version
+
+
+def _citation_release_date(path: Path) -> ReleaseDate:
+    """Read exactly one top-level ISO ``date-released`` value."""
+    matches: list[ReleaseDate] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.startswith("date-released:"):
+            continue
+        match = _CITATION_DATE_RE.fullmatch(line)
+        if match is None:
+            msg = f"{path}:{line_number}: top-level date-released must use ISO YYYY-MM-DD"
+            raise ValueError(msg)
+        value = match.group("date")
+        try:
+            date.fromisoformat(value)
+        except ValueError as exc:
+            msg = f"{path}:{line_number}: invalid date-released {value!r}"
+            raise ValueError(msg) from exc
+        matches.append(ReleaseDate(path=path, line=line_number, value=value))
+
+    if len(matches) != 1:
+        lines = ", ".join(str(match.line) for match in matches) or "none"
+        msg = f"{path}: expected exactly one top-level date-released; found {len(matches)} at lines {lines}"
+        raise ValueError(msg)
+    return matches[0]
+
+
+def _changelog_release_date(path: Path, version: str) -> ReleaseDate | None:
+    """Read the current package-version heading date when that heading exists."""
+    heading_start = rf"## \[v?{re.escape(version)}\]"
+    heading_prefix = re.compile(rf"^{heading_start}")
+    heading = re.compile(rf"^{heading_start}(?:\([^)]+\))? - (?P<date>\d{{4}}-\d{{2}}-\d{{2}})$")
+    matches: list[ReleaseDate] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if heading_prefix.match(line) is None:
+            continue
+        match = heading.fullmatch(line)
+        if match is None:
+            msg = f"{path}:{line_number}: release heading for {version} must end with ISO YYYY-MM-DD"
+            raise ValueError(msg)
+        value = match.group("date")
+        try:
+            date.fromisoformat(value)
+        except ValueError as exc:
+            msg = f"{path}:{line_number}: invalid release heading date {value!r}"
+            raise ValueError(msg) from exc
+        matches.append(ReleaseDate(path=path, line=line_number, value=value))
+
+    if len(matches) > 1:
+        lines = ", ".join(str(match.line) for match in matches)
+        msg = f"{path}: duplicate release headings for {version} at lines {lines}"
+        raise ValueError(msg)
+    return matches[0] if matches else None
+
+
+def _validate_python_readme(root: Path) -> None:
+    """Require package metadata to ship the support-tooling README."""
+    pyproject = root / "pyproject.toml"
+    project = _required_table(_read_toml(pyproject), "project", pyproject)
+    readme = project.get("readme")
+    if readme != _EXPECTED_PYTHON_README:
+        msg = f"{pyproject}: [project].readme must be {_EXPECTED_PYTHON_README!r}, got {readme!r}"
+        raise ValueError(msg)
+    readme_path = root / _EXPECTED_PYTHON_README
+    if not readme_path.is_file():
+        msg = f"{pyproject}: [project].readme points to missing file {readme_path}"
+        raise FileNotFoundError(msg)
+
+
+def validate_release_metadata(root: Path) -> None:
+    """Validate release metadata rooted at one repository checkout."""
+    version = _package_version(root / "Cargo.toml")
+    citation_date = _citation_release_date(root / "CITATION.cff")
+    _validate_python_readme(root)
+
+    changelog = root / "CHANGELOG.md"
+    if not changelog.is_file():
+        return
+    changelog_date = _changelog_release_date(changelog, version)
+    if changelog_date is not None and citation_date.value != changelog_date.value:
+        msg = (
+            f"release date mismatch: {citation_date.path}:{citation_date.line} has {citation_date.value}, "
+            f"but {changelog_date.path}:{changelog_date.line} has {changelog_date.value}; both must use the generated UTC release date"
+        )
+        raise ValueError(msg)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate release metadata and translate expected failures for the CLI."""
+    parser = argparse.ArgumentParser(
+        prog="check-release-metadata",
+        description="Validate release dates and Python support-package metadata.",
+    )
+    parser.add_argument(
+        "root",
+        nargs="?",
+        default=Path.cwd(),
+        type=Path,
+        help="Repository root to check (default: current directory).",
+    )
+    root = parser.parse_args(argv).root.resolve()
+    try:
+        validate_release_metadata(root)
+    except (OSError, TypeError, ValueError, tomllib.TOMLDecodeError) as error:
+        print(f"Release metadata validation failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -111,10 +111,14 @@ def _changelog_release_date(path: Path, version: str) -> ReleaseDate | None:
     return matches[0] if matches else None
 
 
-def _validate_python_readme(root: Path) -> None:
-    """Require package metadata to ship the support-tooling README."""
+def _validate_python_readme(root: Path, cargo_version: str) -> None:
+    """Require Python package metadata to match the Rust package."""
     pyproject = root / "pyproject.toml"
     project = _required_table(_read_toml(pyproject), "project", pyproject)
+    python_version = project.get("version")
+    if python_version != cargo_version:
+        msg = f"{pyproject}: [project].version must match Cargo [package].version {cargo_version!r}, got {python_version!r}"
+        raise ValueError(msg)
     readme = project.get("readme")
     if readme != _EXPECTED_PYTHON_README:
         msg = f"{pyproject}: [project].readme must be {_EXPECTED_PYTHON_README!r}, got {readme!r}"
@@ -129,7 +133,7 @@ def validate_release_metadata(root: Path) -> None:
     """Validate release metadata rooted at one repository checkout."""
     version = _package_version(root / "Cargo.toml")
     citation_date = _citation_release_date(root / "CITATION.cff")
-    _validate_python_readme(root)
+    _validate_python_readme(root, version)
 
     changelog = root / "CHANGELOG.md"
     if not changelog.is_file():

--- a/scripts/check_semgrep_fixtures.py
+++ b/scripts/check_semgrep_fixtures.py
@@ -5,10 +5,27 @@ import json
 import os
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TypeGuard
 
 RULE_ANNOTATION = re.compile(r"\b(?:ruleid|todoruleid):\s*([A-Za-z0-9_.-]+(?:\s*,\s*[A-Za-z0-9_.-]+)*)")
+
+
+type ParsedObject = dict[str, object]
+type ExpectedFinding = tuple[str, int]
+type ActualFinding = tuple[str, int, int]
+
+
+@dataclass(frozen=True, slots=True)
+class SemgrepResults:
+    """Validated subset of Semgrep JSON needed by fixture checks."""
+
+    results: tuple[ParsedObject, ...]
+
+
+def _is_parsed_object(value: object) -> TypeGuard[ParsedObject]:
+    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
 
 
 def _path_argument(argv: list[str]) -> Path | None:
@@ -29,40 +46,151 @@ def _path_argument(argv: list[str]) -> Path | None:
     return path
 
 
-def _semgrep_results() -> dict[str, Any] | None:
+def _semgrep_results() -> SemgrepResults | None:
     semgrep_json = os.environ.get("SEMGREP_JSON")
     if semgrep_json is None:
         print("Missing required SEMGREP_JSON environment variable", file=sys.stderr)
         return None
     try:
-        return json.loads(semgrep_json)
+        data: object = json.loads(semgrep_json)
     except json.JSONDecodeError as error:
         print(f"Invalid JSON in SEMGREP_JSON: {error}", file=sys.stderr)
         return None
 
+    if not _is_parsed_object(data):
+        print("Invalid SEMGREP_JSON shape: expected a JSON object", file=sys.stderr)
+        return None
+    results = data.get("results")
+    if not isinstance(results, list):
+        print("Invalid SEMGREP_JSON shape: expected 'results' to be a list", file=sys.stderr)
+        return None
+
+    parsed_results: list[ParsedObject] = []
+    malformed_results: list[str] = []
+    for index, result in enumerate(results):
+        if _is_parsed_object(result):
+            parsed_results.append(result)
+        else:
+            malformed_results.append(f"result {index} is not an object")
+
+    if malformed_results:
+        print("Invalid SEMGREP_JSON shape:", file=sys.stderr)
+        for malformed in malformed_results:
+            print(f"  {malformed}", file=sys.stderr)
+        return None
+
+    return SemgrepResults(results=tuple(parsed_results))
+
+
+def _expected_findings(path: Path) -> collections.Counter[ExpectedFinding]:
+    expected: collections.Counter[ExpectedFinding] = collections.Counter()
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for line_number, line in enumerate(lines, start=1):
+        for match in RULE_ANNOTATION.finditer(line):
+            finding_line = line_number + 1
+            while finding_line <= len(lines):
+                candidate = lines[finding_line - 1].strip()
+                if candidate and not candidate.startswith("```"):
+                    break
+                finding_line += 1
+            expected.update((rule_id.strip(), finding_line) for rule_id in match.group(1).split(",") if rule_id.strip())
+    return expected
+
+
+def _actual_findings(semgrep: SemgrepResults) -> tuple[ActualFinding, ...] | None:
+    actual: list[ActualFinding] = []
+    malformed_results: list[str] = []
+    for index, result in enumerate(semgrep.results):
+        check_id = result.get("check_id")
+        start = result.get("start")
+        end = result.get("end")
+        start_line = start.get("line") if _is_parsed_object(start) else None
+        end_line = end.get("line") if _is_parsed_object(end) else None
+
+        check_id_valid = isinstance(check_id, str) and bool(check_id)
+        start_line_valid = isinstance(start_line, int) and not isinstance(start_line, bool) and start_line >= 1
+        end_line_valid = isinstance(end_line, int) and not isinstance(end_line, bool) and end_line >= 1
+        if not check_id_valid:
+            malformed_results.append(f"result {index} is missing non-empty string field 'check_id'")
+        if not start_line_valid:
+            malformed_results.append(f"result {index} is missing positive integer field 'start.line'")
+        if not end_line_valid:
+            malformed_results.append(f"result {index} is missing positive integer field 'end.line'")
+        if start_line_valid and end_line_valid and end_line < start_line:
+            malformed_results.append(f"result {index} has end.line {end_line} before start.line {start_line}")
+
+        if (
+            isinstance(check_id, str)
+            and check_id
+            and isinstance(start_line, int)
+            and not isinstance(start_line, bool)
+            and start_line >= 1
+            and isinstance(end_line, int)
+            and not isinstance(end_line, bool)
+            and end_line >= start_line
+        ):
+            actual.append((check_id, start_line, end_line))
+
+    if not malformed_results:
+        return tuple(actual)
+
+    print("Invalid SEMGREP_JSON shape:", file=sys.stderr)
+    for malformed in malformed_results:
+        print(f"  {malformed}", file=sys.stderr)
+    return None
+
+
+def _finding_mismatches(
+    expected: collections.Counter[ExpectedFinding],
+    actual: tuple[ActualFinding, ...],
+) -> tuple[str, ...]:
+    unmatched_actual = list(actual)
+    mismatches: list[str] = []
+
+    for (rule_id, line), expected_count in sorted(expected.items()):
+        for _ in range(expected_count):
+            match_index = min(
+                (
+                    index
+                    for index, (actual_rule_id, start_line, end_line) in enumerate(unmatched_actual)
+                    if actual_rule_id == rule_id and start_line <= line <= end_line
+                ),
+                key=lambda index: unmatched_actual[index][2],
+                default=None,
+            )
+            if match_index is None:
+                mismatches.append(f"{rule_id} at line {line}: expected finding not reported")
+            else:
+                unmatched_actual.pop(match_index)
+
+    for rule_id, start_line, end_line in sorted(unmatched_actual):
+        span = str(start_line) if start_line == end_line else f"{start_line}-{end_line}"
+        mismatches.append(f"{rule_id} at lines {span}: unexpected finding")
+
+    return tuple(mismatches)
+
 
 def main() -> int:
+    """Compare expected fixture annotations with the supplied Semgrep results."""
     path = _path_argument(sys.argv)
     if path is None:
         return 1
 
-    expected: collections.Counter[str] = collections.Counter()
-    for line in path.read_text(encoding="utf-8").splitlines():
-        for match in RULE_ANNOTATION.finditer(line):
-            expected.update(rule_id.strip() for rule_id in match.group(1).split(",") if rule_id.strip())
-
-    data = _semgrep_results()
-    if data is None:
+    expected = _expected_findings(path)
+    semgrep = _semgrep_results()
+    if semgrep is None:
+        return 1
+    actual = _actual_findings(semgrep)
+    if actual is None:
         return 1
 
-    actual: collections.Counter[str] = collections.Counter(result["check_id"] for result in data["results"])
-    if actual == expected:
+    mismatches = _finding_mismatches(expected, actual)
+    if not mismatches:
         return 0
 
-    print(f"Semgrep fixture mismatch in {path}")
-    for rule in sorted(expected.keys() | actual.keys()):
-        if expected[rule] != actual[rule]:
-            print(f"  {rule}: expected {expected[rule]}, got {actual[rule]}")
+    print(f"Semgrep fixture mismatch in {path}", file=sys.stderr)
+    for mismatch in mismatches:
+        print(f"  {mismatch}", file=sys.stderr)
     return 1
 
 

--- a/scripts/check_semgrep_fixtures.py
+++ b/scripts/check_semgrep_fixtures.py
@@ -155,7 +155,7 @@ def _finding_mismatches(
                     for index, (actual_rule_id, start_line, end_line) in enumerate(unmatched_actual)
                     if actual_rule_id == rule_id and start_line <= line <= end_line
                 ),
-                key=lambda index: unmatched_actual[index][2],
+                key=lambda index: unmatched_actual[index][2] - unmatched_actual[index][1],
                 default=None,
             )
             if match_index is None:

--- a/scripts/subprocess_utils.py
+++ b/scripts/subprocess_utils.py
@@ -16,7 +16,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, cast
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 300.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS: float = 300.0
 
 
 class ExecutableNotFoundError(Exception):

--- a/scripts/subprocess_utils.py
+++ b/scripts/subprocess_utils.py
@@ -16,6 +16,8 @@ import subprocess
 from pathlib import Path
 from typing import Any, cast
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 300.0
+
 
 class ExecutableNotFoundError(Exception):
     """Raised when a required executable is not found in PATH."""
@@ -72,6 +74,7 @@ def _build_run_kwargs(function_name: str, **kwargs: Any) -> dict[str, Any]:
     }
     # Prefer deterministic UTF-8 unless caller overrides
     run_kwargs.setdefault("encoding", "utf-8")
+    run_kwargs.setdefault("timeout", DEFAULT_COMMAND_TIMEOUT_SECONDS)
     return run_kwargs
 
 
@@ -283,8 +286,12 @@ class ProjectRootNotFoundError(Exception):
     """Raised when project root directory cannot be located."""
 
 
-def find_project_root() -> Path:
+def find_project_root(start: Path | None = None) -> Path:
     """Find the project root by looking for Cargo.toml.
+
+    Args:
+        start: File or directory from which to begin walking upward. Defaults to
+            the current working directory.
 
     Returns:
         Path to project root directory
@@ -292,10 +299,11 @@ def find_project_root() -> Path:
     Raises:
         ProjectRootNotFoundError: If Cargo.toml cannot be found in any parent directory
     """
-    current_dir = Path.cwd()
-    project_root = current_dir
+    project_root = (start or Path.cwd()).resolve()
+    if project_root.is_file():
+        project_root = project_root.parent
     while project_root != project_root.parent:
-        if (project_root / "Cargo.toml").exists():
+        if (project_root / "Cargo.toml").is_file():
             return project_root
         project_root = project_root.parent
     msg = "Could not locate Cargo.toml to determine project root"

--- a/scripts/tag_release.py
+++ b/scripts/tag_release.py
@@ -17,6 +17,7 @@ import logging
 import re
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 from subprocess_utils import (
@@ -108,6 +109,38 @@ def find_changelog(start: Path | None = None) -> Path:
             return candidate
     msg = "CHANGELOG.md not found in current directory or parent directory."
     raise FileNotFoundError(msg)
+
+
+def _package_version(changelog: Path) -> str:
+    """Return the authoritative Cargo package version beside the changelog."""
+    cargo_toml = changelog.parent / "Cargo.toml"
+    try:
+        data = tomllib.loads(cargo_toml.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        msg = f"Could not parse {cargo_toml}: {exc}"
+        raise ValueError(msg) from exc
+
+    package = data.get("package")
+    if not isinstance(package, dict):
+        msg = f"{cargo_toml} does not define a [package] table"
+        raise TypeError(msg)
+    version = package.get("version")
+    if not isinstance(version, str) or not version.strip():
+        msg = f"{cargo_toml} does not define a non-empty package version"
+        raise TypeError(msg)
+    return version
+
+
+def _validated_release_target(tag_version: str) -> tuple[str, Path]:
+    """Validate a requested tag and return its version plus changelog path."""
+    validate_semver(tag_version)
+    version = parse_version(tag_version)
+    changelog = find_changelog()
+    package_version = _package_version(changelog)
+    if version != package_version:
+        msg = f"Tag version {version!r} does not match Cargo package version {package_version!r}"
+        raise ValueError(msg)
+    return version, changelog
 
 
 def _archive_path_for_version(changelog: Path, version: str) -> Path | None:
@@ -347,8 +380,7 @@ def create_tag(tag_version: str, *, force: bool = False) -> None:
         tag_version (str): The tag to create (must follow the project's SemVer format, e.g., "v1.2.3").
         force (bool): If True, replace the tag when it already exists; otherwise bail out.
     """
-    validate_semver(tag_version)
-    version = parse_version(tag_version)
+    version, changelog = _validated_release_target(tag_version)
 
     # Check for existing tag (but don't delete yet — validate first)
     tag_existed = _tag_exists(tag_version)
@@ -358,7 +390,6 @@ def create_tag(tag_version: str, *, force: bool = False) -> None:
         sys.exit(1)
 
     # Extract changelog section (before any mutation)
-    changelog = find_changelog()
     section, source = extract_changelog_section(changelog, version)
     section_bytes = len(section.encode("utf-8"))
 
@@ -446,8 +477,9 @@ def main() -> None:
     try:
         create_tag(args.version, force=args.force)
     except (
+        TypeError,
         ValueError,
-        FileNotFoundError,
+        OSError,
         LookupError,
         ExecutableNotFoundError,
         subprocess.CalledProcessError,

--- a/scripts/tests/test_archive_changelog.py
+++ b/scripts/tests/test_archive_changelog.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import archive_changelog as archive_changelog_module
 from archive_changelog import (
     _extract_link_defs,
     _format_link_defs,
@@ -158,13 +159,39 @@ class TestParseChangelog:
         assert unreleased == ""
         assert len(blocks) == 2
 
-    def test_skips_non_semver_headings(self) -> None:
+    def test_rejects_non_semver_headings(self) -> None:
         text = _PREAMBLE + _V072 + "## [CustomLabel]\n\n- Something\n\n" + _V071
-        _, _, blocks = parse_changelog(text)
-        # The non-semver heading should be silently skipped.
-        assert len(blocks) == 2
-        assert blocks[0][0] == "0.7.2"
-        assert blocks[1][0] == "0.7.1"
+
+        with pytest.raises(ValueError, match="Unrecognized changelog version heading"):
+            parse_changelog(text)
+
+    def test_rejects_unreleased_heading_without_closing_bracket_boundary(self) -> None:
+        text = _PREAMBLE + "## [Unreleased]invalid\n\n- Something\n\n" + _V072
+
+        with pytest.raises(ValueError, match="Unrecognized changelog version heading"):
+            parse_changelog(text)
+
+    @pytest.mark.parametrize("version", ["01.2.3", "1.02.3", "1.2.03", "1.2.3garbage", "1.2.3-01"])
+    def test_rejects_malformed_semver_headings(self, version: str) -> None:
+        text = _PREAMBLE + f"## [{version}] - 2026-01-01\n"
+
+        with pytest.raises(ValueError, match="semantic version"):
+            parse_changelog(text)
+
+    def test_accepts_strict_semver_prerelease_build_and_inline_link(self) -> None:
+        text = _PREAMBLE + "## [1.2.3-rc.1+build.7](https://example.com/release) - 2026-01-01\n"
+
+        _preamble, _unreleased, blocks = parse_changelog(text)
+
+        assert blocks == [("1.2.3-rc.1+build.7", "## [1.2.3-rc.1+build.7](https://example.com/release) - 2026-01-01\n")]
+
+    def test_rejects_duplicate_unreleased_headings(self) -> None:
+        with pytest.raises(ValueError, match="Duplicate Unreleased"):
+            parse_changelog(_PREAMBLE + _UNRELEASED + _UNRELEASED + _V072)
+
+    def test_rejects_duplicate_release_headings(self) -> None:
+        with pytest.raises(ValueError, match="Duplicate changelog version"):
+            parse_changelog(_PREAMBLE + _V072 + _V072)
 
 
 class TestGroupByMinor:
@@ -349,8 +376,7 @@ class TestArchiveChangelog:
         original_archive = "# Changelog - 0.6.x\n\nPrior valid archive\n"
         existing_archive.write_text(original_archive, encoding="utf-8")
 
-        path_type = type(changelog)
-        real_replace = path_type.replace
+        real_replace = archive_changelog_module._replace_path
         root_failure_injected = False
 
         def fail_when_publishing_root(source: Path, destination: Path) -> Path:
@@ -361,7 +387,7 @@ class TestArchiveChangelog:
                 raise OSError(message)
             return real_replace(source, destination)
 
-        monkeypatch.setattr(path_type, "replace", fail_when_publishing_root)
+        monkeypatch.setattr(archive_changelog_module, "_replace_path", fail_when_publishing_root)
 
         with pytest.raises(OSError, match="injected root publication failure"):
             archive_changelog(changelog, archive_dir)
@@ -390,8 +416,7 @@ class TestArchiveChangelog:
         original_older_archive = "# Changelog - 0.2.x\n\nPrior older archive\n"
         existing_older_archive.write_text(original_older_archive, encoding="utf-8")
 
-        path_type = type(changelog)
-        real_replace = path_type.replace
+        real_replace = archive_changelog_module._replace_path
         root_failure_injected = False
 
         def fail_publication_and_rollback(source: Path, destination: Path) -> Path:
@@ -405,17 +430,43 @@ class TestArchiveChangelog:
                 raise OSError(message)
             return real_replace(source, destination)
 
-        monkeypatch.setattr(path_type, "replace", fail_publication_and_rollback)
+        monkeypatch.setattr(archive_changelog_module, "_replace_path", fail_publication_and_rollback)
 
-        with pytest.raises(RuntimeError, match="original content retained at") as error:
+        with pytest.raises(ExceptionGroup, match="original content retained at") as error:
             archive_changelog(changelog, archive_dir)
 
         recovery_files = list(archive_dir.glob("*.tmp"))
         assert len(recovery_files) == 1
         assert f"{existing_archive} -> {recovery_files[0]}" in str(error.value)
+        failure_messages = [str(failure) for failure in error.value.exceptions]
+        assert "injected root publication failure" in failure_messages[0]
+        assert f"failed to restore {existing_archive}: injected archive rollback failure" in failure_messages[1]
         assert recovery_files[0].read_text(encoding="utf-8") == original_archive
         assert changelog.read_text(encoding="utf-8") == original_root
         assert existing_older_archive.read_text(encoding="utf-8") == original_older_archive
+
+    @pytest.mark.parametrize(
+        "invalid_text",
+        [
+            _PREAMBLE + _UNRELEASED + "## [CustomLabel]\n\n- Invalid\n",
+            _PREAMBLE + _UNRELEASED + _V072 + _V072,
+        ],
+    )
+    def test_invalid_headings_leave_root_and_archives_unchanged(self, tmp_path: Path, invalid_text: str) -> None:
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text(invalid_text, encoding="utf-8")
+        archive_dir = tmp_path / "docs" / "archive" / "changelog"
+        archive_dir.mkdir(parents=True)
+        existing_archive = archive_dir / "0.6.md"
+        original_archive = b"# Existing archive\r\n"
+        existing_archive.write_bytes(original_archive)
+
+        with pytest.raises(ValueError, match=r"Unrecognized|Duplicate"):
+            archive_changelog(changelog, archive_dir)
+
+        assert changelog.read_text(encoding="utf-8") == invalid_text
+        assert existing_archive.read_bytes() == original_archive
+        assert not list(tmp_path.rglob("*.tmp"))
 
     def test_output_directory_is_rejected_before_publication(self, tmp_path: Path) -> None:
         """A directory at an output path must leave every existing file untouched."""
@@ -563,6 +614,61 @@ class TestArchiveChangelog:
         assert "path is on mount 'D:', start on mount 'C:'" in caplog.text
         assert str(archive_dir) in caplog.text
         assert str(changelog_dir) in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveChangelogCli:
+    def test_malformed_heading_reports_stderr_without_modifying_files(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        changelog = tmp_path / "CHANGELOG.md"
+        malformed = _PREAMBLE + _UNRELEASED + "## [CustomLabel]\n\n- Invalid\n"
+        changelog.write_text(malformed, encoding="utf-8")
+        archive_dir = tmp_path / "archive"
+
+        status = archive_changelog_module.main([str(changelog), "--archive-dir", str(archive_dir)])
+
+        captured = capsys.readouterr()
+        assert status == 1
+        assert captured.out == ""
+        assert "Error: Unrecognized changelog version heading" in captured.err
+        assert "Traceback" not in captured.err
+        assert changelog.read_text(encoding="utf-8") == malformed
+        assert not archive_dir.exists()
+
+    def test_publication_and_rollback_failures_remain_visible(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text(_PREAMBLE + _V072, encoding="utf-8")
+        grouped_error = ExceptionGroup(
+            "publication failed and rollback failed",
+            [OSError("root replacement failed"), OSError("archive restoration failed")],
+        )
+
+        def fail_publication(_changelog: Path, _archive_dir: Path | None) -> None:
+            raise grouped_error
+
+        monkeypatch.setattr(archive_changelog_module, "archive_changelog", fail_publication)
+
+        status = archive_changelog_module.main([str(changelog)])
+
+        captured = capsys.readouterr()
+        assert status == 1
+        assert captured.out == ""
+        assert "Error: publication failed and rollback failed" in captured.err
+        assert "root replacement failed" in captured.err
+        assert "archive restoration failed" in captured.err
+        assert "Traceback" not in captured.err
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_check_release_metadata.py
+++ b/scripts/tests/test_check_release_metadata.py
@@ -1,13 +1,11 @@
 """Tests for release-date and Python package metadata validation."""
 
-from typing import TYPE_CHECKING
+# Keep runtime annotation resolution available during test collection.
+from pathlib import Path  # noqa: TC003
 
 import pytest
 
 import check_release_metadata
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _write_repository(
@@ -15,6 +13,7 @@ def _write_repository(
     *,
     citation_dates: tuple[str, ...] = ("2026-06-02",),
     changelog_headings: tuple[str, ...] = ("## [0.1.0] - 2026-06-02",),
+    python_version: str = "0.1.0",
     python_readme: str = "scripts/README.md",
 ) -> None:
     (root / "Cargo.toml").write_text('[package]\nname = "causal-triangulations"\nversion = "0.1.0"\n', encoding="utf-8")
@@ -26,7 +25,7 @@ def _write_repository(
     (root / "scripts").mkdir()
     (root / "scripts" / "README.md").write_text("# Support scripts\n", encoding="utf-8")
     (root / "pyproject.toml").write_text(
-        f'[project]\nname = "causal-triangulations-scripts"\nversion = "0.1.0"\nreadme = "{python_readme}"\n',
+        f'[project]\nname = "causal-triangulations-scripts"\nversion = "{python_version}"\nreadme = "{python_readme}"\n',
         encoding="utf-8",
     )
 
@@ -129,6 +128,13 @@ def test_python_package_readme_must_target_support_documentation(tmp_path: Path)
     _write_repository(tmp_path, python_readme="README.md")
 
     with pytest.raises(ValueError, match=r"pyproject\.toml: \[project\]\.readme must be 'scripts/README\.md'"):
+        check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_python_package_version_must_match_cargo_package(tmp_path: Path) -> None:
+    _write_repository(tmp_path, python_version="0.2.0")
+
+    with pytest.raises(ValueError, match=r"\[project\]\.version must match Cargo \[package\]\.version '0\.1\.0', got '0\.2\.0'"):
         check_release_metadata.validate_release_metadata(tmp_path)
 
 

--- a/scripts/tests/test_check_release_metadata.py
+++ b/scripts/tests/test_check_release_metadata.py
@@ -1,0 +1,141 @@
+"""Tests for release-date and Python package metadata validation."""
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import check_release_metadata
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_repository(
+    root: Path,
+    *,
+    citation_dates: tuple[str, ...] = ("2026-06-02",),
+    changelog_headings: tuple[str, ...] = ("## [0.1.0] - 2026-06-02",),
+    python_readme: str = "scripts/README.md",
+) -> None:
+    (root / "Cargo.toml").write_text('[package]\nname = "causal-triangulations"\nversion = "0.1.0"\n', encoding="utf-8")
+    (root / "CITATION.cff").write_text(
+        "cff-version: 1.2.0\nversion: 0.1.0\n" + "".join(f"date-released: {release_date}\n" for release_date in citation_dates),
+        encoding="utf-8",
+    )
+    (root / "CHANGELOG.md").write_text("# Changelog\n\n" + "\n\n".join(changelog_headings) + "\n", encoding="utf-8")
+    (root / "scripts").mkdir()
+    (root / "scripts" / "README.md").write_text("# Support scripts\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "causal-triangulations-scripts"\nversion = "0.1.0"\nreadme = "{python_readme}"\n',
+        encoding="utf-8",
+    )
+
+
+def test_matching_release_dates_and_python_readme_pass(tmp_path: Path) -> None:
+    _write_repository(tmp_path)
+
+    check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_matching_inline_linked_release_dates_pass(tmp_path: Path) -> None:
+    _write_repository(
+        tmp_path,
+        changelog_headings=("## [0.1.0](https://example.com/releases/0.1.0) - 2026-06-02",),
+    )
+
+    check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_missing_current_version_heading_still_validates_citation_date(tmp_path: Path) -> None:
+    _write_repository(tmp_path, changelog_headings=("## [Unreleased]",))
+
+    check_release_metadata.validate_release_metadata(tmp_path)
+
+
+@pytest.mark.parametrize("release_date", ["2026-6-02", "June 2, 2026", "'2026-06-02\"", ""])
+def test_malformed_citation_date_reports_file_and_line(tmp_path: Path, release_date: str) -> None:
+    _write_repository(tmp_path, citation_dates=(release_date,))
+
+    with pytest.raises(ValueError, match=r"CITATION\.cff:3: top-level date-released must use ISO YYYY-MM-DD"):
+        check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_invalid_citation_calendar_date_reports_file_and_line(tmp_path: Path) -> None:
+    _write_repository(tmp_path, citation_dates=("2026-02-30",))
+
+    with pytest.raises(ValueError, match=r"CITATION\.cff:3: invalid date-released"):
+        check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_missing_citation_date_reports_file_context(tmp_path: Path) -> None:
+    _write_repository(tmp_path, citation_dates=())
+
+    with pytest.raises(ValueError, match=r"CITATION\.cff: expected exactly one top-level date-released; found 0"):
+        check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_duplicate_citation_dates_report_both_lines(tmp_path: Path) -> None:
+    _write_repository(tmp_path, citation_dates=("2026-06-02", "2026-06-02"))
+
+    with pytest.raises(ValueError, match=r"CITATION\.cff: expected exactly one top-level date-released; found 2 at lines 3, 4"):
+        check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_mismatched_release_dates_report_both_sources(tmp_path: Path) -> None:
+    _write_repository(tmp_path, changelog_headings=("## [0.1.0] - 2026-06-03",))
+
+    with pytest.raises(ValueError, match=r"CITATION\.cff:3 has 2026-06-02, but .*CHANGELOG\.md:3 has 2026-06-03"):
+        check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_mismatched_inline_linked_release_dates_report_both_sources(tmp_path: Path) -> None:
+    _write_repository(
+        tmp_path,
+        changelog_headings=("## [0.1.0](https://example.com/releases/0.1.0) - 2026-06-03",),
+    )
+
+    with pytest.raises(ValueError, match=r"CITATION\.cff:3 has 2026-06-02, but .*CHANGELOG\.md:3 has 2026-06-03"):
+        check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_malformed_current_release_heading_reports_line(tmp_path: Path) -> None:
+    _write_repository(tmp_path, changelog_headings=("## [0.1.0] - June 2, 2026",))
+
+    with pytest.raises(ValueError, match=r"CHANGELOG\.md:3: release heading for 0\.1\.0 must end with ISO YYYY-MM-DD"):
+        check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_malformed_inline_linked_release_heading_reports_line(tmp_path: Path) -> None:
+    _write_repository(
+        tmp_path,
+        changelog_headings=("## [0.1.0](https://example.com/releases/0.1.0) - June 2, 2026",),
+    )
+
+    with pytest.raises(ValueError, match=r"CHANGELOG\.md:3: release heading for 0\.1\.0 must end with ISO YYYY-MM-DD"):
+        check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_duplicate_current_release_headings_report_lines(tmp_path: Path) -> None:
+    _write_repository(
+        tmp_path,
+        changelog_headings=("## [0.1.0] - 2026-06-02", "## [0.1.0] - 2026-06-02"),
+    )
+
+    with pytest.raises(ValueError, match=r"CHANGELOG\.md: duplicate release headings for 0\.1\.0 at lines 3, 5"):
+        check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_python_package_readme_must_target_support_documentation(tmp_path: Path) -> None:
+    _write_repository(tmp_path, python_readme="README.md")
+
+    with pytest.raises(ValueError, match=r"pyproject\.toml: \[project\]\.readme must be 'scripts/README\.md'"):
+        check_release_metadata.validate_release_metadata(tmp_path)
+
+
+def test_cli_reports_validation_failures_on_stderr(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write_repository(tmp_path, citation_dates=())
+
+    assert check_release_metadata.main([str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Release metadata validation failed:" in captured.err

--- a/scripts/tests/test_check_semgrep_fixtures.py
+++ b/scripts/tests/test_check_semgrep_fixtures.py
@@ -1,0 +1,123 @@
+"""Tests for Semgrep fixture-annotation validation."""
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+import check_semgrep_fixtures
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _result(check_id: str, line: int, end_line: int | None = None) -> dict[str, object]:
+    return {"check_id": check_id, "start": {"line": line}, "end": {"line": line if end_line is None else end_line}}
+
+
+def _run_main(monkeypatch: pytest.MonkeyPatch, fixture: Path, payload: object) -> int:
+    monkeypatch.setenv("SEMGREP_JSON", json.dumps(payload))
+    monkeypatch.setattr(check_semgrep_fixtures.sys, "argv", ["check_semgrep_fixtures.py", str(fixture)])
+    return check_semgrep_fixtures.main()
+
+
+def test_semgrep_results_parses_valid_result_objects(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "SEMGREP_JSON",
+        json.dumps({"results": [_result("rust.foo", 2), _result("rust.bar", 4)]}),
+    )
+
+    results = check_semgrep_fixtures._semgrep_results()
+
+    assert results is not None
+    assert len(results.results) == 2
+
+
+@pytest.mark.parametrize(
+    ("payload", "diagnostic"),
+    [
+        ([], "expected a JSON object"),
+        ({}, "expected 'results' to be a list"),
+        ({"results": {}}, "expected 'results' to be a list"),
+        ({"results": [_result("rust.foo", 2), "bad"]}, "result 1 is not an object"),
+    ],
+)
+def test_semgrep_results_rejects_malformed_container_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    payload: object,
+    diagnostic: str,
+) -> None:
+    monkeypatch.setenv("SEMGREP_JSON", json.dumps(payload))
+
+    assert check_semgrep_fixtures._semgrep_results() is None
+    assert diagnostic in capsys.readouterr().err
+
+
+def test_main_accepts_matching_rule_and_line_annotations(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fixture = tmp_path / "fixture.rs"
+    fixture.write_text(
+        "// ruleid: rust.foo, rust.bar\nbad_one();\n// todoruleid: rust.foo\nbad_two();\n",
+        encoding="utf-8",
+    )
+    payload = {"results": [_result("rust.foo", 2), _result("rust.bar", 2), _result("rust.foo", 4)]}
+
+    assert _run_main(monkeypatch, fixture, payload) == 0
+
+
+@pytest.mark.parametrize(
+    ("result", "diagnostic"),
+    [
+        ({"start": {"line": 2}, "end": {"line": 2}}, "missing non-empty string field 'check_id'"),
+        (_result("", 2), "missing non-empty string field 'check_id'"),
+        ({"check_id": "rust.foo", "start": {}, "end": {"line": 2}}, "missing positive integer field 'start.line'"),
+        ({"check_id": "rust.foo", "start": {"line": True}, "end": {"line": 2}}, "missing positive integer field 'start.line'"),
+        ({"check_id": "rust.foo", "start": {"line": 2}, "end": {}}, "missing positive integer field 'end.line'"),
+        ({"check_id": "rust.foo", "start": {"line": 3}, "end": {"line": 2}}, "end.line 2 before start.line 3"),
+    ],
+)
+def test_main_rejects_malformed_finding_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    result: dict[str, object],
+    diagnostic: str,
+) -> None:
+    fixture = tmp_path / "fixture.rs"
+    fixture.write_text("// ruleid: rust.foo\nbad();\n", encoding="utf-8")
+
+    assert _run_main(monkeypatch, fixture, {"results": [result]}) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert diagnostic in captured.err
+
+
+def test_main_rejects_findings_at_wrong_lines_even_when_rule_counts_match(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = tmp_path / "fixture.rs"
+    fixture.write_text("// ruleid: rust.foo\nbad_one();\n// ruleid: rust.foo\nbad_two();\n", encoding="utf-8")
+    payload = {"results": [_result("rust.foo", 2), _result("rust.foo", 5)]}
+
+    assert _run_main(monkeypatch, fixture, payload) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "rust.foo at line 4: expected finding not reported" in captured.err
+    assert "rust.foo at lines 5: unexpected finding" in captured.err
+
+
+def test_main_matches_overlapping_spans_by_earliest_end_line(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fixture = tmp_path / "fixture.rs"
+    fixture.write_text("// ruleid: rust.foo\nbad_one();\n// ruleid: rust.foo\nbad_two();\n", encoding="utf-8")
+    payload = {"results": [_result("rust.foo", 2, 4), _result("rust.foo", 2)]}
+
+    assert _run_main(monkeypatch, fixture, payload) == 0
+
+
+def test_main_matches_markdown_finding_after_blank_line_and_code_fence(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fixture = tmp_path / "fixture.md"
+    fixture.write_text("<!-- ruleid: docs.foo -->\n\n```bash\nbad-command\n```\n", encoding="utf-8")
+
+    assert _run_main(monkeypatch, fixture, {"results": [_result("docs.foo", 4)]}) == 0

--- a/scripts/tests/test_check_semgrep_fixtures.py
+++ b/scripts/tests/test_check_semgrep_fixtures.py
@@ -1,5 +1,6 @@
 """Tests for Semgrep fixture-annotation validation."""
 
+import collections
 import json
 from typing import TYPE_CHECKING
 
@@ -108,12 +109,19 @@ def test_main_rejects_findings_at_wrong_lines_even_when_rule_counts_match(
     assert "rust.foo at lines 5: unexpected finding" in captured.err
 
 
-def test_main_matches_overlapping_spans_by_earliest_end_line(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_main_matches_overlapping_spans_by_shortest_span(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     fixture = tmp_path / "fixture.rs"
     fixture.write_text("// ruleid: rust.foo\nbad_one();\n// ruleid: rust.foo\nbad_two();\n", encoding="utf-8")
     payload = {"results": [_result("rust.foo", 2, 4), _result("rust.foo", 2)]}
 
     assert _run_main(monkeypatch, fixture, payload) == 0
+
+
+def test_finding_mismatches_consumes_shorter_span_when_it_ends_later() -> None:
+    expected = collections.Counter({("rust.foo", 4): 1})
+    actual = (("rust.foo", 1, 4), ("rust.foo", 3, 5))
+
+    assert check_semgrep_fixtures._finding_mismatches(expected, actual) == ("rust.foo at lines 1-4: unexpected finding",)
 
 
 def test_main_matches_markdown_finding_after_blank_line_and_code_fence(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/scripts/tests/test_subprocess_utils.py
+++ b/scripts/tests/test_subprocess_utils.py
@@ -21,9 +21,12 @@ if TYPE_CHECKING:
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from subprocess_utils import (
+    DEFAULT_COMMAND_TIMEOUT_SECONDS,
     ExecutableNotFoundError,
+    _build_run_kwargs,
     check_git_history,
     check_git_repo,
+    find_project_root,
     get_git_commit_hash,
     get_git_remote_url,
     get_safe_executable,
@@ -32,6 +35,20 @@ from subprocess_utils import (
     run_git_command_with_input,
     run_safe_command,
 )
+
+
+class TestBuildRunKwargs:
+    """Test bounded subprocess defaults and explicit overrides."""
+
+    def test_uses_finite_default_timeout(self) -> None:
+        kwargs = _build_run_kwargs("test_func")
+
+        assert kwargs["timeout"] == DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+    def test_respects_explicit_longer_timeout(self) -> None:
+        kwargs = _build_run_kwargs("test_func", timeout=1800)
+
+        assert kwargs["timeout"] == 1800
 
 
 class TestGetSafeExecutable:
@@ -303,6 +320,27 @@ class TestSecurityFeatures:
         """Test that run_git_command_with_input raises ValueError when executable is overridden."""
         with pytest.raises(ValueError, match="Overriding 'executable' is not allowed"):
             run_git_command_with_input(["hash-object", "--stdin"], "test content", executable="/malicious/fake/git")
+
+
+class TestFindProjectRoot:
+    """Test explicit file and directory project-root discovery."""
+
+    def test_accepts_nested_directory_start(self, tmp_path: Path) -> None:
+        root = tmp_path / "checkout"
+        nested = root / "target" / "wheel"
+        nested.mkdir(parents=True)
+        (root / "Cargo.toml").write_text("[package]\n", encoding="utf-8")
+
+        assert find_project_root(nested) == root
+
+    def test_accepts_file_start(self, tmp_path: Path) -> None:
+        root = tmp_path / "checkout"
+        source = root / "scripts" / "tool.py"
+        source.parent.mkdir(parents=True)
+        source.write_text("", encoding="utf-8")
+        (root / "Cargo.toml").write_text("[package]\n", encoding="utf-8")
+
+        assert find_project_root(source) == root
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_subprocess_utils.py
+++ b/scripts/tests/test_subprocess_utils.py
@@ -6,6 +6,7 @@ These tests ensure the security utilities function correctly and maintain
 their secure-by-default behavior while providing flexibility through kwargs.
 """
 
+import math
 import shutil
 import subprocess
 import sys
@@ -43,6 +44,7 @@ class TestBuildRunKwargs:
     def test_uses_finite_default_timeout(self) -> None:
         kwargs = _build_run_kwargs("test_func")
 
+        assert math.isfinite(kwargs["timeout"])
         assert kwargs["timeout"] == DEFAULT_COMMAND_TIMEOUT_SECONDS
 
     def test_respects_explicit_longer_timeout(self) -> None:

--- a/scripts/tests/test_tag_release.py
+++ b/scripts/tests/test_tag_release.py
@@ -2,11 +2,16 @@
 
 import subprocess
 from pathlib import PureWindowsPath
-from unittest.mock import patch
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+import tag_release
 from tag_release import _get_repo_url, create_tag, main, validate_semver
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # _get_repo_url
@@ -88,6 +93,10 @@ class TestValidateSemver:
 
 
 class TestCreateTag:
+    @pytest.fixture(autouse=True)
+    def _matching_package_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(tag_release, "_package_version", lambda _changelog: "1.2.3")
+
     def test_next_step_sets_release_title(self, tmp_path, capsys: pytest.CaptureFixture[str]) -> None:
         changelog = tmp_path / "CHANGELOG.md"
         with (
@@ -141,6 +150,29 @@ class TestCreateTag:
         mock_delete_tag.assert_not_called()
         mock_run_git_with_input.assert_called_once()
         assert mock_run_git_with_input.call_args.args[0] == ["tag", "-f", "-a", "v1.2.3", "-F", "-", "--cleanup=verbatim"]
+
+    def test_rejects_tag_that_differs_from_cargo_before_git(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n", encoding="utf-8")
+        tag_exists = MagicMock()
+        extract_section = MagicMock()
+        monkeypatch.setattr(tag_release, "find_changelog", lambda: changelog)
+        monkeypatch.setattr(tag_release, "_package_version", lambda _changelog: "1.2.4")
+        monkeypatch.setattr(tag_release, "_tag_exists", tag_exists)
+        monkeypatch.setattr(tag_release, "extract_changelog_section", extract_section)
+
+        with pytest.raises(ValueError, match="does not match Cargo package version"):
+            create_tag("v1.2.3")
+
+        tag_exists.assert_not_called()
+        extract_section.assert_not_called()
+
+
+def test_package_version_reads_cargo_manifest_beside_changelog(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "demo"\nversion = "2.3.4"\n', encoding="utf-8")
+
+    assert tag_release._package_version(changelog) == "2.3.4"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/semgrep/notebooks/dirty.ipynb
+++ b/tests/semgrep/notebooks/dirty.ipynb
@@ -2,11 +2,11 @@
   "cells": [
     {
       "cell_type": "code",
+      "semgrep_annotation": "# ruleid: causal-triangulations.notebooks.no-committed-outputs",
       "execution_count": 1,
       "metadata": {},
       "outputs": [],
       "source": [
-        "# ruleid: causal-triangulations.notebooks.no-committed-outputs\n",
         "print(\"execution count should be cleared\")\n"
       ]
     },
@@ -14,6 +14,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {},
+      "semgrep_annotation": "# ruleid: causal-triangulations.notebooks.no-committed-outputs",
       "outputs": [
         {
           "name": "stdout",
@@ -24,7 +25,6 @@
         }
       ],
       "source": [
-        "# ruleid: causal-triangulations.notebooks.no-committed-outputs\n",
         "print(\"outputs should be cleared\")\n"
       ]
     }


### PR DESCRIPTION
- Reject mismatched tag versions, invalid release dates, and malformed or duplicate changelog headings before mutation.
- Publish changelog outputs transactionally while preserving rollback diagnostics.
- Match Semgrep fixture findings by rule and source span and reject malformed result payloads.
- Bound shared subprocesses and make project-root discovery configurable.
- Synchronize citation and support-package metadata through the release validation gate.

Closes #249